### PR TITLE
fix: double newlines in for-loop and multi-statement output

### DIFF
--- a/crates/kaish-kernel/docs/help/limits.md
+++ b/crates/kaish-kernel/docs/help/limits.md
@@ -82,6 +82,9 @@ cargo build  # Error: cannot run external from virtual directory
 | `[ -f file ]` | Supported via builtin; prefer `[[ ]]` |
 | `*.txt` expands at shell | Passed literally to tools |
 | Regex in `=~` is unquoted | Quotes allowed: `=~ "\.rs$"` |
+| `printf "a"; printf "b"` → `ab` | → `a\nb` (line-separated) |
+
+**Output model:** Bash concatenates raw byte streams — `printf "a"; printf "b"` produces `ab`. kaish separates statement outputs by newlines, so the same produces `a\nb`. This is intentional: line-oriented output is more predictable for agents parsing results. Each statement's output is one or more complete lines.
 
 ## Workarounds
 

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -96,6 +96,8 @@ cmd1 || cmd2                    # run cmd2 only if cmd1 fails
 mkdir /tmp/work && cd /tmp/work && echo "ready"
 ```
 
+> **Output model:** Unlike bash, which concatenates raw byte streams (`printf "a"; printf "b"` → `ab`), kaish separates statement outputs by newlines (`a\nb`). Each statement produces one or more complete lines. This is intentional — line-oriented output is more predictable for agents parsing results.
+
 ## Test Expressions
 
 ```bash


### PR DESCRIPTION
## Summary

- `accumulate_result()` unconditionally added a `\n` separator between outputs, but `echo` (and other builtins) already terminate with `\n` — producing blank lines in iteration output
- Fix: only add separator when accumulated output doesn't already end with a newline

## Root cause

```
echo "path" → "path\n"
accumulate_result joins: "path1\n" + "\n" + "path2\n" = "path1\n\npath2\n"
```

The extra `\n` manifested as blank lines in `for f in $(glob ...); do echo "$f"; done` and similar patterns.

## Test plan

- [x] `test_accumulate_no_double_newlines` — newline-terminated outputs don't get double newlines
- [x] `test_accumulate_adds_separator_when_needed` — non-newline outputs still get separated
- [x] `test_accumulate_empty_into_nonempty` — empty + non-empty works
- [x] `test_accumulate_nonempty_into_empty` — non-empty + empty works
- [x] `test_accumulate_stderr_no_double_newlines` — stderr gets same treatment
- [x] `test_multiple_echo_no_blank_lines` — `echo one; echo two; echo three` exact output
- [x] `test_for_loop_no_blank_lines` — `for X in a b c; do echo $X; done` exact output
- [x] `test_for_command_subst_no_blank_lines` — `for N in $(seq 1 3); do echo $N; done` exact output
- [x] 654 existing kernel tests still pass
- [x] clippy clean, insta snapshots unchanged

Fixes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)