### PR TITLE
docs: adopt PR-based workflow + README/issues polish

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,14 @@ fixture IS the test failing). `cargo clippy --all` alone skips test targets — 
 
 ### Version Control
 
+- **Work on a branch, open a PR.** Don't commit changes directly to `main`.
+  Branch first (`git switch -c <type>/<short-desc>`), push, and open a PR with
+  `gh pr create` so changes are reviewable before they land. Releases (the
+  `/release` skill) are the deliberate exception — they tag and publish from
+  `main`.
+- **Have the PR reviewed before merging** — `/code-review` on the diff, or another
+  agent/model. A few tokens on review goes a long way (this is what we ask outside
+  contributors to do too; see README "Contributing").
 - **Always add files by name**
 - Before committing, both must be clean:
   - `cargo test --all`

--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@
   <img src="docs/banner.svg" alt="Kai the hermit crab — kaish mascot — looking at kaish code" width="720">
 </p>
 
-Kaish is an embeddable Bourne-like shell with many builtins and a virtual filesystem that can be
-bridged to an underlying system or completely sandboxed.
+Kaish is a predictable Bourne-like shell for AI agents — embeddable in Rust and available as an
+MCP server. It ships many in-process builtins and a virtual filesystem that can be bridged to an
+underlying system or completely sandboxed.
 
 ## Install
 
@@ -65,6 +66,10 @@ for file in *.txt; do              # bare glob expansion
     echo "Found: $file"
 done
 
+# Quote to join: adjacent unquoted tokens never paste together
+echo "$GREETING/world.txt"          # ✅  quote the whole word
+# echo $GREETING/world.txt          # ❌  parse error — kaish won't paste $GREETING and /world.txt
+
 # Pipes and redirects
 cat urls.txt | grep "https" | head -n 10 > filtered.txt
 
@@ -79,7 +84,7 @@ jq -n --argjson r "$RESULT" -r '$r.name'
 # Glob patterns expand inline, or use the glob builtin for options
 glob "**/*.rs" --exclude="*_test.rs"
 
-# Parallel execution with scatter/gather
+# Parallel execution with scatter/gather — --as N binds $N in each worker; --limit caps concurrency
 seq 1 10 | scatter --as N --limit 4 | echo "processing $N" | gather
 ```
 
@@ -346,9 +351,11 @@ cargo build --release
 ## Contributing
 
 Agent-generated PRs are welcome! 🤖 This project is built with AI agents and we
-love seeing what other agents come up with. That said, please have your agent (or
-another model) review the PR before submitting — a few tokens on review goes a long
-way. Same goes for issues: agent-filed is fine, just make sure it makes sense.
+love seeing what other agents come up with. **All changes go through a PR** —
+branch, push, and open a PR rather than committing to `main` (releases are the
+exception). That said, please have your agent (or another model) review the PR
+before submitting — a few tokens on review goes a long way. Same goes for issues:
+agent-filed is fine, just make sure it makes sense.
 
 If you're working with AI coding agents, you might also be interested in:
 

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -24,6 +24,15 @@ subprocess capture, arithmetic token leak) **all validate as fixed** on
 
 ## P1 — High-leverage features and diagnostics
 
+### `sed -e EXPR -e EXPR` silently keeps only the last expression
+(real bug, pre-existing — `SedArgs::expression` is `Option<String>` and
+`collect_expressions` does single-key `args.named` lookups, so the kernel's
+`consumes<=1` HashMap overwrite drops earlier `-e`s). The `help` example
+`sed -e 's/a/b/' -e 's/c/d/' file.txt` advertises a feature that doesn't fully
+work — a "never silently corrupt" violation. Fix: `expression: Vec<String>`
+with `ArgAction::Append`, plus kernel accumulation of repeated 1-value flags
+into a `Value::Json(Array)`. Same class likely affects other repeatable flags.
+
 ### OverlayFs — ALL HUNKS LANDED 2026-06-10; residuals only
 Hunk 1 `69c42e3`+`2a62a72` (MemoryFs lift, overlay core), accounting vfs half
 `dddc85d` (resident_bytes, ByteBudget), hunk 2 `6fe2225` (inspection API),
@@ -302,14 +311,6 @@ E007-ing — was investigated and rejected: the equals form is not a legal jq
 invocation, real jq exits 2 "Unknown option", so rejecting it before execution
 is correct. Pinned by `jq_equals_form_arg_is_rejected_not_silently_run`.)
 
-- **`sed -e EXPR -e EXPR` silently keeps only the last expression** (real bug,
-  pre-existing — `SedArgs::expression` is `Option<String>` and
-  `collect_expressions` does single-key `args.named` lookups, so the kernel's
-  `consumes<=1` HashMap overwrite drops earlier `-e`s). The `help` example
-  `sed -e 's/a/b/' -e 's/c/d/' file.txt` advertises a feature that doesn't fully
-  work — a "never silently corrupt" violation. Fix: `expression: Vec<String>`
-  with `ArgAction::Append`, plus kernel accumulation of repeated 1-value flags
-  into a `Value::Json(Array)`. Same class likely affects other repeatable flags.
 - **Combined short flags only bind a glued value when the value-flag is first**
   (feature gap, pre-existing — `cut -f1` works, but `grep -ivC 3` treats `C` as a
   bool because the leading `i`/`v` are bool flags, leaving `3` as a stray


### PR DESCRIPTION
Start using PRs for changes going forward, and bank a small sync-docs pass while we're here.

## Changes

**Adopt PR-based workflow**
- `CLAUDE.md` (which `AGENTS.md`/`GEMINI.md` symlink) Version Control section now directs: work on a branch, open a PR, don't commit to `main` — with `/release` as the explicit exception (it tags/publishes from `main`).
- Reinforced in the README Contributing section so the human-facing doc and agent instructions agree.

**README polish** (from a sync-docs pass; Phase 0 reconciled clean — 89 builtins = 89 table rows, 12 crates = 12 listed)
- Lead the intro with the AI-agent + MCP value proposition (it previously didn't surface either until far down the page).
- Add a quote-to-join gotcha to the Quick Tour.
- Annotate `scatter --as N --limit 4`.

**Issue triage**
- Promote the pre-existing `sed -e EXPR -e EXPR` silent-drop bug to P1 and fix its malformed heading.

## Testing
Markdown-only — no Rust or compiled help content (`content/en/*.md`) touched, so no test/clippy gate is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)