### PR TITLE
test(grep): pin -n with -A/-B context line numbering + separators

### DIFF
--- a/crates/kaish-kernel/src/tools/builtin/grep.rs
+++ b/crates/kaish-kernel/src/tools/builtin/grep.rs
@@ -1564,6 +1564,28 @@ mod tests {
         assert!(result.text_out().contains("line three"));
     }
 
+    /// `-n` with `-B`/`-A` context must number every emitted line and keep the
+    /// GNU separator convention: matched lines use `:`, context lines use `-`.
+    #[tokio::test]
+    async fn test_grep_line_numbers_with_context() {
+        let mut ctx = make_ctx().await;
+        let mut args = ToolArgs::new();
+        args.positional.push(Value::String("two".into()));
+        args.positional.push(Value::String("/lines.txt".into()));
+        args.flags.insert("n".to_string());
+        args.named.insert("before-context".to_string(), Value::Int(1));
+        args.named.insert("after-context".to_string(), Value::Int(1));
+
+        let result = Grep.execute(args, &mut ctx).await;
+        assert!(result.ok());
+        // /lines.txt = "line one\nline two\nline three\nfour"; match is line 2.
+        // Before/after context get `-`; the match gets `:`.
+        assert_eq!(
+            &*result.text_out(),
+            "1-line one\n2:line two\n3-line three\n",
+        );
+    }
+
     async fn make_recursive_ctx() -> ExecContext {
         let mut vfs = VfsRouter::new();
         let mem = MemoryFs::new();


### PR DESCRIPTION
## What

Adds `test_grep_line_numbers_with_context`, exercising `-n` together with `-A`/`-B` context — a combination no existing test covered (we had `-n` alone and context alone).

## Why

`-n`'s interaction with context is where GNU compatibility lives: matched lines use the `:` separator, context lines use `-`, and every emitted line must be numbered. Nothing pinned that, so a regression in either the numbering or the separator logic would have passed silently.

## Test

Matches `two` in `/lines.txt` (`line one\nline two\nline three\nfour`) with `-n -B1 -A1` and asserts exact output:

```
1-line one
2:line two
3-line three
```

Exact-equality so it fails loudly on any drift.

- `cargo test -p kaish-kernel --lib grep` — 44 passed
- `cargo clippy --all-targets` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)