### PR TITLE
fix(grep/sed): combined short-flag values + sed BRE false positives; cull issues.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ breaking entries are marked **BREAKING**.
 
 ### Fixed
 - **Combined short flags now bind a trailing value flag** (`grep -ivC 3`, `grep -inC1`): the value-taking flag in a bundle used to be treated as a boolean, stranding its argument as a stray positional → arity error. Bool flags still stack (`ls -la`); the first value-taking flag in the bundle consumes the rest of the token (`-ivC3` → `C=3`) or, if it's the last char, the next positional (`-ivC 3` → `C=3`).
-- **`sed` no longer false-errors valid ERE as a BRE capture-group idiom**: a literal `\\1` in the replacement (escaped backslash + `1`) is no longer mistaken for a `\1` backref, and a pattern that mixes a real ERE group `(a)` with literal escaped parens `\(b\)` plus a `\1` backref is accepted instead of rejected.
+- **Glued repeatable short flags accumulate instead of clobbering**: the glued first-char form of a repeatable flag (e.g. `sed -e1d -e2d`) now keeps every value like the separated `-e 1d -e 2d`, instead of silently dropping all but the last.
+- **`sed` no longer false-errors valid ERE as a BRE capture-group idiom**: a literal `\\1` in the replacement (escaped backslash + `1`) is no longer mistaken for a `\1` backref; a pattern that mixes a real ERE group `(a)` with literal escaped parens `\(b\)` plus a `\1` backref is accepted; and — conversely — a literal `(` inside a bracket class (`[(]\(x\)`) no longer *suppresses* the BRE error, so a genuine BRE capture-group mistake beside it still fails loud.
 
 ## [0.9.0] - 2026-06-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ breaking entries are marked **BREAKING**.
 
 ## [Unreleased]
 
+### Fixed
+- **Combined short flags now bind a trailing value flag** (`grep -ivC 3`, `grep -inC1`): the value-taking flag in a bundle used to be treated as a boolean, stranding its argument as a stray positional → arity error. Bool flags still stack (`ls -la`); the first value-taking flag in the bundle consumes the rest of the token (`-ivC3` → `C=3`) or, if it's the last char, the next positional (`-ivC 3` → `C=3`).
+- **`sed` no longer false-errors valid ERE as a BRE capture-group idiom**: a literal `\\1` in the replacement (escaped backslash + `1`) is no longer mistaken for a `\1` backref, and a pattern that mixes a real ERE group `(a)` with literal escaped parens `\(b\)` plus a `\1` backref is accepted instead of rejected.
+
 ## [0.9.0] - 2026-06-18
 
 ### Added

--- a/crates/kaish-kernel/src/kernel.rs
+++ b/crates/kaish-kernel/src/kernel.rs
@@ -3228,20 +3228,24 @@ impl Kernel {
                             )
                             .await?;
                         }
-                    } else if let Some(&(canonical, _, _, _)) = param_lookup
+                    } else if let Some(&(canonical, _, consumes, repeatable)) = param_lookup
                         .get(&name[..1])
                         .filter(|(_, typ, ..)| !is_bool_type(typ))
                     {
                         // Glued short-flag value: `cut -f1`, `head -c5`, `cut -f1-3`,
-                        // `grep -A1`. The first char is a declared value-taking short
-                        // flag, so the rest of the token is its value — the coreutils
-                        // idiom. The lexer's flag char class is `[a-zA-Z][a-zA-Z0-9-]*`,
-                        // so the first byte is always ASCII (safe to slice) and the tail
-                        // is a plain literal. Single value only; no builtin short flag
-                        // declares consumes>1.
-                        tool_args
-                            .named
-                            .insert(canonical.to_string(), Value::String(name[1..].to_string()));
+                        // `grep -A1`, `sed -e1d`. The first char is a declared
+                        // value-taking short flag, so the rest of the token is its
+                        // value — the coreutils idiom. The lexer's flag char class is
+                        // `[a-zA-Z][a-zA-Z0-9-]*`, so the first byte is always ASCII
+                        // (safe to slice) and the tail is a plain literal.
+                        bind_glued_short_value(
+                            &mut tool_args,
+                            &name[..1],
+                            canonical,
+                            consumes,
+                            repeatable,
+                            name[1..].to_string(),
+                        )?;
                     } else {
                         // Multi-char combined short flags. Bool flags stack
                         // (`-la`), but the FIRST value-taking flag reached
@@ -3253,27 +3257,25 @@ impl Kernel {
                         // error). Undeclared/bool chars stay bare flags, so a
                         // schemaless tool keeps the old all-boolean behavior.
                         // The first char being value-taking is handled by the
-                        // glued arm above, so it never reaches here.
-                        let chars: Vec<char> = name.chars().collect();
+                        // glued arm above, so it never reaches here. The flag
+                        // char class is ASCII, so byte indexing is char indexing
+                        // (no `Vec<char>` allocation needed).
+                        let bytes = name.as_bytes();
                         let mut p = 0;
-                        while p < chars.len() {
-                            let key = chars[p].to_string();
-                            match param_lookup.get(key.as_str()) {
+                        while p < bytes.len() {
+                            let key = &name[p..p + 1];
+                            match param_lookup.get(key) {
                                 Some(&(canonical, typ, consumes, repeatable))
                                     if !is_bool_type(typ) =>
                                 {
-                                    // A glued tail is a single value, so it only
-                                    // honors a `consumes <= 1` flag — same
-                                    // assumption as the first-char glued arm
-                                    // above (no builtin short flag declares
-                                    // `consumes > 1`). The last-char branch routes
-                                    // through `consume_flag_positionals`, which
-                                    // does respect `consumes`.
-                                    let glued: String = chars[p + 1..].iter().collect();
+                                    let glued = name[p + 1..].to_string();
                                     if glued.is_empty() {
+                                        // Value flag is the last char: take the
+                                        // next positional. `consume_flag_positionals`
+                                        // respects `consumes`.
                                         self.consume_flag_positionals(
                                             args,
-                                            &key,
+                                            key,
                                             canonical,
                                             consumes,
                                             repeatable,
@@ -3283,22 +3285,20 @@ impl Kernel {
                                             &mut tool_args,
                                         )
                                         .await?;
-                                    } else if repeatable {
-                                        push_repeatable_value(
-                                            &mut tool_args,
-                                            &key,
-                                            canonical,
-                                            Value::String(glued),
-                                        )?;
                                     } else {
-                                        tool_args
-                                            .named
-                                            .insert(canonical.to_string(), Value::String(glued));
+                                        bind_glued_short_value(
+                                            &mut tool_args,
+                                            key,
+                                            canonical,
+                                            consumes,
+                                            repeatable,
+                                            glued,
+                                        )?;
                                     }
                                     break;
                                 }
                                 _ => {
-                                    tool_args.flags.insert(key);
+                                    tool_args.flags.insert(key.to_string());
                                     p += 1;
                                 }
                             }
@@ -5175,6 +5175,35 @@ fn push_repeatable_value(
         Ok(())
     } else {
         anyhow::bail!("--{flag_name}: named[{canonical}] already holds a non-array value")
+    }
+}
+
+/// Bind a *glued* short-flag value (`-f1` → f=1, `-e1d`, `-A2`). The whole tail
+/// is one token, so it carries a single value: a repeatable flag accumulates
+/// (never clobbers — `-e1d -e2d` keeps both), a plain one inserts. Shared by the
+/// first-char glued arm and the combined-bundle arm so the two can't drift on
+/// `repeatable` handling. A `consumes > 1` flag can't be expressed glued — that
+/// is a loud error, not a silent single-value bind.
+fn bind_glued_short_value(
+    tool_args: &mut ToolArgs,
+    flag_name: &str,
+    canonical: &str,
+    consumes: usize,
+    repeatable: bool,
+    value: String,
+) -> anyhow::Result<()> {
+    if consumes > 1 {
+        anyhow::bail!(
+            "-{flag_name} takes {consumes} arguments; use the separated form, not a glued value"
+        );
+    }
+    if repeatable {
+        push_repeatable_value(tool_args, flag_name, canonical, Value::String(value))
+    } else {
+        tool_args
+            .named
+            .insert(canonical.to_string(), Value::String(value));
+        Ok(())
     }
 }
 

--- a/crates/kaish-kernel/src/kernel.rs
+++ b/crates/kaish-kernel/src/kernel.rs
@@ -3243,9 +3243,65 @@ impl Kernel {
                             .named
                             .insert(canonical.to_string(), Value::String(name[1..].to_string()));
                     } else {
-                        // Multi-char combined flags like -la: always boolean
-                        for c in name.chars() {
-                            tool_args.flags.insert(c.to_string());
+                        // Multi-char combined short flags. Bool flags stack
+                        // (`-la`), but the FIRST value-taking flag reached
+                        // consumes the rest of the token as its glued value
+                        // (`-ivC3` → C=3) or, if it is the last char, the next
+                        // positional (`grep -ivC 3` → C=3). Before this, a
+                        // trailing value-flag was silently treated as a bool,
+                        // stranding its argument as a stray positional (arity
+                        // error). Undeclared/bool chars stay bare flags, so a
+                        // schemaless tool keeps the old all-boolean behavior.
+                        // The first char being value-taking is handled by the
+                        // glued arm above, so it never reaches here.
+                        let chars: Vec<char> = name.chars().collect();
+                        let mut p = 0;
+                        while p < chars.len() {
+                            let key = chars[p].to_string();
+                            match param_lookup.get(key.as_str()) {
+                                Some(&(canonical, typ, consumes, repeatable))
+                                    if !is_bool_type(typ) =>
+                                {
+                                    // A glued tail is a single value, so it only
+                                    // honors a `consumes <= 1` flag — same
+                                    // assumption as the first-char glued arm
+                                    // above (no builtin short flag declares
+                                    // `consumes > 1`). The last-char branch routes
+                                    // through `consume_flag_positionals`, which
+                                    // does respect `consumes`.
+                                    let glued: String = chars[p + 1..].iter().collect();
+                                    if glued.is_empty() {
+                                        self.consume_flag_positionals(
+                                            args,
+                                            &key,
+                                            canonical,
+                                            consumes,
+                                            repeatable,
+                                            &positional_indices,
+                                            &mut consumed,
+                                            i,
+                                            &mut tool_args,
+                                        )
+                                        .await?;
+                                    } else if repeatable {
+                                        push_repeatable_value(
+                                            &mut tool_args,
+                                            &key,
+                                            canonical,
+                                            Value::String(glued),
+                                        )?;
+                                    } else {
+                                        tool_args
+                                            .named
+                                            .insert(canonical.to_string(), Value::String(glued));
+                                    }
+                                    break;
+                                }
+                                _ => {
+                                    tool_args.flags.insert(key);
+                                    p += 1;
+                                }
+                            }
                         }
                     }
                 }

--- a/crates/kaish-kernel/src/tools/builtin/sed.rs
+++ b/crates/kaish-kernel/src/tools/builtin/sed.rs
@@ -575,14 +575,23 @@ fn detect_bre_idiom(pattern: &str, replacement: &str) -> Result<(), String> {
     let b = pattern.as_bytes();
     let mut escaped_group = false;
     let mut real_group = false;
+    // Track bracket-expression context so a literal `(` inside `[...]` is not
+    // mistaken for a real ERE group. (The `[]…]` / `[^]…]` literal-`]`-first
+    // edge isn't handled — vanishingly rare in agent-written sed.)
+    let mut in_bracket = false;
     let mut i = 0;
     while i < b.len() {
         if b[i] != b'\\' {
-            // An unescaped `(` opens a real ERE group: the author is already
-            // writing ERE, so any `\(` beside it is a literal paren, not a BRE
-            // capture group. Suppresses the capture-group false positive.
-            if b[i] == b'(' {
-                real_group = true;
+            match b[i] {
+                b'[' if !in_bracket => in_bracket = true,
+                b']' if in_bracket => in_bracket = false,
+                // An unescaped `(` OUTSIDE a bracket class opens a real ERE
+                // group: the author is already writing ERE, so any `\(` beside
+                // it is a literal paren, not a BRE capture group. A `(` inside
+                // `[...]` is a literal and says nothing about ERE intent, so it
+                // must NOT suppress detection (silent-wrong otherwise).
+                b'(' if !in_bracket => real_group = true,
+                _ => {}
             }
             i += 1;
             continue;
@@ -1544,6 +1553,18 @@ mod tests {
         assert!(detect_bre_idiom(r"(a)\(b\)", r"\1").is_ok());
         let expr = parse_expression(r"s/(a)\(b\)/\1/").unwrap();
         assert_eq!(execute_sed("a(b)", &[expr], false), "a\n");
+    }
+
+    #[test]
+    fn literal_paren_in_bracket_class_does_not_suppress_bre_detection() {
+        // `[(]` is a bracket expression matching a literal `(` — NOT a real ERE
+        // group, so it must not arm `real_group` and silently suppress the BRE
+        // error. The `\(x\)` beside it IS a genuine BRE capture-group mistake
+        // and must still fail loud. (code-review finding: unescaped `(` inside
+        // `[...]` was wrongly treated as a real group.)
+        assert!(detect_bre_idiom(r"[(]\(x\)", r"\1").is_err());
+        // The real-group suppression still works for a true unescaped group.
+        assert!(detect_bre_idiom(r"(a)\(b\)", r"\1").is_ok());
     }
 
     #[test]

--- a/crates/kaish-kernel/src/tools/builtin/sed.rs
+++ b/crates/kaish-kernel/src/tools/builtin/sed.rs
@@ -574,9 +574,16 @@ fn compile_pattern(pattern: &str, case_insensitive: bool, multiline: bool) -> Re
 fn detect_bre_idiom(pattern: &str, replacement: &str) -> Result<(), String> {
     let b = pattern.as_bytes();
     let mut escaped_group = false;
+    let mut real_group = false;
     let mut i = 0;
     while i < b.len() {
         if b[i] != b'\\' {
+            // An unescaped `(` opens a real ERE group: the author is already
+            // writing ERE, so any `\(` beside it is a literal paren, not a BRE
+            // capture group. Suppresses the capture-group false positive.
+            if b[i] == b'(' {
+                real_group = true;
+            }
             i += 1;
             continue;
         }
@@ -603,12 +610,7 @@ fn detect_bre_idiom(pattern: &str, replacement: &str) -> Result<(), String> {
         i += 2;
     }
 
-    let bytes = replacement.as_bytes();
-    let has_backref = bytes
-        .iter()
-        .enumerate()
-        .any(|(i, &b)| b == b'\\' && bytes.get(i + 1).is_some_and(u8::is_ascii_digit));
-    if escaped_group && has_backref {
+    if escaped_group && !real_group && replacement_has_backref(replacement) {
         return Err(
             "pattern uses BRE capture groups \\(...\\); kaish sed is ERE \
              (egrep-style) — write (...) and backreference \\1, not \\(...\\)"
@@ -616,6 +618,28 @@ fn detect_bre_idiom(pattern: &str, replacement: &str) -> Result<(), String> {
         );
     }
     Ok(())
+}
+
+/// True if the replacement holds a `\N` backreference (N a digit) whose
+/// backslash is not itself escaped. A literal `\\1` (escaped backslash + `1`)
+/// is text, not a backref, and must not arm BRE capture-group detection —
+/// mirrors the pattern scan's `\\`-as-a-unit consumption.
+fn replacement_has_backref(replacement: &str) -> bool {
+    let b = replacement.as_bytes();
+    let mut i = 0;
+    while i < b.len() {
+        if b[i] != b'\\' {
+            i += 1;
+            continue;
+        }
+        if b.get(i + 1).is_some_and(u8::is_ascii_digit) {
+            return true;
+        }
+        // `\` + the next byte form one escape unit; consume both so a `\\` pair
+        // can't leave a dangling backslash that re-arms detection on a digit.
+        i += 2;
+    }
+    false
 }
 
 /// Given `start` pointing just past a `\{`, return true if a BRE interval body
@@ -1499,6 +1523,27 @@ mod tests {
     fn ere_groups_with_backref_work_normally() {
         let expr = parse_expression(r"s/(a)(b)/\2\1/").unwrap();
         assert_eq!(execute_sed("ab", &[expr], false), "ba\n");
+    }
+
+    #[test]
+    fn literal_double_backslash_digit_in_replacement_is_not_a_backref() {
+        // `\\1` is an escaped backslash + literal `1`, not a `\1` backref. The
+        // detector must consume `\\` as a unit so it doesn't see a phantom
+        // backref alongside `\(...\)` and reject valid ERE. (issues.md P2 (a))
+        assert!(detect_bre_idiom(r"\(x\)", r"\\1").is_ok());
+        // End to end: `\(x\)` matches literal `(x)`, `\\1` emits literal `\1`.
+        let expr = parse_expression(r"s/\(x\)/\\1/").unwrap();
+        assert_eq!(execute_sed("(x)", &[expr], false), "\\1\n");
+    }
+
+    #[test]
+    fn real_ere_group_alongside_literal_escaped_parens_is_allowed() {
+        // A genuine ERE group `(a)` means the author is writing ERE, so the
+        // `\(b\)` beside it is a literal paren — `\1` backrefs the real group.
+        // Must not be mistaken for BRE capture groups. (issues.md P2 (b))
+        assert!(detect_bre_idiom(r"(a)\(b\)", r"\1").is_ok());
+        let expr = parse_expression(r"s/(a)\(b\)/\1/").unwrap();
+        assert_eq!(execute_sed("a(b)", &[expr], false), "a\n");
     }
 
     #[test]

--- a/crates/kaish-kernel/tests/glued_short_flag_tests.rs
+++ b/crates/kaish-kernel/tests/glued_short_flag_tests.rs
@@ -70,6 +70,40 @@ async fn grep_glued_after_context() {
 }
 
 #[tokio::test]
+async fn combined_bools_then_glued_value_flag() {
+    // `-inA1`: bools `i`,`n` stack, then value-taking `A` glues its value `1`.
+    // Before the fix, `A` was treated as a bool and `1`... had nowhere to go.
+    let tmp = tempfile::tempdir().unwrap();
+    fs::write(tmp.path().join("f.txt"), "alpha\nMATCH\nbeta\n").unwrap();
+    let kernel = kernel_at(tmp.path());
+
+    let (out, code) = run(&kernel, "grep -inA1 match f.txt").await;
+    assert_eq!(code, 0, "got: {out}");
+    assert!(out.contains("MATCH"), "case-insensitive match missing: {out}");
+    assert!(out.contains("beta"), "after-context line missing: {out}");
+    assert!(out.contains("2:"), "line numbers (-n) missing: {out}");
+}
+
+#[tokio::test]
+async fn combined_bools_then_value_flag_takes_next_positional() {
+    // `grep -ivC 3` — the headline case from issues.md. `i`,`v` are bools and
+    // `C` is value-taking as the LAST char, so it must consume the next
+    // positional `3` (context). Before the fix `C` was a bool and `3` was a
+    // stray positional → arity error.
+    let tmp = tempfile::tempdir().unwrap();
+    fs::write(tmp.path().join("f.txt"), "alpha\nMATCH\nbeta\n").unwrap();
+    let kernel = kernel_at(tmp.path());
+
+    // Use -n (not -v) so the assertion is deterministic; the binding path for
+    // `C`-as-last-char is identical.
+    let (out, code) = run(&kernel, "grep -inC 1 match f.txt").await;
+    assert_eq!(code, 0, "got: {out}");
+    assert!(out.contains("MATCH"), "match missing: {out}");
+    assert!(out.contains("alpha"), "before-context missing: {out}");
+    assert!(out.contains("beta"), "after-context missing: {out}");
+}
+
+#[tokio::test]
 async fn combined_bool_flags_still_split() {
     // `ls -la` is a run of bare bool flags, not a glued value — must keep
     // splitting into individual flags, not bind "a" as a value of "-l".

--- a/crates/kaish-kernel/tests/glued_short_flag_tests.rs
+++ b/crates/kaish-kernel/tests/glued_short_flag_tests.rs
@@ -104,6 +104,24 @@ async fn combined_bools_then_value_flag_takes_next_positional() {
 }
 
 #[tokio::test]
+async fn glued_first_char_repeatable_accumulates() {
+    // `sed -e1d -e2d`: the GLUED first-char form of a repeatable flag (`-e`)
+    // must accumulate both expressions (delete lines 1 and 2 of `1\n2\n3` → "3"),
+    // not keep only the last (which left "1\n3"). Matches the separated
+    // `-e 1d -e 2d`. (code-review finding: the first-char glued arm did a plain
+    // `named.insert` and ignored `repeatable`, clobbering earlier values.)
+    // NB: piped (no file operand) on purpose — the file-positional form
+    // (`sed -e1d f`) is separately blocked by the schema-less validation
+    // arg-builder; tracked in issues.md.
+    let tmp = tempfile::tempdir().unwrap();
+    let kernel = kernel_at(tmp.path());
+
+    let (out, code) = run(&kernel, "seq 1 3 | sed -e1d -e2d").await;
+    assert_eq!(code, 0, "got: {out}");
+    assert_eq!(out.trim(), "3", "both -e expressions must apply: {out}");
+}
+
+#[tokio::test]
 async fn combined_bool_flags_still_split() {
     // `ls -la` is a run of bare bool flags, not a glued value — must keep
     // splitting into individual flags, not bind "a" as a value of "-l".

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -126,3 +126,45 @@ leak — all validated as fixed and were retired from the punch list.
   post-`--` glue — are in issues.md.)
 - **No generic `encode`/`decode`; no `random` builtin (2026-06-13).** See the
   binary-data section above.
+
+## Accepted risks & waived items (decided, not open work)
+
+These were on the issues.md punch list but reached a verdict — recorded so the
+deferral stays a decision, not drift. Reopen only if a real failure surfaces.
+
+- **Non-Linux `kill` keeps PID-based signalling.** `pidfd` is Linux-only;
+  elsewhere we `kill(pid, sig)` and accept the PID-reuse race for the direct
+  child. Acceptable — kaish runs predominantly on Linux.
+- **Process-group kill PID-reuse window.** The PG-wide kill that catches
+  grandchildren goes through `killpg(pgid, sig)` — no PGID equivalent of pidfd.
+  If a leader is reaped and its PGID reused before `killpg` fires, an unrelated
+  group could be signalled. Mitigations (cgroup v2 `cgroup.kill`,
+  `PR_SET_CHILD_SUBREAPER`) are significant complexity; deferred until a real
+  failure.
+- **`JobManager::spawn` busy-waits** with `std::hint::spin_loop()` for immediate
+  visibility — works, wastes CPU under contention. Channel coordination would be
+  cleaner; no trigger.
+- **`head -n -0` / signed-zero line counts (waived).** `-0` lexes as `Int(0)`
+  (sign lost at the lexer) and `line_spec` only treats a *negative* Int as
+  all-but-last, so `head -n -0` prints nothing instead of the whole file. Not
+  fixable without lexer changes to preserve signed zero. Obscure; waived.
+- **`mktemp` random-suffix modulo bias (recorded by choice).** `byte % 36` skews
+  the first four alphabet chars (~3.1% vs ~2.7%, since `256 % 36 = 4`). Negligible
+  for temp suffixes; the rejection-sampling fix complicates the
+  fail-loud-on-no-entropy contract.
+- **`uname -v` discloses build provenance unconditionally.** Formats
+  `kaish {version} ({git_hash} {build_date})` from compile-time `option_env!`; an
+  embedder that sets `KAISH_GIT_HASH`/`KAISH_BUILD_DATE` fingerprints the exact
+  commit even in a minimal build. Gate behind a `verbose-identity` feature only if
+  a threat model cares.
+- **`mktemp` entropy-failure message is unhelpful on wasm.** A
+  `getrandom::fill` failure on `wasm32-wasip1` surfaces a near-empty `Display`.
+  Add a `cfg!(target_arch = "wasm32")` hint if it ever matters.
+- **`to_argv()` flattens a repeatable scalar array to one JSON token (no live
+  trigger).** `ParamSchema.repeatable` stores repeated single-value flags as
+  `named[key] = Json(Array([scalar, …]))`; `to_argv()` only splits the
+  *array-of-arrays* (`consumes > 1`) shape, so a flat scalar array becomes one
+  JSON-text token. `sed` is unaffected (it reads the raw `ToolArgs`); a future
+  repeatable-flag builtin that trusts its clap struct after a `to_argv()`
+  round-trip would see one mangled value. The real fix needs schema context in
+  `to_argv` (it has none). Record-then-defer until a builtin hits it.

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -74,14 +74,28 @@ still does an unconditional `named.insert` of a single `Value::String`. So
 value, but it's the same silent-drop class. Fix: route the glued path through
 `push_repeatable_value` when the matched param is repeatable.
 
-### `sed -i` (in-place edit) — deferred pending a write-model design
+### `sed -i` (in-place edit) — design decided, ready to build with tee/patch
 Both lite models in the sed usability panel reached for `sed -i 's/…/…/' file` —
-the strongest remaining ergonomic gap. Deferred because in-place editing is a
-file-mutating side effect that must route through kaish's write machinery (VFS
-resolution, overlay transactions, latch/trash rails) so sandbox/`--overlay`/confirm
-modes all hold. That's a design (where does the write go under overlay? does `-i`
-need a latch nonce? `-i.bak`?), not a parser tweak. Today `sed` loud-errors on
-`-i`. Pairs with the tee/patch write-model work below.
+the strongest remaining ergonomic gap. In-place editing is a file-mutating side
+effect that must route through kaish's write machinery (VFS resolution, overlay
+transactions, latch/trash rails) so sandbox/`--overlay`/confirm modes all hold.
+`sed -i` is *always* a truncating overwrite of an existing file, so it inherits
+the tee/patch "truncating overwrite gates" rule below. Today `sed` loud-errors on
+`-i`. **Amy decisions (2026-06-21):**
+- **Confirm flag:** `--confirm=<nonce>` across the whole mutation family
+  (`tee`/`patch`/`sed -i`) — one mental model, matching `rm`.
+- **`-i.bak`:** support the explicit backup suffix to match convention. `sed
+  -i.bak` is the user's deliberate, named backup; trash is the *transparent*
+  safety net for the gating, not a substitute for the explicit `.bak`.
+- **Multi-file:** one nonce scoping the whole path set (like `rm`'s
+  `NonceScope.paths`), not per-file.
+- **Overlay prior-content capture:** trash snapshots the *overlay's current
+  view* (what would actually be lost on overwrite in-transaction), not the
+  real-FS baseline.
+- **No file operands:** loud error (`sed -i requires file operands`) — in-place
+  editing of a stream is meaningless; do not fall back to stdin.
+- **Atomicity:** write-temp-then-atomic-rename through the VFS (crash-safe);
+  this surfaces an atomic-replace capability question on the `Filesystem` trait.
 
 ### `tee` / `patch` bypass the latch + trash machinery (write-model design)
 `tee`/`patch` mutate files through the VFS (overlay-safe) but don't honor
@@ -93,8 +107,9 @@ Proceed}` (same priority chain + `/tmp`,`/v` excludes; tee can create a nonexist
 file with no trash). **Amy decisions (2026-06-17):** latch+trash stay ON even in
 overlay mode (the protections are about agent-operation safety, not just real-FS
 data); truncating overwrite gates, `tee -a` append does NOT (for now); new file →
-just write. Open impl detail: the `--confirm` flag name (tee/patch have none), and
-how trash captures prior content in overlay mode. Do it with the `sed -i` work.
+just write. **Resolved (2026-06-21, with the `sed -i` decisions above):** the
+family-wide confirm flag is `--confirm=<nonce>`; in overlay mode trash captures
+the overlay's current view of the prior content. Do it with the `sed -i` work.
 
 ### Streaming file reads — remaining
 (wc/checksum/grep/cmp/cat landed — see devlog.) Open:

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -203,6 +203,21 @@ clap arg parsing. Fix: bespoke argv handling (à la `set.rs`) stripping a leadin
 P2→P3 (Amy):** the shorthand leans POSIX-y and touches OS signal-number variance;
 the loud `--signal NAME %N` form covers the need. Defer.
 
+### Validator's schema-less arg-builder misparses glued value flags (false E-codes)
+`build_tool_args_for_validation` (`validator/walker.rs`) is a *third* arg-builder
+(beside `build_args_async` and the sync `build_tool_args`). It is schema-blind:
+`Arg::ShortFlag("e1d")` becomes `flags={"e1d"}` with no glued-value split, so a
+tool whose `validate()` reads positionals semantically misclassifies them. Concrete:
+`sed -e1d -e2d file` fails validation with `E006 unknown command: f` — with no `-e`
+bound, `collect_expressions` falls back to the *filename* as the expression. (The
+piped form `seq 1 3 | sed -e1d -e2d` validates fine — no file operand to misparse —
+and the execute path now accumulates correctly.) Pre-existing; surfaced by the
+2026-06-21 combined-short-flag work. Right fix is schema-aware validation arg
+binding, which converges with the twin-elimination below (there are really *two*
+non-async builders to retire). Until then, glued domain-value flags on sed/awk with
+a trailing file operand false-error at validation. Affects sed/awk; `grep -ivC`,
+`cut -f1` etc. validate fine (their `validate()` doesn't parse positionals).
+
 ### Eliminate the sync `build_tool_args` twin entirely
 Retire the sync arg builder so there's one path. Real commands already bind through
 `build_args_async`; the sync twin (`scheduler/pipeline.rs`) survives only in (a)
@@ -214,6 +229,8 @@ those test sites. Doing so closes three divergences the sync path carries today
 `map_positionals=false`): it lacks the async path's undeclared-space-flag guard, its
 glued short-flag handling (`cut -f1`), and its repeatable/`consumes>1` accumulation
 (the sync builder overwrites where the async one accumulates into `Json(Array)`).
+Fold the validation arg-builder (above) into the same effort — schema-aware binding
+in one place would fix all three surfaces at once.
 
 ### Undeclared space-flag guard covers long flags only (`-t val` still divorces)
 The guard errors on undeclared `--type value` but not single-char `-t value`

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -74,14 +74,6 @@ still does an unconditional `named.insert` of a single `Value::String`. So
 value, but it's the same silent-drop class. Fix: route the glued path through
 `push_repeatable_value` when the matched param is repeatable.
 
-### `sed` `detect_bre_idiom` false positives
-The BRE-rejection heuristic fires on `pattern has \( or \)` AND `replacement has
-\<digit>`. Two false positives: (a) a *literal* `\\1` in the replacement trips the
-`\<digit>` check; (b) a pattern mixing a real ERE group `(a)` with a literal `\(b\)`
-plus a legit `\1` backref is valid ERE but rejected. Tighten: only treat `\<digit>`
-as a backref when the preceding backslash isn't itself escaped. A false error is
-worse than the silent no-op it replaced for these inputs.
-
 ### `sed -i` (in-place edit) — deferred pending a write-model design
 Both lite models in the sed usability panel reached for `sed -i 's/…/…/' file` —
 the strongest remaining ergonomic gap. Deferred because in-place editing is a
@@ -142,10 +134,6 @@ The six-field `ExecContext` ↔ kernel-state sync appears near every fork call s
   positionals only; post-`--` and flag-adjacent-to-positional glue aren't flagged.
 
 ### v0.8.4 review residuals (Gemini Pro, 2026-06-14)
-- **Combined short flags only bind a glued value when the value-flag is first**
-  (`cut -f1` works, but `grep -ivC 3` treats `C` as a bool, leaving `3` a stray
-  positional → arity error). Fix: in `build_args_async`'s multi-char short-flag
-  arm, consume the tail/next positional once a value-taking flag is reached.
 - **`diff -C 3 -C 4` miscounts arity** (P4-trivial — `context_steals_positional`
   subtracts 1 for a deduped `-C`). Redundant usage; fix only if it bites.
 
@@ -200,44 +188,17 @@ clap arg parsing. Fix: bespoke argv handling (à la `set.rs`) stripping a leadin
 P2→P3 (Amy):** the shorthand leans POSIX-y and touches OS signal-number variance;
 the loud `--signal NAME %N` form covers the need. Defer.
 
-### Process-group kill PID-reuse window
-The direct-child path uses `pidfd_send_signal` on Linux (immune to PID reuse for
-the child), but the PG-wide kill that catches grandchildren goes through
-`killpg(pgid, sig)` — no PGID equivalent of pidfd. If the leader is reaped and its
-PGID reused before `killpg` fires, an unrelated group could be signalled.
-Mitigations (cgroup v2 `cgroup.kill`, `PR_SET_CHILD_SUBREAPER`) are significant
-complexity; defer until a real failure.
-
-### Non-Linux unix targets keep PID-based kill
-`pidfd` is Linux-only; elsewhere we send `kill(pid, sig)` and accept the PID-reuse
-race for the direct child. Acceptable — kaish runs predominantly on Linux.
-
-### Sync `build_tool_args` lacks the undeclared-space-flag guard
-The async `build_args_async` fails loud when an undeclared flag under a
-`map_positionals` schema would silently divorce a space-form value; the sync twin
-`build_tool_args` (`scheduler/pipeline.rs`) has no equivalent guard, and also lacks
-the glued short-flag handling (`cut -f1`) the async path gained. Can't trigger the
-production bug today (only production callers are scatter/gather option parsing,
-`map_positionals=false`). Subsumed by the twin-elimination below.
-
 ### Eliminate the sync `build_tool_args` twin entirely
 Retire the sync arg builder so there's one path. Real commands already bind through
-`build_args_async`; the sync twin survives only in (a) scatter/gather *option*
-parsing in `run_scatter_gather` (an `async fn` that already holds a `&dyn
-CommandDispatcher`) and (b) the `#[cfg(test)]` `BackendDispatcher` + ~27 test sites.
-Eliminating it means an async scheduler arg-builder and converting those test sites.
-Subsumes the guard-parity item above **and** the repeatable/`consumes>1` gap (the
-sync builder overwrites on a repeated occurrence where the async one accumulates
-into `Json(Array)` — safe today only because scatter/gather expose scalar flags).
-
-### `to_argv()` flattens a repeatable scalar array to one JSON token
-`ParamSchema.repeatable` stores repeated single-value flags as `named[key] =
-Json(Array([scalar, ...]))`; `to_argv()`/`render_named_value` only splits the
-*array-of-arrays* (`consumes > 1`) shape, so a flat scalar array becomes one
-JSON-text token. `sed` is unaffected (it reads the raw `ToolArgs`, not the
-clap-parsed `Vec`), but a future repeatable-flag builtin that trusts its clap struct
-after a `to_argv()` round-trip would see one mangled value. Needs schema context in
-`to_argv` (it has none) to tell a flat repeatable array from a single `Json(Array)`.
+`build_args_async`; the sync twin (`scheduler/pipeline.rs`) survives only in (a)
+scatter/gather *option* parsing in `run_scatter_gather` (an `async fn` that already
+holds a `&dyn CommandDispatcher`) and (b) the `#[cfg(test)]` `BackendDispatcher` +
+~27 test sites. Eliminating it means an async scheduler arg-builder and converting
+those test sites. Doing so closes three divergences the sync path carries today
+(all currently un-triggerable because scatter/gather only expose scalar flags with
+`map_positionals=false`): it lacks the async path's undeclared-space-flag guard, its
+glued short-flag handling (`cut -f1`), and its repeatable/`consumes>1` accumulation
+(the sync builder overwrites where the async one accumulates into `Json(Array)`).
 
 ### Undeclared space-flag guard covers long flags only (`-t val` still divorces)
 The guard errors on undeclared `--type value` but not single-char `-t value`
@@ -287,22 +248,12 @@ or a dedicated `Callback` trait would smooth it. Not blocking.
 long time/IO future without yielding — audit and apply the same `tokio::select!`
 pattern. None currently known.
 
-### `JobManager::spawn` busy-waits
-Uses `std::hint::spin_loop()` for immediate visibility — works, wastes CPU on
-contention. Channel-based coordination would be cleaner.
-
 ### Piped stdin isn't shared across statements in one `kaish -c 'a; b'` call
 The consume-once logic in `execute_pipeline` moves the seeded `pipe_stdin` into the
 FIRST top-level statement's pipeline; if that statement doesn't read stdin, the
 reader is dropped, so a later reader gets nothing — `printf hi | kaish -c 'echo x;
 cat'` prints only `x`. A real shell leaves fd 0 shared. Fix: keep the source on the
 persistent `exec_ctx` and let whichever command first reads it take it. Niche; defer.
-
-### `head -n -0` / signed-zero line counts can't be distinguished (lexer-level)
-`head -n -0` should mean "all but the last 0 lines" (= whole file) but prints
-nothing — `-0` lexes as `Int(0)` (sign lost at the lexer) and `line_spec` only
-treats a *negative* Int as all-but-last. Obscure; not fixable without lexer changes
-to preserve signed zero. Waived.
 
 ### `PipelineRunner::run_single`'s `stdin` parameter is vestigial
 `scheduler/pipeline.rs:362` — `run_single(cmd, ctx, stdin)` is always called with
@@ -337,23 +288,6 @@ shellcheck dialect at all. Net: kaish is neither a strict POSIX-`sh` nor a bash
 subset. Reframe to something like *"inspired by POSIX sh and bash, informed by
 shellcheck's lints."* Corollary worth stating: shellcheck gives zero coverage for
 kaish's extensions, so the kaish validator is their sole safety net.
-
-### `mktemp` random suffix has slight modulo bias
-`random_suffix` maps random bytes onto a 36-char alphabet with `byte % 36`; since
-`256 % 36 = 4`, bytes 252–255 skew the first four chars (~3.1% vs ~2.7%). Negligible
-for temp suffixes; not worth the rejection-sampling loop (which complicates the
-fail-loud-on-no-entropy contract). Recorded by choice.
-
-### `uname -v` discloses build provenance unconditionally
-`uname.rs` formats the version field as `kaish {version} ({git_hash} {build_date})`
-from compile-time `option_env!`. If an embedder sets `KAISH_GIT_HASH`/
-`KAISH_BUILD_DATE`, `uname -v` fingerprints the exact commit/build even in a minimal
-build. Gate behind a `verbose-identity`-style feature if a threat model cares.
-
-### `mktemp` entropy-failure message is unhelpful on wasm
-On `wasm32-wasip1` a `getrandom::fill` failure surfaces an opaque error whose
-`Display` may be near-empty, so `mktemp: could not obtain system entropy: {e}` loses
-detail. Add a `cfg!(target_arch = "wasm32")` hint if it ever matters.
 
 ### `touch <dir>` on a local mount fails (EISDIR); memory mounts succeed
 `LocalFs::set_mtime` opens the path with `write(true)`, so `touch existing_dir/`


### PR DESCRIPTION
Two agent-facing correctness fixes (TDD, DeepSeek-reviewed), an `issues.md` cull, and the recorded write-model decisions.

## Fixes

**`grep` combined short flags now bind a trailing value flag.** `grep -ivC 3` and `grep -inC1` used to treat the value-taking flag in a bundle as a boolean, stranding its argument as a stray positional → arity error. The combined-flags arm in `build_args_async` now walks the bundle char-by-char: bools stack (`ls -la`), and the first value-taking flag consumes the rest of the token (`-ivC3` → `C=3`) or the next positional if it's the last char (`-ivC 3` → `C=3`). Honors `repeatable`/`consumes`; schemaless tools keep the old all-boolean behavior.

**`sed` stops false-erroring valid ERE as a BRE capture-group idiom.** A literal `\\1` in the replacement (escaped backslash + digit) is no longer read as a `\1` backref, and a pattern mixing a real ERE group `(a)` with literal escaped parens `\(b\)` plus a `\1` backref is now accepted. A genuine unescaped `(` suppresses the heuristic. The genuine BRE idiom still errors.

## Docs

- **Cull:** 8 accepted-decision/waived items moved from `issues.md` to a new *"Accepted risks & waived items"* section in `devlog.md`; the 3 sync-`build_tool_args` items collapsed into one. `issues.md` is open-work-only.
- **Write-model decisions recorded** against the `sed -i` / tee / patch entries (`--confirm=<nonce>` family-wide, `-i.bak` supported, one nonce over the path set, overlay-view trash capture, no-file→error, atomic temp+rename) so that design session starts from a settled surface.

## Review

DeepSeek reviewed the diff. One actionable note (the glued-tail `consumes>1` assumption) is documented inline; the other two findings were assessed and declined with verification (1(c)'s "degrade to bool" is pre-existing, consistent, and surfaces as a loud exit-2 clap error — confirmed against the single-char path).

## Tests / gates

- New failing-first tests: `combined_bools_then_glued_value_flag`, `combined_bools_then_value_flag_takes_next_positional` (`glued_short_flag_tests.rs`); `literal_double_backslash_digit_in_replacement_is_not_a_backref`, `real_ere_group_alongside_literal_escaped_parens_is_allowed` (`sed.rs`).
- `cargo test --all` green; `cargo clippy --all --all-targets` clean; real-binary smoke tests confirm both fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)