### PR TITLE
docs: align working-notes conventions (devlog wording, commit messages, gitignore signoff)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,7 @@ Thumbs.db
 # Fuzz artifacts
 /fuzz/artifacts/
 /fuzz/corpus/
+
+# signoff.md — ephemeral, personal cross-session handoff; never commit.
+# Shared working notes live in docs/issues.md and docs/devlog.md.
+signoff.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,13 @@ fixture IS the test failing). `cargo clippy --all` alone skips test targets — 
     (`--all-targets` so test code is linted too; see Build Commands for the
     test-code allow convention)
 
+### Commit messages
+
+Explain **why, not what** — the diff shows what changed. Write the body as a short
+summary of the decisions behind the change, drawn from the working conversation with
+the user: what we chose, what we rejected, and why. Subject is imperative (the decision
+or outcome). Set a `Co-Authored-By:` trailer crediting the model that did the work.
+
 ## Architecture
 
 The 核 (kaku/kernel) is the unit of execution. Multiple frontends connect to the same kernel:
@@ -130,8 +137,8 @@ Tests live in `crates/kaish-kernel/tests/`. Snapshots in `crates/kaish-kernel/te
 - `crates/kaish-help/src/` — composition surface: `fragments.rs` (the English
   fragment registry, concept-organized) + `compose.rs` (recipes). Design:
   `docs/composable-help.md`.
-- `docs/issues.md` — open work only (P1–P4). `docs/devlog.md` — landed-work
-  narrative + standing decisions (don't re-litigate). Keep history out of
+- `docs/issues.md` — open work only (P1–P4). `docs/devlog.md` — a durable narrative
+  from the agent's perspective; write your story there. Keep history out of
   `issues.md` so it stays cheap to read for actual open work.
 
 **Keep in sync:** When adding builtins or changing syntax, update the relevant help files.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,8 +102,6 @@ change, **drawn from the conversation with the user**. Commit messages briefly e
 what happened as context for the more important task of explaining the decisions we
 made.
 
-Set a `Co-Authored-By:` trailer crediting the model that did the work.
-
 ## Architecture
 
 The 核 (kaku/kernel) is the unit of execution. Multiple frontends connect to the same kernel:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,10 +97,12 @@ fixture IS the test failing). `cargo clippy --all` alone skips test targets — 
 
 ### Commit messages
 
-Explain **why, not what** — the diff shows what changed. Write the body as a short
-summary of the decisions behind the change, drawn from the working conversation with
-the user: what we chose, what we rejected, and why. Subject is imperative (the decision
-or outcome). Set a `Co-Authored-By:` trailer crediting the model that did the work.
+Commit and pull request bodies should usually summarize the decisions behind the
+change, **drawn from the conversation with the user**. Commit messages briefly explain
+what happened as context for the more important task of explaining the decisions we
+made.
+
+Set a `Co-Authored-By:` trailer crediting the model that did the work.
 
 ## Architecture
 


### PR DESCRIPTION
Aligns kaish with the working-notes conventions Amy is propagating across the repos:

- **Simpler devlog wording** — `docs/devlog.md` becomes "a durable narrative from the agent's perspective; write your story there."
- **Commit-message guidance** — a new "Commit messages" subsection: bodies summarize the decisions from the working conversation with the user (why-not-what), per kaibo's ethos.
- **gitignore signoff.md** — keep the ephemeral personal handoff out of the repo.

Doc/ignore-only, no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)