### PR TITLE
fix(printf): \0NNN octal parity with GNU (+ spot-check followups)

### DIFF
--- a/crates/kaish-kernel/src/scheduler/pipeline.rs
+++ b/crates/kaish-kernel/src/scheduler/pipeline.rs
@@ -517,11 +517,11 @@ impl PipelineRunner {
                     }
                 }
 
-                // Send structured data to next stage via oneshot BEFORE pipe write.
-                // The pipe write may block on backpressure (>64KB output), and the
-                // consumer awaits this oneshot before starting execution. Sending
-                // first prevents a circular wait (producer blocked on pipe write,
-                // consumer blocked on oneshot).
+                // Send structured data to the next stage via the oneshot BEFORE
+                // the pipe write. The consumer's `resolve_stdin` drains the pipe
+                // FIRST and only THEN awaits this oneshot, so by the time it
+                // reads the sideband the value is already here — sending before
+                // the (possibly backpressured) pipe write keeps that ordering.
                 if let Some(tx) = data_sender {
                     let _ = tx.send(result.data.clone());
                 }

--- a/crates/kaish-kernel/src/tools/builtin/format_string.rs
+++ b/crates/kaish-kernel/src/tools/builtin/format_string.rs
@@ -111,9 +111,13 @@ fn parse_backslash_escape(
         Some('\\') => { chars.next(); output.push('\\'); }
         Some('0') => {
             chars.next();
-            // May be \0NNN (octal) or just \0 (null byte).
+            // \0NNN: GNU printf reads the leading `0` as the FIRST of up to 3
+            // octal digits, so at most 2 more follow (`\0101` → octal `010` = BS,
+            // then a literal `1`; `\0377` → octal `037`, then `7`). Reading 3
+            // more here would make `\0101` = octal 101 = 'A', diverging from
+            // GNU/bash/dash. Bare `\NNN` (no leading 0, below) takes the full 3.
             let mut octal = String::new();
-            while octal.len() < 3 {
+            while octal.len() < 2 {
                 match chars.peek().copied() {
                     Some(d) if d.is_ascii_digit() && d != '8' && d != '9' => {
                         octal.push(d);
@@ -852,9 +856,11 @@ mod tests {
 
     #[test]
     fn test_octal_escape_format() {
-        // \0101 in format → 'A' (octal 101 = 65)
+        // \0NNN: leading 0 is the first of up to 3 octal digits (≤2 more), like
+        // GNU/bash/dash. \0101 → octal 010 (BS) + literal '1', NOT 'A'.
         let args: Vec<TestVal> = vec![];
-        assert_eq!(format_string("\\0101", &args), "A");
+        assert_eq!(format_string("\\0101", &args), "\u{8}1");
+        assert_eq!(format_string("\\012", &args), "\n");
     }
 
     #[test]

--- a/crates/kaish-kernel/tests/printf_format_tests.rs
+++ b/crates/kaish-kernel/tests/printf_format_tests.rs
@@ -277,11 +277,31 @@ async fn printf_b_plain_string_passthrough() {
 
 #[tokio::test]
 async fn printf_format_octal_escape_zero_prefix() {
-    // printf '\0101' → A (octal 101 = 65 = 'A')
-    // \0NNN is the octal escape in format strings
+    // `\0NNN`: the leading `0` is the FIRST of up to 3 octal digits, so at most
+    // 2 more follow — matching GNU coreutils, bash, and dash (all verified).
+    // `\0101` → octal `010` (BS) then a literal `1`; NOT octal 101 ('A').
     let k = kernel();
     let result = k.execute(r#"printf '\0101'"#).await.expect("execute");
-    assert_eq!(result.text_out(), "A", "printf '\\0101' should produce A (octal 101)");
+    assert_eq!(
+        result.text_out(),
+        "\u{8}1",
+        "printf '\\0101' → BS + '1' (octal 010, then literal 1), like GNU printf"
+    );
+    // \012 = octal 12 = newline (2 digits after the 0).
+    assert_eq!(
+        kernel().execute(r#"printf '\012'"#).await.expect("execute").text_out(),
+        "\n",
+    );
+    // \0377 → octal 037 (0x1f) then a literal '7'.
+    assert_eq!(
+        kernel().execute(r#"printf '\0377'"#).await.expect("execute").text_out(),
+        "\u{1f}7",
+    );
+    // Bare \NNN (no leading 0) still takes the full 3 digits: \101 = 'A'.
+    assert_eq!(
+        kernel().execute(r#"printf '\101'"#).await.expect("execute").text_out(),
+        "A",
+    );
 }
 
 #[tokio::test]

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -322,7 +322,9 @@ sites in job.rs for other across-await holds while there.
 Low-frequency sub-cases left after the P1 builtin fixes:
 - **`sort`**: only one `-k` accepted (clap `Option<String>`) — GNU chains `-k` for
   tiebreaking; `.C` char-within-field offsets are accepted but ignored; per-key
-  `b`/`d`/`f`/`i` modifiers are accepted but not implemented. (`tools/builtin/sort.rs`)
+  `b`/`d`/`f`/`i` modifiers are accepted but not implemented; **`-k2,1` (stop <
+  start)** sorts by field 2, but GNU treats the lower field as the stop boundary
+  (sorts by field 1). (`tools/builtin/sort.rs`; spot-check 2026-06-24)
 - **`printf`**: `%b` doesn't honor `\c` (stop *all* output) at the whole-format
   level; `%c` ignores width/flags. (`tools/builtin/format_string.rs`)
 - **`ls -1`**: the fix recovers `-1` by stripping a `Value::Int(-1)` positional,


### PR DESCRIPTION
Follow-ups from the post-merge spot-check of #17/#22/#21 (three Sonnet agents, read-only). Off `main`, not stacked.

**Real bug fixed — `printf \0NNN` octal.** GNU coreutils 9.11, bash, and dash all read the leading `0` as the first of up to 3 octal digits (≤2 more), so `printf '\0101'` → octal `010` (BS) + literal `1`, and `\0377` → octal `037` + `7`. kaish read 3 digits *after* the `0`, so `\0101` became octal 101 = `A`. One-char fix in the `\0` branch; bare `\NNN` is unchanged (still 3). The two tests that had pinned the wrong `A` (so a revert wouldn't fail them) are corrected to GNU-verified expectations + extra cases.

**Doc/notes (no behavior change):** refreshed a stale `pipeline.rs` comment (it described the old `try_recv` ordering, not `resolve_stdin`'s drain-then-await); filed `sort -k2,1` (stop < start field) as a P3 edge in issues.md.

**Spot-check verdict:** the merged code is sound — all targeted fixes confirmed present and tested, no other real bugs. Other spot-check observations were already-filed P3 residuals (`mv` cross-mount symlink-child copy) or pre-existing (`wait` on a stopped job). The agent's "`&&`/`||` diverges from bash" note was a mistake (bash list-level `&&`/`||` *are* equal-precedence; our fix matches it).

`cargo test --all` + `cargo clippy --all --all-targets` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)