### PR TITLE
chore: bump to v0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ breaking entries are marked **BREAKING**.
 
 ## [Unreleased]
 
+## [0.9.1] - 2026-06-25
+
 ### Added
 - **BREAKING: `diff --json` emits structured hunks** instead of the unified-diff text wrapped as a JSON string: `{old_file, new_file, differ:true, hunks:[{old_start, old_lines, new_start, new_lines, changes:[{tag, content, missing_newline}]}]}` (`tag` ∈ `equal`/`delete`/`insert`, `content` newline-stripped for clean `jq`, `missing_newline` flags a line with no terminal newline so a final-newline-only change stays distinguishable). Plain `diff` output is unchanged; `diff -q --json` reports `{old_file, new_file, differ:true}`. Identical files emit a consistent `{old_file, new_file, differ:false, hunks:[]}` object (exit 0, empty text) so a `--json` consumer always parses an object, never an empty string.
 
@@ -491,7 +493,8 @@ Initial public release of **kaish** (会sh) — a predictable Bourne-like shell 
 - **REPL** (`kaish-repl`) with multi-line input, completion, and history; **MCP server** (`kaish-mcp`) exposing `kaish_execute` with help resources and structured + plain-text content blocks.
 - **`KernelClient` trait** + `EmbeddedClient` for in-process embedding; topic-based help system; `kaish-wasi` `wasm32-wasip1` target.
 
-[Unreleased]: https://github.com/tobert/kaish/compare/v0.9.0...HEAD
+[Unreleased]: https://github.com/tobert/kaish/compare/v0.9.1...HEAD
+[0.9.1]: https://github.com/tobert/kaish/compare/v0.9.0...v0.9.1
 [0.9.0]: https://github.com/tobert/kaish/compare/v0.8.4...v0.9.0
 [0.8.4]: https://github.com/tobert/kaish/compare/v0.8.3...v0.8.4
 [0.8.3]: https://github.com/tobert/kaish/compare/v0.8.2...v0.8.3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -872,7 +872,7 @@ dependencies = [
 
 [[package]]
 name = "kaish-client"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -886,7 +886,7 @@ dependencies = [
 
 [[package]]
 name = "kaish-glob"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "async-trait",
  "ignore",
@@ -897,14 +897,14 @@ dependencies = [
 
 [[package]]
 name = "kaish-help"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "kaish-types",
 ]
 
 [[package]]
 name = "kaish-kernel"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "ariadne",
@@ -960,7 +960,7 @@ dependencies = [
 
 [[package]]
 name = "kaish-repl"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -980,7 +980,7 @@ dependencies = [
 
 [[package]]
 name = "kaish-tool-api"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "async-trait",
  "clap",
@@ -990,7 +990,7 @@ dependencies = [
 
 [[package]]
 name = "kaish-tools-host"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "async-trait",
  "clap",
@@ -1001,7 +1001,7 @@ dependencies = [
 
 [[package]]
 name = "kaish-types"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "base64",
  "schemars",
@@ -1013,7 +1013,7 @@ dependencies = [
 
 [[package]]
 name = "kaish-vfs"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "async-trait",
  "getrandom 0.3.4",
@@ -1024,7 +1024,7 @@ dependencies = [
 
 [[package]]
 name = "kaish-wasi"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "kaish-kernel",
  "kaish-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.9.0"
+version = "0.9.1"
 edition = "2024"
 rust-version = "1.85"
 authors = ["Amy Tobey <tobert@gmail.com>"]

--- a/crates/kaish-client/Cargo.toml
+++ b/crates/kaish-client/Cargo.toml
@@ -13,7 +13,7 @@ categories.workspace = true
 readme = "../../README.md"
 
 [dependencies]
-kaish-kernel = { path = "../kaish-kernel", version = "0.9.0" }
+kaish-kernel = { path = "../kaish-kernel", version = "0.9.1" }
 
 # Async runtime
 tokio = { workspace = true }

--- a/crates/kaish-help/Cargo.toml
+++ b/crates/kaish-help/Cargo.toml
@@ -13,7 +13,7 @@ categories.workspace = true
 readme = "../../README.md"
 
 [dependencies]
-kaish-types = { path = "../kaish-types", version = "0.9.0" }
+kaish-types = { path = "../kaish-types", version = "0.9.1" }
 
 [lints]
 workspace = true

--- a/crates/kaish-kernel/Cargo.toml
+++ b/crates/kaish-kernel/Cargo.toml
@@ -14,11 +14,11 @@ readme = "../../README.md"
 exclude = ["tests/snapshots/"]
 
 [dependencies]
-kaish-glob = { path = "../kaish-glob", version = "0.9.0" }
-kaish-types = { path = "../kaish-types", version = "0.9.0", features = [] }
-kaish-help = { path = "../kaish-help", version = "0.9.0" }
-kaish-tool-api = { path = "../kaish-tool-api", version = "0.9.0" }
-kaish-vfs = { path = "../kaish-vfs", version = "0.9.0", features = ["memory", "overlay"] }
+kaish-glob = { path = "../kaish-glob", version = "0.9.1" }
+kaish-types = { path = "../kaish-types", version = "0.9.1", features = [] }
+kaish-help = { path = "../kaish-help", version = "0.9.1" }
+kaish-tool-api = { path = "../kaish-tool-api", version = "0.9.1" }
+kaish-vfs = { path = "../kaish-vfs", version = "0.9.1", features = ["memory", "overlay"] }
 
 # Async runtime — minimal base; `localfs` adds tokio/fs, `subprocess` adds
 # tokio/process + tokio/rt-multi-thread (see [features]).
@@ -83,7 +83,7 @@ jaq-json = { workspace = true }
 # Optional deps, each pulled in by its capability feature:
 #   kaish-tools-host → host, trash/directories → os-integration,
 #   tiktoken-rs → tokens.
-kaish-tools-host = { path = "../kaish-tools-host", version = "0.9.0", optional = true }
+kaish-tools-host = { path = "../kaish-tools-host", version = "0.9.1", optional = true }
 trash = { workspace = true, optional = true }
 directories = { workspace = true, optional = true }
 tiktoken-rs = { workspace = true, optional = true }

--- a/crates/kaish-repl/Cargo.toml
+++ b/crates/kaish-repl/Cargo.toml
@@ -19,8 +19,8 @@ path = "src/main.rs"
 [dependencies]
 # The REPL is the full interactive human shell: it needs every capability
 # (external commands + job control, git, host introspection, tokens, trash).
-kaish-kernel = { path = "../kaish-kernel", version = "0.9.0", features = ["full"] }
-kaish-client = { path = "../kaish-client", version = "0.9.0" }
+kaish-kernel = { path = "../kaish-kernel", version = "0.9.1", features = ["full"] }
+kaish-client = { path = "../kaish-client", version = "0.9.1" }
 
 # Line editing
 rustyline = { workspace = true }

--- a/crates/kaish-tool-api/Cargo.toml
+++ b/crates/kaish-tool-api/Cargo.toml
@@ -12,7 +12,7 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-kaish-types = { path = "../kaish-types", version = "0.9.0", features = [] }
+kaish-types = { path = "../kaish-types", version = "0.9.1", features = [] }
 
 async-trait = { workspace = true }
 clap = { workspace = true }

--- a/crates/kaish-tools-host/Cargo.toml
+++ b/crates/kaish-tools-host/Cargo.toml
@@ -12,8 +12,8 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-kaish-types = { path = "../kaish-types", version = "0.9.0", features = [] }
-kaish-tool-api = { path = "../kaish-tool-api", version = "0.9.0" }
+kaish-types = { path = "../kaish-types", version = "0.9.1", features = [] }
+kaish-tool-api = { path = "../kaish-tool-api", version = "0.9.1" }
 
 async-trait = { workspace = true }
 clap = { workspace = true }

--- a/crates/kaish-vfs/Cargo.toml
+++ b/crates/kaish-vfs/Cargo.toml
@@ -12,7 +12,7 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-kaish-types = { path = "../kaish-types", version = "0.9.0", features = [] }
+kaish-types = { path = "../kaish-types", version = "0.9.1", features = [] }
 async-trait = { workspace = true }
 # DevFs's /dev/urandom pulls from the OS CSPRNG. Pure (no tokio); works on
 # Unix/macOS/WASI.


### PR DESCRIPTION
Version bump + changelog stamp for the **v0.9.1** release.

## What's in the bump

- Workspace `version` 0.9.0 → 0.9.1, all 13 inter-crate `path + version` pins, and `Cargo.lock` (10 workspace crates). `cargo check --all` resolves cleanly.
- `CHANGELOG.md`: `[Unreleased]` stamped to `[0.9.1] - 2026-06-25`, fresh empty `[Unreleased]` above it, `[0.9.1]` compare link added.

## Release contents (already reviewed)

0.9.1 is a fix-focused release over 0.9.0: builtin fidelity (printf, tr, sort, cut, cat -n, find, grep, sed, dd, seq, tail), structured `diff --json` + GNU-fuzz `patch` (**both BREAKING**, flagged in the changelog), symlink-safe rm/mv, PATH hermeticity (no OS-PATH fallback), and deadlock fixes (background jobs under `wait`, large buffered stdin to external commands, builtin→builtin pipeline structured-data race).

The substantive review of the v0.9.0..HEAD contents happened pre-release via gemini-pro; its two findings (a changelog `wait`-bullet inaccuracy and a narrow `JobManager::wait`/`cleanup` race) landed in #27. This PR is just the mechanical bump — a light check that the pins all moved together and the changelog stamped cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)