### PR TITLE
fix: write binary content from $() verbatim, not the placeholder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ breaking entries are marked **BREAKING**.
 
 ## [Unreleased]
 
+### Fixed
+- **`write` no longer corrupts binary content from `$(…)`.** `write FILE $(producer)`
+  (and `producer | write FILE`) now persists the raw bytes of a `Value::Bytes`
+  verbatim instead of stringifying it to the `[binary: N bytes]` placeholder — that
+  placeholder reaching a file was silent corruption. Content from a positional,
+  `--content`, or stdin is all read as bytes. (`tee` already read stdin as raw bytes
+  and is unaffected; pinned by a regression test.)
+
 ### Added
 - **Validator advisory `W006` steers `test` to `[[ … ]]`.** Using a bare `test` as a
   command now surfaces a one-time stderr note (`use [[ … ]] …`) and still runs. A

--- a/crates/kaish-kernel/src/tools/builtin/write.rs
+++ b/crates/kaish-kernel/src/tools/builtin/write.rs
@@ -66,38 +66,42 @@ impl Tool for Write {
             None => return ExecResult::failure(1, "write: missing path argument"),
         };
 
-        // Content can be positional[1], named "content", or stdin (pipe or
-        // buffered — `read_stdin_to_text` prefers the streaming pipe).
-        let content = if let Some(v) = args.named.get("content") {
-            value_to_string(v)
+        // Content can be positional[1], named "content", or stdin. Read it as
+        // raw bytes so a `Value::Bytes` (e.g. from `$(producer)`) is written
+        // verbatim instead of stringified to the `[binary: N bytes]` marker —
+        // that placeholder reaching a file is silent corruption. Stdin uses the
+        // byte reader (pipe-preferred) for the same reason.
+        let content: Vec<u8> = if let Some(v) = args.named.get("content") {
+            value_to_bytes(v)
         } else if let Some(v) = args.positional.get(1) {
-            value_to_string(v)
+            value_to_bytes(v)
         } else {
-            match ctx.read_stdin_to_text().await {
-                Ok(Some(s)) => s,
-                Ok(None) => return ExecResult::failure(1, "write: missing content argument"),
-                Err(e) => return ExecResult::failure(2, format!("write: {e}")),
+            match ctx.read_stdin_to_bytes().await {
+                Some(bytes) => bytes,
+                None => return ExecResult::failure(1, "write: missing content argument"),
             }
         };
 
         let resolved = ctx.resolve_path(&path);
 
-        match ctx.backend.write(Path::new(&resolved), content.as_bytes(), WriteMode::Overwrite).await {
+        match ctx.backend.write(Path::new(&resolved), &content, WriteMode::Overwrite).await {
             Ok(()) => ExecResult::with_output(OutputData::text(format!("Wrote {} bytes to {}", content.len(), path))),
             Err(e) => ExecResult::failure(1, format!("write: {}: {}", path, e)),
         }
     }
 }
 
-fn value_to_string(value: &Value) -> String {
+/// Render a value as the raw bytes to write. `Bytes` is written verbatim;
+/// every other variant uses its lossless string form.
+fn value_to_bytes(value: &Value) -> Vec<u8> {
     match value {
-        Value::String(s) => s.clone(),
-        Value::Int(i) => i.to_string(),
-        Value::Float(f) => f.to_string(),
-        Value::Bool(b) => b.to_string(),
-        Value::Null => "null".to_string(),
-        Value::Json(json) => json.to_string(),
-        Value::Bytes(b) => format!("[binary: {} bytes]", b.len()),
+        Value::Bytes(b) => b.clone(),
+        Value::String(s) => s.clone().into_bytes(),
+        Value::Int(i) => i.to_string().into_bytes(),
+        Value::Float(f) => f.to_string().into_bytes(),
+        Value::Bool(b) => b.to_string().into_bytes(),
+        Value::Null => b"null".to_vec(),
+        Value::Json(json) => json.to_string().into_bytes(),
     }
 }
 

--- a/crates/kaish-kernel/tests/binary_write_tests.rs
+++ b/crates/kaish-kernel/tests/binary_write_tests.rs
@@ -63,3 +63,46 @@ async fn tee_preserves_bytes_through_to_file() {
     let written = fs::read(dir.path().join("out.bin")).unwrap();
     assert_eq!(written, BIN, "tee must keep binary intact to the file");
 }
+
+// ── gemini-pro review (#30) follow-ups: named-flag, empty stream, multi-sink ──
+
+#[tokio::test]
+async fn write_named_content_flag_preserves_bytes() {
+    let dir = tempdir().unwrap();
+    fs::write(dir.path().join("src.bin"), BIN).unwrap();
+
+    let kernel = kernel_at(dir.path());
+    // The `--content` named branch must not stringify a `Value::Bytes` either.
+    let (_out, code) = run(&kernel, "write dst.bin --content $(cat src.bin)").await;
+    assert_eq!(code, 0, "write --content should succeed");
+
+    let written = fs::read(dir.path().join("dst.bin")).unwrap();
+    assert_eq!(written, BIN, "named --content must preserve raw bytes");
+}
+
+#[tokio::test]
+async fn write_empty_pipe_creates_empty_file() {
+    let dir = tempdir().unwrap();
+    let kernel = kernel_at(dir.path());
+    // An empty pipe is `Some(vec![])`, not `None` — write an empty file rather
+    // than erroring with "missing content argument".
+    let (_out, code) = run(&kernel, "printf '' | write dst.bin").await;
+    assert_eq!(code, 0, "empty pipe should write an empty file, not error");
+
+    let written = fs::read(dir.path().join("dst.bin")).unwrap();
+    assert!(written.is_empty(), "empty pipe yields an empty file: {written:?}");
+}
+
+#[tokio::test]
+async fn tee_preserves_bytes_to_multiple_sinks() {
+    let dir = tempdir().unwrap();
+    fs::write(dir.path().join("src.bin"), BIN).unwrap();
+
+    let kernel = kernel_at(dir.path());
+    // The per-file loop must not drain/mangle the buffer after the first sink.
+    let (_out, code) = run(&kernel, "cat src.bin | tee a.bin b.bin").await;
+    assert_eq!(code, 0, "multi-sink tee should succeed");
+
+    assert_eq!(fs::read(dir.path().join("a.bin")).unwrap(), BIN);
+    assert_eq!(fs::read(dir.path().join("b.bin")).unwrap(), BIN, "second sink intact");
+}

--- a/crates/kaish-kernel/tests/binary_write_tests.rs
+++ b/crates/kaish-kernel/tests/binary_write_tests.rs
@@ -1,0 +1,65 @@
+//! Kernel-routed regression tests for the binary-`$()` write corruption bug.
+//!
+//! `write FILE $(producer)` and `producer | write FILE` must persist the raw
+//! bytes of a `Value::Bytes` verbatim, not stringify it to the `[binary: N
+//! bytes]` placeholder — that placeholder reaching a file is silent corruption.
+//! `tee` already reads stdin as raw bytes; pinned here so it stays that way.
+//!
+//! All tests route through `kernel.execute()` so the full dispatch chain runs.
+
+// Test-fixture code: unwrap/expect on known-good setup is the idiom.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+#![cfg(feature = "localfs")]
+
+mod common;
+
+use common::{kernel_at, run};
+use std::fs;
+use tempfile::tempdir;
+
+/// Bytes with several invalid-UTF-8 octets (`\xff`, `\x80`, `\xc0`, `\xf5`) so a
+/// producer marks them as binary (`Value::Bytes`) rather than capturing a
+/// `String` — that's the path that used to corrupt to the placeholder.
+const BIN: &[u8] = b"\xff\x00\xfe\x80\x01\xc0kaish\xf5";
+
+#[tokio::test]
+async fn write_positional_cmdsubst_preserves_bytes() {
+    let dir = tempdir().unwrap();
+    fs::write(dir.path().join("src.bin"), BIN).unwrap();
+
+    let kernel = kernel_at(dir.path());
+    let (_out, code) = run(&kernel, "write dst.bin $(cat src.bin)").await;
+    assert_eq!(code, 0, "write should succeed");
+
+    let written = fs::read(dir.path().join("dst.bin")).unwrap();
+    assert_eq!(
+        written, BIN,
+        "write must persist raw bytes, not the [binary: N bytes] placeholder"
+    );
+}
+
+#[tokio::test]
+async fn write_pipe_stdin_preserves_bytes() {
+    let dir = tempdir().unwrap();
+    fs::write(dir.path().join("src.bin"), BIN).unwrap();
+
+    let kernel = kernel_at(dir.path());
+    let (_out, code) = run(&kernel, "cat src.bin | write dst.bin").await;
+    assert_eq!(code, 0, "write should succeed");
+
+    let written = fs::read(dir.path().join("dst.bin")).unwrap();
+    assert_eq!(written, BIN);
+}
+
+#[tokio::test]
+async fn tee_preserves_bytes_through_to_file() {
+    let dir = tempdir().unwrap();
+    fs::write(dir.path().join("src.bin"), BIN).unwrap();
+
+    let kernel = kernel_at(dir.path());
+    let (_out, code) = run(&kernel, "cat src.bin | tee out.bin").await;
+    assert_eq!(code, 0, "tee should succeed");
+
+    let written = fs::read(dir.path().join("out.bin")).unwrap();
+    assert_eq!(written, BIN, "tee must keep binary intact to the file");
+}

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -179,10 +179,6 @@ NOTE: `xxd -r -p` trailing odd nibble was a **false positive** — kaish already
 matches GNU xxd (silently drops it); pinned by a test, not a bug.
 
 Still open (deferred — bigger than a builtin fix, each its own focused PR):
-- **`write`/`tee` write binary-via-`$()` as the literal text `[binary: N bytes]`**
-  (silent corruption; the stdin path is safe). Extends the binary-data
-  var-interpolation placeholder (P1 binary-data residuals) — here the placeholder
-  reaches a file. Best folded into the tee/patch write-model work below.
 - **Interpreter trio:** `export` inside a function is dropped on return — needs
   scope-frame-model work (the single `Scope.exported` set isn't merged back when a
   function's forked scope returns), `interpreter/scope.rs`; file tests skip tilde —


### PR DESCRIPTION
## What

`write FILE $(producer)` (and `producer | write FILE`) now persists the raw bytes of a `Value::Bytes` verbatim instead of stringifying it to the literal text `[binary: N bytes]` and writing **that** to the file — silent corruption.

First PR of the **0.9.2 write-model bundle**.

## Why

`write`'s content path ran every value through a local `value_to_string` whose `Bytes` arm produced `[binary: N bytes]`. So `write out.bin $(cat some.bin)` wrote the 16-ish-char placeholder, not the bytes. The stdin branch also used `read_stdin_to_text` (lossy/erroring on binary). Crash-or-correct is the standard; we never silently corrupt.

## Fix

Read `write`'s content as raw bytes from every source:
- a new `value_to_bytes` helper writes `Bytes` verbatim; other variants use their lossless string form,
- stdin uses `read_stdin_to_bytes` (pipe-preferred), matching `tee`.

## Scope note

The issue named `write`/`tee`, but `tee`/`patch` were verified **already safe** and left untouched: `tee` reads stdin as raw bytes (its `value_to_string` is for the *path* operand, not content), and `patch`'s content is a text diff. `tee` is pinned by a regression test so it stays that way.

## Tests

Kernel-routed (`binary_write_tests.rs`), invalid-UTF-8 fixture so the producer yields `Value::Bytes`:
- `write_positional_cmdsubst_preserves_bytes` — reproduces **red** against the pre-fix stringify
- `write_pipe_stdin_preserves_bytes`
- `tee_preserves_bytes_through_to_file` (pin)

Also smoke-verified byte-identical 1 KiB `/dev/urandom` round-trips for both paths.

## Gate

`cargo test --all` green · `cargo clippy --all --all-targets` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)