### PR TITLE
feat: gate patch overwrites through latch + trash (write-model)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,13 +22,14 @@ breaking entries are marked **BREAKING**.
   `filetype` module
   (pure-Rust `infer`, no C deps) — `detect` for magic-only, `classify` for the
   text-aware path — so embedders can classify bytes the same way the shell does.
-- **`tee` honors `set -o latch` / `set -o trash` on a truncating overwrite**, like
-  `rm` gates a delete. Overwriting an existing file under `trash` first copies its
-  prior content to trash (recoverable, via the new `TrashBackend::trash_bytes`),
-  leaving the file in place for the new content; under `latch` it needs
-  `tee --confirm=<nonce>` (exit 2 until confirmed, one nonce scoping all files). A new
-  file or `tee -a` append never gates. Both gates are off by default, so default `tee`
-  is unchanged. (`patch`/`sed -i` adopt the same gate next.)
+- **`tee` and `patch` honor `set -o latch` / `set -o trash` on a truncating
+  overwrite**, like `rm` gates a delete. Overwriting an existing file under `trash`
+  first copies its prior content to trash (recoverable, via the new
+  `TrashBackend::trash_bytes`), leaving the file in place for the new content; under
+  `latch` it needs `--confirm=<nonce>` (exit 2 until confirmed, one nonce scoping all
+  files a command touches). A new file, `tee -a` append, or `patch --dry-run` never
+  gates. Both gates are off by default, so default behavior is unchanged. (`sed -i`
+  adopts the same gate next.)
 - **Validator advisory `W006` steers `test` to `[[ … ]]`.** Using a bare `test` as a
   command now surfaces a one-time stderr note (`use [[ … ]] …`) and still runs. A
   path-qualified form (`/usr/bin/test`, `./test`) is left alone — it's an explicit

--- a/crates/kaish-help/content/en/syntax.md
+++ b/crates/kaish-help/content/en/syntax.md
@@ -207,8 +207,9 @@ Env vars: `KAISH_LATCH=1`, `KAISH_TRASH=1` enable at startup.
 
 **Latch:** Nonces scoped to (command, paths). A nonce for `rm A` rejects `rm B`.
 Confirmed paths must be subset of authorized paths. Exit code 2 = needs confirmation.
-Applies to `rm` and to truncating overwrites (`tee`; `patch`/`sed -i` next) —
-confirm those with `--confirm=<nonce>`. `tee -a` append and new files don't gate.
+Applies to `rm` and to truncating overwrites (`tee`, `patch`; `sed -i` next) —
+confirm those with `--confirm=<nonce>`. `tee -a` append, new files, and
+`patch --dry-run` don't gate.
 
 **Trash:** Files <= 10MB and directories always trash. `/tmp`, `/v/*` excluded.
 A truncating overwrite under `trash` snapshots the file's prior content first

--- a/crates/kaish-help/src/fragments.rs
+++ b/crates/kaish-help/src/fragments.rs
@@ -422,8 +422,9 @@ Env vars: `KAISH_LATCH=1`, `KAISH_TRASH=1` enable at startup.
 
 **Latch:** Nonces scoped to (command, paths). A nonce for `rm A` rejects `rm B`.
 Confirmed paths must be subset of authorized paths. Exit code 2 = needs confirmation.
-Applies to `rm` and to truncating overwrites (`tee`; `patch`/`sed -i` next) —
-confirm those with `--confirm=<nonce>`. `tee -a` append and new files don't gate.
+Applies to `rm` and to truncating overwrites (`tee`, `patch`; `sed -i` next) —
+confirm those with `--confirm=<nonce>`. `tee -a` append, new files, and
+`patch --dry-run` don't gate.
 
 **Trash:** Files <= 10MB and directories always trash. `/tmp`, `/v/*` excluded.
 A truncating overwrite under `trash` snapshots the file's prior content first

--- a/crates/kaish-kernel/src/tools/builtin/patch.rs
+++ b/crates/kaish-kernel/src/tools/builtin/patch.rs
@@ -42,6 +42,10 @@ struct PatchArgs {
     #[arg(long = "file")]
     file: Option<String>,
 
+    /// Confirmation nonce for a latch-gated overwrite.
+    #[arg(long = "confirm")]
+    confirm: Option<String>,
+
     #[command(flatten)]
     global: GlobalFlags,
 
@@ -127,10 +131,37 @@ impl Tool for Patch {
             return ExecResult::failure(1, "patch: no valid hunks found in input");
         }
 
+        let groups = group_by_file(&hunks);
+
+        // Gate truncating overwrites through latch + trash (no-op when both are
+        // off; skipped for --dry-run, which never writes). patch always rewrites
+        // an existing file, so every target is a non-append overwrite; one nonce
+        // scopes the whole set of files the diff touches. The snapshot copies
+        // the prior content (it doesn't move the file), so the read + CAS write
+        // below still see the file in place.
+        if !dry_run {
+            let targets: Vec<(String, bool)> = groups
+                .iter()
+                .map(|fh| {
+                    let p = match &explicit_file {
+                        Some(explicit) => explicit.clone(),
+                        None => strip_path(&fh.target_file, strip_level),
+                    };
+                    (p, false)
+                })
+                .collect();
+            if let Err(blocked) = ctx
+                .gate_overwrites("patch", &targets, parsed.confirm.as_deref())
+                .await
+            {
+                return blocked;
+            }
+        }
+
         let mut output = String::new();
 
         // Group hunks by target file
-        for file_hunks in group_by_file(&hunks) {
+        for file_hunks in &groups {
             let target_path = if let Some(ref explicit) = explicit_file {
                 explicit.clone()
             } else {

--- a/crates/kaish-kernel/src/tools/builtin/patch.rs
+++ b/crates/kaish-kernel/src/tools/builtin/patch.rs
@@ -151,7 +151,9 @@ impl Tool for Patch {
                 })
                 .collect();
             if let Err(blocked) = ctx
-                .gate_overwrites("patch", &targets, parsed.confirm.as_deref())
+                .gate_overwrites("patch", &targets, parsed.confirm.as_deref(), |nonce, joined| {
+                    format!("patch --confirm=\"{nonce}\" {joined}")
+                })
                 .await
             {
                 return blocked;

--- a/crates/kaish-kernel/tests/latch_trash_tests.rs
+++ b/crates/kaish-kernel/tests/latch_trash_tests.rs
@@ -441,3 +441,79 @@ async fn tee_overlay_overwrite_snapshots_bytes_via_trash_bytes() {
     let out = run(&kernel, "cat /v/f.txt").await;
     assert_eq!(out.text_out().trim(), "new", "new content written after the snapshot");
 }
+
+// ============================================================================
+// Write-model gate: patch overwrites honor latch + trash (same gate as tee)
+// ============================================================================
+
+/// A one-line unified diff turning `old` into `new` in `f.txt`, fed via a
+/// heredoc. The `f.txt` operand overrides the diff header, so strip level
+/// doesn't matter.
+const PATCH_SCRIPT: &str = "patch f.txt <<'EOF'\n--- a/f.txt\n+++ b/f.txt\n@@ -1 +1 @@\n-old\n+new\nEOF\n";
+
+#[tokio::test]
+async fn patch_overwrite_under_trash_snapshots_prior_bytes() {
+    let dir = tempdir();
+    std::fs::write(dir.path().join("f.txt"), "old\n").expect("write");
+    let mock = Arc::new(MockTrash::default());
+    let kernel = kernel_with_trash(dir.path(), &mock);
+
+    run(&kernel, "set -o trash").await;
+    let r = run(&kernel, PATCH_SCRIPT).await;
+    assert_eq!(r.code, 0, "err: {}", r.err);
+
+    // Prior content copied to trash before the patch write; file stays in place
+    // (the read-modify-write still saw it) and now holds the patched content.
+    let snaps = mock.snapshots();
+    assert_eq!(snaps.len(), 1, "one byte-snapshot before the patch: {snaps:?}");
+    assert_eq!(snaps[0].1, b"old\n", "snapshot captured the prior content");
+    assert_eq!(
+        std::fs::read_to_string(dir.path().join("f.txt")).expect("read"),
+        "new\n"
+    );
+}
+
+#[tokio::test]
+async fn patch_overwrite_under_latch_requires_confirm() {
+    let dir = tempdir();
+    std::fs::write(dir.path().join("f.txt"), "old\n").expect("write");
+    let mock = Arc::new(MockTrash::default());
+    let kernel = kernel_with_trash(dir.path(), &mock);
+
+    run(&kernel, "set -o latch").await;
+    let r = run(&kernel, PATCH_SCRIPT).await;
+    assert_eq!(r.code, 2, "latch gates the patch: {}", r.err);
+    assert!(r.err.contains("--confirm="));
+    assert_eq!(
+        std::fs::read_to_string(dir.path().join("f.txt")).expect("read"),
+        "old\n",
+        "the file must be untouched until confirmed"
+    );
+
+    let nonce = latch_data_str(&r, "nonce");
+    let confirmed = PATCH_SCRIPT.replace("patch f.txt", &format!("patch --confirm=\"{nonce}\" f.txt"));
+    let r2 = run(&kernel, &confirmed).await;
+    assert_eq!(r2.code, 0, "confirmed patch succeeds: {}", r2.err);
+    assert_eq!(
+        std::fs::read_to_string(dir.path().join("f.txt")).expect("read"),
+        "new\n"
+    );
+}
+
+#[tokio::test]
+async fn patch_dry_run_does_not_gate() {
+    let dir = tempdir();
+    std::fs::write(dir.path().join("f.txt"), "old\n").expect("write");
+    let mock = Arc::new(MockTrash::default());
+    let kernel = kernel_with_trash(dir.path(), &mock);
+
+    run(&kernel, "set -o latch").await;
+    let dry = PATCH_SCRIPT.replace("patch f.txt", "patch --dry-run f.txt");
+    let r = run(&kernel, &dry).await;
+    assert_eq!(r.code, 0, "dry-run never writes, so it never gates: {}", r.err);
+    assert_eq!(
+        std::fs::read_to_string(dir.path().join("f.txt")).expect("read"),
+        "old\n",
+        "dry-run leaves the file untouched"
+    );
+}

--- a/crates/kaish-kernel/tests/latch_trash_tests.rs
+++ b/crates/kaish-kernel/tests/latch_trash_tests.rs
@@ -501,6 +501,63 @@ async fn patch_overwrite_under_latch_requires_confirm() {
 }
 
 #[tokio::test]
+async fn patch_explicit_file_multi_group_diff_snapshots_once() {
+    // A multi-group diff applied to one explicit target lists that file once per
+    // group; the gate must dedup so it snapshots the prior bytes a single time,
+    // not once per group.
+    let dir = tempdir();
+    std::fs::write(dir.path().join("f.txt"), "alpha\nbeta\n").expect("write");
+    let mock = Arc::new(MockTrash::default());
+    let kernel = kernel_with_trash(dir.path(), &mock);
+
+    let script = "patch f.txt <<'EOF'\n\
+        --- a/x\n+++ b/x\n@@ -1 +1 @@\n-alpha\n+ALPHA\n\
+        --- a/y\n+++ b/y\n@@ -2 +2 @@\n-beta\n+BETA\n\
+        EOF\n";
+
+    run(&kernel, "set -o trash").await;
+    let r = run(&kernel, script).await;
+    assert_eq!(r.code, 0, "err: {}", r.err);
+
+    let snaps = mock.snapshots();
+    assert_eq!(
+        snaps.len(),
+        1,
+        "the explicit target is deduped to one snapshot: {snaps:?}"
+    );
+    assert_eq!(snaps[0].1, b"alpha\nbeta\n", "snapshot captured prior content");
+    assert_eq!(
+        std::fs::read_to_string(dir.path().join("f.txt")).expect("read"),
+        "ALPHA\nBETA\n"
+    );
+}
+
+#[tokio::test]
+async fn patch_explicit_file_multi_group_latch_lists_target_once() {
+    // The latch prompt must not list the same explicit target once per group.
+    let dir = tempdir();
+    std::fs::write(dir.path().join("f.txt"), "alpha\nbeta\n").expect("write");
+    let mock = Arc::new(MockTrash::default());
+    let kernel = kernel_with_trash(dir.path(), &mock);
+
+    let script = "patch f.txt <<'EOF'\n\
+        --- a/x\n+++ b/x\n@@ -1 +1 @@\n-alpha\n+ALPHA\n\
+        --- a/y\n+++ b/y\n@@ -2 +2 @@\n-beta\n+BETA\n\
+        EOF\n";
+
+    run(&kernel, "set -o latch").await;
+    let r = run(&kernel, script).await;
+    assert_eq!(r.code, 2, "latch gates: {}", r.err);
+    // The path legitimately appears twice (the "Authorized:" line and the hint),
+    // but a dedup miss would repeat it within each: "f.txt, f.txt" / "f.txt f.txt".
+    assert!(
+        !r.err.contains("f.txt, f.txt") && !r.err.contains("f.txt f.txt"),
+        "the deduped target must not repeat within the prompt: {}",
+        r.err
+    );
+}
+
+#[tokio::test]
 async fn patch_dry_run_does_not_gate() {
     let dir = tempdir();
     std::fs::write(dir.path().join("f.txt"), "old\n").expect("write");

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -220,17 +220,17 @@ the tee/patch "truncating overwrite gates" rule below. Today `sed` loud-errors o
 - **Atomicity:** write-temp-then-atomic-rename through the VFS (crash-safe);
   this surfaces an atomic-replace capability question on the `Filesystem` trait.
 
-### `patch` bypasses the latch + trash machinery (write-model design)
-**`tee` DONE** (`feat/mutation-write-gate`): the shared gate landed — pure
-`decide_mutation_action → {TrashFirst, Latch, Proceed}` + `ExecContext::
-gate_overwrites`/`snapshot_for_overwrite` + `TrashBackend::trash_bytes` (overlay
-byte-snapshot) + `tee --confirm=<nonce>`. **`patch` still open** (and `sed -i`
-below): wire it into `gate_overwrites` the same way `tee` is — `patch` already
-reads the target's current content before its whole-file `Replace`, so the snapshot
-is a natural pre-write step. Decisions stand: latch+trash stay ON even in overlay
-mode; truncating overwrite gates, `tee -a` append does NOT; new file → just write;
-family-wide `--confirm=<nonce>`; overlay trash captures the overlay's current view
-of the prior content (`trash_bytes`).
+### Write-model gate — `sed -i` remains
+**`tee` + `patch` DONE** (`feat/mutation-write-gate` → `feat/patch-write-gate`):
+the shared gate landed — pure `decide_mutation_action → {TrashFirst, Latch,
+Proceed}` + `ExecContext::gate_overwrites`/`snapshot_for_overwrite` (copies prior
+content via `TrashBackend::trash_bytes`, leaving the file in place) + family-wide
+`--confirm=<nonce>`; `tee` and `patch` both wired in (`patch` gates non-dry-run
+overwrites with one nonce per diff). **`sed -i` still open** (its own design entry
+below): it's *always* a truncating overwrite, so it inherits the same gate — call
+`gate_overwrites` before the in-place write. Decisions stand: latch+trash stay ON
+even in overlay mode; truncating overwrite gates, `tee -a` append does NOT; new
+file → just write; overlay trash captures the prior content via `trash_bytes`.
 
 ### Streaming file reads — remaining
 (wc/checksum/grep/cmp/cat landed — see devlog.) Open:


### PR DESCRIPTION
## What

Wires `patch` into the shared write-model gate from #31, so an agent can't silently rewrite a file under `set -o latch` / `set -o trash` with no confirmation and no recoverable prior copy. **Third PR of the 0.9.2 write-model bundle**; `sed -i` is the last.

**Stacked on #31** (`feat/mutation-write-gate`) — base is that branch, not main. Review #31 first.

## How

`patch` always truncating-overwrites an existing file, so each target is a non-append overwrite. After parsing + grouping hunks, it calls `gate_overwrites("patch", targets, --confirm)` with **one nonce scoping every file the diff touches**, skipped for `--dry-run` (which never writes).

The copy-bytes snapshot from #31 leaves the file **in place**, so patch's existing read → apply → compare-and-swap write path is unchanged — that's exactly why #31 switched the snapshot from move to copy (a move would have yanked the file out from under patch's read).

Added `--confirm` to the clap layer.

## Tests

Kernel-routed (`latch_trash_tests.rs`):
- `patch_overwrite_under_trash_snapshots_prior_bytes` — prior content captured before the patch lands.
- `patch_overwrite_under_latch_requires_confirm` — exit 2 + `--confirm` round-trip; file untouched until confirmed.
- `patch_dry_run_does_not_gate` — `--dry-run` never gates.

Help fragment + regenerated `syntax.md` note `patch` joining the gate.

## Gate

`cargo test --all` green · `cargo clippy --all --all-targets` clean · syntax drift test passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)