### PR TITLE
feat: sed -i in-place edit, gated through latch + trash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,9 +25,12 @@ breaking entries are marked **BREAKING**.
 - **`sed -i` edits files in place** instead of streaming to stdout, across one or
   more file operands. It is always a truncating overwrite, so it routes through the
   same latch/trash gate as `tee`/`patch` below. With no file operands it's a loud
-  error (editing a stream in place is meaningless). The GNU glued backup suffix
-  (`-i.bak`) is **not yet supported** — kaish's lexer splits `-i.bak` at the dot; the
-  trash snapshot under `set -o trash` already keeps a recoverable prior copy.
+  error (editing a stream in place is meaningless). Each file is written with a
+  whole-file compare-and-swap (like `patch`), so a concurrent change between read and
+  write is a loud conflict, never a silent clobber; a per-file failure doesn't abort
+  the batch and every error is reported. The GNU glued backup suffix (`-i.bak`) is
+  **not yet supported** — kaish's lexer splits `-i.bak` at the dot; the trash snapshot
+  under `set -o trash` already keeps a recoverable prior copy.
 - **`tee`, `patch`, and `sed -i` honor `set -o latch` / `set -o trash` on a truncating
   overwrite**, like `rm` gates a delete. Overwriting an existing file under `trash`
   first copies its prior content to trash (recoverable, via the new

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,14 +22,19 @@ breaking entries are marked **BREAKING**.
   `filetype` module
   (pure-Rust `infer`, no C deps) — `detect` for magic-only, `classify` for the
   text-aware path — so embedders can classify bytes the same way the shell does.
-- **`tee` and `patch` honor `set -o latch` / `set -o trash` on a truncating
+- **`sed -i` edits files in place** instead of streaming to stdout, across one or
+  more file operands. It is always a truncating overwrite, so it routes through the
+  same latch/trash gate as `tee`/`patch` below. With no file operands it's a loud
+  error (editing a stream in place is meaningless). The GNU glued backup suffix
+  (`-i.bak`) is **not yet supported** — kaish's lexer splits `-i.bak` at the dot; the
+  trash snapshot under `set -o trash` already keeps a recoverable prior copy.
+- **`tee`, `patch`, and `sed -i` honor `set -o latch` / `set -o trash` on a truncating
   overwrite**, like `rm` gates a delete. Overwriting an existing file under `trash`
   first copies its prior content to trash (recoverable, via the new
   `TrashBackend::trash_bytes`), leaving the file in place for the new content; under
   `latch` it needs `--confirm=<nonce>` (exit 2 until confirmed, one nonce scoping all
   files a command touches). A new file, `tee -a` append, or `patch --dry-run` never
-  gates. Both gates are off by default, so default behavior is unchanged. (`sed -i`
-  adopts the same gate next.)
+  gates. Both gates are off by default, so default behavior is unchanged.
 - **Validator advisory `W006` steers `test` to `[[ … ]]`.** Using a bare `test` as a
   command now surfaces a one-time stderr note (`use [[ … ]] …`) and still runs. A
   path-qualified form (`/usr/bin/test`, `./test`) is left alone — it's an explicit

--- a/crates/kaish-help/content/en/syntax.md
+++ b/crates/kaish-help/content/en/syntax.md
@@ -207,7 +207,7 @@ Env vars: `KAISH_LATCH=1`, `KAISH_TRASH=1` enable at startup.
 
 **Latch:** Nonces scoped to (command, paths). A nonce for `rm A` rejects `rm B`.
 Confirmed paths must be subset of authorized paths. Exit code 2 = needs confirmation.
-Applies to `rm` and to truncating overwrites (`tee`, `patch`; `sed -i` next) —
+Applies to `rm` and to truncating overwrites (`tee`, `patch`, `sed -i`) —
 confirm those with `--confirm=<nonce>`. `tee -a` append, new files, and
 `patch --dry-run` don't gate.
 

--- a/crates/kaish-help/src/fragments.rs
+++ b/crates/kaish-help/src/fragments.rs
@@ -422,7 +422,7 @@ Env vars: `KAISH_LATCH=1`, `KAISH_TRASH=1` enable at startup.
 
 **Latch:** Nonces scoped to (command, paths). A nonce for `rm A` rejects `rm B`.
 Confirmed paths must be subset of authorized paths. Exit code 2 = needs confirmation.
-Applies to `rm` and to truncating overwrites (`tee`, `patch`; `sed -i` next) —
+Applies to `rm` and to truncating overwrites (`tee`, `patch`, `sed -i`) —
 confirm those with `--confirm=<nonce>`. `tee -a` append, new files, and
 `patch --dry-run` don't gate.
 

--- a/crates/kaish-kernel/src/tools/builtin/sed.rs
+++ b/crates/kaish-kernel/src/tools/builtin/sed.rs
@@ -9,7 +9,7 @@ use regex::{Regex, RegexBuilder};
 use std::path::Path;
 
 use crate::ast::Value;
-use crate::backend::WriteMode;
+use crate::backend::PatchOp;
 use crate::interpreter::{ExecResult, OutputData};
 use crate::tools::{schema_from_clap, validate_against_schema, ExecContext, ToolCtx, GlobalFlags, Tool, ToolArgs, ToolSchema};
 use crate::validator::{IssueCode, ValidationIssue};
@@ -123,10 +123,17 @@ impl Tool for Sed {
         issues
     }
 
-    async fn execute(&self, args: ToolArgs, ctx: &mut dyn ToolCtx) -> ExecResult {
+    async fn execute(&self, mut args: ToolArgs, ctx: &mut dyn ToolCtx) -> ExecResult {
         let Some(ctx) = ctx.as_any_mut().downcast_mut::<ExecContext>() else {
             return ExecResult::failure(1, "internal error: kernel builtin requires ExecContext");
         };
+        // A structured call (`{"in-place": true}`) binds a bool into args.named,
+        // which to_argv renders as `--in-place=true` — and clap's SetTrue rejects
+        // a value. Move bool-schema named entries into flags so they render bare.
+        // (`-i.bak` arrives as named["i"]=".bak", a string, so it's left to be
+        // rejected by clap as the unsupported glued-suffix form, as intended.)
+        args.flagify_bool_named(&self.schema());
+
         let parsed = match SedArgs::try_parse_from(
             std::iter::once("sed".to_string()).chain(args.to_argv()),
         ) {
@@ -187,14 +194,32 @@ impl Tool for Sed {
                 );
             }
 
-            // Gate every target with one nonce before touching any file.
+            // Gate every target with one nonce before touching any file. The
+            // latch hint must reinject the flags the operation can't run without:
+            // a bare `sed --confirm=… file` would read `file` as the expression
+            // and then hang on stdin. Rebuild `-i [-n] -e '<expr>'…` so the
+            // advertised re-run actually does the in-place edit.
+            let mut hint_prefix = String::from("sed -i");
+            if quiet {
+                hint_prefix.push_str(" -n");
+            }
+            for expr in &expressions {
+                let escaped = expr.replace('\'', r"'\''");
+                hint_prefix.push_str(&format!(" -e '{escaped}'"));
+            }
             let targets: Vec<(String, bool)> = files.iter().map(|f| (f.clone(), false)).collect();
-            if let Err(blocked) = ctx.gate_overwrites("sed", &targets, confirm.as_deref()).await {
+            if let Err(blocked) = ctx
+                .gate_overwrites("sed", &targets, confirm.as_deref(), |nonce, joined| {
+                    format!("{hint_prefix} --confirm=\"{nonce}\" {joined}")
+                })
+                .await
+            {
                 return blocked;
             }
 
-            // Apply per file; continue past per-file errors and report the last.
-            let mut last_err: Option<String> = None;
+            // Apply per file; continue past per-file errors but report every one
+            // so a multi-file failure isn't masked down to just the last.
+            let mut errors: Vec<String> = Vec::new();
             for path in &files {
                 let resolved = ctx.resolve_path(path);
                 let target = Path::new(&resolved);
@@ -202,27 +227,33 @@ impl Tool for Sed {
                     Ok(data) => match String::from_utf8(data) {
                         Ok(s) => s,
                         Err(_) => {
-                            last_err = Some(format!("sed: {}: invalid UTF-8", path));
+                            errors.push(format!("sed: {}: invalid UTF-8", path));
                             continue;
                         }
                     },
                     Err(e) => {
-                        last_err = Some(format!("sed: {}: {}", path, e));
+                        errors.push(format!("sed: {}: {}", path, e));
                         continue;
                     }
                 };
                 let output = execute_sed(&content, &parsed, quiet);
-                if let Err(e) = ctx
-                    .backend
-                    .write(target, output.as_bytes(), WriteMode::Overwrite)
-                    .await
-                {
-                    last_err = Some(format!("sed: {}: {}", path, e));
+                // Whole-file compare-and-swap, matching patch: the `expected`
+                // makes a concurrent change between read and write a loud
+                // Conflict, never a silent clobber.
+                let ops = vec![PatchOp::Replace {
+                    offset: 0,
+                    len: content.len(),
+                    content: output,
+                    expected: Some(content.clone()),
+                }];
+                if let Err(e) = ctx.backend.patch(target, &ops).await {
+                    errors.push(format!("sed: {}: {}", path, e));
                 }
             }
-            return match last_err {
-                Some(msg) => ExecResult::failure(1, msg),
-                None => ExecResult::success(""),
+            return if errors.is_empty() {
+                ExecResult::success("")
+            } else {
+                ExecResult::failure(1, errors.join("\n"))
             };
         }
 

--- a/crates/kaish-kernel/src/tools/builtin/sed.rs
+++ b/crates/kaish-kernel/src/tools/builtin/sed.rs
@@ -9,6 +9,7 @@ use regex::{Regex, RegexBuilder};
 use std::path::Path;
 
 use crate::ast::Value;
+use crate::backend::WriteMode;
 use crate::interpreter::{ExecResult, OutputData};
 use crate::tools::{schema_from_clap, validate_against_schema, ExecContext, ToolCtx, GlobalFlags, Tool, ToolArgs, ToolSchema};
 use crate::validator::{IssueCode, ValidationIssue};
@@ -38,6 +39,17 @@ struct SedArgs {
     /// rejected with a hint; see the regex notes in `help sed`.)
     #[arg(short = 'E', short_alias = 'r', long = "regexp-extended")]
     extended: bool,
+
+    /// Edit files in place (-i) instead of streaming to stdout. Requires file
+    /// operands. (The GNU glued backup suffix `-i.bak` is not yet supported —
+    /// kaish's lexer splits `-i.bak` at the dot; the trash snapshot under
+    /// `set -o trash` already keeps a recoverable prior copy. See issues.md.)
+    #[arg(short = 'i', long = "in-place")]
+    in_place: bool,
+
+    /// Confirmation nonce for a latch-gated in-place overwrite.
+    #[arg(long = "confirm")]
+    confirm: Option<String>,
 
     #[command(flatten)]
     global: GlobalFlags,
@@ -125,6 +137,12 @@ impl Tool for Sed {
 
         let quiet = parsed.quiet || args.has_flag("quiet") || args.has_flag("n");
 
+        // In-place editing (-i [SUFFIX]) and its confirm nonce — captured before
+        // `parsed` is shadowed by the built program below. Read raw too: the
+        // kernel may surface `-i.bak` as named["i"]=".bak" or bare `-i` as a flag.
+        let in_place = parsed.in_place || args.has_flag("i");
+        let confirm = parsed.confirm.clone();
+
         // Collect expressions from the *raw* args, not `parsed.expression`: the
         // kernel accumulates repeated `-e` into a `Value::Json(Array)`, which
         // `ToolArgs::to_argv()` renders as one JSON token (it can't tell a
@@ -146,11 +164,69 @@ impl Tool for Sed {
             }
         }
 
-        // Get input: file or stdin. When `-e` supplied the expression(s), every
-        // positional is a file (file at position 0); otherwise the first
-        // positional is the expression and the file is at position 1.
+        // When `-e` supplied the expression(s), every positional is a file (file
+        // at position 0); otherwise the first positional is the expression and
+        // the file is at position 1.
         let file_pos = if expression_from_flag(&args) { 0 } else { 1 };
 
+        // In-place: edit each file operand on disk instead of streaming to
+        // stdout. It is *always* a truncating overwrite of an existing file, so
+        // it routes through the same latch+trash gate as tee/patch. Editing a
+        // stream in place is meaningless, so no operands is a loud error.
+        if in_place {
+            let files: Vec<String> = args
+                .positional
+                .iter()
+                .skip(file_pos)
+                .map(crate::interpreter::value_to_string)
+                .collect();
+            if files.is_empty() {
+                return ExecResult::failure(
+                    1,
+                    "sed: -i requires file operands (cannot edit a stream in place)",
+                );
+            }
+
+            // Gate every target with one nonce before touching any file.
+            let targets: Vec<(String, bool)> = files.iter().map(|f| (f.clone(), false)).collect();
+            if let Err(blocked) = ctx.gate_overwrites("sed", &targets, confirm.as_deref()).await {
+                return blocked;
+            }
+
+            // Apply per file; continue past per-file errors and report the last.
+            let mut last_err: Option<String> = None;
+            for path in &files {
+                let resolved = ctx.resolve_path(path);
+                let target = Path::new(&resolved);
+                let content = match ctx.backend.read(target, None).await {
+                    Ok(data) => match String::from_utf8(data) {
+                        Ok(s) => s,
+                        Err(_) => {
+                            last_err = Some(format!("sed: {}: invalid UTF-8", path));
+                            continue;
+                        }
+                    },
+                    Err(e) => {
+                        last_err = Some(format!("sed: {}: {}", path, e));
+                        continue;
+                    }
+                };
+                let output = execute_sed(&content, &parsed, quiet);
+                if let Err(e) = ctx
+                    .backend
+                    .write(target, output.as_bytes(), WriteMode::Overwrite)
+                    .await
+                {
+                    last_err = Some(format!("sed: {}: {}", path, e));
+                }
+            }
+            return match last_err {
+                Some(msg) => ExecResult::failure(1, msg),
+                None => ExecResult::success(""),
+            };
+        }
+
+        // Streaming mode: read one file (or stdin) and write to stdout.
         let input = match args.get_string("path", file_pos) {
             Some(path) => {
                 let resolved = ctx.resolve_path(&path);

--- a/crates/kaish-kernel/tests/latch_trash_tests.rs
+++ b/crates/kaish-kernel/tests/latch_trash_tests.rs
@@ -574,3 +574,63 @@ async fn patch_dry_run_does_not_gate() {
         "dry-run leaves the file untouched"
     );
 }
+
+// ============================================================================
+// Write-model gate: sed -i in-place edits honor latch + trash (same gate)
+// ============================================================================
+
+#[tokio::test]
+async fn sed_in_place_under_trash_snapshots_prior_bytes() {
+    let dir = tempdir();
+    std::fs::write(dir.path().join("f.txt"), "old\n").expect("write");
+    let mock = Arc::new(MockTrash::default());
+    let kernel = kernel_with_trash(dir.path(), &mock);
+
+    run(&kernel, "set -o trash").await;
+    let r = run(&kernel, "sed -i 's/old/new/' f.txt").await;
+    assert_eq!(r.code, 0, "err: {}", r.err);
+
+    let snaps = mock.snapshots();
+    assert_eq!(snaps.len(), 1, "one byte-snapshot before the in-place write: {snaps:?}");
+    assert_eq!(snaps[0].1, b"old\n", "snapshot captured the prior content");
+    assert_eq!(
+        std::fs::read_to_string(dir.path().join("f.txt")).expect("read"),
+        "new\n"
+    );
+}
+
+#[tokio::test]
+async fn sed_in_place_under_latch_requires_confirm() {
+    let dir = tempdir();
+    std::fs::write(dir.path().join("f.txt"), "old\n").expect("write");
+    let mock = Arc::new(MockTrash::default());
+    let kernel = kernel_with_trash(dir.path(), &mock);
+
+    run(&kernel, "set -o latch").await;
+    let r = run(&kernel, "sed -i 's/old/new/' f.txt").await;
+    assert_eq!(r.code, 2, "latch gates the in-place edit: {}", r.err);
+    assert!(r.err.contains("--confirm="));
+    assert_eq!(
+        std::fs::read_to_string(dir.path().join("f.txt")).expect("read"),
+        "old\n",
+        "the file must be untouched until confirmed"
+    );
+
+    let nonce = latch_data_str(&r, "nonce");
+    let r2 = run(&kernel, &format!("sed -i --confirm=\"{nonce}\" 's/old/new/' f.txt")).await;
+    assert_eq!(r2.code, 0, "confirmed in-place edit succeeds: {}", r2.err);
+    assert_eq!(
+        std::fs::read_to_string(dir.path().join("f.txt")).expect("read"),
+        "new\n"
+    );
+}
+
+#[tokio::test]
+async fn sed_in_place_without_operands_is_a_loud_error() {
+    let dir = tempdir();
+    let kernel = kernel_at(dir.path());
+    // Editing a stream in place is meaningless — loud error, not a fall-through.
+    let r = run(&kernel, "echo hi | sed -i 's/h/H/'").await;
+    assert_eq!(r.code, 1, "no file operands must error: {}", r.err);
+    assert!(r.err.contains("requires file operands"), "err: {}", r.err);
+}

--- a/crates/kaish-kernel/tests/latch_trash_tests.rs
+++ b/crates/kaish-kernel/tests/latch_trash_tests.rs
@@ -626,6 +626,63 @@ async fn sed_in_place_under_latch_requires_confirm() {
 }
 
 #[tokio::test]
+async fn sed_in_place_latch_hint_is_runnable() {
+    // Regression: the hint must reinject `-i` and the expression. A bare
+    // `sed --confirm=… f.txt` would read f.txt as the expression and hang on
+    // stdin. Run the advertised hint verbatim and require it to edit the file.
+    let dir = tempdir();
+    std::fs::write(dir.path().join("f.txt"), "old\n").expect("write");
+    let kernel = kernel_at(dir.path());
+
+    run(&kernel, "set -o latch").await;
+    let r = run(&kernel, "sed -i 's/old/new/' f.txt").await;
+    assert_eq!(r.code, 2, "latch gates: {}", r.err);
+
+    let hint = latch_data_str(&r, "hint");
+    assert!(hint.contains("-i"), "hint keeps -i: {hint}");
+    assert!(hint.contains("s/old/new/"), "hint keeps the expression: {hint}");
+
+    let r2 = run(&kernel, &hint).await;
+    assert_eq!(r2.code, 0, "running the hint verbatim edits the file: {}", r2.err);
+    assert_eq!(
+        std::fs::read_to_string(dir.path().join("f.txt")).expect("read"),
+        "new\n"
+    );
+}
+
+#[tokio::test]
+async fn sed_in_place_multi_file_and_e_flag_edits_all() {
+    let dir = tempdir();
+    std::fs::write(dir.path().join("a.txt"), "old\n").expect("write");
+    std::fs::write(dir.path().join("b.txt"), "old\n").expect("write");
+    let kernel = kernel_at(dir.path());
+
+    // -i alongside -e, across multiple file operands (gates off by default).
+    let r = run(&kernel, "sed -i -e 's/old/new/' a.txt b.txt").await;
+    assert_eq!(r.code, 0, "err: {}", r.err);
+    assert_eq!(std::fs::read_to_string(dir.path().join("a.txt")).expect("read"), "new\n");
+    assert_eq!(std::fs::read_to_string(dir.path().join("b.txt")).expect("read"), "new\n");
+}
+
+#[tokio::test]
+async fn sed_in_place_continues_past_per_file_error() {
+    let dir = tempdir();
+    std::fs::write(dir.path().join("good.txt"), "old\n").expect("write");
+    let kernel = kernel_at(dir.path());
+
+    // A missing operand must not abort the batch: the good file is still edited
+    // and the run reports failure for the missing one.
+    let r = run(&kernel, "sed -i 's/old/new/' missing.txt good.txt").await;
+    assert_eq!(r.code, 1, "a per-file failure yields a non-zero exit: {}", r.err);
+    assert!(r.err.contains("missing.txt"), "error names the bad file: {}", r.err);
+    assert_eq!(
+        std::fs::read_to_string(dir.path().join("good.txt")).expect("read"),
+        "new\n",
+        "the good file is still edited"
+    );
+}
+
+#[tokio::test]
 async fn sed_in_place_without_operands_is_a_loud_error() {
     let dir = tempdir();
     let kernel = kernel_at(dir.path());

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -840,7 +840,8 @@ These are documented limitations of the current implementation:
   - **Addresses** line number `N`, last line `$`, `/regex/`, and ranges `N,M` / `/start/,/end/`.
   - **Chaining** multiple commands with `;` *or* repeated `-e` (applied in order); both forms compose into one program.
   - **Regex is ERE** (extended, like `egrep`) — *always*. `-E`/`-r` are accepted no-ops. The BRE escapes that mean something different under ERE are **rejected with a hint** instead of silently matching the wrong thing: capture groups `\(…\)` (use `(…)`), alternation `\|` (use `a|b`), and intervals `\{N,M\}` (use `a{2,5}`). A pattern-side backreference (`\1` in the pattern) is also rejected — the linear-time engine has none, in any dialect. (`\+`/`\?` are left alone: they're valid ERE escapes for literal `+`/`?`, so the BRE-vs-literal intent is ambiguous.)
-  - **Out of scope** (errors loudly, never half-runs): hold space (`h`/`H`/`g`/`G`/`x`), labels/branching (`b`/`t`/`:`), `w`/`r` file I/O, in-place `-i`, and GNU address extensions (`1~2`, `0,/re/`, `/re/,+N`). Reach for a real `sed` (external command) when you need those.
+  - **In-place edit** `-i` rewrites one or more file operands instead of streaming to stdout (no operands is a loud error). It routes through the latch/trash gate like `tee`/`patch`. The GNU glued backup suffix `-i.bak` is **not** supported (kaish's lexer splits it at the dot); `set -o trash` keeps a recoverable copy instead.
+  - **Out of scope** (errors loudly, never half-runs): hold space (`h`/`H`/`g`/`G`/`x`), labels/branching (`b`/`t`/`:`), `w`/`r` file I/O, the `-i.bak` backup suffix, and GNU address extensions (`1~2`, `0,/re/`, `/re/,+N`). Reach for a real `sed` (external command) when you need those.
 
 ### Execution
 

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -197,40 +197,26 @@ still does an unconditional `named.insert` of a single `Value::String`. So
 value, but it's the same silent-drop class. Fix: route the glued path through
 `push_repeatable_value` when the matched param is repeatable.
 
-### `sed -i` (in-place edit) — design decided, ready to build with tee/patch
-Both lite models in the sed usability panel reached for `sed -i 's/…/…/' file` —
-the strongest remaining ergonomic gap. In-place editing is a file-mutating side
-effect that must route through kaish's write machinery (VFS resolution, overlay
-transactions, latch/trash rails) so sandbox/`--overlay`/confirm modes all hold.
-`sed -i` is *always* a truncating overwrite of an existing file, so it inherits
-the tee/patch "truncating overwrite gates" rule below. Today `sed` loud-errors on
-`-i`. **Amy decisions (2026-06-21):**
-- **Confirm flag:** `--confirm=<nonce>` across the whole mutation family
-  (`tee`/`patch`/`sed -i`) — one mental model, matching `rm`.
-- **`-i.bak`:** support the explicit backup suffix to match convention. `sed
-  -i.bak` is the user's deliberate, named backup; trash is the *transparent*
-  safety net for the gating, not a substitute for the explicit `.bak`.
-- **Multi-file:** one nonce scoping the whole path set (like `rm`'s
-  `NonceScope.paths`), not per-file.
-- **Overlay prior-content capture:** trash snapshots the *overlay's current
-  view* (what would actually be lost on overwrite in-transaction), not the
-  real-FS baseline.
-- **No file operands:** loud error (`sed -i requires file operands`) — in-place
-  editing of a stream is meaningless; do not fall back to stdin.
-- **Atomicity:** write-temp-then-atomic-rename through the VFS (crash-safe);
-  this surfaces an atomic-replace capability question on the `Filesystem` trait.
+### Write-model gate — DONE; two residuals
+**`tee` + `patch` + `sed -i` all gated** (`feat/mutation-write-gate` →
+`feat/patch-write-gate` → `feat/sed-in-place`): pure `decide_mutation_action →
+{TrashFirst, Latch, Proceed}` + `ExecContext::gate_overwrites`/
+`snapshot_for_overwrite` (copies prior content via `TrashBackend::trash_bytes`,
+leaving the file in place) + family-wide `--confirm=<nonce>`, one nonce per command.
+`sed -i` edits one-or-more files in place (no operands → loud error). Latch+trash
+stay ON in overlay mode; `tee -a` append / new file / `patch --dry-run` don't gate.
 
-### Write-model gate — `sed -i` remains
-**`tee` + `patch` DONE** (`feat/mutation-write-gate` → `feat/patch-write-gate`):
-the shared gate landed — pure `decide_mutation_action → {TrashFirst, Latch,
-Proceed}` + `ExecContext::gate_overwrites`/`snapshot_for_overwrite` (copies prior
-content via `TrashBackend::trash_bytes`, leaving the file in place) + family-wide
-`--confirm=<nonce>`; `tee` and `patch` both wired in (`patch` gates non-dry-run
-overwrites with one nonce per diff). **`sed -i` still open** (its own design entry
-below): it's *always* a truncating overwrite, so it inherits the same gate — call
-`gate_overwrites` before the in-place write. Decisions stand: latch+trash stay ON
-even in overlay mode; truncating overwrite gates, `tee -a` append does NOT; new
-file → just write; overlay trash captures the prior content via `trash_bytes`.
+Residuals:
+- **`sed -i.bak` backup suffix.** Not supported: kaish's lexer splits `-i.bak` at
+  the dot (dot-prefixed barewords), and the kernel value-flag binder consumes the
+  *next* token greedily, so GNU's glued-optional-suffix isn't modelable post-lexing.
+  The trash snapshot already gives a recoverable copy, so this is convenience, not
+  safety. Needs lexer/binder work (or a bespoke pre-clap argv pass à la `set.rs`).
+- **Atomicity (whole family).** `tee`/`patch`/`sed -i` overwrite via
+  `backend.write(Overwrite)` (patch uses a CAS `Replace`), not write-temp-then-
+  atomic-rename, so a crash mid-write can truncate. The fix surfaces an atomic-
+  replace capability question on the `Filesystem` trait — do it once for the whole
+  family, not per-builtin.
 
 ### Streaming file reads — remaining
 (wc/checksum/grep/cmp/cat landed — see devlog.) Open:

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -213,10 +213,29 @@ Residuals:
   The trash snapshot already gives a recoverable copy, so this is convenience, not
   safety. Needs lexer/binder work (or a bespoke pre-clap argv pass à la `set.rs`).
 - **Atomicity (whole family).** `tee`/`patch`/`sed -i` overwrite via
-  `backend.write(Overwrite)` (patch uses a CAS `Replace`), not write-temp-then-
-  atomic-rename, so a crash mid-write can truncate. The fix surfaces an atomic-
+  `backend.write(Overwrite)` (`patch`/`sed -i` use a CAS `Replace`), not write-temp-
+  then-atomic-rename, so a crash mid-write can truncate. The fix surfaces an atomic-
   replace capability question on the `Filesystem` trait — do it once for the whole
   family, not per-builtin.
+- **TOCTOU window B — snapshot/CAS double-read (P3).** Gated `patch`/`sed -i` read
+  the file twice: `gate_overwrites → snapshot_for_overwrite` reads state A and copies
+  it to trash, then the builtin re-reads state B for its transform and binds the CAS
+  `expected` to **B**. The read#2→write window is CAS-protected (a change there fails
+  loud), but a concurrent change A→B in the snapshot→read#2 gap leaves the trash
+  holding the *stale* A while B→C is written — recovery is one version behind, and CAS
+  doesn't catch it because `expected` is the later read. **Fixable cheaply:** have
+  `gate_overwrites` return the snapshotted bytes per TrashFirst target and let the
+  builtin transform *those* and set `expected` to *those* — one read, snapshot ==
+  expected, only the CAS-guarded read→write window remains. Contained API change to
+  the three callers.
+- **TOCTOU window A — existence-check race (P3).** `decide_mutation_action` keys on
+  `exists` at gate time; a path absent then returns `Proceed` (no snapshot, no latch).
+  If it's created before the builtin's `write`, it's clobbered ungated. Inherent with
+  today's primitives — `WriteMode` has no `O_EXCL`/create-exclusive or write-if-absent
+  CAS. Closing it needs a new write mode across LocalFs/MemoryFs/OverlayFs. Practical
+  risk is low (foreground `execute` is serialized by `execute_lock`; the window only
+  opens against an external process, a background fork, or a second kernel on the same
+  localfs).
 
 ### Streaming file reads — remaining
 (wc/checksum/grep/cmp/cat landed — see devlog.) Open:


### PR DESCRIPTION
## What

`sed -i` edits one or more file operands in place instead of streaming to stdout — the strongest remaining sed ergonomic gap (both sed-panel models reached for `sed -i 's/…/…/' file`). **Last PR of the 0.9.2 write-model bundle.**

**Stacked on #32** (`feat/patch-write-gate`) → which is stacked on #31. Review the stack in order.

## How

`sed -i` is always a truncating overwrite, so it routes through the shared `gate_overwrites` from #31 (latch + trash, one nonce per command). Added `--confirm`. No file operands is a loud error (editing a stream in place is meaningless). Streaming mode is untouched; the 78 existing sed unit tests still pass.

## Scope cut: `-i.bak` is NOT supported (architectural, flagged for your call)

Amy's spec wanted the GNU glued backup suffix `-i.bak`. It turns out kaish can't model it post-lexing:
- the **lexer** splits `-i.bak` at the dot (dot-prefixed barewords → `-i` + `.bak`), and
- the kernel **value-flag binder** consumes the *next* token greedily, so declaring `-i` as a value flag makes `sed -i 's/…/…/' f` eat the expression as the suffix.

Neither glued nor spaced optional-suffix survives. Recovering it needs lexer/binder work (or a bespoke pre-clap argv pass à la `set.rs`). Since the **trash snapshot already keeps a recoverable prior copy**, the explicit `.bak` is convenience, not safety — so I shipped `-i` without it and filed `-i.bak` + the family-wide atomicity question (overwrite-in-place vs write-temp-rename) in `issues.md`. Happy to revisit `-i.bak` as its own lexer PR if you want it.

## Tests

Kernel-routed (`latch_trash_tests.rs`): trash snapshots prior bytes before the in-place write; latch gates with exit 2 + `--confirm` round-trip; no-operands loud error. Docs synced (CHANGELOG, LANGUAGE.md sed scope, help fragment + regenerated `syntax.md`, issues.md consolidated to DONE + residuals).

## Gate

`cargo test --all` green · `cargo clippy --all --all-targets` clean · syntax drift test passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)