### PR TITLE
fix: pre-0.10 fidelity bundle — four silent-wrong cases made loud/correct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,25 @@ breaking entries are marked **BREAKING**.
 ## [Unreleased]
 
 ### Fixed
+- **`sed -e <number>` is a loud error, not a silent drop.** A non-string `-e`
+  expression (e.g. `sed -e 5`) now exits 2 with a usage error instead of being
+  ignored — silently dropping it once let the *filename* be parsed as the program.
+- **Unterminated arithmetic `$(( …` is a lexer error**, not a silent partial
+  evaluation — `$(( 1 + 2` (no closing `))`) no longer evaluates to `3`.
+- **`printf '%c'` honors width and the left-align flag** (`printf '%5c' x` →
+  `␠␠␠␠x`), and a `\c` in a `%b` argument — or in the format literal — now stops
+  *all* output rather than only the rest of that argument, matching GNU `printf`.
+- **File tests expand `~`.** `[[ -f ~/x ]]` resolves the tilde against the session
+  `HOME` before stat'ing (it was always false). Hermetic kernels with no `HOME`
+  keep `~` literal.
+- **`<<-` strips leading tabs from the literal source only**, no longer eating
+  tabs that came from an interpolated variable's value (bash strips source-line
+  tabs before expansion).
+- **`export NAME=VALUE` inside a function persists after the function returns**,
+  matching a plain assignment and bash — it was previously dropped with the
+  function frame.
+- **`jq` no longer errors on indexing `null`** — `null | .a` yields `null` (jq
+  parity), from the jaq-core 3 / jaq-json 2 upgrade.
 - **`write` no longer corrupts binary content from `$(…)`.** `write FILE $(producer)`
   (and `producer | write FILE`) now persists the raw bytes of a `Value::Bytes`
   verbatim instead of stringifying it to the `[binary: N bytes]` placeholder — that
@@ -58,6 +77,13 @@ breaking entries are marked **BREAKING**.
   host filesystem, bypassing the VFS/overlay (a silent wrong boolean into `if`/`&&`).
 
 ### Changed
+- **BREAKING: `cp` no longer accepts `-p`/`--preserve`.** It was parsed and
+  silently discarded (the VFS has no mode, mtime, or ownership to preserve), so
+  `cp -p src dst` used to copy and exit 0; it now exits 2 as an unknown-argument
+  usage error. Drop the flag — plain `cp` performs the same copy.
+- **`jq` renders integral results without a trailing `.0`** — `6/2` → `3`,
+  `1e10` → `10000000000` (were `3.0` / `10000000000.0`), and large integers print
+  exactly on stdout. (jaq-core 3 / jaq-json 2.)
 - **`jq` object keys now preserve insertion order** instead of being sorted
   alphabetically — `echo '{"b":1,"a":2}' | jq .` emits `{"b":1,"a":2}`, matching
   real jq. This comes from upgrading the native jq engine to jaq-core 3 / jaq-json 2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ breaking entries are marked **BREAKING**.
   ignored — silently dropping it once let the *filename* be parsed as the program.
 - **Unterminated arithmetic `$(( …` is a lexer error**, not a silent partial
   evaluation — `$(( 1 + 2` (no closing `))`) no longer evaluates to `3`.
+- **`sed 's/x/y/0'` is a loud error**, matching GNU — the `0` occurrence flag
+  ("replace the 0th match") was silently treated as the first match.
 - **`printf '%c'` honors width and the left-align flag** (`printf '%5c' x` →
   `␠␠␠␠x`), and a `\c` in a `%b` argument — or in the format literal — now stops
   *all* output rather than only the rest of that argument, matching GNU `printf`.

--- a/crates/kaish-kernel/src/lexer.rs
+++ b/crates/kaish-kernel/src/lexer.rs
@@ -113,6 +113,10 @@ pub enum LexerError {
     InvalidFloatNoTrailing,
     /// Nesting depth exceeded (too many nested parentheses in arithmetic).
     NestingTooDeep,
+    /// Arithmetic expansion `$((` reached end of input without a closing `))`.
+    /// Silently evaluating the partial expression would mask a typo (`$(( 1 + 2`
+    /// would compute `3`), so we surface it loudly instead.
+    UnterminatedArithmetic,
     /// Heredoc body ended without seeing the closing delimiter on its own line.
     /// The user almost certainly meant to type the delimiter — silently using
     /// whatever was collected up to EOF would mask missing data.
@@ -142,6 +146,9 @@ impl fmt::Display for LexerError {
             LexerError::InvalidFloatNoLeading => write!(f, "float must have leading digit"),
             LexerError::InvalidFloatNoTrailing => write!(f, "float must have trailing digit"),
             LexerError::NestingTooDeep => write!(f, "nesting depth exceeded (max {})", MAX_PAREN_DEPTH),
+            LexerError::UnterminatedArithmetic => {
+                write!(f, "unterminated arithmetic expansion, expected closing `))`")
+            }
             LexerError::UnterminatedHeredoc { delimiter } => {
                 write!(f, "unterminated heredoc, expected closing delimiter `{}` on its own line", delimiter)
             }
@@ -1345,6 +1352,7 @@ fn preprocess_arithmetic(source: &str) -> Result<ArithmeticPreprocessResult, Lex
             // Collect expression until matching ))
             let mut expr = String::new();
             let mut paren_depth: usize = 0;
+            let mut closed = false;
 
             while i < chars_vec.len() {
                 let c = chars_vec[i];
@@ -1368,6 +1376,7 @@ fn preprocess_arithmetic(source: &str) -> Result<ArithmeticPreprocessResult, Lex
                             // Found closing ))
                             i += 2;
                             source_pos += 2;
+                            closed = true;
                             break;
                         } else {
                             // Single ) inside - keep going
@@ -1382,6 +1391,12 @@ fn preprocess_arithmetic(source: &str) -> Result<ArithmeticPreprocessResult, Lex
                         source_pos += c.len_utf8();
                     }
                 }
+            }
+
+            // Reached EOF without the closing `))` — don't silently evaluate the
+            // partial expression (`$(( 1 + 2` must not become `3`).
+            if !closed {
+                return Err(LexerError::UnterminatedArithmetic);
             }
 
             // Calculate original length: from $$(( to ))

--- a/crates/kaish-kernel/src/tools/builtin/cp.rs
+++ b/crates/kaish-kernel/src/tools/builtin/cp.rs
@@ -23,10 +23,6 @@ struct CpArgs {
     #[arg(short = 'n', long = "no-clobber", visible_alias = "no_clobber")]
     no_clobber: bool,
 
-    /// Preserve file attributes (-p)
-    #[arg(short = 'p', long = "preserve")]
-    preserve: bool,
-
     #[command(flatten)]
     global: GlobalFlags,
 
@@ -66,8 +62,9 @@ impl Tool for Cp {
 
         let recursive = parsed.recursive;
         let no_clobber = parsed.no_clobber;
-        // preserve flag is recognized but VFS doesn't support attributes
-        let _preserve = parsed.preserve;
+        // `-p`/`--preserve` is intentionally NOT accepted: the VFS has no mode,
+        // mtime, or ownership to preserve, so advertising the flag would be a
+        // silent no-op. clap rejects it loudly as an unknown argument instead.
 
         // POSIX: `cp SRC DST` for one source, `cp SRC... DIR/` for many.
         // Last positional is the destination.

--- a/crates/kaish-kernel/src/tools/builtin/format_string.rs
+++ b/crates/kaish-kernel/src/tools/builtin/format_string.rs
@@ -38,7 +38,7 @@ struct FormatSpec {
 /// consumed — see [`format_string_cycling`].
 pub fn format_string<A: FormatArg>(format: &str, args: &[A]) -> String {
     let mut output = String::new();
-    format_pass(format, args, &mut output);
+    let _ = format_pass(format, args, &mut output);
     output
 }
 
@@ -53,22 +53,27 @@ pub fn format_string_cycling<A: FormatArg>(format: &str, args: &[A]) -> String {
     let mut output = String::new();
     // The first pass always runs, so a zero-operand call still prints the
     // literal text and an all-default conversion line.
-    let per_pass = format_pass(format, args, &mut output);
-    if per_pass == 0 {
+    let (per_pass, stop) = format_pass(format, args, &mut output);
+    if stop || per_pass == 0 {
         return output;
     }
     let mut start = per_pass;
     while start < args.len() {
         let end = (start + per_pass).min(args.len());
-        format_pass(format, &args[start..end], &mut output);
+        let (_, stop) = format_pass(format, &args[start..end], &mut output);
+        if stop {
+            break;
+        }
         start = end;
     }
     output
 }
 
 /// Run one formatting pass, appending to `output`. Returns the number of
-/// conversion specifiers applied (i.e. operand slots consumed this pass).
-fn format_pass<A: FormatArg>(format: &str, args: &[A], output: &mut String) -> usize {
+/// conversion specifiers applied (i.e. operand slots consumed this pass) and
+/// whether output should stop entirely (a `\c` was reached, in the format
+/// literal or via a `%b` argument).
+fn format_pass<A: FormatArg>(format: &str, args: &[A], output: &mut String) -> (usize, bool) {
     let mut arg_index = 0;
     let mut chars = format.chars().peekable();
 
@@ -77,8 +82,11 @@ fn format_pass<A: FormatArg>(format: &str, args: &[A], output: &mut String) -> u
             match parse_specifier(&mut chars) {
                 Some(spec) => {
                     let arg = args.get(arg_index);
-                    apply_specifier(&spec, arg, output);
+                    let stop = apply_specifier(&spec, arg, output);
                     arg_index += 1;
+                    if stop {
+                        return (arg_index, true);
+                    }
                 }
                 None => {
                     // Was %% → literal %
@@ -86,13 +94,17 @@ fn format_pass<A: FormatArg>(format: &str, args: &[A], output: &mut String) -> u
                 }
             }
         } else if c == '\\' {
+            // `\c` in the format literal stops all output (GNU printf).
+            if chars.peek() == Some(&'c') {
+                return (arg_index, true);
+            }
             parse_backslash_escape(&mut chars, output);
         } else {
             output.push(c);
         }
     }
 
-    arg_index
+    (arg_index, false)
 }
 
 /// Parse and emit a backslash escape sequence, starting after the `\`.
@@ -160,16 +172,18 @@ fn parse_backslash_escape(
 /// Interpret backslash escapes in an argument string, as done by `%b`.
 ///
 /// Same escape set as the format string itself, but applied to the argument
-/// value rather than the format template. `\c` stops output (like GNU printf).
-fn interpret_backslash_escapes(s: &str) -> String {
+/// value rather than the format template. Returns the interpreted string and
+/// whether a `\c` was seen — `\c` stops *all* further printf output (like GNU
+/// printf), not just the rest of this argument, so the caller propagates it.
+fn interpret_backslash_escapes(s: &str) -> (String, bool) {
     let mut output = String::new();
     let mut chars = s.chars().peekable();
     while let Some(c) = chars.next() {
         if c == '\\' {
             match chars.peek().copied() {
                 Some('c') => {
-                    // \c: suppress further output (like GNU printf %b)
-                    break;
+                    // \c: suppress this and all further output.
+                    return (output, true);
                 }
                 _ => parse_backslash_escape(&mut chars, &mut output),
             }
@@ -177,7 +191,7 @@ fn interpret_backslash_escapes(s: &str) -> String {
             output.push(c);
         }
     }
-    output
+    (output, false)
 }
 
 /// Parse a format specifier after the initial `%`.
@@ -260,7 +274,10 @@ fn parse_specifier(chars: &mut std::iter::Peekable<std::str::Chars<'_>>) -> Opti
 }
 
 /// Apply a parsed format specifier to an argument, writing to `output`.
-fn apply_specifier<A: FormatArg>(spec: &FormatSpec, arg: Option<&A>, output: &mut String) {
+///
+/// Returns `true` if output should stop entirely (a `%b` argument contained
+/// `\c`), so the caller can abandon the rest of the format and any cycling.
+fn apply_specifier<A: FormatArg>(spec: &FormatSpec, arg: Option<&A>, output: &mut String) -> bool {
     match spec.conversion {
         's' => {
             let val = arg.map(|a| a.as_format_string()).unwrap_or_default();
@@ -344,15 +361,18 @@ fn apply_specifier<A: FormatArg>(spec: &FormatSpec, arg: Option<&A>, output: &mu
             apply_int_format(spec, val, output, IntBase::Octal);
         }
         'c' => {
+            // %c honors width and the left-align flag (`printf '%5c' x` → `    x`).
             if let Some(ch) = arg.and_then(|a| a.as_format_char()) {
-                output.push(ch);
+                apply_string_padding(spec, &ch.to_string(), output);
             }
         }
         'b' => {
-            // %b: interpret backslash escapes in the argument string.
+            // %b: interpret backslash escapes in the argument string. A `\c`
+            // stops all further output, so propagate the stop signal upward.
             let raw = arg.map(|a| a.as_format_string()).unwrap_or_default();
-            let val = interpret_backslash_escapes(&raw);
+            let (val, stop) = interpret_backslash_escapes(&raw);
             apply_string_padding(spec, &val, output);
+            return stop;
         }
         other => {
             // Unknown conversion — output literally
@@ -360,6 +380,7 @@ fn apply_specifier<A: FormatArg>(spec: &FormatSpec, arg: Option<&A>, output: &mu
             output.push(other);
         }
     }
+    false
 }
 
 enum IntBase {

--- a/crates/kaish-kernel/src/tools/builtin/sed.rs
+++ b/crates/kaish-kernel/src/tools/builtin/sed.rs
@@ -610,7 +610,15 @@ fn parse_substitute(expr: &str) -> Result<(Command, String), String> {
     let occurrence = if digits.is_empty() {
         0
     } else {
-        digits.parse().map_err(|_| "invalid s/// occurrence number")?
+        let n = digits
+            .parse()
+            .map_err(|_| "invalid s/// occurrence number")?;
+        // `s///0` is meaningless ("replace the 0th match") — GNU sed rejects it
+        // rather than silently treating it as the first match.
+        if n == 0 {
+            return Err("number option to `s' command may not be zero".to_string());
+        }
+        n
     };
 
     detect_bre_idiom(&pattern_str, &replacement)?;

--- a/crates/kaish-kernel/src/tools/builtin/sed.rs
+++ b/crates/kaish-kernel/src/tools/builtin/sed.rs
@@ -96,7 +96,11 @@ impl Tool for Sed {
         // first positional. Any `<dynamic>` marker means a variable/substitution
         // whose value is unknown at parse time — skip the whole expression so we
         // don't false-error on `F='s/a/b/'; sed $F`.
-        let exprs = collect_expressions(args);
+        // A non-string `-e` is a runtime error; execute() surfaces it loudly.
+        // Validation stays lenient here (don't double-author the message).
+        let Ok(exprs) = collect_expressions(args) else {
+            return issues;
+        };
         for expr in &exprs {
             if expr.contains("<dynamic>") {
                 return issues;
@@ -155,7 +159,10 @@ impl Tool for Sed {
         // `ToolArgs::to_argv()` renders as one JSON token (it can't tell a
         // repeatable scalar array from a single array value). `parsed` above is
         // only consulted for `-n`/global flags; expressions live here.
-        let expressions = collect_expressions(&args);
+        let expressions = match collect_expressions(&args) {
+            Ok(e) => e,
+            Err(msg) => return ExecResult::failure(2, format!("sed: {msg}")),
+        };
         if expressions.is_empty() {
             return ExecResult::failure(1, "sed: missing expression");
         }
@@ -298,24 +305,35 @@ fn expression_from_flag(args: &ToolArgs) -> bool {
 /// `consume_flag_positionals`); a single value may arrive as a bare
 /// `Value::String`. When no `-e` is used, the first positional is the
 /// expression. Order is preserved so `-e A -e B` applies A then B.
-fn collect_expressions(args: &ToolArgs) -> Vec<String> {
+fn collect_expressions(args: &ToolArgs) -> Result<Vec<String>, String> {
     let mut exprs = Vec::new();
 
     // Both paths canonicalize `-e`/`--expression` to the long name `expression`,
     // so `e` is never actually populated today; it's defensive insurance against
     // a future change that binds under the short alias. Because only one key is
     // ever present, iterating both can't double-count or reorder.
+    //
+    // A non-string `-e` value (e.g. `sed -e 5`, which binds `5` as an integer)
+    // is rejected loudly rather than silently dropped — `-e <number>` isn't a
+    // valid sed program, and silently ignoring it once led to the *filename*
+    // being parsed as the program.
     for key in ["expression", "e"] {
         match args.named.get(key) {
             Some(Value::Json(serde_json::Value::Array(items))) => {
                 for item in items {
-                    if let serde_json::Value::String(s) = item {
-                        exprs.push(s.clone());
+                    match item {
+                        serde_json::Value::String(s) => exprs.push(s.clone()),
+                        other => return Err(format!(
+                            "-e expression must be a string, got `{other}`"
+                        )),
                     }
                 }
             }
             Some(Value::String(e)) => exprs.push(e.clone()),
-            _ => {}
+            Some(other) => {
+                return Err(format!("-e expression must be a string, got `{other:?}`"));
+            }
+            None => {}
         }
     }
 
@@ -324,7 +342,7 @@ fn collect_expressions(args: &ToolArgs) -> Vec<String> {
         exprs.push(e.clone());
     }
 
-    exprs
+    Ok(exprs)
 }
 
 // ============================================================================
@@ -1391,7 +1409,7 @@ mod tests {
             Value::Json(serde_json::json!(["s/a/b/", "s/c/d/"])),
         );
         assert_eq!(
-            collect_expressions(&args),
+            collect_expressions(&args).unwrap(),
             vec!["s/a/b/".to_string(), "s/c/d/".to_string()]
         );
         assert!(expression_from_flag(&args));
@@ -1403,7 +1421,7 @@ mod tests {
         let mut args = ToolArgs::new();
         args.named
             .insert("expression".to_string(), Value::String("s/a/b/".into()));
-        assert_eq!(collect_expressions(&args), vec!["s/a/b/".to_string()]);
+        assert_eq!(collect_expressions(&args).unwrap(), vec!["s/a/b/".to_string()]);
         assert!(expression_from_flag(&args));
     }
 
@@ -1413,7 +1431,7 @@ mod tests {
         let mut args = ToolArgs::new();
         args.positional.push(Value::String("s/a/b/".into()));
         args.positional.push(Value::String("file.txt".into()));
-        assert_eq!(collect_expressions(&args), vec!["s/a/b/".to_string()]);
+        assert_eq!(collect_expressions(&args).unwrap(), vec!["s/a/b/".to_string()]);
         assert!(!expression_from_flag(&args));
     }
 

--- a/crates/kaish-kernel/tests/pre_0_10_fidelity_tests.rs
+++ b/crates/kaish-kernel/tests/pre_0_10_fidelity_tests.rs
@@ -1,0 +1,132 @@
+//! Kernel-routed regression tests for the pre-0.10 fidelity bundle.
+//!
+//! Each fix turns a previously *silent* wrong behavior loud or correct
+//! (`docs/issues.md`):
+//!   - `sed -e <numeric>` was silently dropped → now a loud error.
+//!   - `cp -p`/`--preserve` was parsed then discarded → now rejected (the VFS
+//!     has no attributes to preserve, so the flag is no longer advertised).
+//!   - unterminated `$(( … ` silently evaluated the partial expression → now a
+//!     loud lexer error.
+//!   - `printf '%c'` ignored width/flags, and `%b`'s `\c` only truncated its
+//!     own argument instead of stopping all output.
+//!
+//! Each routes through `kernel.execute()` so the full pipeline runs.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use kaish_kernel::{Kernel, KernelConfig};
+
+fn kernel() -> Kernel {
+    Kernel::new(KernelConfig::transient().with_skip_validation(true)).expect("kernel")
+}
+
+// ---------------------------------------------------------------------------
+// sed -e <numeric> → loud
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn sed_numeric_expression_is_loud_not_dropped() {
+    // `sed -e 5` binds `5` as an integer; it must not be silently ignored
+    // (which once let the *filename* be parsed as the program).
+    let k = kernel();
+    let result = k
+        .execute("echo abc | sed -e 5 -e 's/a/X/'")
+        .await
+        .expect("execute");
+    assert_eq!(result.code, 2, "numeric -e must fail (POSIX usage), got {result:?}");
+    assert!(
+        result.err.contains("must be a string"),
+        "stderr should explain the non-string expression: {:?}",
+        result.err
+    );
+}
+
+#[tokio::test]
+async fn sed_string_expression_still_works() {
+    // Positive control: a normal string -e is unaffected.
+    let k = kernel();
+    let result = k
+        .execute("echo abc | sed -e 's/a/X/'")
+        .await
+        .expect("execute");
+    assert_eq!(result.code, 0, "valid sed must succeed: {result:?}");
+    assert_eq!(result.text_out().trim_end(), "Xbc");
+}
+
+// ---------------------------------------------------------------------------
+// cp -p → rejected
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn cp_preserve_flag_is_rejected() {
+    // The VFS can't preserve mode/mtime/ownership, so `-p` must not be a
+    // silent no-op — clap rejects it as an unknown argument.
+    let k = kernel();
+    let result = k.execute("cp -p a b").await.expect("execute");
+    assert_eq!(result.code, 2, "cp -p must be a usage error: {result:?}");
+    assert!(
+        result.err.contains("-p"),
+        "stderr should name the rejected flag: {:?}",
+        result.err
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Unterminated $(( → loud
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn unterminated_arithmetic_is_loud() {
+    // `$(( 1 + 2` (no closing `))`) must not silently evaluate to 3.
+    let k = kernel();
+    let result = k.execute("echo $(( 1 + 2").await;
+    let err = result.expect_err("unterminated arithmetic must error");
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("unterminated arithmetic"),
+        "error should name the unterminated arithmetic: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn terminated_arithmetic_still_works() {
+    // Positive control: the closed form still evaluates.
+    let k = kernel();
+    let result = k.execute("echo $(( 1 + 2 ))").await.expect("execute");
+    assert_eq!(result.text_out().trim_end(), "3");
+}
+
+// ---------------------------------------------------------------------------
+// printf %c width + %b \c whole-format stop
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn printf_percent_c_honors_width() {
+    let k = kernel();
+    let result = k.execute("printf '[%5c]' x").await.expect("execute");
+    assert_eq!(result.text_out(), "[    x]", "%c should right-pad to width 5");
+}
+
+#[tokio::test]
+async fn printf_percent_c_left_align() {
+    let k = kernel();
+    let result = k.execute("printf '[%-5c]' x").await.expect("execute");
+    assert_eq!(result.text_out(), "[x    ]", "%-5c should left-pad to width 5");
+}
+
+#[tokio::test]
+async fn printf_percent_b_backslash_c_stops_all_output() {
+    // `\c` inside a %b argument stops ALL further output, including the
+    // trailing literal `c` of the format — not just the rest of the argument.
+    let k = kernel();
+    let result = k.execute(r#"printf "a%bc" "X\cY""#).await.expect("execute");
+    assert_eq!(result.text_out(), "aX", "%b \\c must stop the whole format");
+}
+
+#[tokio::test]
+async fn printf_format_literal_backslash_c_stops_output() {
+    // `\c` in the format literal itself also stops output (GNU printf).
+    let k = kernel();
+    let result = k.execute(r#"printf "a\cb""#).await.expect("execute");
+    assert_eq!(result.text_out(), "a", "format-literal \\c must stop output");
+}

--- a/crates/kaish-kernel/tests/pre_0_10_fidelity_tests.rs
+++ b/crates/kaish-kernel/tests/pre_0_10_fidelity_tests.rs
@@ -53,6 +53,23 @@ async fn sed_string_expression_still_works() {
     assert_eq!(result.text_out().trim_end(), "Xbc");
 }
 
+#[tokio::test]
+async fn sed_substitute_zero_occurrence_is_loud() {
+    // `s///0` ("replace the 0th match") is meaningless — GNU sed errors instead
+    // of silently treating it as the first match.
+    let k = kernel();
+    let result = k
+        .execute("echo aaa | sed 's/a/b/0'")
+        .await
+        .expect("execute");
+    assert_ne!(result.code, 0, "s///0 must fail, got {result:?}");
+    assert!(
+        result.err.contains("may not be zero"),
+        "stderr should reject the zero occurrence: {:?}",
+        result.err
+    );
+}
+
 // ---------------------------------------------------------------------------
 // cp -p → rejected
 // ---------------------------------------------------------------------------

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -201,14 +201,6 @@ Still open (deferred — bigger than a builtin fix, each its own focused PR):
     (`eval.rs`, non-kernel embedders only) still doesn't expand — it has no `HOME`
     source on the trait; left as-is until an embedder needs the sync `[[ ]]` path.
 
-### Repeatable flags: glued short-flag form still overwrites (`-es/a/b/`)
-The `-e A -e B` and `--expression=A --expression=B` forms accumulate correctly,
-but the *glued* short-flag value path in `kernel.rs` (parses `cut -f1`, `head -c5`)
-still does an unconditional `named.insert` of a single `Value::String`. So
-`sed -es/a/b/` then `-e X` overwrites the accumulated array. Nobody glues `-e`'s
-value, but it's the same silent-drop class. Fix: route the glued path through
-`push_repeatable_value` when the matched param is repeatable.
-
 ### Write-model gate — DONE; two residuals
 **`tee` + `patch` + `sed -i` all gated** (`feat/mutation-write-gate` →
 `feat/patch-write-gate` → `feat/sed-in-place`): pure `decide_mutation_action →
@@ -326,8 +318,6 @@ Low-frequency sub-cases left after the P1 builtin fixes:
   `b`/`d`/`f`/`i` modifiers are accepted but not implemented; **`-k2,1` (stop <
   start)** sorts by field 2, but GNU treats the lower field as the stop boundary
   (sorts by field 1). (`tools/builtin/sort.rs`; spot-check 2026-06-24)
-- **`printf`**: `%b` doesn't honor `\c` (stop *all* output) at the whole-format
-  level; `%c` ignores width/flags. (`tools/builtin/format_string.rs`)
 - **`ls -1`**: the fix recovers `-1` by stripping a `Value::Int(-1)` positional,
   so `ls -- -1` (listing a file literally named `-1`) misfires and lists cwd
   instead. Rare; the real fix is lexing `-1` as a flag, not an int. (`$VAR=-1`
@@ -346,8 +336,6 @@ loses link-ness. Fix: teach `move_dir_recursive` to `lstat` children and
 `move_path`). Cross-mount only (same-mount uses atomic `rename`, already correct).
 
 ### Pre-release sweep — lower-frequency fidelity gaps (2026-06-23, verified)
-- **`cp -p`/`--preserve` parsed then discarded** (no mode/mtime preserve; VFS has no
-  attributes) — silent. (`tools/builtin/cp.rs`)
 - **`rm <empty-dir>` without `-r` silently removes it** (coreutils needs `-d`/`-r`);
   **`mkdir` is always `-p`-like** — `mkdir existing` → exit 0 (no "File exists"),
   `mkdir a/b/c` (no `-p`) creates the chain. (`tools/builtin/{rm,mkdir}.rs`)
@@ -431,10 +419,6 @@ Low-frequency, record-then-defer:
 - **head streaming-vs-buffered binary-stdin divergence**: the streaming path emits
   earlier valid lines downstream before erroring on a non-UTF-8 line (buffered
   emits nothing) and uses a different message. Both loud; cosmetic.
-- **sed `-e <numeric>` is dropped**: `collect_expressions` only matches string
-  values, so `sed -e 5 -e 's/a/b/'` silently ignores the `5`. Loud when it's the
-  only `-e` (empty expr list), silent when mixed. `-e 5` isn't valid sed anyway;
-  coerce non-string values to string (or reject loudly). (0.9.0 review, 2026-06-18.)
 
 ### `GlobPath::walk_match` globstar recursion has no work bound
 `walk_match`/`match_segments` backtrack on globstar with no `MAX_MATCH_CALLS` guard
@@ -556,8 +540,6 @@ Revisit when the first external tool bundle wants unit tests.
 - **Backticks inside double-quotes and heredoc bodies are silently literal** — bare
   backticks are a loud lexer error, but quoted/heredoc ones slip through
   `parse_string_literal`. Should reject with the same `$(cmd)` hint. (`lexer.rs`)
-- **Unterminated arithmetic `$(( 1 + 2`** reaches EOF and is silently evaluated as `3`
-  instead of erroring. (`lexer.rs` `preprocess_arithmetic`)
 - **Comment `#` mid-word truncates** — `echo http://x/#frag` → `http://x/`, `echo a#b`
   → `a`; any `#` outside double-quotes starts a comment with no word-boundary check.
   (`lexer.rs`)

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -396,8 +396,8 @@ loses link-ness. Fix: teach `move_dir_recursive` to `lstat` children and
 Low-frequency, record-then-defer:
 - **sed `p` / `s///p` in non-quiet mode** suppress the auto-print → one print where
   GNU/POSIX print twice (invisible in tests — all `p` tests use `-n`).
-- **sed `s///0`** silently treated as first-match (GNU errors); **empty `//`**
-  compiles an always-match regex instead of reusing the last pattern.
+- **sed empty `//`** compiles an always-match regex instead of reusing the last
+  pattern (needs runtime last-regex state, not a parse-time fix).
 - **awk `"1e"` → 0** (partial-exponent parse + `unwrap_or(0.0)`); **`FILENAME`
   always empty**; **`RS=""` paragraph mode** splits on exactly `"\n\n"`; **`OFMT`
   ignored** (hardcoded `%.6g`).


### PR DESCRIPTION
Five cheap, contained fidelity residuals folded in ahead of the 0.10.0 release. Each turns a **silently-wrong** behavior into a loud error or correct output — the kaish standard (crashing > silent corruption). Reviewed by kaibo (deepseek cast): all correct, no regressions, no missed call paths.

## Fixes

- **sed `-e <number>` → loud.** `collect_expressions` was string-only, so a numeric `-e` (e.g. `sed -e 5`, bound as a JSON Number in the accumulated array) was silently dropped — which once let the *filename* be parsed as the program. Now returns a `Result` and rejects a non-string expression with exit 2. `validate()` stays lenient so `execute()` is the single authoritative message.
- **sed `s///0` → loud.** The zero occurrence flag ("replace the 0th match") was silently treated as the first match; GNU sed errors. Guarded in `parse_substitute`. Valid forms (`s///2`, `s///g`, `s///2g`) unaffected.
- **cp `-p`/`--preserve` → rejected.** Was a clap field parsed then discarded — a silent no-op on a flag the user asked for, and a lie in `help cp`. Deleted the field; clap now rejects `-p` as unknown (exit 2). The VFS has no mode/mtime/ownership to preserve. **BREAKING:** `cp -p` previously exited 0 (copying, ignoring `-p`); it now exits 2.
- **Unterminated `$(( …` → loud.** The preprocessor collected to EOF and silently evaluated the partial expression (`$(( 1 + 2` → `3`). Now tracks a `closed` flag and returns a new `LexerError::UnterminatedArithmetic` when `))` is never found.
- **printf `%c` width + `%b` `\c` stop.** `%c` ignored width/flags (now routes through `apply_string_padding`); `%b`'s `\c` only truncated its own argument instead of stopping all output (the stop now propagates through `apply_specifier`/`format_pass`/cycling, and a `\c` in the format literal stops too).

## Also

- Removes the now-stale `issues.md` "glued repeatable short-flag overwrites" entry — `bind_glued_short_value` already routes repeatable flags through `push_repeatable_value` (verified).
- CHANGELOG backfills landed-but-unbulletted #35/#36 items (file-test tilde, `<<-` tabs, export-in-function, jq integral number formatting + null-index).

## Tests

`crates/kaish-kernel/tests/pre_0_10_fidelity_tests.rs` — 10 kernel-routed regression tests (positive + negative). `cargo test --all` and `cargo clippy --all --all-targets` both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)