### PR TITLE
feat: rg-style file-type filtering for grep + glob (--ftype, --max-count, --hidden)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ breaking entries are marked **BREAKING**.
   TYPE→globs table (works with `--json`); no pattern required.
 - **`grep --hidden`** — include dotfiles/dot-directories in the recursive walk
   (off by default, bash no-dotglob semantics).
+- **`grep --max-count <N>`** — stop after N matching lines per file (GNU
+  semantics; `--max-count 0` matches nothing). Streaming single-file and piped
+  searches stop reading once the cap is hit, so it bounds work on large inputs.
 
 ### Fixed
 - **`sed -e <number>` is a loud error, not a silent drop.** A non-string `-e`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ breaking entries are marked **BREAKING**.
 
 ## [Unreleased]
 
+### Added
+- **`grep --ftype <NAME>` / `--ftype-not <NAME>`** — filter the recursive (`-r`)
+  walk to (or away from) a named file type, e.g. `grep -r needle . --ftype rust`
+  (searches `*.rs`). Both are repeatable. `--ftype` is the kaish-wide file-type
+  filter (distinct from file/dir *entry-kind*). An unknown type name is a loud
+  exit-2 error, never a silent empty match.
+- **`grep --ftype-list`** — print the known file types and their globs as a
+  TYPE→globs table (works with `--json`); no pattern required.
+- **`grep --hidden`** — include dotfiles/dot-directories in the recursive walk
+  (off by default, bash no-dotglob semantics).
+
 ### Fixed
 - **`sed -e <number>` is a loud error, not a silent drop.** A non-string `-e`
   expression (e.g. `sed -e 5`) now exits 2 with a usage error instead of being

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@ breaking entries are marked **BREAKING**.
 - **`grep --max-count <N>`** — stop after N matching lines per file (GNU
   semantics; `--max-count 0` matches nothing). Streaming single-file and piped
   searches stop reading once the cap is hit, so it bounds work on large inputs.
+- **`glob --ftype <NAME>` / `--ftype-not <NAME>` / `--ftype-list`** — the same
+  file-type filtering on `glob`, sharing grep's type registry. `--ftype` (rg-style
+  file type, by extension) is distinct from glob's existing `-t`/`--type` (entry
+  *kind*: file/dir); the two compose. A file-type filter narrows files only —
+  directories pass it untouched. Unknown type → loud exit 2.
 
 ### Fixed
 - **`sed -e <number>` is a loud error, not a silent drop.** A non-string `-e`

--- a/crates/kaish-glob/src/file_types.rs
+++ b/crates/kaish-glob/src/file_types.rs
@@ -1,0 +1,114 @@
+//! rg-style file-type filtering — the `--ftype` surface shared by search builtins.
+//!
+//! Wraps `ignore::types` so kaish's search builtins (`grep`, `glob`) share one
+//! file-type model and one source of type names. `--ftype rust` selects `*.rs`;
+//! `--ftype-not rust` excludes it; `--ftype-list` enumerates the known types.
+//!
+//! `--ftype` is the kaish-wide convention for file-type filtering (distinct from
+//! glob's `-t`/`--type`, which is *entry kind* — file/dir/symlink, the fd convention).
+
+use std::sync::Arc;
+
+use ignore::types::{Types, TypesBuilder};
+use thiserror::Error;
+
+/// Failure building a file-type filter from `--ftype`/`--ftype-not` names.
+#[derive(Debug, Error)]
+pub enum FileTypeError {
+    /// A requested type name isn't one of the known definitions. Loud by
+    /// design — `--ftype nonsense` must fail, never silently match nothing.
+    #[error("unknown file type '{0}' (see --ftype-list)")]
+    UnknownType(String),
+    /// A type definition's glob failed to compile. Shouldn't happen with the
+    /// built-in defaults; surfaced rather than swallowed.
+    #[error("file-type filter error: {0}")]
+    Build(String),
+}
+
+/// Build a file-type filter from rg-style type names.
+///
+/// Returns `Ok(None)` when both lists are empty (no filtering configured).
+/// `select` is a whitelist (only matching files pass); `negate` excludes
+/// matching files; both may be combined per ripgrep semantics. Unknown names
+/// are an error — never a silent empty match.
+///
+/// The returned `Types` goes straight into `WalkOptions::types`; the walker
+/// applies it per-file and leaves directories untraversed-through (a `Types`
+/// match on a directory is always `None`, so traversal is unaffected).
+pub fn build_file_types(
+    select: &[String],
+    negate: &[String],
+) -> Result<Option<Arc<Types>>, FileTypeError> {
+    if select.is_empty() && negate.is_empty() {
+        return Ok(None);
+    }
+    let mut builder = TypesBuilder::new();
+    builder.add_defaults();
+    for name in select {
+        builder.select(name);
+    }
+    for name in negate {
+        builder.negate(name);
+    }
+    match builder.build() {
+        Ok(types) => Ok(Some(Arc::new(types))),
+        Err(ignore::Error::UnrecognizedFileType(name)) => Err(FileTypeError::UnknownType(name)),
+        Err(other) => Err(FileTypeError::Build(other.to_string())),
+    }
+}
+
+/// All known file-type definitions as `(name, globs)` rows, for `--ftype-list`.
+///
+/// Sorted by name (the `ignore` crate sorts definitions and their globs).
+pub fn list_file_types() -> Vec<(String, Vec<String>)> {
+    let mut builder = TypesBuilder::new();
+    builder.add_defaults();
+    builder
+        .definitions()
+        .into_iter()
+        .map(|def| (def.name().to_string(), def.globs().to_vec()))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_lists_mean_no_filter() {
+        assert!(build_file_types(&[], &[]).expect("ok").is_none());
+    }
+
+    #[test]
+    fn select_known_type_builds() {
+        let types = build_file_types(&["rust".to_string()], &[]).expect("ok");
+        assert!(types.is_some());
+    }
+
+    #[test]
+    fn negate_known_type_builds() {
+        let types = build_file_types(&[], &["rust".to_string()]).expect("ok");
+        assert!(types.is_some());
+    }
+
+    #[test]
+    fn unknown_type_is_loud() {
+        let err = build_file_types(&["definitely-not-a-type".to_string()], &[])
+            .expect_err("unknown type must error");
+        assert!(
+            matches!(err, FileTypeError::UnknownType(ref name) if name == "definitely-not-a-type"),
+            "got {err:?}",
+        );
+    }
+
+    #[test]
+    fn list_is_nonempty_and_maps_rust_to_rs() {
+        let defs = list_file_types();
+        assert!(!defs.is_empty());
+        let (_, globs) = defs
+            .iter()
+            .find(|(name, _)| name == "rust")
+            .expect("rust type must be defined");
+        assert!(globs.iter().any(|g| g == "*.rs"), "rust globs: {globs:?}");
+    }
+}

--- a/crates/kaish-glob/src/lib.rs
+++ b/crates/kaish-glob/src/lib.rs
@@ -10,6 +10,7 @@
 //! The walker is generic over `WalkerFs`, a minimal read-only filesystem trait.
 //! Consumers implement `WalkerFs` to adapt their own filesystem abstraction.
 
+pub mod file_types;
 mod filter;
 pub mod filetype;
 pub mod glob;
@@ -17,6 +18,7 @@ mod glob_path;
 mod ignore;
 mod walker;
 
+pub use file_types::{build_file_types, list_file_types, FileTypeError};
 pub use filetype::{classify, detect, looks_like_text, Category, FileType, SNIFF_PREFIX_LEN};
 pub use filter::{FilterResult, IncludeExclude};
 pub use glob::{contains_glob, expand_braces, glob_match};

--- a/crates/kaish-kernel/src/lib.rs
+++ b/crates/kaish-kernel/src/lib.rs
@@ -51,8 +51,9 @@ pub mod glob {
 /// Recursive file walking infrastructure (re-exported from kaish-glob).
 pub mod walker {
     pub use kaish_glob::{
-        EntryTypes, FileWalker, FilterResult, GlobPath, IgnoreFilter, IncludeExclude,
-        PathSegment, PatternError, WalkOptions, WalkerDirEntry, WalkerError, WalkerFs,
+        build_file_types, list_file_types, EntryTypes, FileTypeError, FileWalker, FilterResult,
+        GlobPath, IgnoreFilter, IncludeExclude, PathSegment, PatternError, WalkOptions,
+        WalkerDirEntry, WalkerError, WalkerFs,
     };
     pub use crate::backend_walker_fs::BackendWalkerFs;
 }

--- a/crates/kaish-kernel/src/tools/builtin/glob.rs
+++ b/crates/kaish-kernel/src/tools/builtin/glob.rs
@@ -6,8 +6,11 @@ use clap::{CommandFactory, Parser};
 use crate::ast::Value;
 use crate::backend_walker_fs::BackendWalkerFs;
 use crate::interpreter::{EntryType, ExecResult, OutputData, OutputNode};
+use crate::tools::builtin::read_repeatable_strings;
 use crate::tools::{schema_from_clap, ExecContext, ToolCtx, GlobalFlags, Tool, ToolArgs, ToolSchema};
-use crate::walker::{EntryTypes, FileWalker, GlobPath, IncludeExclude, WalkOptions};
+use crate::walker::{
+    build_file_types, list_file_types, EntryTypes, FileWalker, GlobPath, IncludeExclude, WalkOptions,
+};
 
 /// Glob tool: expand glob patterns to matching file paths.
 pub struct Glob;
@@ -31,6 +34,20 @@ struct GlobArgs {
     /// Entry type: f=files, d=dirs, a=all.
     #[arg(id = "type", short = 't', long = "type")]
     type_: Option<String>,
+
+    /// Filter to files of the given type(s), e.g. `--ftype rust`. Repeatable.
+    /// File-type (rg-style, by extension) — distinct from `-t`/`--type`, which
+    /// is *entry kind* (file/dir). See `--ftype-list`.
+    #[arg(long = "ftype")]
+    ftype: Vec<String>,
+
+    /// Exclude files of the given type(s). Repeatable.
+    #[arg(long = "ftype-not")]
+    ftype_not: Vec<String>,
+
+    /// List known file types (TYPE → globs) and exit. No pattern needed.
+    #[arg(long = "ftype-list")]
+    ftype_list: bool,
 
     /// Null-separated output.
     #[arg(short = '0', long = "null")]
@@ -89,6 +106,26 @@ impl Tool for Glob {
             Err(e) => return ExecResult::failure(2, format!("glob: {e}")),
         };
         parsed.global.apply(ctx);
+
+        // `--ftype-list`: emit the TYPE→globs table and exit, no pattern needed.
+        if parsed.ftype_list {
+            let rows: Vec<OutputNode> = list_file_types()
+                .into_iter()
+                .map(|(name, globs)| OutputNode::new(&name).with_cells(vec![globs.join(", ")]))
+                .collect();
+            let table = OutputData::table(vec!["TYPE".to_string(), "GLOBS".to_string()], rows);
+            return ExecResult::with_output(table);
+        }
+
+        // Build the rg-style file-type filter from `--ftype`/`--ftype-not`.
+        // Repeatable value flags arrive as `Json(Array)`; read them off the raw
+        // args (shared with grep). An unknown type name is loud (exit 2).
+        let ftype_select = read_repeatable_strings(&args, "ftype");
+        let ftype_negate = read_repeatable_strings(&args, "ftype-not");
+        let file_types = match build_file_types(&ftype_select, &ftype_negate) {
+            Ok(t) => t,
+            Err(e) => return ExecResult::failure(2, format!("glob: {e}")),
+        };
 
         // Get the pattern
         let pattern = match args.get_string("pattern", 0) {
@@ -185,6 +222,7 @@ impl Tool for Glob {
             respect_gitignore: if no_ignore { false } else { ctx.ignore_config.auto_gitignore() },
             include_hidden,
             filter,
+            types: file_types.clone(),
             ..WalkOptions::default()
         };
 

--- a/crates/kaish-kernel/src/tools/builtin/grep.rs
+++ b/crates/kaish-kernel/src/tools/builtin/grep.rs
@@ -131,6 +131,10 @@ struct GrepArgs {
     #[arg(long = "hidden")]
     hidden: bool,
 
+    /// Stop after NUM matching lines per file (GNU `--max-count`).
+    #[arg(long = "max-count")]
+    max_count: Option<String>,
+
     #[command(flatten)]
     global: GlobalFlags,
 
@@ -326,6 +330,14 @@ impl Tool for Grep {
             Err(e) => return ExecResult::failure(1, format!("grep: invalid pattern: {}", e)),
         };
 
+        // `--max-count N`: stop after N matching lines per file (GNU semantics).
+        // `--max-count 0` matches nothing. A non-numeric value is a loud usage
+        // error, reusing the same parser as the context flags.
+        let max_count = match parse_context("--max-count", &parsed.max_count) {
+            Ok(c) => c,
+            Err(e) => return ExecResult::failure(2, e),
+        };
+
         let grep_opts = GrepOptions {
             show_line_numbers: line_number,
             invert,
@@ -336,6 +348,7 @@ impl Tool for Grep {
             multiline,
             encoding: encoding.clone(),
             binary_detection,
+            max_count,
         };
 
         // Handle recursive search
@@ -432,7 +445,7 @@ impl Tool for Grep {
             if let (Some(pipe_stdin), Some(pipe_stdout)) =
                 (ctx.pipe_stdin.take(), ctx.pipe_stdout.take())
             {
-                return self.stream_grep(ctx, pipe_stdin, pipe_stdout, &regex, invert, line_number).await;
+                return self.stream_grep(ctx, pipe_stdin, pipe_stdout, &regex, invert, line_number, max_count).await;
             }
         }
 
@@ -450,8 +463,14 @@ impl Tool for Grep {
                 "none" | "text" | "without-match" => None,
                 _ => Some(b'\x00'),
             };
-            let mut scanner =
-                GrepLineScanner::new(&regex, invert, line_number, quit_byte, Some(path.clone()));
+            let mut scanner = GrepLineScanner::new(
+                &regex,
+                invert,
+                line_number,
+                quit_byte,
+                Some(path.clone()),
+                max_count,
+            );
             let scan_result = ctx
                 .read_file_chunked(
                     Path::new(&resolved),
@@ -459,9 +478,9 @@ impl Tool for Grep {
                     |chunk| {
                         scanner.push(chunk);
                         // Once the scanner has decided the file is binary (bad
-                        // UTF-8) or hit the quit byte, the rest of the file is
-                        // irrelevant — stop reading it.
-                        if scanner.saw_invalid_utf8 || scanner.stopped_early {
+                        // UTF-8), hit the quit byte, or reached --max-count, the
+                        // rest of the file is irrelevant — stop reading it.
+                        if scanner.saw_invalid_utf8 || scanner.stopped_early || scanner.hit_limit {
                             std::ops::ControlFlow::Break(())
                         } else {
                             std::ops::ControlFlow::Continue(())
@@ -596,6 +615,7 @@ impl Tool for Grep {
 
 impl Grep {
     /// Stream grep: read lines from pipe_stdin, write matching lines to pipe_stdout.
+    #[allow(clippy::too_many_arguments)]
     async fn stream_grep(
         &self,
         _ctx: &mut ExecContext,
@@ -604,6 +624,7 @@ impl Grep {
         regex: &regex::Regex,
         invert: bool,
         show_line_numbers: bool,
+        max_count: Option<usize>,
     ) -> ExecResult {
         use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 
@@ -621,6 +642,13 @@ impl Grep {
                     let matches = regex.is_match(line_buf.trim_end_matches('\n'));
                     let should_output = if invert { !matches } else { matches };
                     if should_output {
+                        // --max-count: stop before emitting the (N+1)th line.
+                        // `Some(0)` breaks before the first, matching nothing.
+                        if let Some(max) = max_count
+                            && match_count >= max
+                        {
+                            break;
+                        }
                         match_count += 1;
                         let output = if show_line_numbers {
                             format!("{}:{}", line_num, line_buf)
@@ -814,6 +842,13 @@ struct GrepLineScanner<'r> {
     /// Set to `true` when the `quit_byte` is encountered.  Scanning stops but
     /// the matched output collected so far is still returned (no error).
     stopped_early: bool,
+    /// `--max-count`: stop after this many emitted lines. `None` = no limit;
+    /// `Some(0)` emits nothing.
+    max_count: Option<usize>,
+    /// Set when `max_count` is reached. Like `stopped_early` it halts the chunk
+    /// reader, but — unlike a quit byte — it does *not* trigger the whole-buffer
+    /// re-read fallback (the cap is already honored by the scanner).
+    hit_limit: bool,
 }
 
 impl<'r> GrepLineScanner<'r> {
@@ -823,6 +858,7 @@ impl<'r> GrepLineScanner<'r> {
         show_line_numbers: bool,
         quit_byte: Option<u8>,
         path: Option<String>,
+        max_count: Option<usize>,
     ) -> Self {
         Self {
             regex,
@@ -839,6 +875,8 @@ impl<'r> GrepLineScanner<'r> {
             match_count: 0,
             saw_invalid_utf8: false,
             stopped_early: false,
+            max_count,
+            hit_limit: false,
         }
     }
 
@@ -846,7 +884,7 @@ impl<'r> GrepLineScanner<'r> {
     /// - Sets `saw_invalid_utf8 = true` on a genuinely bad UTF-8 byte (exit 2).
     /// - Sets `stopped_early = true` on a `quit_byte` (stop silently, no error).
     fn push(&mut self, chunk: &[u8]) {
-        if self.saw_invalid_utf8 || self.stopped_early {
+        if self.saw_invalid_utf8 || self.stopped_early || self.hit_limit {
             return;
         }
         // Honour BinaryDetection::quit(byte): stop at the first occurrence of
@@ -952,9 +990,22 @@ impl<'r> GrepLineScanner<'r> {
     }
 
     fn match_line(&mut self, line: &str, byte_offset: u64) {
+        if self.hit_limit {
+            return;
+        }
         let matches = self.regex.is_match(line);
         let should_output = if self.invert { !matches } else { matches };
         if !should_output {
+            return;
+        }
+
+        // --max-count: don't emit beyond the cap. `Some(0)` stops before the
+        // first match. Flagging `hit_limit` halts the chunk reader after this
+        // chunk (without the quit-byte whole-buffer fallback).
+        if let Some(max) = self.max_count
+            && self.match_count >= max
+        {
+            self.hit_limit = true;
             return;
         }
 
@@ -1030,6 +1081,9 @@ struct GrepOptions {
     /// auto-detect via BOM sniffing.
     encoding: Option<String>,
     binary_detection: BinaryDetection,
+    /// Stop after this many matching lines (GNU `--max-count`). `None` = no
+    /// limit; `Some(0)` matches nothing.
+    max_count: Option<usize>,
 }
 
 /// Search bytes via grep-searcher and return the rendered output bundle.
@@ -1111,6 +1165,17 @@ fn render_events(events: &[SearchEvent], opts: &GrepOptions, filename: Option<&s
     let mut emitted_any = false;
 
     for event in events {
+        // Honor --max-count: once N matching lines are emitted, stop. Trailing
+        // after-context of the Nth match still flows (a new match or a group
+        // break ends emission), matching GNU `grep -m N -A k`.
+        if let Some(max) = opts.max_count
+            && match_count >= max
+        {
+            match event {
+                SearchEvent::Context(c) if matches!(c.kind, ContextKind::After) => {}
+                _ => break,
+            }
+        }
         match event {
             SearchEvent::Match(m) => {
                 let line_num = m.line_number.unwrap_or(0);
@@ -1859,6 +1924,7 @@ mod tests {
             multiline: false,
             encoding: None,
             binary_detection: BinaryDetection::quit(b'\x00'),
+            max_count: None,
         };
         grep_lines_structured(content, &matcher, &opts, path).unwrap()
     }
@@ -1873,7 +1939,7 @@ mod tests {
     ) -> (RenderResult, bool) {
         let regex = regex::RegexBuilder::new(pattern).build().unwrap();
         let mut scanner =
-            GrepLineScanner::new(&regex, false, line_numbers, Some(b'\x00'), path.map(str::to_string));
+            GrepLineScanner::new(&regex, false, line_numbers, Some(b'\x00'), path.map(str::to_string), None);
         for chunk in content.chunks(chunk_size.max(1)) {
             scanner.push(chunk);
         }
@@ -1885,7 +1951,7 @@ mod tests {
     /// Convenience wrapper used by the binary/quit tests.
     fn scanner_grep(content: &[u8], pattern: &str, invert: bool, line_numbers: bool, chunk_size: usize) -> (String, usize, bool) {
         let regex = regex::RegexBuilder::new(pattern).build().unwrap();
-        let mut scanner = GrepLineScanner::new(&regex, invert, line_numbers, Some(b'\x00'), None);
+        let mut scanner = GrepLineScanner::new(&regex, invert, line_numbers, Some(b'\x00'), None, None);
         for chunk in content.chunks(chunk_size) {
             scanner.push(chunk);
         }
@@ -2124,7 +2190,7 @@ mod tests {
         // Use read_file_chunked directly with a small chunk to force multiple reads.
         let regex = regex::Regex::new("line").unwrap();
         let mut scanner =
-            GrepLineScanner::new(&regex, false, false, Some(b'\x00'), Some("/big.txt".to_string()));
+            GrepLineScanner::new(&regex, false, false, Some(b'\x00'), Some("/big.txt".to_string()), None);
         ctx.read_file_chunked(Path::new("/big.txt"), 256, |c| {
             scanner.push(c);
             std::ops::ControlFlow::Continue(())

--- a/crates/kaish-kernel/src/tools/builtin/grep.rs
+++ b/crates/kaish-kernel/src/tools/builtin/grep.rs
@@ -16,6 +16,7 @@ use crate::ast::Value;
 use crate::backend_walker_fs::BackendWalkerFs;
 use crate::interpreter::{ExecResult, OutputData, OutputNode};
 use crate::tools::builtin::grep_engine::{AccumulatorSink, ContextKind, SearchEvent};
+use crate::tools::builtin::read_repeatable_strings;
 use crate::tools::{schema_from_clap, ExecContext, ToolCtx, GlobalFlags, Tool, ToolArgs, ToolSchema, validate_against_schema};
 use crate::validator::{IssueCode, ValidationIssue};
 use crate::walker::{
@@ -142,25 +143,6 @@ struct GrepArgs {
     pattern: Vec<String>,
 }
 
-/// Read a repeatable string-valued flag off the raw args.
-///
-/// Repeatable value flags (clap `Append`) are accumulated by the kernel into a
-/// `Value::Json(Array)` under the flag's long name; a single occurrence may
-/// arrive as a bare `Value::String`. Mirrors sed's `collect_expressions` — see
-/// the repeatable-flag gotcha in `arch_repeatable_flags`. `to_argv()` can't
-/// round-trip the array, so the clap field isn't a reliable source.
-fn read_string_list(args: &ToolArgs, key: &str) -> Vec<String> {
-    match args.named.get(key) {
-        Some(Value::Json(serde_json::Value::Array(items))) => items
-            .iter()
-            .filter_map(|v| v.as_str().map(|s| s.to_string()))
-            .collect(),
-        Some(Value::String(s)) => vec![s.clone()],
-        Some(other) => vec![crate::interpreter::value_to_string(other)],
-        None => Vec::new(),
-    }
-}
-
 #[async_trait]
 impl Tool for Grep {
     fn name(&self) -> &str {
@@ -235,8 +217,8 @@ impl Tool for Grep {
         // unknown type name is loud (exit 2), never a silent empty match. The
         // filter only takes effect on the `-r` walk below, but we validate the
         // names here regardless so a typo is caught on any invocation.
-        let ftype_select = read_string_list(&args, "ftype");
-        let ftype_negate = read_string_list(&args, "ftype-not");
+        let ftype_select = read_repeatable_strings(&args, "ftype");
+        let ftype_negate = read_repeatable_strings(&args, "ftype-not");
         let file_types = match build_file_types(&ftype_select, &ftype_negate) {
             Ok(t) => t,
             Err(e) => return ExecResult::failure(2, format!("grep: {e}")),

--- a/crates/kaish-kernel/src/tools/builtin/grep.rs
+++ b/crates/kaish-kernel/src/tools/builtin/grep.rs
@@ -18,7 +18,9 @@ use crate::interpreter::{ExecResult, OutputData, OutputNode};
 use crate::tools::builtin::grep_engine::{AccumulatorSink, ContextKind, SearchEvent};
 use crate::tools::{schema_from_clap, ExecContext, ToolCtx, GlobalFlags, Tool, ToolArgs, ToolSchema, validate_against_schema};
 use crate::validator::{IssueCode, ValidationIssue};
-use crate::walker::{FileWalker, GlobPath, IncludeExclude, WalkOptions};
+use crate::walker::{
+    build_file_types, list_file_types, FileWalker, GlobPath, IncludeExclude, WalkOptions,
+};
 
 /// Grep tool: search for patterns in text.
 pub struct Grep;
@@ -110,11 +112,49 @@ struct GrepArgs {
     #[arg(long = "binary")]
     binary: Option<String>,
 
+    /// Filter the recursive walk to files of the given type(s), e.g.
+    /// `--ftype rust`. Repeatable. `--ftype` is the kaish-wide file-type
+    /// filter (see `--ftype-list`).
+    #[arg(long = "ftype")]
+    ftype: Vec<String>,
+
+    /// Exclude files of the given type(s) from the recursive walk. Repeatable.
+    #[arg(long = "ftype-not")]
+    ftype_not: Vec<String>,
+
+    /// List known file types (TYPE → globs) and exit. No pattern needed.
+    #[arg(long = "ftype-list")]
+    ftype_list: bool,
+
+    /// Include hidden files and directories (dotfiles) in the recursive walk.
+    /// Off by default; applies to `-r` only.
+    #[arg(long = "hidden")]
+    hidden: bool,
+
     #[command(flatten)]
     global: GlobalFlags,
 
     /// Pattern to search for, followed by optional file paths.
     pattern: Vec<String>,
+}
+
+/// Read a repeatable string-valued flag off the raw args.
+///
+/// Repeatable value flags (clap `Append`) are accumulated by the kernel into a
+/// `Value::Json(Array)` under the flag's long name; a single occurrence may
+/// arrive as a bare `Value::String`. Mirrors sed's `collect_expressions` — see
+/// the repeatable-flag gotcha in `arch_repeatable_flags`. `to_argv()` can't
+/// round-trip the array, so the clap field isn't a reliable source.
+fn read_string_list(args: &ToolArgs, key: &str) -> Vec<String> {
+    match args.named.get(key) {
+        Some(Value::Json(serde_json::Value::Array(items))) => items
+            .iter()
+            .filter_map(|v| v.as_str().map(|s| s.to_string()))
+            .collect(),
+        Some(Value::String(s)) => vec![s.clone()],
+        Some(other) => vec![crate::interpreter::value_to_string(other)],
+        None => Vec::new(),
+    }
 }
 
 #[async_trait]
@@ -172,6 +212,32 @@ impl Tool for Grep {
             Err(e) => return ExecResult::failure(2, format!("grep: {e}")),
         };
         parsed.global.apply(ctx);
+
+        // `--ftype-list` is a pure info query: emit the TYPE→globs table and
+        // exit, no pattern required.
+        if parsed.ftype_list {
+            let rows: Vec<OutputNode> = list_file_types()
+                .into_iter()
+                .map(|(name, globs)| OutputNode::new(&name).with_cells(vec![globs.join(", ")]))
+                .collect();
+            let table = OutputData::table(vec!["TYPE".to_string(), "GLOBS".to_string()], rows);
+            return ExecResult::with_output(table);
+        }
+
+        // Build the file-type filter from `--ftype`/`--ftype-not`. Repeatable
+        // value flags arrive as `Json(Array)` (or a bare `String` for one) —
+        // read them off the raw args like sed's `-e`, since `to_argv()` can't
+        // round-trip a repeatable array back through the clap re-parse. An
+        // unknown type name is loud (exit 2), never a silent empty match. The
+        // filter only takes effect on the `-r` walk below, but we validate the
+        // names here regardless so a typo is caught on any invocation.
+        let ftype_select = read_string_list(&args, "ftype");
+        let ftype_negate = read_string_list(&args, "ftype-not");
+        let file_types = match build_file_types(&ftype_select, &ftype_negate) {
+            Ok(t) => t,
+            Err(e) => return ExecResult::failure(2, format!("grep: {e}")),
+        };
+        let include_hidden = parsed.hidden;
 
         let pattern = match args.get_string("pattern", 0) {
             Some(p) => p,
@@ -299,8 +365,9 @@ impl Tool for Grep {
                 max_depth: None,
                 entry_types: crate::walker::EntryTypes::files_only(),
                 respect_gitignore: ctx.ignore_config.auto_gitignore(),
-                include_hidden: false,
+                include_hidden,
                 filter,
+                types: file_types.clone(),
                 ..WalkOptions::default()
             };
 

--- a/crates/kaish-kernel/src/tools/builtin/grep.rs
+++ b/crates/kaish-kernel/src/tools/builtin/grep.rs
@@ -948,8 +948,14 @@ impl<'r> GrepLineScanner<'r> {
 
     /// Flush the remaining carry as the final (unterminated) line.
     /// Sets `saw_invalid_utf8` if the remaining bytes are genuinely invalid UTF-8.
+    ///
+    /// `hit_limit` short-circuits like `stopped_early`: once `--max-count` is
+    /// reached the reader stops mid-file, so the leftover carry may be a UTF-8
+    /// multibyte sequence we *artificially* truncated at a chunk boundary.
+    /// Validating it would raise a spurious "binary data" exit-2 and clobber a
+    /// correct capped result — so don't.
     fn finish(&mut self) {
-        if self.saw_invalid_utf8 || self.stopped_early || self.carry.is_empty() {
+        if self.saw_invalid_utf8 || self.stopped_early || self.hit_limit || self.carry.is_empty() {
             return;
         }
         match std::str::from_utf8(&self.carry) {
@@ -2198,5 +2204,29 @@ mod tests {
         let render = scanner.into_render_result();
         // All 40 lines match "line".
         assert_eq!(render.match_count, 40, "expected 40 matches");
+    }
+
+    /// Regression (DeepSeek review, 2026-06-28): when `--max-count` is hit and
+    /// the reader stops mid-file at a chunk boundary that splits a UTF-8
+    /// multibyte sequence, the artificially truncated carry must NOT be reported
+    /// as binary data. Before the `finish()` `hit_limit` guard, the leftover
+    /// `\xC3` (lead byte of `é`) was validated and raised a spurious exit-2 over
+    /// a correct 2-match result.
+    #[test]
+    fn max_count_does_not_flag_truncated_multibyte_carry() {
+        let regex = regex::Regex::new("m").unwrap();
+        let mut scanner = GrepLineScanner::new(&regex, false, false, Some(b'\x00'), None, Some(2));
+        // 3 matching lines (cap is 2) then a lone UTF-8 lead byte with no
+        // continuation — in production the reader stops here because the cap was
+        // hit, so the continuation byte is never fed.
+        scanner.push(b"m\nm\nm\n\xC3");
+        assert!(scanner.hit_limit, "cap of 2 must be reached");
+        scanner.finish();
+        assert!(
+            !scanner.saw_invalid_utf8,
+            "a truncated-at-cap carry must not be flagged as binary",
+        );
+        let render = scanner.into_render_result();
+        assert_eq!(render.match_count, 2, "exactly the capped number of matches");
     }
 }

--- a/crates/kaish-kernel/src/tools/builtin/mod.rs
+++ b/crates/kaish-kernel/src/tools/builtin/mod.rs
@@ -100,6 +100,27 @@ mod xxd;
 
 use super::ToolRegistry;
 
+/// Read a repeatable string-valued flag off the raw `ToolArgs`.
+///
+/// Repeatable value flags (clap `Append`) are accumulated by the kernel into a
+/// `Value::Json(Array)` under the flag's long name; a single occurrence may
+/// arrive as a bare `Value::String`. `to_argv()` can't round-trip the array, so
+/// the clap field isn't a reliable source — search builtins read the raw args
+/// here. Shared by grep/glob `--ftype`/`--ftype-not`; mirrors sed's
+/// `collect_expressions` (see the repeatable-flag gotcha in `arch_repeatable_flags`).
+pub(crate) fn read_repeatable_strings(args: &super::ToolArgs, key: &str) -> Vec<String> {
+    use crate::ast::Value;
+    match args.named.get(key) {
+        Some(Value::Json(serde_json::Value::Array(items))) => items
+            .iter()
+            .filter_map(|v| v.as_str().map(|s| s.to_string()))
+            .collect(),
+        Some(Value::String(s)) => vec![s.clone()],
+        Some(other) => vec![crate::interpreter::value_to_string(other)],
+        None => Vec::new(),
+    }
+}
+
 /// Register all built-in tools with the registry.
 pub fn register_builtins(registry: &mut ToolRegistry) {
     registry.register(alias::Alias);

--- a/crates/kaish-kernel/tests/glob_search_features_tests.rs
+++ b/crates/kaish-kernel/tests/glob_search_features_tests.rs
@@ -1,0 +1,120 @@
+//! Kernel-routed tests for glob's file-type features: `--ftype` /
+//! `--ftype-not` / `--ftype-list`, plus a regression that glob's existing
+//! `-t` (entry-kind, fd-style) still works alongside the new file-type axis.
+//!
+//! Shares the `kaish-glob::build_file_types` engine with grep; these pin the
+//! glob *surface*.
+
+// Test-fixture code: unwrap/expect on known-good setup is the idiom here.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+#![cfg(feature = "localfs")]
+
+mod common;
+
+use std::fs;
+use tempfile::tempdir;
+
+use common::{kernel_at, run};
+
+fn mixed_tree(dir: &std::path::Path) {
+    fs::write(dir.join("main.rs"), "fn main() {}\n").expect("write rs");
+    fs::write(dir.join("util.py"), "x = 1\n").expect("write py");
+    fs::write(dir.join("README.md"), "# doc\n").expect("write md");
+}
+
+#[tokio::test]
+async fn ftype_selects_only_that_type() {
+    let dir = tempdir().unwrap();
+    mixed_tree(dir.path());
+    let kernel = kernel_at(dir.path());
+
+    let (out, code) = run(&kernel, "glob '**/*' --ftype rust").await;
+    assert_eq!(code, 0, "out={out:?}");
+    assert!(out.contains("main.rs"), "rust file listed: {out:?}");
+    assert!(!out.contains("util.py"), "python filtered: {out:?}");
+    assert!(!out.contains("README.md"), "markdown filtered: {out:?}");
+}
+
+#[tokio::test]
+async fn ftype_not_excludes_that_type() {
+    let dir = tempdir().unwrap();
+    mixed_tree(dir.path());
+    let kernel = kernel_at(dir.path());
+
+    let (out, code) = run(&kernel, "glob '**/*' --ftype-not rust").await;
+    assert_eq!(code, 0, "out={out:?}");
+    assert!(!out.contains("main.rs"), "rust excluded: {out:?}");
+    assert!(out.contains("util.py"), "python remains: {out:?}");
+    assert!(out.contains("README.md"), "markdown remains: {out:?}");
+}
+
+#[tokio::test]
+async fn ftype_unknown_is_loud() {
+    let dir = tempdir().unwrap();
+    mixed_tree(dir.path());
+    let kernel = kernel_at(dir.path());
+
+    let result = kernel
+        .execute("glob '**/*' --ftype definitely-not-a-type")
+        .await
+        .expect("execute");
+    assert_eq!(result.code, 2, "unknown type → exit 2; out={:?}", result.text_out());
+    assert!(
+        result.err.contains("definitely-not-a-type") || result.err.contains("unknown file type"),
+        "error names the bad type: {:?}",
+        result.err
+    );
+}
+
+#[tokio::test]
+async fn ftype_list_emits_table() {
+    let dir = tempdir().unwrap();
+    let kernel = kernel_at(dir.path());
+
+    let (out, code) = run(&kernel, "glob --ftype-list").await;
+    assert_eq!(code, 0, "out={out:?}");
+    assert!(out.contains("rust"), "list includes rust: {out:?}");
+    assert!(out.contains("*.rs"), "list shows rust's globs: {out:?}");
+}
+
+/// Regression: glob's `-t` (entry-kind, fd-style) is untouched by the new
+/// file-type axis. `-t d` lists directories only.
+#[tokio::test]
+async fn entry_kind_dash_t_still_works() {
+    let dir = tempdir().unwrap();
+    fs::create_dir(dir.path().join("sub")).expect("mkdir");
+    fs::write(dir.path().join("sub/main.rs"), "fn main() {}\n").expect("write");
+    fs::write(dir.path().join("top.rs"), "fn x() {}\n").expect("write");
+    let kernel = kernel_at(dir.path());
+
+    let (out, code) = run(&kernel, "glob '**/*' -t d").await;
+    assert_eq!(code, 0, "out={out:?}");
+    assert!(out.contains("sub"), "directory listed: {out:?}");
+    assert!(!out.contains("main.rs"), "files excluded by -t d: {out:?}");
+    assert!(!out.contains("top.rs"), "files excluded by -t d: {out:?}");
+}
+
+/// `-t` (entry-kind) and `--ftype` (file-type) are independent flags, not
+/// aliases. A file-type filter narrows *files*; directories pass it untouched
+/// (the property that keeps recursive type-filtered walks traversable). So:
+/// - default entry-kind (files) + `--ftype rust` → only the rust file
+/// - `-t d` + `--ftype rust` → the directory still lists (ftype no-ops on dirs)
+#[tokio::test]
+async fn entry_kind_and_ftype_compose_independently() {
+    let dir = tempdir().unwrap();
+    fs::create_dir(dir.path().join("sub")).expect("mkdir");
+    fs::write(dir.path().join("main.rs"), "fn main() {}\n").expect("write");
+    let kernel = kernel_at(dir.path());
+
+    // Files of type rust: finds main.rs, not the directory.
+    let (files, fcode) = run(&kernel, "glob '**/*' --ftype rust").await;
+    assert_eq!(fcode, 0);
+    assert!(files.contains("main.rs"), "rust file found: {files:?}");
+    assert!(!files.contains("sub"), "dir not listed in files mode: {files:?}");
+
+    // Dirs-only + a file-type: the directory passes (ftype doesn't gate dirs).
+    let (dirs, dcode) = run(&kernel, "glob '**/*' -t d --ftype rust").await;
+    assert_eq!(dcode, 0, "dirs still list under a file-type filter: {dirs:?}");
+    assert!(dirs.contains("sub"), "directory passes the file-type filter: {dirs:?}");
+    assert!(!dirs.contains("main.rs"), "files excluded by -t d: {dirs:?}");
+}

--- a/crates/kaish-kernel/tests/grep_search_features_tests.rs
+++ b/crates/kaish-kernel/tests/grep_search_features_tests.rs
@@ -138,3 +138,67 @@ async fn hidden_flag_reaches_dotfiles() {
     assert!(out_h.contains(".env"), "--hidden must reach the dotfile: {out_h:?}");
     assert!(out_h.contains("visible.txt"), "visible still matches: {out_h:?}");
 }
+
+/// `--max-count N` caps a single-file search at N matching lines (the
+/// streaming-scanner path).
+#[tokio::test]
+async fn max_count_caps_single_file() {
+    let dir = tempdir().unwrap();
+    fs::write(dir.path().join("f.txt"), "x\nx\nx\nx\nx\n").expect("write");
+    let kernel = kernel_at(dir.path());
+
+    let (out, code) = run(&kernel, "grep --max-count 2 x f.txt").await;
+    assert_eq!(code, 0, "match expected; out={out:?}");
+    assert_eq!(out.lines().count(), 2, "must cap at 2 lines: {out:?}");
+}
+
+/// `--max-count 0` matches nothing and exits 1.
+#[tokio::test]
+async fn max_count_zero_matches_nothing() {
+    let dir = tempdir().unwrap();
+    fs::write(dir.path().join("f.txt"), "x\nx\nx\n").expect("write");
+    let kernel = kernel_at(dir.path());
+
+    let result = kernel.execute("grep --max-count 0 x f.txt").await.expect("execute");
+    assert_eq!(result.code, 1, "max-count 0 matches nothing → exit 1");
+    assert!(result.text_out().trim().is_empty(), "no output: {:?}", result.text_out());
+}
+
+/// `--max-count` combined with `-c` reports the capped count (whole-buffer
+/// path).
+#[tokio::test]
+async fn max_count_with_count_reports_capped() {
+    let dir = tempdir().unwrap();
+    fs::write(dir.path().join("f.txt"), "x\nx\nx\nx\nx\n").expect("write");
+    let kernel = kernel_at(dir.path());
+
+    let (out, code) = run(&kernel, "grep -c --max-count 2 x f.txt").await;
+    assert_eq!(code, 0, "out={out:?}");
+    assert_eq!(out.trim(), "2", "count must be capped to max-count: {out:?}");
+}
+
+/// `--max-count` is per-file under a recursive walk: two files of 5 matches
+/// each, capped at 2, yields 4 matching lines total.
+#[tokio::test]
+async fn max_count_is_per_file_when_recursive() {
+    let dir = tempdir().unwrap();
+    fs::write(dir.path().join("a.txt"), "x\nx\nx\nx\nx\n").expect("write a");
+    fs::write(dir.path().join("b.txt"), "x\nx\nx\nx\nx\n").expect("write b");
+    let kernel = kernel_at(dir.path());
+
+    let (out, code) = run(&kernel, "grep -r --max-count 2 x .").await;
+    assert_eq!(code, 0, "out={out:?}");
+    assert_eq!(out.lines().count(), 4, "2 per file across 2 files: {out:?}");
+}
+
+/// `--max-count` caps a piped (streaming-stdin) search.
+#[tokio::test]
+async fn max_count_caps_streaming_stdin() {
+    let dir = tempdir().unwrap();
+    let kernel = kernel_at(dir.path());
+
+    // seq 1..5 → grep '.' matches every line; cap at 2 keeps the first two.
+    let (out, code) = run(&kernel, "seq 5 | grep --max-count 2 .").await;
+    assert_eq!(code, 0, "out={out:?}");
+    assert_eq!(out.lines().count(), 2, "stdin stream capped at 2: {out:?}");
+}

--- a/crates/kaish-kernel/tests/grep_search_features_tests.rs
+++ b/crates/kaish-kernel/tests/grep_search_features_tests.rs
@@ -1,0 +1,140 @@
+//! Kernel-routed tests for grep's rg-style search features:
+//! `--ftype` / `--ftype-not` (file-type filtering), `--ftype-list`, and
+//! `--hidden`. Driven through `kernel.execute()` so flag binding, repeatable
+//! `Json(Array)` accumulation, and dispatch all run the real path.
+//!
+//! The walker engine (`WalkOptions.types`) is already unit-tested in
+//! kaish-glob; these pin the builtin *surface* — that the flags reach the
+//! walker, that an unknown type is loud, and that repeatable `--ftype` works.
+
+// Test-fixture code: unwrap/expect on known-good setup is the idiom here.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+#![cfg(feature = "localfs")]
+
+mod common;
+
+use std::fs;
+use tempfile::tempdir;
+
+use common::{kernel_at, run};
+
+/// A small mixed-language tree: every file contains the same needle so the
+/// only thing that varies a match is the file-type filter.
+fn mixed_tree(dir: &std::path::Path) {
+    fs::write(dir.join("main.rs"), "let needle = 1;\n").expect("write rs");
+    fs::write(dir.join("util.py"), "needle = 1\n").expect("write py");
+    fs::write(dir.join("README.md"), "the needle doc\n").expect("write md");
+}
+
+#[tokio::test]
+async fn ftype_rust_only_searches_rust_files() {
+    let dir = tempdir().unwrap();
+    mixed_tree(dir.path());
+    let kernel = kernel_at(dir.path());
+
+    let (out, code) = run(&kernel, "grep -r needle . --ftype rust").await;
+    assert_eq!(code, 0, "match expected; out={out:?}");
+    assert!(out.contains("main.rs"), "rust file must match: {out:?}");
+    assert!(!out.contains("util.py"), "python file must be filtered out: {out:?}");
+    assert!(!out.contains("README.md"), "markdown file must be filtered out: {out:?}");
+}
+
+#[tokio::test]
+async fn ftype_not_excludes_the_type() {
+    let dir = tempdir().unwrap();
+    mixed_tree(dir.path());
+    let kernel = kernel_at(dir.path());
+
+    let (out, code) = run(&kernel, "grep -r needle . --ftype-not rust").await;
+    assert_eq!(code, 0, "match expected; out={out:?}");
+    assert!(!out.contains("main.rs"), "rust file must be excluded: {out:?}");
+    assert!(out.contains("util.py"), "python file must remain: {out:?}");
+    assert!(out.contains("README.md"), "markdown file must remain: {out:?}");
+}
+
+/// Repeatable `--ftype` accumulates (the `Json(Array)` binder path), unioning
+/// the selected types.
+#[tokio::test]
+async fn ftype_repeatable_unions_types() {
+    let dir = tempdir().unwrap();
+    mixed_tree(dir.path());
+    let kernel = kernel_at(dir.path());
+
+    let (out, code) = run(&kernel, "grep -r needle . --ftype rust --ftype py").await;
+    assert_eq!(code, 0, "match expected; out={out:?}");
+    assert!(out.contains("main.rs"), "rust selected: {out:?}");
+    assert!(out.contains("util.py"), "python selected: {out:?}");
+    assert!(!out.contains("README.md"), "markdown not selected: {out:?}");
+}
+
+/// An unknown type name is a loud usage error (exit 2), never a silent empty
+/// match.
+#[tokio::test]
+async fn ftype_unknown_is_loud() {
+    let dir = tempdir().unwrap();
+    mixed_tree(dir.path());
+    let kernel = kernel_at(dir.path());
+
+    let result = kernel
+        .execute("grep -r needle . --ftype definitely-not-a-type")
+        .await
+        .expect("execute");
+    assert_eq!(result.code, 2, "unknown type must exit 2; out={:?}", result.text_out());
+    assert!(
+        result.err.contains("definitely-not-a-type") || result.err.contains("unknown file type"),
+        "error must name the bad type: {:?}",
+        result.err
+    );
+}
+
+/// `--ftype-list` emits the TYPE→globs table and exits 0 with no pattern.
+#[tokio::test]
+async fn ftype_list_emits_table() {
+    let dir = tempdir().unwrap();
+    let kernel = kernel_at(dir.path());
+
+    let (out, code) = run(&kernel, "grep --ftype-list").await;
+    assert_eq!(code, 0, "ftype-list must exit 0; out={out:?}");
+    assert!(out.contains("rust"), "list must include rust: {out:?}");
+    assert!(out.contains("*.rs"), "list must show rust's globs: {out:?}");
+}
+
+/// `--ftype-list` is valid JSON-shaped too (kernel `--json` path).
+#[tokio::test]
+async fn ftype_list_json_shape() {
+    let dir = tempdir().unwrap();
+    let kernel = kernel_at(dir.path());
+
+    let (out, code) = run(&kernel, "grep --ftype-list --json").await;
+    assert_eq!(code, 0, "out={out:?}");
+    let v: serde_json::Value = serde_json::from_str(&out).expect("valid json");
+    assert!(v.is_array(), "table --json is an array of rows: {out:?}");
+    let has_rust = v
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|row| row.get("TYPE").and_then(|t| t.as_str()) == Some("rust"));
+    assert!(has_rust, "rust row present: {out:?}");
+}
+
+/// `--hidden` reaches dotfiles in the recursive walk; without it they're
+/// skipped (bash no-dotglob default).
+#[tokio::test]
+async fn hidden_flag_reaches_dotfiles() {
+    let dir = tempdir().unwrap();
+    fs::write(dir.path().join(".env"), "needle=secret\n").expect("write dotfile");
+    fs::write(dir.path().join("visible.txt"), "needle plain\n").expect("write visible");
+    let kernel = kernel_at(dir.path());
+
+    // Default: dotfiles skipped.
+    let (out, code) = run(&kernel, "grep -r needle .").await;
+    assert_eq!(code, 0, "visible match expected; out={out:?}");
+    assert!(out.contains("visible.txt"), "visible file matches: {out:?}");
+    assert!(!out.contains(".env"), "dotfile skipped by default: {out:?}");
+
+    // --hidden: dotfiles included.
+    let (out_h, code_h) = run(&kernel, "grep -r needle . --hidden").await;
+    assert_eq!(code_h, 0, "out={out_h:?}");
+    assert!(out_h.contains(".env"), "--hidden must reach the dotfile: {out_h:?}");
+    assert!(out_h.contains("visible.txt"), "visible still matches: {out_h:?}");
+}

--- a/docs/NAMING.md
+++ b/docs/NAMING.md
@@ -35,6 +35,12 @@ The REPL calls these if defined. All are optional.
 
 The `kaish-` prefix on builtins signals "this is about the shell itself, not a general utility." Use it for tools that expose kernel state, inspect the runtime, or control kaish-specific features.
 
+### Shared flag conventions
+
+When a flag means the same thing across builtins, it gets one name everywhere — so an agent that learns it once is never wrong on another tool:
+
+- **`--ftype <NAME>` / `--ftype-not <NAME>` / `--ftype-list`** — rg-style *file-type* filtering (by extension/name, e.g. `--ftype rust` → `*.rs`), on every search builtin (`grep`, `glob`). Deliberately distinct from `-t`/`--type`, which on `find`/`glob` is *entry kind* (file/dir/symlink, the POSIX/fd convention) — two different axes, two names. A file-type filter narrows files only; directories pass it untouched.
+
 ## Style Rules
 
 - Full words, no abbreviations: `kaish_post_command` not `kaish_postcmd`

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -432,6 +432,19 @@ Low-frequency, record-then-defer:
 matches real FS paths; not a regression). If kaish ever matches user patterns
 against user-supplied path *strings*, add a call counter.
 
+### `--no-ignore` for the search builtins (deferred from search-features-port)
+The rg-features port (grep `--ftype`/`--hidden`/`--max-count`, glob `--ftype`)
+landed without `--no-ignore` on grep — the honest semantics of a per-call
+ignore-bypass under an embedder's `Enforced` scope (kaibo's preset) aren't
+designed yet: should an explicit user flag override the embedder's context-flood
+protection? That's an embedder-policy question, not a one-liner. Decide it once,
+then add `--no-ignore` across the search builtins consistently. **Related audit:**
+`glob`'s *existing* `--no-ignore` already bypasses the filter unconditionally,
+regardless of scope (`tools/builtin/glob.rs`) — confirm that's intended (vs.
+silently escaping `Enforced`) as part of the same design. Note: ignore is
+context-control, not a security boundary (the VFS mount is) — so this is about
+predictability, not a sandbox hole.
+
 ### `find --no-ignore` escape under `Enforced` ignore scope (deferred from search-features-port)
 `find` stays POSIX in the rg-features port (see search-features-port.md). But under
 `IgnoreScope::Enforced` (kaibo/agent preset) `find` *does* respect the ignore config,

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -111,17 +111,21 @@ a differential harness over the single-command corpus (argv door ≡ string door
 model (`to_argv()` re-parse) caps typed passthrough to `args.positional`-reading
 builtins. Full writeup: [multicall.md](multicall.md).
 
-### Port useful `rg`-only features into `kaish-glob` / `grep` (Amy, 2026-06-17)
-`rg` was removed (80%-rule: one search builtin). Some dropped flags are worth
-re-homing in `kaish-glob` (which already wraps `ignore::types::Types`) and
-surfacing through `grep`/`glob`/`find` rather than a second search builtin:
-- **`--type`/`-t`/`-T`** (file-type filters) — strongest candidate; the `Types`
-  machinery already exists, so it's mostly surface wiring on the walkers.
-- **`--hidden`** — kaish-glob already has dotglob-style hidden handling; thread it
-  through a `grep --hidden`.
-- **`--no-ignore`** (bypass gitignore), **`--max-count`** (early-stop).
-Design first: decide whether these live on `grep` flags or on the file-walking
-layer so search and listing share one type/hidden/ignore model. Not urgent.
+### Port useful `rg`-only features into `grep` + `glob` (Amy, 2026-06-17) — DESIGNED
+`rg` was removed (80%-rule); the still-useful filtering re-homes on kaish's two
+*modern* search builtins. **Design + punch-list: [search-features-port.md](search-features-port.md)**
+(transient — delete on ship). Driver: kaibo's hot path (`grep -t rust`, `-m N`
+early-stop). Engine is already done — `WalkOptions.types` is live but dormant
+(walker.rs:286); this is surface wiring.
+
+Resolved scope (2026-06-28): **grep + glob only, find untouched** (stays POSIX).
+**`--ftype` is the kaish-wide file-type-filter standard** (not rg `-t`) — both get
+`--ftype`/`--ftype-not`/`--ftype-list`; **all new flags long-only, no shorts**
+(sidesteps GNU grep `-T`/`-m` muscle memory). grep also gets `--hidden` + GNU-semantics
+`--max-count`; glob keeps its fd-style `-t`=entry-kind. **`--no-ignore` DEFERRED on grep**
+("don't ship a flag that lies" — the `Enforced`-scope override semantics aren't designed
+yet); glob's existing one untouched pending an audit. Shared `kaish-glob::build_file_types`
+helper so the two can't drift. Highest-leverage *kaibo*-aligned item on the board.
 
 ### OverlayFs residuals
 (Core landed — see devlog.) Open:
@@ -427,6 +431,14 @@ Low-frequency, record-then-defer:
 (`a/**/b/**/c/**/…`) against a deep path could blow up. Low risk today (walker only
 matches real FS paths; not a regression). If kaish ever matches user patterns
 against user-supplied path *strings*, add a call counter.
+
+### `find --no-ignore` escape under `Enforced` ignore scope (deferred from search-features-port)
+`find` stays POSIX in the rg-features port (see search-features-port.md). But under
+`IgnoreScope::Enforced` (kaibo/agent preset) `find` *does* respect the ignore config,
+diverging from POSIX find (which ignores `.gitignore` entirely). An agent stuck in
+Enforced may want a per-call `find --no-ignore` to recover traditional find behavior.
+Record-don't-build: only meaningful under Enforced, and adds a non-POSIX flag to the
+"trained-in habits" builtin. Add if an Enforced-mode consumer actually hits it.
 
 ### `kill -<sig>` bash shorthand (`kill -9 %1`, `kill -STOP %1`) isn't accepted
 `kill` takes the signal via `--signal NAME` / `-s NAME` only; `-9`/`-STOP` fail at

--- a/docs/search-features-port.md
+++ b/docs/search-features-port.md
@@ -131,10 +131,11 @@ GNU/rg faithful, **per file**:
 - [x] grep clap: `--ftype` (Vec), `--ftype-not` (Vec), `--ftype-list`, `--hidden`.
 - [x] grep execute: populate `WalkOptions.types`/`include_hidden`; `--ftype-list`
       short-circuit; loud unknown-type. (`grep_search_features_tests.rs`, 7 kernel-routed.)
-- [ ] **grep `--max-count` — split to its own commit/PR** (touches every match
-      path: streaming-stdin, single-file scanner, whole-buffer, multi-file). Per-file
-      cap + early chunk-reader stop; `-c`/`-l`/`-q`/`-v` interplay. Deferred from the
-      file-type slice to keep that PR tight and reviewable.
+- [x] **grep `--max-count`** — per-file cap across all four match paths
+      (streaming-stdin, single-file scanner, whole-buffer, multi-file). Streaming
+      paths early-stop the chunk reader (`hit_limit`, distinct from the quit-byte
+      fallback); whole-buffer caps in `render_events` (lets trailing after-context
+      through). `--max-count 0` = exit 1, no output. (5 more kernel-routed tests.)
 
 **P2 — glob parity**
 - [ ] glob clap: `--ftype` (Vec), `--ftype-not` (Vec), `--ftype-list`. Keep

--- a/docs/search-features-port.md
+++ b/docs/search-features-port.md
@@ -121,6 +121,11 @@ GNU/rg faithful, **per file**:
 - Unknown type → exit 2 (decision 4).
 - `--ftype` + `--ftype-not` together: rg-defined; pass both to `TypesBuilder`.
 - glob entry-kind `-t d` must remain intact alongside `--ftype` (regression test).
+- **`--ftype` is a no-op on directories** — `Types::matched` returns `None` for a
+  dir, so a file-type filter narrows *files* but never gates dirs (the same
+  property that keeps recursive type-filtered walks traversable). Consequence:
+  `glob -t d --ftype rust` still lists directories. Worth a line in help so it
+  doesn't read as a bug.
 
 ## Punch list
 
@@ -138,9 +143,12 @@ GNU/rg faithful, **per file**:
       through). `--max-count 0` = exit 1, no output. (5 more kernel-routed tests.)
 
 **P2 — glob parity**
-- [ ] glob clap: `--ftype` (Vec), `--ftype-not` (Vec), `--ftype-list`. Keep
+- [x] glob clap: `--ftype` (Vec), `--ftype-not` (Vec), `--ftype-list`. Kept
       `-t`=entry-kind, `-a/--hidden`, existing `--no-ignore`.
-- [ ] glob execute: populate `WalkOptions.types` via shared helper; `--ftype-list`.
+- [x] glob execute: populate `WalkOptions.types` via shared helper; `--ftype-list`.
+      `read_repeatable_strings` lifted to `builtin/mod.rs` so grep+glob share one
+      reader (can't drift). (`glob_search_features_tests.rs`, 6 kernel-routed,
+      incl. the `-t` entry-kind regression + the dirs-no-op interaction.)
 
 **Deferred (record-don't-build)**
 - grep `--no-ignore`: design the `Enforced`-scope interaction first (decision 5).

--- a/docs/search-features-port.md
+++ b/docs/search-features-port.md
@@ -1,0 +1,169 @@
+# Search features port — rg-style filtering for `grep` + `glob`
+
+**Status:** design + punch-list, **transient** — delete this file when the work ships
+(awk-overhaul.md precedent). Tracked from `docs/issues.md` P1.
+
+Port the still-useful ripgrep-only flags onto kaish's two *modern* search builtins.
+`rg` was removed under the 80%-rule (one search builtin); some of its filtering is
+worth re-homing on the file-walking layer kaish-glob already owns. Driver: **kaibo**,
+a read-only codebase-analysis MCP whose hot path is "grep this repo" — `grep --ftype rust`
+and `--max-count N` early-stop are the ergonomics that make it feel fast and precise.
+
+## What already exists (engine is done)
+
+This is surface wiring, not engine work. The walker already supports everything:
+
+- `WalkOptions.types: Option<Arc<ignore::types::Types>>` (`kaish-glob/src/walker.rs:86`),
+  **applied at walker.rs:286** and tested (`test_walk_types_select_only_rust`,
+  `test_walk_types_negate_excludes`). The directory-pruning hazard is already handled:
+  `Types::matched` returns `Match::None` for directories, so a type filter never stops
+  traversal (walker.rs:284-285, comment + behavior).
+- `WalkOptions.include_hidden` — dotglob semantics (walker.rs:268-273).
+- `IgnoreConfig` (`kaish-kernel/src/ignore_config.rs`) — the gitignore policy layer with
+  `IgnoreScope::{Advisory, Enforced}`, `.ignore`/`.rgignore` precedence, ancestor
+  walk-up, global-gitignore, and a runtime `ignore` builtin. `IgnoreConfig::agent()`
+  (kaibo's preset) is `Enforced` + `auto_gitignore`.
+
+No builtin populates `types` today — the machinery is live but dormant. No new
+dependency (`ignore` is already in kaish-glob).
+
+## Decisions (the design forks, resolved)
+
+1. **`find` is not modified.** It stays POSIX (`--type f` = entry-kind, includes
+   hidden, traditional). Users wanting modern filtering reach for `glob`. (Deferred
+   note: an optional `find --no-ignore` escape *only* matters under `Enforced` scope —
+   recorded in `docs/issues.md` P3, record-don't-build.)
+
+2. **`--ftype` is the kaish-wide standard for file-type filtering.** Not rg-native
+   `-t/--type`. One flag name, every search builtin, now and future:
+   - select: `--ftype <NAME>` (repeatable)
+   - negate: `--ftype-not <NAME>` (repeatable)
+   - discover: `--ftype-list` (print the type→globs table)
+
+   Rationale: `glob` already owns `-t/--type` for **entry-kind** (`f`/`d`/`a`, the fd
+   convention) — file-type is a different axis and gets its own consistent name rather
+   than colliding or splitting per-builtin. This becomes a kaish naming convention
+   (record in `docs/NAMING.md` on ship).
+
+3. **New flags are long-only — no short forms.** `--ftype`, `--ftype-not`,
+   `--ftype-list`, `--hidden`, `--max-count`. No `-t`/`-T`/`-m`. Side benefit: sidesteps
+   GNU grep's `-T`/`--initial-tab` and `-m` muscle-memory entirely — kaish isn't
+   pretending to be GNU grep's short-flag surface, just borrowing the useful long names.
+   (Existing shorts on existing flags — glob's `-t`/`-a` — are untouched; the rule is
+   for *new* flags.)
+
+4. **Unknown type name is loud.** `grep --ftype nonsense` → exit 2 (usage), never a
+   silent empty match. (`TypesBuilder::build()` surfaces `UnrecognizedFileType`; map it
+   to a builtin usage error — verify the exact error path during impl.) Per the
+   no-silent-fallback directive.
+
+5. **`--no-ignore` is DEFERRED — don't ship a flag that lies.** The honest semantics of
+   a per-call ignore-bypass under an embedder's `Enforced` scope aren't designed yet
+   (should an explicit user flag override an embedder's context-flood protection? that's
+   an embedder-policy question, not a one-liner). So `grep` does **not** get `--no-ignore`
+   this round; figure out the correct `Enforced` interaction first, then add it across
+   the search builtins consistently. `glob`'s *existing* `--no-ignore` is left exactly
+   as-is (pre-existing behavior, separate question — see the audit note below).
+
+## Surface matrix
+
+| flag (all long-only) | grep | glob | find |
+|---|---|---|---|
+| `--ftype <NAME>` (file-type select, repeatable) | ✅ new | ✅ new | ✗ |
+| `--ftype-not <NAME>` (negate, repeatable) | ✅ new | ✅ new | ✗ |
+| `--ftype-list` (print types→globs table) | ✅ new | ✅ new | ✗ |
+| `--hidden` (include dotfiles in walk) | ✅ new (default off) | exists (`-a/--hidden`) | ✗ (always on) |
+| `--max-count <N>` (stop after N matches/file) | ✅ new (GNU semantics) | — (no line matching) | — |
+| `--no-ignore` | ✗ DEFERRED (decision 5) | exists (audit) | ✗ |
+
+`--ftype*`/`--hidden` on grep apply to the **`-r` recursive walk** only; on explicit
+file args they're inert (don't error).
+
+## Shared helper (kaish-glob)
+
+One place builds the `Types` so grep + glob can't drift. New module
+`kaish-glob/src/file_types.rs`:
+
+```rust
+/// Build an rg-style file-type filter. `Ok(None)` when both lists are empty.
+/// `Err` on an unrecognized type name (loud — never a silent empty match).
+pub fn build_file_types(
+    select: &[String],
+    negate: &[String],
+) -> Result<Option<Arc<ignore::types::Types>>, FileTypeError>;
+
+/// All known type definitions as (name, globs) rows, for `--ftype-list`.
+pub fn list_file_types() -> Vec<(String, Vec<String>)>;
+
+#[derive(Debug, thiserror::Error)]
+pub enum FileTypeError { /* UnrecognizedFileType(String), Build(..) */ }
+```
+
+Builtins call `build_file_types(...)`, stuff the result into `WalkOptions.types`, and
+map `FileTypeError` → `failure(2, ...)`. `--ftype-list` emits
+`OutputData::table(["TYPE","GLOBS"], rows)` (→ `--json` for free), valid with no
+pattern, exit 0.
+
+## `--max-count <N>` semantics (grep)
+
+GNU/rg faithful, **per file**:
+- Stop after N matching lines in a given file; under `-r`, each file gets its own N.
+- **Early-terminates the chunk reader** — once N matches land, stop pulling that file's
+  remaining 256 KiB windows (reuse the existing binary/quit-byte stop signal — a real
+  streaming win on big files, which is the kaibo case).
+- `--max-count 0` → match nothing, exit 1.
+- with `-c/--count`: report `min(matches, N)`.
+- with `-l`/`-q`: naturally satisfied at the first match (`--max-count 1`-equivalent).
+- with `-v` (invert): N *non*-matching lines.
+
+## Edge cases / loud behavior
+
+- Unknown type → exit 2 (decision 4).
+- `--ftype` + `--ftype-not` together: rg-defined; pass both to `TypesBuilder`.
+- glob entry-kind `-t d` must remain intact alongside `--ftype` (regression test).
+
+## Punch list
+
+**P1 — ship (grep, kaibo's hot path)**
+- [x] `kaish-glob/src/file_types.rs`: `build_file_types`, `list_file_types`,
+      `FileTypeError`; export from `lib.rs` + re-export in kernel `walker` mod.
+      (5 unit tests.)
+- [x] grep clap: `--ftype` (Vec), `--ftype-not` (Vec), `--ftype-list`, `--hidden`.
+- [x] grep execute: populate `WalkOptions.types`/`include_hidden`; `--ftype-list`
+      short-circuit; loud unknown-type. (`grep_search_features_tests.rs`, 7 kernel-routed.)
+- [ ] **grep `--max-count` — split to its own commit/PR** (touches every match
+      path: streaming-stdin, single-file scanner, whole-buffer, multi-file). Per-file
+      cap + early chunk-reader stop; `-c`/`-l`/`-q`/`-v` interplay. Deferred from the
+      file-type slice to keep that PR tight and reviewable.
+
+**P2 — glob parity**
+- [ ] glob clap: `--ftype` (Vec), `--ftype-not` (Vec), `--ftype-list`. Keep
+      `-t`=entry-kind, `-a/--hidden`, existing `--no-ignore`.
+- [ ] glob execute: populate `WalkOptions.types` via shared helper; `--ftype-list`.
+
+**Deferred (record-don't-build)**
+- grep `--no-ignore`: design the `Enforced`-scope interaction first (decision 5).
+- **Audit glob's existing `--no-ignore` under `Enforced`** — it unconditionally skips
+  the filter regardless of scope; confirm that's intended (vs. silently escaping an
+  embedder's context-flood protection). Feeds the deferred `--no-ignore` design.
+- `find --no-ignore` escape under `Enforced` → `docs/issues.md` P3.
+
+## Test plan (kernel-routed)
+
+- **kaish-glob unit:** `build_file_types` select/negate/unknown-error/empty;
+  `list_file_types` nonempty + contains `rust→*.rs`. (Walk-level type filtering already
+  covered by walker.rs tests.)
+- **grep (`grep_search_features_tests.rs`):** `--ftype rust` over a temp tree of `.rs`/
+  `.py`/`.md` → only `.rs`; `--ftype-not rust` excludes; unknown type → exit 2;
+  `--hidden` reaches a dotfile under `-r`; `--max-count 2` caps per file + a >2-match
+  file proves early stop; `--max-count` with `-c` reports capped; `--ftype-list` table +
+  `--json` shape.
+- **glob (`glob_search_features_tests.rs`):** `--ftype rust` → only `.rs`; `--ftype-not`;
+  unknown → exit 2; **`-t d` entry-kind still works** (regression); `--ftype-list`.
+
+## Docs to sync (on ship)
+
+- `docs/NAMING.md` — record the `--ftype` file-type-filter convention (decision 2).
+- `help grep` / `help glob` content (`kaish-help/content/en/`) — new flags.
+- `README` builtin notes; `CHANGELOG.md` Added bullets (one per builtin).
+- Delete this file.

--- a/docs/search-features-port.md
+++ b/docs/search-features-port.md
@@ -172,7 +172,12 @@ GNU/rg faithful, **per file**:
 
 ## Docs to sync (on ship)
 
-- `docs/NAMING.md` — record the `--ftype` file-type-filter convention (decision 2).
-- `help grep` / `help glob` content (`kaish-help/content/en/`) — new flags.
-- `README` builtin notes; `CHANGELOG.md` Added bullets (one per builtin).
-- Delete this file.
+- [x] `docs/NAMING.md` — `--ftype` file-type-filter convention recorded (decision 2).
+- [x] builtin help — flag descriptions live in the clap doc-comments and flow
+      through `schema_from_clap` into `help grep`/`help glob` automatically; no
+      hand-written per-builtin help file exists to edit.
+- [x] `CHANGELOG.md` Added bullets (grep ×3, glob ×1). README describes builtins
+      only at category level (no per-flag list), so nothing to sync there.
+- [ ] **Delete this file** once the port lands (the work is complete; this is the
+      last open box). Deferred `--no-ignore` design + the glob `--no-ignore`-under-
+      Enforced audit live in `docs/issues.md`, so they survive deletion.


### PR DESCRIPTION
Ports the still-useful ripgrep-only filtering onto kaish's two *modern* search
builtins — **grep** and **glob** — reusing the `ignore::types` machinery the
walker already wrapped (it was live but dormant: no builtin populated
`WalkOptions.types`). `find` stays POSIX, untouched. Driver: **kaibo**, whose
hot path is "grep this codebase" — `grep --ftype rust` and `--max-count` are the
ergonomics that make it fast and precise.

## What's new

| builtin | flags | notes |
|---|---|---|
| **grep** | `--ftype`, `--ftype-not`, `--ftype-list`, `--hidden`, `--max-count` | file-type filter on the `-r` walk; `--max-count` early-stops the chunk reader (big-file win) |
| **glob** | `--ftype`, `--ftype-not`, `--ftype-list` | keeps `-t`/`--type` = entry-kind (file/dir, fd-style); the two axes compose |
| **find** | — | unchanged, POSIX |

## Design decisions (from the conversation)

- **`--ftype` is the kaish-wide file-type-filter standard**, not rg-native `-t`.
  `glob` already owns `-t`/`--type` for *entry kind*; file-type is a different
  axis and gets one consistent name across search builtins. Recorded in
  `docs/NAMING.md`.
- **New flags are long-only, no shorts** — sidesteps GNU grep's `-T`/`--initial-tab`
  and `-m` muscle memory; kaish borrows the useful long names, not the short surface.
- **Unknown type name is a loud exit-2 error**, never a silent empty match.
- **`--no-ignore` deliberately deferred** — won't ship a flag whose `Enforced`-scope
  override semantics aren't designed yet (tracked in `docs/issues.md`).
- Shared `kaish-glob::build_file_types` + `tools/builtin::read_repeatable_strings`
  so grep and glob can't drift.

## `--max-count` (GNU semantics, per file)

Threaded through all four match paths — streaming-stdin, single-file chunked
scanner, whole-buffer, and multi-file. Streaming paths halt the chunk reader once
the cap is hit (the kaibo big-file win). `--max-count 0` matches nothing (exit 1).
The whole-buffer path lets trailing after-context of the Nth match through
(`grep -m N -A k`).

## Review

DeepSeek reviewed via kaibo (Gemini was provider-down). Verdict: design sound
across the board; found one rare "loud-in-the-wrong-direction" bug — a
`--max-count` stop at a 256 KiB boundary splitting a UTF-8 multibyte char made
`finish()` flag the truncated carry as binary (spurious exit-2). **Fixed**
(`finish()` now guards on `hit_limit`) with a regression test verified red-then-green.

## Tests

24 new: 5 `kaish-glob::file_types` unit + 12 grep + 6 glob kernel-routed
(`*_search_features_tests.rs`) + 1 scanner regression. Covers repeatable
`Json(Array)` accumulation, per-file `--max-count` across all paths + the
truncated-carry case, loud unknown-type, `--hidden` dotfile reach, the glob `-t`
entry-kind regression, and the dirs-no-op interaction. `cargo test --all` and
`cargo clippy --all --all-targets` clean throughout.

`docs/search-features-port.md` is the design + punch-list (transient — delete on
the follow-up once it's served its purpose).

🤖 Generated with [Claude Code](https://claude.com/claude-code)