### PR TITLE
fix+docs: latch output contract — preserve nonce on .data under --json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ breaking entries are marked **BREAKING**.
 ## [Unreleased]
 
 ### Fixed
+- **`--json` no longer drops the structured payload of an error result.** A
+  non-zero exit that carries both a diagnostic message and structured `.data`
+  — notably the latch confirmation nonce from `rm`/`tee`/`patch`/`sed -i` — kept
+  only `{error, code}` under `--json`, silently clobbering the nonce. The error
+  envelope now nests the payload under `data`: `{error, code, data: {nonce, …}}`.
 - **`sed -e <number>` is a loud error, not a silent drop.** A non-string `-e`
   expression (e.g. `sed -e 5`) now exits 2 with a usage error instead of being
   ignored — silently dropping it once let the *filename* be parsed as the program.

--- a/crates/kaish-help/content/en/syntax.md
+++ b/crates/kaish-help/content/en/syntax.md
@@ -210,7 +210,8 @@ Confirmed paths must be subset of authorized paths. Exit code 2 = needs confirma
 Applies to `rm` and to truncating overwrites (`tee`, `patch`, `sed -i`) —
 confirm those with `--confirm=<nonce>`. `tee -a` append, new files, and
 `patch --dry-run` don't gate. The prompt prints to stderr (stdout stays empty);
-under `--json` the nonce is in the result's `data` field.
+the nonce is on the result's `data` field — nested under `data` in the error
+envelope when `--json` is on.
 
 **Trash:** Files <= 10MB and directories always trash. `/tmp`, `/v/*` excluded.
 A truncating overwrite under `trash` snapshots the file's prior content first

--- a/crates/kaish-help/content/en/syntax.md
+++ b/crates/kaish-help/content/en/syntax.md
@@ -209,7 +209,8 @@ Env vars: `KAISH_LATCH=1`, `KAISH_TRASH=1` enable at startup.
 Confirmed paths must be subset of authorized paths. Exit code 2 = needs confirmation.
 Applies to `rm` and to truncating overwrites (`tee`, `patch`, `sed -i`) —
 confirm those with `--confirm=<nonce>`. `tee -a` append, new files, and
-`patch --dry-run` don't gate.
+`patch --dry-run` don't gate. The prompt prints to stderr (stdout stays empty);
+under `--json` the nonce is in the result's `data` field.
 
 **Trash:** Files <= 10MB and directories always trash. `/tmp`, `/v/*` excluded.
 A truncating overwrite under `trash` snapshots the file's prior content first

--- a/crates/kaish-help/src/fragments.rs
+++ b/crates/kaish-help/src/fragments.rs
@@ -424,7 +424,8 @@ Env vars: `KAISH_LATCH=1`, `KAISH_TRASH=1` enable at startup.
 Confirmed paths must be subset of authorized paths. Exit code 2 = needs confirmation.
 Applies to `rm` and to truncating overwrites (`tee`, `patch`, `sed -i`) —
 confirm those with `--confirm=<nonce>`. `tee -a` append, new files, and
-`patch --dry-run` don't gate.
+`patch --dry-run` don't gate. The prompt prints to stderr (stdout stays empty);
+under `--json` the nonce is in the result's `data` field.
 
 **Trash:** Files <= 10MB and directories always trash. `/tmp`, `/v/*` excluded.
 A truncating overwrite under `trash` snapshots the file's prior content first

--- a/crates/kaish-help/src/fragments.rs
+++ b/crates/kaish-help/src/fragments.rs
@@ -425,7 +425,8 @@ Confirmed paths must be subset of authorized paths. Exit code 2 = needs confirma
 Applies to `rm` and to truncating overwrites (`tee`, `patch`, `sed -i`) —
 confirm those with `--confirm=<nonce>`. `tee -a` append, new files, and
 `patch --dry-run` don't gate. The prompt prints to stderr (stdout stays empty);
-under `--json` the nonce is in the result's `data` field.
+the nonce is on the result's `data` field — nested under `data` in the error
+envelope when `--json` is on.
 
 **Trash:** Files <= 10MB and directories always trash. `/tmp`, `/v/*` excluded.
 A truncating overwrite under `trash` snapshots the file's prior content first

--- a/crates/kaish-types/src/output.rs
+++ b/crates/kaish-types/src/output.rs
@@ -560,14 +560,23 @@ pub fn apply_output_format(mut result: ExecResult, format: OutputFormat) -> Exec
         if !result.ok() && !result.err.is_empty() {
             match format {
                 OutputFormat::Json => {
-                    let obj = serde_json::json!({
+                    let mut obj = serde_json::json!({
                         "error": result.err,
                         "code": result.code,
                     });
-                    result.data = Some(crate::result::json_to_value(obj.clone()));
-                    result.set_out(
-                        serde_json::to_string(&obj).unwrap_or_else(|_| "null".to_string()),
-                    );
+                    // A tool that attached structured data to an error result —
+                    // notably the latch nonce payload {nonce, command, paths,
+                    // hint, ttl} from `ToolCtx::latch_result` — must keep it
+                    // reachable under --json. Nest it under `data` so the error
+                    // envelope holds the diagnostic *and* the structured truth
+                    // instead of clobbering one with the other.
+                    if let Some(data) = &result.data {
+                        obj["data"] = crate::result::value_to_json(data);
+                    }
+                    let out =
+                        serde_json::to_string(&obj).unwrap_or_else(|_| "null".to_string());
+                    result.set_out(out);
+                    result.data = Some(crate::result::json_to_value(obj));
                 }
             }
         }
@@ -818,6 +827,35 @@ mod tests {
         );
         // .data mirrors the JSON object.
         assert!(matches!(formatted.data, Some(crate::value::Value::Json(_))));
+    }
+
+    #[test]
+    fn apply_output_format_preserves_structured_data_on_error() {
+        // A latch result is a failure (exit 2, empty stdout, populated err) that
+        // ALSO carries a structured nonce payload on .data. Under --json the
+        // error-envelope path must not clobber that payload — the nonce stays
+        // reachable, nested under `data`, alongside the error/code envelope.
+        let mut result = ExecResult::failure(2, "rm: confirmation required (latch enabled)");
+        result.data = Some(crate::value::Value::Json(serde_json::json!({
+            "nonce": "a3f7b2c1",
+            "command": "rm",
+            "paths": ["important.dat"],
+            "hint": "rm --confirm=\"a3f7b2c1\" important.dat",
+            "ttl": 60,
+        })));
+
+        let formatted = apply_output_format(result, OutputFormat::Json);
+        let out = formatted.text_out().into_owned();
+        let parsed: serde_json::Value = serde_json::from_str(&out).expect("valid JSON");
+        assert_eq!(parsed["error"], "rm: confirmation required (latch enabled)");
+        assert_eq!(parsed["code"], 2);
+        assert_eq!(parsed["data"]["nonce"], "a3f7b2c1");
+        assert_eq!(parsed["data"]["ttl"], 60);
+        // .data mirrors the serialized envelope (nonce reachable from the struct too).
+        match &formatted.data {
+            Some(crate::value::Value::Json(v)) => assert_eq!(v["data"]["nonce"], "a3f7b2c1"),
+            other => panic!("expected nested JSON data, got {other:?}"),
+        }
     }
 
     #[test]

--- a/docs/EMBEDDING.md
+++ b/docs/EMBEDDING.md
@@ -140,15 +140,22 @@ With `.with_latch(true)`, a destructive op (`rm`, and the overwrite gate behind
 `ExecResult` with **exit code 2** and a confirmation nonce. The re-run is the
 same argv plus `--confirm=<nonce>`. The output contract:
 
-- **stderr** (`ExecResult.err`) carries the human-readable prompt;
+- **`ExecResult.err`** (which a frontend routes to stderr) carries the
+  human-readable prompt;
 - **stdout** is empty (nothing happened, so there is no success output);
 - **`ExecResult.data`** carries the nonce as structured JSON — read it here
-  rather than parsing the stderr text:
+  rather than parsing the `err` text:
 
   ```json
   { "nonce": "a3f7b2c1", "command": "rm",
     "paths": ["important.dat"], "hint": "...", "ttl": 60 }
   ```
+
+  If you executed with `--json` (`OutputFormat::Json`), this is a non-zero exit
+  with a diagnostic, so the result is wrapped in the standard JSON error envelope
+  and the nonce payload is nested one level down, under `data`:
+  `{ "error": "...", "code": 2, "data": { "nonce": ... } }`. Reading
+  `ExecResult.data` from the struct without `--json` gives you the bare payload.
 
 Nonces are scoped to `(command, paths)`, expire after 60s, and are not consumed
 on use (idempotent retries). To confirm a nonce issued in one `execute()` call

--- a/docs/EMBEDDING.md
+++ b/docs/EMBEDDING.md
@@ -129,9 +129,32 @@ let config = KernelConfig::agent();
 ```
 
 Other builders: `.with_latch(bool)` / `.with_trash(bool)` (destructive-op
-rails), `.with_vfs_budget(bytes)` / `.without_vfs_budget()` (cap in-memory
-VFS growth), `.with_skip_validation(bool)`, `.with_initial_vars(map)`
+rails — see below), `.with_vfs_budget(bytes)` / `.without_vfs_budget()` (cap
+in-memory VFS growth), `.with_skip_validation(bool)`, `.with_initial_vars(map)`
 (below).
+
+#### Destructive-op rails: reading the latch nonce
+
+With `.with_latch(true)`, a destructive op (`rm`, and the overwrite gate behind
+`tee` / `patch` / `sed -i`) does not run on first call — it returns an
+`ExecResult` with **exit code 2** and a confirmation nonce. The re-run is the
+same argv plus `--confirm=<nonce>`. The output contract:
+
+- **stderr** (`ExecResult.err`) carries the human-readable prompt;
+- **stdout** is empty (nothing happened, so there is no success output);
+- **`ExecResult.data`** carries the nonce as structured JSON — read it here
+  rather than parsing the stderr text:
+
+  ```json
+  { "nonce": "a3f7b2c1", "command": "rm",
+    "paths": ["important.dat"], "hint": "...", "ttl": 60 }
+  ```
+
+Nonces are scoped to `(command, paths)`, expire after 60s, and are not consumed
+on use (idempotent retries). To confirm a nonce issued in one `execute()` call
+from a *later* call, share the store with
+`KernelConfig::with_nonce_store()` — the default `NonceStore` is fresh per
+kernel. See [LANGUAGE.md](LANGUAGE.md) for the full latch/trash semantics.
 
 ### Custom Backend (`Kernel::with_backend`)
 

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -457,19 +457,31 @@ To confirm, run: rm --confirm="a3f7b2c1" important.dat
 Nonce expires in 60 seconds.
 ```
 
-**Latch output contract.** The prompt above is written to **stderr** (the
-`ExecResult.err` channel); **stdout is empty** — nothing was deleted, so there is
-no success output. The nonce is also attached as structured data, so a program
-driving the shell reads it off `--json` (`ExecResult.data`) rather than scraping
-the stderr text:
+**Latch output contract.** The prompt above is written to the result's **`err`
+channel** (what a frontend renders to stderr); **stdout is empty** — nothing was
+deleted, so there is no success output. The nonce is also attached as structured
+data, so a program driving the shell reads it from the result rather than scraping
+the stderr text. Where it lands depends on the output format:
 
-```json
-{ "nonce": "a3f7b2c1", "command": "rm",
-  "paths": ["important.dat"], "hint": "...", "ttl": 60 }
-```
+- **No `--json`** — `ExecResult.data` is the bare nonce payload:
+
+  ```json
+  { "nonce": "a3f7b2c1", "command": "rm",
+    "paths": ["important.dat"], "hint": "...", "ttl": 60 }
+  ```
+
+- **`--json`** — the result is a non-zero exit with a diagnostic, so it's wrapped
+  in the standard JSON error envelope; the nonce payload is nested under `data`:
+
+  ```json
+  { "error": "rm: confirmation required (latch enabled)…",
+    "code": 2,
+    "data": { "nonce": "a3f7b2c1", "command": "rm", "paths": ["important.dat"],
+              "hint": "...", "ttl": 60 } }
+  ```
 
 The same contract holds for the overwrite gate (`tee`, `patch`, `sed -i`): exit 2,
-human prompt on stderr, nonce on `.data`.
+human prompt on the `err` channel, nonce on `.data` (nested under `--json`).
 
 The `kaish-trash` builtin manages trashed files: `list`, `restore`, `empty`, `config`.
 

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -457,6 +457,20 @@ To confirm, run: rm --confirm="a3f7b2c1" important.dat
 Nonce expires in 60 seconds.
 ```
 
+**Latch output contract.** The prompt above is written to **stderr** (the
+`ExecResult.err` channel); **stdout is empty** — nothing was deleted, so there is
+no success output. The nonce is also attached as structured data, so a program
+driving the shell reads it off `--json` (`ExecResult.data`) rather than scraping
+the stderr text:
+
+```json
+{ "nonce": "a3f7b2c1", "command": "rm",
+  "paths": ["important.dat"], "hint": "...", "ttl": 60 }
+```
+
+The same contract holds for the overwrite gate (`tee`, `patch`, `sed -i`): exit 2,
+human prompt on stderr, nonce on `.data`.
+
 The `kaish-trash` builtin manages trashed files: `list`, `restore`, `empty`, `config`.
 
 When output is truncated by the limit, the result exits **3** with `did_spill: true` and `original_code` set. The spill file path is in the output. To read it in full:


### PR DESCRIPTION
## Why

Started as a docs task: answering "what channel does latch return the nonce on?" revealed the docs never said. The latch sections showed the confirmation prompt as a terminal block but never stated it goes to the `err` channel with stdout empty, and never documented the structured nonce payload at all — the gap that most bites embedders.

A **kaibo / DeepSeek review** of the doc PR then caught a real bug behind one of the claims: the nonce I documented as readable on `.data` under `--json` was actually being **dropped** there.

## The bug (now fixed)

`apply_output_format`'s error-envelope branch (empty stdout + non-zero exit + non-empty `err`) unconditionally overwrote `result.data` with a generic `{error, code}` object (`crates/kaish-types/src/output.rs`). So a `--json` consumer of a latched `rm`/`tee`/`patch`/`sed -i` got **no nonce** — only an embedder reading `ExecResult.data` from the Rust struct directly (no `--json`) saw it. No test covered the latch×`--json` interaction.

**Fix:** the error envelope now nests any pre-existing structured `.data` under a `data` key:

```json
{ "error": "rm: confirmation required (latch enabled)…",
  "code": 2,
  "data": { "nonce": "a3f7b2c1", "command": "rm", "paths": ["important.dat"], "hint": "...", "ttl": 60 } }
```

The non-error structured path already preserved `.data`; only this branch didn't. New test `apply_output_format_preserves_structured_data_on_error` pins it (fails on the old code).

## Docs (the original goal, now accurate to the fixed contract)

- **`docs/LANGUAGE.md`** — "Latch output contract" note: prompt on the `err` channel, stdout empty, nonce on `.data` (bare payload without `--json`; nested under `data` in the error envelope with `--json`). Same for the `tee`/`patch`/`sed -i` gate.
- **`docs/EMBEDDING.md`** — "Destructive-op rails: reading the latch nonce" subsection where `.with_latch` is introduced; covers both consumption paths and points at `with_nonce_store()` for cross-call confirmation.
- **`kaish-help` fragment** → regenerates `syntax.md` (drift test green): one agent-facing sentence.

## Verification

- `cargo test --all` — clean (90 `test result: ok`, no failures).
- `cargo clippy --all --all-targets` — zero warnings.
- Documented JSON shape verified against `latch_result` / `gate_overwrites` in `context.rs`.
- CHANGELOG: Fixed bullet (additive `--json` error shape).

🤖 Generated with [Claude Code](https://claude.com/claude-code)