### PR TITLE
fix(vfs): LocalFs::list tolerates an entry that vanishes mid-scan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,13 @@ breaking entries are marked **BREAKING**.
   directories pass it untouched. Unknown type → loud exit 2.
 
 ### Fixed
+- **Listing a live directory no longer fails when one entry vanishes mid-scan.**
+  `LocalFs::list` (`ls`, and any walk over a real directory) stats each entry in a
+  step separate from the `read_dir` that yielded it, so a sibling unlinked in that
+  window (a concurrent writer, a build churning `target/`, an editor's temp file)
+  made the whole listing fail with `ENOENT` (`ls: .: not found`). A vanished entry
+  is now skipped, the way `ls(1)` tolerates a file removed mid-scan; a *dangling*
+  symlink still lists (its link stat succeeds), and other stat errors still surface.
 - **`--json` no longer drops the structured payload of an error result.** A
   non-zero exit that carries both a diagnostic message and structured `.data`
   — notably the latch confirmation nonce from `rm`/`tee`/`patch`/`sed -i` — kept

--- a/crates/kaish-vfs/src/local.rs
+++ b/crates/kaish-vfs/src/local.rs
@@ -199,6 +199,49 @@ impl LocalFs {
     fn extract_permissions(_meta: &std::fs::Metadata) -> Option<u32> {
         None
     }
+
+    /// Build a [`DirEntry`] for one directory member named by `path`, *without*
+    /// following symlinks — or `Ok(None)` if that member has vanished since the
+    /// enclosing `read_dir` snapshot was taken.
+    ///
+    /// [`list`](LocalFs::list) stats each entry in a step separate from the `read_dir`
+    /// that yielded it, so on a *live* directory an entry can be unlinked in that window
+    /// (a concurrent writer, a build churning `target/`, an editor swapping a temp file).
+    /// A removed entry is not a listing failure: report it gone so the caller skips it —
+    /// the way `ls(1)` tolerates a file deleted mid-scan — rather than letting one
+    /// `ENOENT` from a single sibling sink the whole listing. Any *other* stat error
+    /// (e.g. `EACCES`) is genuine and still propagates. A *dangling* symlink is reported,
+    /// not skipped: `symlink_metadata` stats the link itself, which still exists.
+    async fn dir_entry_no_follow(path: &Path) -> io::Result<Option<DirEntry>> {
+        let metadata = match fs::symlink_metadata(path).await {
+            Ok(m) => m,
+            Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(None),
+            Err(e) => return Err(e),
+        };
+        let file_type = metadata.file_type();
+
+        let (kind, symlink_target) = if file_type.is_symlink() {
+            // The link's own target, best-effort — a dangling link still lists.
+            (DirEntryKind::Symlink, fs::read_link(path).await.ok())
+        } else if file_type.is_dir() {
+            (DirEntryKind::Directory, None)
+        } else {
+            // Special files (sockets, pipes, devices) → File. See stat().
+            (DirEntryKind::File, None)
+        };
+
+        Ok(Some(DirEntry {
+            name: path
+                .file_name()
+                .map(|n| n.to_string_lossy().into_owned())
+                .unwrap_or_default(),
+            kind,
+            size: metadata.len(),
+            modified: metadata.modified().ok(),
+            permissions: Self::extract_permissions(&metadata),
+            symlink_target,
+        }))
+    }
 }
 
 #[async_trait]
@@ -280,29 +323,12 @@ impl Filesystem for LocalFs {
         let mut dir = fs::read_dir(&full_path).await?;
 
         while let Some(entry) = dir.next_entry().await? {
-            // Use symlink_metadata to detect symlinks without following them
-            let metadata = fs::symlink_metadata(entry.path()).await?;
-            let file_type = metadata.file_type();
-
-            let (kind, symlink_target) = if file_type.is_symlink() {
-                // Read the symlink target
-                let target = fs::read_link(entry.path()).await.ok();
-                (DirEntryKind::Symlink, target)
-            } else if file_type.is_dir() {
-                (DirEntryKind::Directory, None)
-            } else {
-                // Special files (sockets, pipes, devices) → File. See stat() comment.
-                (DirEntryKind::File, None)
-            };
-
-            entries.push(DirEntry {
-                name: entry.file_name().to_string_lossy().into_owned(),
-                kind,
-                size: metadata.len(),
-                modified: metadata.modified().ok(),
-                permissions: Self::extract_permissions(&metadata),
-                symlink_target,
-            });
+            // Stat each entry separately from the `read_dir` above, so an entry unlinked
+            // in that window is skipped (`Ok(None)`), not fatal — one vanished sibling
+            // must not sink the whole listing. See `dir_entry_no_follow`.
+            if let Some(de) = Self::dir_entry_no_follow(&entry.path()).await? {
+                entries.push(de);
+            }
         }
 
         entries.sort_by(|a, b| a.name.cmp(&b.name));
@@ -603,6 +629,61 @@ mod tests {
         assert!(names.contains(&&"a.txt".to_string()));
         assert!(names.contains(&&"b.txt".to_string()));
         assert!(names.contains(&&"subdir".to_string()));
+
+        cleanup(&dir).await;
+    }
+
+    // A directory entry can disappear between the `read_dir` snapshot and the per-entry
+    // `symlink_metadata` `list` does on a *live* directory. The helper that does that stat
+    // must report a vanished entry as gone (skippable), not as a hard error — otherwise one
+    // unlinked sibling sinks the whole listing (the bug this fixes).
+    #[tokio::test]
+    async fn dir_entry_no_follow_reports_a_vanished_entry_as_gone() {
+        let (_fs, dir) = setup().await;
+        // A path under the (real) test dir that does not exist — exactly what a stat sees
+        // when the entry was unlinked after `read_dir` yielded it.
+        let gone = dir.join("already-unlinked");
+        let got = LocalFs::dir_entry_no_follow(&gone).await.unwrap();
+        assert!(
+            got.is_none(),
+            "a missing entry must be reported as gone (Ok(None)), not an error — got {got:?}"
+        );
+        cleanup(&dir).await;
+    }
+
+    #[tokio::test]
+    async fn dir_entry_no_follow_builds_a_real_files_entry() {
+        let (fs, dir) = setup().await;
+        fs.write(Path::new("hi.txt"), b"hello").await.unwrap();
+
+        let entry = LocalFs::dir_entry_no_follow(&dir.join("hi.txt"))
+            .await
+            .unwrap()
+            .expect("a present file must produce an entry");
+        assert_eq!(entry.name, "hi.txt");
+        assert_eq!(entry.kind, DirEntryKind::File);
+        assert_eq!(entry.size, 5);
+
+        cleanup(&dir).await;
+    }
+
+    // The skip is precise: it drops only entries whose stat says *gone*. A **dangling**
+    // symlink is not gone — `symlink_metadata` stats the link itself, which still exists —
+    // so it must stay in the listing (as a Symlink), proving we don't over-skip.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn list_keeps_a_dangling_symlink() {
+        let (fs, dir) = setup().await;
+        fs.write(Path::new("real.txt"), b"r").await.unwrap();
+        std::os::unix::fs::symlink("nowhere", dir.join("dangling")).unwrap();
+
+        let entries = fs.list(Path::new("")).await.unwrap();
+        let dangling = entries
+            .iter()
+            .find(|e| e.name == "dangling")
+            .expect("a dangling symlink must still be listed, not skipped as gone");
+        assert_eq!(dangling.kind, DirEntryKind::Symlink);
+        assert!(entries.iter().any(|e| e.name == "real.txt"));
 
         cleanup(&dir).await;
     }

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -339,6 +339,22 @@ loses link-ness. Fix: teach `move_dir_recursive` to `lstat` children and
 `read_link`+`symlink` the symlinks (mirroring the top-level branch in
 `move_path`). Cross-mount only (same-mount uses atomic `rename`, already correct).
 
+### `find -mtime`/`-size` emits an un-stattable entry instead of dropping it
+Surfaced by the cross-family review of the LocalFs list TOCTOU fix (PR #41,
+2026-06-29; Gemini Pro caught it, DeepSeek missed it). In the `find` loop
+(`tools/builtin/find.rs:314-342`) the per-entry stat is best-effort
+(`ctx.backend.stat(&path).await.ok()`), and each filter is a chained
+`if let Some(..) = mtime_filter && let Some(ref info) = info { … continue }`.
+When a filter *is* set but `info` is `None` (the entry vanished between the walk
+and the stat, or a backend doesn't populate the field), the whole block
+short-circuits, **no `continue` fires**, and the entry falls through to output
+unfiltered — so `find . -mtime +30` can print a file it can't confirm matches.
+The leniency is deliberate for "stat field unavailable" (comment at
+`passes_mtime_size`, ~`find.rs:425`), but it conflates that with "file is gone."
+Fix: when a filter is requested but `info`/the field is `None`, drop the entry
+(treat as non-match) rather than passing it through. Note this is the *inverse*
+of the PR-#41 bug — a false inclusion, not an aborted walk — and is pre-existing.
+
 ### Pre-release sweep — lower-frequency fidelity gaps (2026-06-23, verified)
 - **`rm <empty-dir>` without `-r` silently removes it** (coreutils needs `-d`/`-r`);
   **`mkdir` is always `-p`-like** — `mkdir existing` → exit 0 (no "File exists"),
@@ -639,6 +655,26 @@ never call `flagify_bool_named` (seq, find, stat, cp, mkdir, …) hand clap a
 bare `seq --json` works. Better fix: flagify **once in the kernel** before dispatch
 and drop the per-builtin calls. The global `--json` stripper also misses the `=true`
 form (it scans `flags`, not `named`). (P3)
+
+### `FileWalker` symlink-following is broken (dormant — no production caller)
+Surfaced by the cross-family review of the LocalFs list TOCTOU fix (PR #41,
+2026-06-29, Gemini Pro). Both bugs are latent: nothing in production sets
+`FileWalkOptions::follow_symlinks: true` (only the doc comment and tests
+reference it), so they bite only once a builtin exposes a `-L`/`--follow` flag.
+- **Dir symlinks are never recursed.** The walker decides recursion on
+  `entry.is_dir()` (`kaish-glob/src/walker.rs:248,308`), but `DirEntry::is_dir()`
+  is `kind == Directory` and a symlink is the distinct `Symlink` kind
+  (`kaish-types/src/dir_entry.rs:72`), so `is_dir()` is always false for a
+  directory symlink — even with `follow_symlinks` on, the link is yielded as a
+  file, never descended. Fix: gate on `is_dir || (is_symlink && follow_symlinks)`
+  and `stat`-through (`self.fs.is_dir(&full_path)`, which follows the link) to
+  decide whether the target is a directory.
+- **Cycle detection is a no-op in production.** Cycle detection keys
+  `visited_dirs` on `self.fs.canonicalize(&full_path)`, but `BackendWalkerFs`
+  (`kaish-kernel/src/backend_walker_fs.rs:37`) doesn't override `canonicalize`,
+  so it returns the path unresolved — a circular symlink would grow unique paths
+  forever (infinite loop / OOM). Fix: implement `canonicalize` on
+  `BackendWalkerFs` via `KernelBackend` link resolution before any `-L` flag ships.
 
 ### Smaller refactors
 - **Extract `skip_quoted_content()`** shared by `preprocess_arithmetic()` and


### PR DESCRIPTION
## What & why

`LocalFs::list` enumerates a directory with `read_dir`, then stats **each** entry with `fs::symlink_metadata(entry.path()).await?` in a separate step. On a *live* directory, an entry can be unlinked in that window — a concurrent writer, a build churning `target/`, an editor swapping a temp file. The `?` then propagated the `ENOENT` and failed the **whole** listing (surfaced to an agent as `ls: .: not found`).

Because every directory-walking builtin (`ls`, `grep -rn`, `find`, `wc` over a tree) routes through this read-only boundary, one fleeting temp file could abort an entire `explore` sweep on a live repo.

## How it surfaced

This is the contributing factor behind a ~10%-flaky test in **kaibo** (which embeds `kaish-kernel` + `kaish-vfs`): its zero-config containment test ran `ls` over the live crate root while a parallel `cargo test` churned `target/`. Traced it from `KaishWorker` → `LocalBackend` → here.

## The fix

Extract `dir_entry_no_follow`: stat one entry without following symlinks, returning `Ok(None)` when it's gone so `list` skips it — the way `ls(1)` tolerates a file removed mid-scan. Precise by design:
- A **dangling symlink** still lists (`symlink_metadata` stats the *link*, which exists) — not skipped.
- **Other** stat errors (`EACCES`, …) still propagate.

## Tests (TDD, with teeth)

- `dir_entry_no_follow_reports_a_vanished_entry_as_gone` — a missing path → `Ok(None)`. **Teeth:** reverting the skip to `?` makes this fail (verified).
- `dir_entry_no_follow_builds_a_real_files_entry` — name/kind/size for a present file.
- `list_keeps_a_dangling_symlink` — proves the skip is precise, not over-eager.

`cargo test -p kaish-vfs --features localfs` green (33 passed); clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)