### PR TITLE
feat: complete the write-model gate (write/cp/mv/dd) + close 4 review gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,13 +55,20 @@ breaking entries are marked **BREAKING**.
   the batch and every error is reported. The GNU glued backup suffix (`-i.bak`) is
   **not yet supported** — kaish's lexer splits `-i.bak` at the dot; the trash snapshot
   under `set -o trash` already keeps a recoverable prior copy.
-- **`tee`, `patch`, and `sed -i` honor `set -o latch` / `set -o trash` on a truncating
-  overwrite**, like `rm` gates a delete. Overwriting an existing file under `trash`
-  first copies its prior content to trash (recoverable, via the new
-  `TrashBackend::trash_bytes`), leaving the file in place for the new content; under
-  `latch` it needs `--confirm=<nonce>` (exit 2 until confirmed, one nonce scoping all
-  files a command touches). A new file, `tee -a` append, or `patch --dry-run` never
-  gates. Both gates are off by default, so default behavior is unchanged.
+- **The write-model gate (`set -o latch` / `set -o trash`) covers every truncating
+  overwrite** — `tee`, `patch`, `sed -i`, **and now `write`, `cp`, `mv`, and `dd of=`**
+  (these four previously bypassed it) — like `rm` gates a delete. Overwriting an
+  existing file under `trash` first copies its prior content to trash (recoverable,
+  via the new `TrashBackend::trash_bytes`), leaving the file in place for the new
+  content; under `latch` it needs `--confirm=<nonce>` (exit 2 until confirmed, one
+  nonce scoping all files a command touches; `dd` uses its own `confirm=<nonce>`
+  key=value idiom). A new file, an append (`tee -a`), `patch --dry-run`, or a copy/move
+  *into* a directory never gates. The byte-oriented writers (`tee`/`write`/`dd`/`cp`)
+  now compare-and-swap against the gate's snapshot, so a concurrent change between the
+  gate and the write is a loud conflict rather than a silent clobber (`mv`'s same-mount
+  rename is already atomic). A prior file too large to snapshot (over the trash
+  max-size) falls through to `latch`/proceed, matching `rm`. Both gates are off by
+  default, so default behavior is unchanged.
 - **Validator advisory `W006` steers `test` to `[[ … ]]`.** Using a bare `test` as a
   command now surfaces a one-time stderr note (`use [[ … ]] …`) and still runs. A
   path-qualified form (`/usr/bin/test`, `./test`) is left alone — it's an explicit

--- a/crates/kaish-kernel/src/tools/builtin/cp.rs
+++ b/crates/kaish-kernel/src/tools/builtin/cp.rs
@@ -107,8 +107,18 @@ impl Tool for Cp {
                 .await
                 .map(|info| !info.is_dir())
                 .unwrap_or(false);
-            if dst_is_existing_file {
-                let src_display = crate::interpreter::value_to_string(&sources[0]);
+            let src_display = crate::interpreter::value_to_string(&sources[0]);
+            let src_resolved = ctx.resolve_path(&src_display);
+            let src_is_dir = ctx
+                .backend
+                .stat(Path::new(&src_resolved))
+                .await
+                .map(|info| info.is_dir())
+                .unwrap_or(false);
+            // Only a file→existing-file copy is a truncating overwrite. A dir
+            // source onto a file errors at mkdir anyway, so gating it would just
+            // take a spurious trash snapshot of a file that's never overwritten.
+            if dst_is_existing_file && !src_is_dir {
                 let snapshots = match ctx
                     .gate_overwrites("cp", &[(dest.clone(), false)], parsed.confirm.as_deref(), |nonce, joined| {
                         format!("cp --confirm=\"{nonce}\" {src_display} {joined}")

--- a/crates/kaish-kernel/src/tools/builtin/cp.rs
+++ b/crates/kaish-kernel/src/tools/builtin/cp.rs
@@ -6,7 +6,7 @@ use std::path::{Path, PathBuf};
 
 use crate::backend::{BackendError, KernelBackend, WriteMode};
 use crate::interpreter::ExecResult;
-use crate::tools::{schema_from_clap, ExecContext, ToolCtx, GlobalFlags, Tool, ToolArgs, ToolSchema};
+use crate::tools::{cas_overwrite, schema_from_clap, ExecContext, ToolCtx, GlobalFlags, Tool, ToolArgs, ToolSchema};
 
 /// Cp tool: copy files and directories.
 pub struct Cp;
@@ -20,6 +20,10 @@ struct CpArgs {
     recursive: bool,
 
     /// Do not overwrite existing files (-n)
+    /// Confirmation nonce for a latch-gated overwrite.
+    #[arg(long = "confirm")]
+    confirm: Option<String>,
+
     #[arg(short = 'n', long = "no-clobber", visible_alias = "no_clobber")]
     no_clobber: bool,
 
@@ -91,11 +95,47 @@ impl Tool for Cp {
             }
         }
 
+        // Gate a direct file clobber (`cp SRC EXISTING_FILE`) through latch +
+        // trash. Copying *into* a directory or a recursive directory merge is
+        // not a single-file truncation, so it stays ungated (documented
+        // write-model residual). Only the named destination is gated here.
+        let mut expected_dst: Option<Vec<u8>> = None;
+        if sources.len() == 1 {
+            let dst_is_existing_file = ctx
+                .backend
+                .stat(Path::new(&dst_path))
+                .await
+                .map(|info| !info.is_dir())
+                .unwrap_or(false);
+            if dst_is_existing_file {
+                let src_display = crate::interpreter::value_to_string(&sources[0]);
+                let snapshots = match ctx
+                    .gate_overwrites("cp", &[(dest.clone(), false)], parsed.confirm.as_deref(), |nonce, joined| {
+                        format!("cp --confirm=\"{nonce}\" {src_display} {joined}")
+                    })
+                    .await
+                {
+                    Ok(s) => s,
+                    Err(blocked) => return blocked,
+                };
+                expected_dst = snapshots.get(&dst_path).cloned();
+            }
+        }
+
         let mut last_err: Option<String> = None;
         for src_value in sources {
             let source = crate::interpreter::value_to_string(src_value);
             let src_path = ctx.resolve_path(&source);
-            if let Err(e) = copy_path(&*ctx.backend, &src_path, &dst_path, recursive, no_clobber).await {
+            if let Err(e) = copy_path(
+                &*ctx.backend,
+                &src_path,
+                &dst_path,
+                recursive,
+                no_clobber,
+                expected_dst.as_deref(),
+            )
+            .await
+            {
                 last_err = Some(format!("cp: {}", e));
             }
         }
@@ -113,6 +153,7 @@ async fn copy_path(
     dst: &Path,
     recursive: bool,
     no_clobber: bool,
+    expected: Option<&[u8]>,
 ) -> Result<(), BackendError> {
     let info = backend.stat(src).await?;
 
@@ -143,7 +184,10 @@ async fn copy_path(
         }
 
         let data = backend.read(src, None).await?;
-        backend.write(&final_dst, &data, WriteMode::Overwrite).await
+        // CAS against the gate snapshot (`expected`) when this is a gated direct
+        // file clobber — a concurrent change is a loud conflict, not a silent
+        // clobber. `expected` is `None` for a new file or an ungated path.
+        cas_overwrite(backend, &final_dst, &data, expected).await
     }
 }
 

--- a/crates/kaish-kernel/src/tools/builtin/dd.rs
+++ b/crates/kaish-kernel/src/tools/builtin/dd.rs
@@ -11,7 +11,7 @@ use async_trait::async_trait;
 use std::path::Path;
 
 use crate::ast::Value;
-use crate::backend::{ReadRange, WriteMode};
+use crate::backend::ReadRange;
 use crate::interpreter::{value_to_string, ExecResult};
 use crate::tools::{ExecContext, Tool, ToolArgs, ToolCtx, ToolSchema};
 
@@ -63,6 +63,7 @@ impl Tool for Dd {
         let mut bs: u64 = 512;
         let mut count: Option<u64> = None;
         let mut skip: u64 = 0;
+        let mut confirm: Option<String> = None;
 
         for operand in &args.positional {
             let raw = match operand {
@@ -92,6 +93,9 @@ impl Tool for Dd {
                     Ok(n) => skip = n,
                     Err(e) => return ExecResult::failure(2, format!("dd: skip: {e}")),
                 },
+                // Confirmation nonce for a latch-gated `of=` overwrite (dd's
+                // key=value idiom rather than the `--confirm` flag form).
+                "confirm" => confirm = Some(val.to_string()),
                 other => {
                     return ExecResult::failure(2, format!("dd: unknown operand {other:?}"))
                 }
@@ -158,9 +162,33 @@ impl Tool for Dd {
         match output {
             Some(out) => {
                 let out_resolved = ctx.resolve_path(&out);
+
+                // Gate the truncating `of=` overwrite through latch + trash. The
+                // latch re-run hint reinjects the operands `dd` can't run without
+                // (otherwise the advertised command would do nothing).
+                let hint_cmd = {
+                    let mut s = format!("dd if={input} of={out} bs={bs}");
+                    if let Some(c) = count {
+                        s.push_str(&format!(" count={c}"));
+                    }
+                    if skip > 0 {
+                        s.push_str(&format!(" skip={skip}"));
+                    }
+                    s
+                };
+                let snapshots = match ctx
+                    .gate_overwrites("dd", &[(out.clone(), false)], confirm.as_deref(), |nonce, _joined| {
+                        format!("{hint_cmd} confirm=\"{nonce}\"")
+                    })
+                    .await
+                {
+                    Ok(s) => s,
+                    Err(blocked) => return blocked,
+                };
+
+                let expected = snapshots.get(&out_resolved).map(|v| v.as_slice());
                 if let Err(e) = ctx
-                    .backend
-                    .write(Path::new(&out_resolved), &data, WriteMode::Overwrite)
+                    .overwrite_checked(Path::new(&out_resolved), &data, expected)
                     .await
                 {
                     return ExecResult::failure(1, format!("dd: {out}: {e}"));

--- a/crates/kaish-kernel/src/tools/builtin/mv.rs
+++ b/crates/kaish-kernel/src/tools/builtin/mv.rs
@@ -16,6 +16,10 @@ pub struct Mv;
 #[command(name = "mv", about = "Move (rename) files and directories")]
 struct MvArgs {
     /// Do not overwrite existing files (-n)
+    /// Confirmation nonce for a latch-gated overwrite.
+    #[arg(long = "confirm")]
+    confirm: Option<String>,
+
     #[arg(short = 'n', long = "no-clobber", visible_alias = "no_clobber")]
     no_clobber: bool,
 
@@ -80,6 +84,32 @@ impl Tool for Mv {
                     1,
                     format!("mv: target '{}' is not a directory", dest),
                 );
+            }
+        }
+
+        // Gate a direct file clobber (`mv SRC EXISTING_FILE`) through latch +
+        // trash. The gate snapshots the prior destination content to trash (the
+        // recovery copy) and handles the latch prompt; the move itself replaces
+        // it (an atomic same-mount `rename`, or unlink+write cross-mount), so no
+        // CAS is threaded. Moving *into* a directory or a recursive merge isn't
+        // a single-file truncation and stays ungated (documented residual).
+        if sources.len() == 1 {
+            let dst_is_existing_file = ctx
+                .backend
+                .stat(Path::new(&dst_path))
+                .await
+                .map(|info| !info.is_dir())
+                .unwrap_or(false);
+            if dst_is_existing_file {
+                let src_display = crate::interpreter::value_to_string(&sources[0]);
+                if let Err(blocked) = ctx
+                    .gate_overwrites("mv", &[(dest.clone(), false)], parsed.confirm.as_deref(), |nonce, joined| {
+                        format!("mv --confirm=\"{nonce}\" {src_display} {joined}")
+                    })
+                    .await
+                {
+                    return blocked;
+                }
             }
         }
 

--- a/crates/kaish-kernel/src/tools/builtin/rm.rs
+++ b/crates/kaish-kernel/src/tools/builtin/rm.rs
@@ -9,7 +9,7 @@ use std::path::{Path, PathBuf};
 
 use crate::backend::BackendError;
 use crate::interpreter::ExecResult;
-use crate::tools::{schema_from_clap, ExecContext, ToolCtx, GlobalFlags, Tool, ToolArgs, ToolSchema};
+use crate::tools::{is_trash_excluded, schema_from_clap, ExecContext, ToolCtx, GlobalFlags, Tool, ToolArgs, ToolSchema};
 
 /// clap-derived argv layer for rm.
 #[derive(Parser, Debug)]
@@ -76,13 +76,9 @@ fn decide_rm_action(
 
     if trash_enabled {
         if let Some(rp) = real_path {
-            // Skip trash for excluded paths (/tmp, /v/*)
-            // Use Path::starts_with (component-aware) not str starts_with,
-            // otherwise "/tmp_file.txt" would incorrectly match "/tmp".
-            let excluded = rp.starts_with("/tmp")
-                || rp.starts_with("/v");
-
-            if !excluded {
+            // Skip trash for excluded paths (/tmp, /v/*). Shared with the
+            // overwrite gate via `is_trash_excluded` so the list can't drift.
+            if !is_trash_excluded(Some(rp)) {
                 // Directories always go to trash — stat size is unreliable
                 // and trash::delete handles them atomically.
                 if is_dir {

--- a/crates/kaish-kernel/src/tools/builtin/tee.rs
+++ b/crates/kaish-kernel/src/tools/builtin/tee.rs
@@ -75,14 +75,15 @@ impl Tool for Tee {
             .iter()
             .map(|v| (crate::interpreter::value_to_string(v), append))
             .collect();
-        if let Err(blocked) = ctx
+        let snapshots = match ctx
             .gate_overwrites("tee", &targets, parsed.confirm.as_deref(), |nonce, joined| {
                 format!("tee --confirm=\"{nonce}\" {joined}")
             })
             .await
         {
-            return blocked;
-        }
+            Ok(s) => s,
+            Err(blocked) => return blocked,
+        };
 
         // Read raw bytes so binary passes through tee intact (to files and to
         // the next stage).
@@ -98,13 +99,20 @@ impl Tool for Tee {
             let path = Path::new(&resolved);
 
             // Overwrite writes the borrowed input directly (no clone); append
-            // needs a read-modify-write since the VFS lacks an append mode.
+            // needs a read-modify-write since the VFS lacks an append mode. A
+            // truncating overwrite of a gated target goes through a CAS against
+            // the gate's snapshot, so a concurrent change between the gate and
+            // this write is a loud conflict, not a silent clobber.
             let write_result = if append {
                 let mut combined = ctx.backend.read(path, None).await.unwrap_or_default();
                 combined.extend_from_slice(&input);
-                ctx.backend.write(path, &combined, WriteMode::Overwrite).await
+                ctx.backend
+                    .write(path, &combined, WriteMode::Overwrite)
+                    .await
+                    .map_err(|e| e.to_string())
             } else {
-                ctx.backend.write(path, &input, WriteMode::Overwrite).await
+                let expected = snapshots.get(&resolved).map(|v| v.as_slice());
+                ctx.overwrite_checked(path, &input, expected).await
             };
 
             if let Err(e) = write_result {
@@ -226,5 +234,53 @@ mod tests {
 
         let result = Tee.execute(ToolArgs::new(), &mut ctx).await;
         assert!(!result.ok());
+    }
+
+    // ── CAS overwrite (the primitive tee routes its truncating writes through) ──
+
+    #[tokio::test]
+    async fn overwrite_checked_rejects_concurrent_change() {
+        let ctx = make_ctx().await; // /existing.txt = "original content\n"
+        let path = Path::new("/existing.txt");
+        let snapshot = b"original content\n".to_vec();
+
+        // A concurrent writer changes the file after the gate snapshotted it.
+        ctx.backend
+            .write(path, b"changed elsewhere\n", WriteMode::Overwrite)
+            .await
+            .unwrap();
+
+        // CAS against the now-stale snapshot must refuse to clobber.
+        let result = ctx.overwrite_checked(path, b"my content\n", Some(&snapshot)).await;
+        assert!(result.is_err(), "expected a conflict, got {result:?}");
+
+        // The concurrent writer's content survives untouched.
+        let now = ctx.backend.read(path, None).await.unwrap();
+        assert_eq!(now, b"changed elsewhere\n");
+    }
+
+    #[tokio::test]
+    async fn overwrite_checked_writes_when_snapshot_matches() {
+        let ctx = make_ctx().await;
+        let path = Path::new("/existing.txt");
+        let snapshot = b"original content\n".to_vec();
+
+        ctx.overwrite_checked(path, b"new content\n", Some(&snapshot))
+            .await
+            .unwrap();
+        assert_eq!(
+            ctx.backend.read(path, None).await.unwrap(),
+            b"new content\n"
+        );
+    }
+
+    #[tokio::test]
+    async fn overwrite_checked_skips_cas_without_expectation() {
+        let ctx = make_ctx().await;
+        let path = Path::new("/existing.txt");
+
+        // No snapshot (gate off / new file): a plain overwrite, no CAS.
+        ctx.overwrite_checked(path, b"forced\n", None).await.unwrap();
+        assert_eq!(ctx.backend.read(path, None).await.unwrap(), b"forced\n");
     }
 }

--- a/crates/kaish-kernel/src/tools/builtin/tee.rs
+++ b/crates/kaish-kernel/src/tools/builtin/tee.rs
@@ -283,4 +283,21 @@ mod tests {
         ctx.overwrite_checked(path, b"forced\n", None).await.unwrap();
         assert_eq!(ctx.backend.read(path, None).await.unwrap(), b"forced\n");
     }
+
+    #[tokio::test]
+    async fn overwrite_checked_errors_when_reread_fails_even_for_empty_snapshot() {
+        let ctx = make_ctx().await;
+        // Snapshot an EMPTY file, then have it vanish (concurrent delete).
+        let path = Path::new("/empty.txt");
+        ctx.backend.write(path, b"", WriteMode::Overwrite).await.unwrap();
+        let empty_snapshot: Vec<u8> = Vec::new();
+        ctx.backend.remove(path, false).await.unwrap();
+
+        // A failed re-read must surface loudly — not be swallowed to `[]` and
+        // false-match the empty snapshot, which would silently (re)write.
+        let result = ctx
+            .overwrite_checked(path, b"new\n", Some(&empty_snapshot))
+            .await;
+        assert!(result.is_err(), "vanished target must error, got {result:?}");
+    }
 }

--- a/crates/kaish-kernel/src/tools/builtin/write.rs
+++ b/crates/kaish-kernel/src/tools/builtin/write.rs
@@ -5,7 +5,6 @@ use clap::{CommandFactory, Parser};
 use std::path::Path;
 
 use crate::ast::Value;
-use crate::backend::WriteMode;
 use crate::interpreter::{ExecResult, OutputData};
 use crate::tools::{schema_from_clap, ExecContext, ToolCtx, GlobalFlags, Tool, ToolArgs, ToolSchema};
 
@@ -23,6 +22,10 @@ struct WriteArgs {
     /// Content to write (positional or --content). Falls back to stdin when absent.
     #[arg(long)]
     content: Option<String>,
+
+    /// Confirmation nonce for a latch-gated overwrite.
+    #[arg(long = "confirm")]
+    confirm: Option<String>,
 
     #[command(flatten)]
     global: GlobalFlags,
@@ -66,6 +69,21 @@ impl Tool for Write {
             None => return ExecResult::failure(1, "write: missing path argument"),
         };
 
+        let resolved = ctx.resolve_path(&path);
+
+        // Gate the truncating overwrite through latch + trash (no-op when both
+        // are off). On latch this returns an exit-2 nonce result; under trash
+        // the prior content is snapshotted and returned for the CAS below.
+        let snapshots = match ctx
+            .gate_overwrites("write", &[(path.clone(), false)], parsed.confirm.as_deref(), |nonce, joined| {
+                format!("write --confirm=\"{nonce}\" {joined}")
+            })
+            .await
+        {
+            Ok(s) => s,
+            Err(blocked) => return blocked,
+        };
+
         // Content can be positional[1], named "content", or stdin. Read it as
         // raw bytes so a `Value::Bytes` (e.g. from `$(producer)`) is written
         // verbatim instead of stringified to the `[binary: N bytes]` marker —
@@ -82,9 +100,10 @@ impl Tool for Write {
             }
         };
 
-        let resolved = ctx.resolve_path(&path);
-
-        match ctx.backend.write(Path::new(&resolved), &content, WriteMode::Overwrite).await {
+        // CAS against the gate snapshot: a concurrent change between the gate
+        // and this write is a loud conflict, not a silent clobber.
+        let expected = snapshots.get(&resolved).map(|v| v.as_slice());
+        match ctx.overwrite_checked(Path::new(&resolved), &content, expected).await {
             Ok(()) => ExecResult::with_output(OutputData::text(format!("Wrote {} bytes to {}", content.len(), path))),
             Err(e) => ExecResult::failure(1, format!("write: {}: {}", path, e)),
         }

--- a/crates/kaish-kernel/src/tools/context.rs
+++ b/crates/kaish-kernel/src/tools/context.rs
@@ -177,13 +177,31 @@ pub(crate) enum MutationAction {
     Latch,
 }
 
+/// Prior content the gate snapshotted, keyed by resolved path, for callers that
+/// compare-and-swap their overwrite against it (see `overwrite_checked`). Only
+/// gated existing targets that were trash-snapshotted appear; a new file, an
+/// append, an excluded/ungated path, or a latch-only target is absent — the
+/// caller writes those without a CAS expectation.
+pub(crate) type GateSnapshots = std::collections::HashMap<PathBuf, Vec<u8>>;
+
+/// Real paths the trash gate skips: scratch (`/tmp`) and the in-memory VFS
+/// (`/v`) mounts, where snapshotting prior content to trash is pointless.
+/// Shared by `rm`'s delete gate (`decide_rm_action`) and the overwrite gate
+/// (`decide_mutation_action`) so the exclusion list can't drift between them.
+/// `Path::starts_with` is component-aware, so `/tmp_file` does not match `/tmp`.
+pub(crate) fn is_trash_excluded(real_path: Option<&Path>) -> bool {
+    matches!(real_path, Some(rp) if rp.starts_with("/tmp") || rp.starts_with("/v"))
+}
+
 /// Decide how to gate a truncating overwrite, mirroring `rm`'s trash/latch
 /// priority. Pure so the decision table is unit-testable in isolation.
 ///
 /// - A non-existent target or an append has nothing to lose → `Proceed`.
 /// - A real path under `/tmp` or `/v` is excluded (matches `rm`) → `Proceed`.
-/// - Otherwise trash wins over latch (trash IS the safety net): `TrashFirst`
-///   when trash is on, else `Latch` when latch is on, else `Proceed`.
+/// - Trash wins over latch (trash IS the safety net): `TrashFirst` when trash
+///   is on **and** the prior content fits under `trash_max_size` (a file too
+///   big to snapshot can't be backed up, so it falls through, exactly like
+///   `rm`); else `Latch` when latch is on; else `Proceed`.
 ///
 /// An overlay/in-memory target has `real_path == None`, so it is *not* excluded
 /// and stays gated — the protection is about agent-operation safety, not just
@@ -194,22 +212,52 @@ pub(crate) fn decide_mutation_action(
     real_path: Option<&Path>,
     target_exists: bool,
     is_append: bool,
+    file_size: u64,
+    trash_max_size: u64,
 ) -> MutationAction {
     if !target_exists || is_append {
         return MutationAction::Proceed;
     }
-    if let Some(rp) = real_path {
-        if rp.starts_with("/tmp") || rp.starts_with("/v") {
-            return MutationAction::Proceed;
-        }
+    if is_trash_excluded(real_path) {
+        return MutationAction::Proceed;
     }
-    if trash_enabled {
+    if trash_enabled && file_size <= trash_max_size {
         return MutationAction::TrashFirst;
     }
     if latch_enabled {
         return MutationAction::Latch;
     }
     MutationAction::Proceed
+}
+
+/// Overwrite `resolved` with `content`, optionally compare-and-swapping against
+/// `expected` first. When `expected` is `Some`, the current bytes are re-read
+/// and must equal it (the write-model gate's snapshot), else a concurrent
+/// change is a loud conflict — never a silent clobber. Binary-safe (raw bytes,
+/// unlike the `String`-based `PatchOp` CAS). Shared by the byte-oriented gated
+/// builtins via `ExecContext::overwrite_checked` (`tee`/`write`/`dd`) and
+/// directly by `cp`'s free copy path. Not OS-atomic — a crash mid-write can
+/// still truncate (the atomic write-temp-then-rename primitive is a tracked
+/// write-model residual).
+pub(crate) async fn cas_overwrite(
+    backend: &dyn KernelBackend,
+    resolved: &Path,
+    content: &[u8],
+    expected: Option<&[u8]>,
+) -> Result<(), crate::backend::BackendError> {
+    if let Some(exp) = expected {
+        let current = backend.read(resolved, None).await.unwrap_or_default();
+        if current != exp {
+            return Err(crate::backend::BackendError::InvalidOperation(
+                "file changed since the write-model gate checked it (concurrent write); \
+                 aborting overwrite"
+                    .to_string(),
+            ));
+        }
+    }
+    backend
+        .write(resolved, content, crate::backend::WriteMode::Overwrite)
+        .await
 }
 
 impl ExecContext {
@@ -707,10 +755,13 @@ impl ExecContext {
     /// `--confirm=<nonce>`: the first call returns an exit-2 latch result with
     /// one nonce scoping every latched path.
     ///
-    /// `Ok(())` means every snapshot is done and the caller may write all
-    /// targets. `Err(result)` is what the caller must return verbatim (the
-    /// latch prompt, an invalid nonce, or a trash failure — never fall through
-    /// to a destructive overwrite on error).
+    /// `Ok(snapshots)` means every snapshot is done and the caller may write
+    /// all targets; `snapshots` maps each trash-snapshotted target's resolved
+    /// path to its prior bytes, so a byte-oriented caller can pass them as the
+    /// `expected` to `overwrite_checked` for a binary-safe compare-and-swap.
+    /// `Err(result)` is what the caller must return verbatim (the latch prompt,
+    /// an invalid nonce, or a trash failure — never fall through to a
+    /// destructive overwrite on error).
     ///
     /// `confirm_hint` builds the re-run command shown in the latch prompt, given
     /// the nonce and the space-joined latched paths. Most callers want
@@ -724,13 +775,14 @@ impl ExecContext {
         targets: &[(String, bool)],
         confirm: Option<&str>,
         confirm_hint: impl FnOnce(&str, &str) -> String,
-    ) -> Result<(), ExecResult> {
+    ) -> Result<GateSnapshots, ExecResult> {
         let trash_enabled = self.scope.trash_enabled();
         let latch_enabled = self.scope.latch_enabled();
         // Fast path: both gates off, nothing to do.
         if !trash_enabled && !latch_enabled {
-            return Ok(());
+            return Ok(GateSnapshots::new());
         }
+        let trash_max_size = self.scope.trash_max_size();
 
         struct Decided {
             display: String,
@@ -751,12 +803,25 @@ impl ExecContext {
             // snapshot reads bytes through the backend, not the real path.
             let real = self.backend.resolve_real_path(Path::new(&resolved));
             let exists = self.backend.exists(Path::new(&resolved)).await;
+            // Prior size decides trash eligibility (a file too big to snapshot
+            // can't be backed up). Only stat an existing target.
+            let size = if exists {
+                self.backend
+                    .stat(Path::new(&resolved))
+                    .await
+                    .map(|e| e.size)
+                    .unwrap_or(0)
+            } else {
+                0
+            };
             let action = decide_mutation_action(
                 trash_enabled,
                 latch_enabled,
                 real.as_deref(),
                 exists,
                 *is_append,
+                size,
+                trash_max_size,
             );
             decided.push(Decided { display: display.clone(), resolved, action });
         }
@@ -783,19 +848,24 @@ impl ExecContext {
             }
         }
 
-        // Snapshot prior content for every trash-first target before any write.
+        // Snapshot prior content for every trash-first target before any write,
+        // keeping the bytes so a byte-oriented caller can CAS against them.
+        let mut snapshots = GateSnapshots::new();
         for d in &decided {
             if matches!(d.action, MutationAction::TrashFirst) {
-                if let Err(e) = self.snapshot_for_overwrite(&d.display, &d.resolved).await {
-                    return Err(ExecResult::failure(1, format!("{command}: {e}")));
+                match self.snapshot_for_overwrite(&d.display, &d.resolved).await {
+                    Ok(bytes) => {
+                        snapshots.insert(d.resolved.clone(), bytes);
+                    }
+                    Err(e) => return Err(ExecResult::failure(1, format!("{command}: {e}"))),
                 }
             }
         }
-        Ok(())
+        Ok(snapshots)
     }
 
     /// Copy the prior content of `resolved` into the trash before it's
-    /// overwritten.
+    /// overwritten, returning those bytes for the caller's compare-and-swap.
     ///
     /// We **copy** (not move): the builtin overwrites the file in place next,
     /// and read-modify-write callers (`patch`, `sed -i`) still need to read it —
@@ -804,7 +874,11 @@ impl ExecContext {
     /// through the backend so a real, overlay, or in-memory file is handled the
     /// same way. A missing trash backend or a trash failure is an error — never
     /// a silent fall-through to a destructive overwrite.
-    async fn snapshot_for_overwrite(&self, display: &str, resolved: &Path) -> Result<(), String> {
+    async fn snapshot_for_overwrite(
+        &self,
+        display: &str,
+        resolved: &Path,
+    ) -> Result<Vec<u8>, String> {
         let trash = self
             .trash_backend
             .as_ref()
@@ -817,7 +891,28 @@ impl ExecContext {
         trash
             .trash_bytes(Path::new(display), &bytes)
             .await
-            .map_err(|e| format!("{display}: trash failed: {e}"))
+            .map_err(|e| format!("{display}: trash failed: {e}"))?;
+        Ok(bytes)
+    }
+
+    /// Overwrite `resolved` with `content`. When `expected` is `Some`, this is a
+    /// binary-safe compare-and-swap: the current bytes are re-read and must
+    /// equal `expected` (the gate's snapshot), else it errors — a concurrent
+    /// change since the gate is a loud conflict, never a silent clobber. Unlike
+    /// the `String`-based `PatchOp::Replace` CAS used by `patch`/`sed -i`, this
+    /// operates on raw bytes, so binary overwrites (`tee`, `write`, `dd`, `cp`,
+    /// `mv`) keep the same protection. It is *not* OS-atomic — a crash mid-write
+    /// can still truncate; the atomic write-temp-then-rename primitive remains a
+    /// tracked write-model residual.
+    pub(crate) async fn overwrite_checked(
+        &self,
+        resolved: &Path,
+        content: &[u8],
+        expected: Option<&[u8]>,
+    ) -> Result<(), String> {
+        cas_overwrite(&*self.backend, resolved, content, expected)
+            .await
+            .map_err(|e| e.to_string())
     }
 
     /// Expand a glob pattern to matching file paths.
@@ -1013,7 +1108,9 @@ mod tests {
         exists: bool,
         append: bool,
     ) -> MutationAction {
-        decide_mutation_action(trash, latch, real.map(Path::new), exists, append)
+        // Default to a small file well under the cap; the size-cap behavior
+        // has its own dedicated test below.
+        decide_mutation_action(trash, latch, real.map(Path::new), exists, append, 1, 10_000_000)
     }
 
     #[test]
@@ -1052,5 +1149,26 @@ mod tests {
         // No real path (overlay/in-memory) is NOT excluded — still trash-first.
         assert_eq!(decide(true, true, None, true, false), MutationAction::TrashFirst);
         assert_eq!(decide(false, true, None, true, false), MutationAction::Latch);
+    }
+
+    #[test]
+    fn file_too_big_to_trash_falls_through_like_rm() {
+        // Prior content larger than the cap can't be snapshotted, so trash is
+        // skipped: latch gates if on, else the overwrite proceeds unbacked.
+        let big = 100u64;
+        let cap = 10u64;
+        assert_eq!(
+            decide_mutation_action(true, true, Some(Path::new("/work/f")), true, false, big, cap),
+            MutationAction::Latch
+        );
+        assert_eq!(
+            decide_mutation_action(true, false, Some(Path::new("/work/f")), true, false, big, cap),
+            MutationAction::Proceed
+        );
+        // Exactly at the cap still trashes (inclusive bound, matches rm).
+        assert_eq!(
+            decide_mutation_action(true, false, Some(Path::new("/work/f")), true, false, cap, cap),
+            MutationAction::TrashFirst
+        );
     }
 }

--- a/crates/kaish-kernel/src/tools/context.rs
+++ b/crates/kaish-kernel/src/tools/context.rs
@@ -246,7 +246,11 @@ pub(crate) async fn cas_overwrite(
     expected: Option<&[u8]>,
 ) -> Result<(), crate::backend::BackendError> {
     if let Some(exp) = expected {
-        let current = backend.read(resolved, None).await.unwrap_or_default();
+        // Propagate a re-read failure loudly — never `unwrap_or_default()` it to
+        // empty bytes, which would false-match an empty snapshot (silent
+        // overwrite) or report a bogus "file changed" for a real I/O error. A
+        // target that vanished since the gate (NotFound) is a change → abort.
+        let current = backend.read(resolved, None).await?;
         if current != exp {
             return Err(crate::backend::BackendError::InvalidOperation(
                 "file changed since the write-model gate checked it (concurrent write); \

--- a/crates/kaish-kernel/src/tools/mod.rs
+++ b/crates/kaish-kernel/src/tools/mod.rs
@@ -24,6 +24,7 @@ pub use builtin::register_builtins;
 pub use builtin::resolve_in_path;
 pub use clap_schema::{params_from_clap, schema_from_clap, schema_tree_from_clap};
 pub use context::{ExecContext, OutputContext};
+pub(crate) use context::{cas_overwrite, is_trash_excluded};
 pub use global_flags::GlobalFlags;
 pub use registry::ToolRegistry;
 pub use traits::{is_global_output_flag, validate_against_schema, Tool, ToolArgs, ToolCtx, ToolSchema, ParamSchema};

--- a/crates/kaish-kernel/tests/latch_trash_tests.rs
+++ b/crates/kaish-kernel/tests/latch_trash_tests.rs
@@ -878,3 +878,20 @@ async fn dd_of_overwrite_under_latch_requires_confirm() {
     assert_eq!(r2.code, 0, "confirmed dd succeeds: {}", r2.err);
     assert_eq!(std::fs::read_to_string(dir.path().join("out.bin")).unwrap(), "fresh");
 }
+
+#[tokio::test]
+async fn dd_of_overwrite_under_trash_snapshots_prior_bytes() {
+    let dir = tempdir();
+    std::fs::write(dir.path().join("in.bin"), "fresh").expect("write");
+    std::fs::write(dir.path().join("out.bin"), "old").expect("write");
+    let mock = Arc::new(MockTrash::default());
+    let kernel = kernel_with_trash(dir.path(), &mock);
+
+    run(&kernel, "set -o trash").await;
+    let r = run(&kernel, "dd if=in.bin of=out.bin").await;
+    assert_eq!(r.code, 0, "err: {}", r.err);
+    let snaps = mock.snapshots();
+    assert_eq!(snaps.len(), 1, "snapshot of the prior of= file: {snaps:?}");
+    assert_eq!(snaps[0].1, b"old");
+    assert_eq!(std::fs::read_to_string(dir.path().join("out.bin")).unwrap(), "fresh");
+}

--- a/crates/kaish-kernel/tests/latch_trash_tests.rs
+++ b/crates/kaish-kernel/tests/latch_trash_tests.rs
@@ -691,3 +691,190 @@ async fn sed_in_place_without_operands_is_a_loud_error() {
     assert_eq!(r.code, 1, "no file operands must error: {}", r.err);
     assert!(r.err.contains("requires file operands"), "err: {}", r.err);
 }
+
+// ============================================================================
+// Write-model gate: write / dd / cp / mv overwrites honor latch + trash too
+// (the same gate as tee/patch/sed -i). These builtins previously bypassed it.
+// ============================================================================
+
+#[tokio::test]
+async fn write_overwrite_under_trash_snapshots_prior_bytes() {
+    let dir = tempdir();
+    std::fs::write(dir.path().join("doc.txt"), "old").expect("write");
+    let mock = Arc::new(MockTrash::default());
+    let kernel = kernel_with_trash(dir.path(), &mock);
+
+    run(&kernel, "set -o trash").await;
+    let r = run(&kernel, "write doc.txt \"new\"").await;
+    assert_eq!(r.code, 0, "err: {}", r.err);
+
+    let snaps = mock.snapshots();
+    assert_eq!(snaps.len(), 1, "one snapshot for the overwrite: {snaps:?}");
+    assert_eq!(snaps[0].1, b"old", "the snapshot captured the prior content");
+    assert_eq!(std::fs::read_to_string(dir.path().join("doc.txt")).unwrap(), "new");
+}
+
+#[tokio::test]
+async fn write_overwrite_under_latch_requires_confirm() {
+    let dir = tempdir();
+    std::fs::write(dir.path().join("doc.txt"), "keep").expect("write");
+    let mock = Arc::new(MockTrash::default());
+    let kernel = kernel_with_trash(dir.path(), &mock);
+
+    run(&kernel, "set -o latch").await;
+    let r = run(&kernel, "write doc.txt \"new\"").await;
+    assert_eq!(r.code, 2, "latch gates write: {}", r.err);
+    assert!(r.err.contains("--confirm="));
+    assert_eq!(std::fs::read_to_string(dir.path().join("doc.txt")).unwrap(), "keep");
+
+    let nonce = latch_data_str(&r, "nonce");
+    let r2 = run(&kernel, &format!("write --confirm=\"{nonce}\" doc.txt \"new\"")).await;
+    assert_eq!(r2.code, 0, "confirmed write succeeds: {}", r2.err);
+    assert_eq!(std::fs::read_to_string(dir.path().join("doc.txt")).unwrap(), "new");
+}
+
+#[tokio::test]
+async fn write_new_file_does_not_gate() {
+    let dir = tempdir();
+    let mock = Arc::new(MockTrash::default());
+    let kernel = kernel_with_trash(dir.path(), &mock);
+    run(&kernel, "set -o latch").await;
+    let r = run(&kernel, "write fresh.txt \"hi\"").await;
+    assert_eq!(r.code, 0, "a new file has nothing to lose, no gate: {}", r.err);
+    assert_eq!(std::fs::read_to_string(dir.path().join("fresh.txt")).unwrap(), "hi");
+}
+
+#[tokio::test]
+async fn overwrite_too_big_for_trash_falls_through_to_latch() {
+    let dir = tempdir();
+    std::fs::write(dir.path().join("big.txt"), "0123456789").expect("write"); // 10 bytes
+    let mock = Arc::new(MockTrash::default());
+    let kernel = kernel_with_trash(dir.path(), &mock);
+
+    run(&kernel, "kaish-trash config max-size 2").await; // 2-byte cap
+    run(&kernel, "set -o trash").await;
+    run(&kernel, "set -o latch").await;
+    // 10 bytes > the 2-byte cap: can't snapshot, so trash is skipped and latch
+    // gates instead — mirroring rm's too-big-to-trash fall-through (#3).
+    let r = run(&kernel, "write big.txt \"new\"").await;
+    assert_eq!(r.code, 2, "a file too big to trash should latch: {}", r.err);
+    assert!(mock.snapshots().is_empty(), "no snapshot when over the cap");
+    assert_eq!(
+        std::fs::read_to_string(dir.path().join("big.txt")).unwrap(),
+        "0123456789",
+        "the file is untouched until confirmed"
+    );
+}
+
+#[tokio::test]
+async fn cp_overwrite_under_latch_requires_confirm() {
+    let dir = tempdir();
+    std::fs::write(dir.path().join("src.txt"), "fresh").expect("write");
+    std::fs::write(dir.path().join("dst.txt"), "old").expect("write");
+    let mock = Arc::new(MockTrash::default());
+    let kernel = kernel_with_trash(dir.path(), &mock);
+
+    run(&kernel, "set -o latch").await;
+    let r = run(&kernel, "cp src.txt dst.txt").await;
+    assert_eq!(r.code, 2, "cp onto an existing file gates: {}", r.err);
+    assert!(r.err.contains("--confirm="));
+    assert_eq!(std::fs::read_to_string(dir.path().join("dst.txt")).unwrap(), "old");
+
+    let nonce = latch_data_str(&r, "nonce");
+    let r2 = run(&kernel, &format!("cp --confirm=\"{nonce}\" src.txt dst.txt")).await;
+    assert_eq!(r2.code, 0, "confirmed cp succeeds: {}", r2.err);
+    assert_eq!(std::fs::read_to_string(dir.path().join("dst.txt")).unwrap(), "fresh");
+}
+
+#[tokio::test]
+async fn cp_overwrite_under_trash_snapshots_prior_bytes() {
+    let dir = tempdir();
+    std::fs::write(dir.path().join("src.txt"), "fresh").expect("write");
+    std::fs::write(dir.path().join("dst.txt"), "old").expect("write");
+    let mock = Arc::new(MockTrash::default());
+    let kernel = kernel_with_trash(dir.path(), &mock);
+
+    run(&kernel, "set -o trash").await;
+    let r = run(&kernel, "cp src.txt dst.txt").await;
+    assert_eq!(r.code, 0, "err: {}", r.err);
+    let snaps = mock.snapshots();
+    assert_eq!(snaps.len(), 1, "snapshot of the prior destination: {snaps:?}");
+    assert_eq!(snaps[0].1, b"old");
+    assert_eq!(std::fs::read_to_string(dir.path().join("dst.txt")).unwrap(), "fresh");
+}
+
+#[tokio::test]
+async fn cp_into_existing_directory_does_not_gate_the_dir() {
+    // `cp SRC DIR` targets DIR/SRC (a new file here), never truncates DIR
+    // itself — the named directory must not be gated or snapshotted.
+    let dir = tempdir();
+    std::fs::write(dir.path().join("src.txt"), "data").expect("write");
+    std::fs::create_dir(dir.path().join("d")).expect("mkdir");
+    let mock = Arc::new(MockTrash::default());
+    let kernel = kernel_with_trash(dir.path(), &mock);
+
+    run(&kernel, "set -o latch").await;
+    let r = run(&kernel, "cp src.txt d").await;
+    assert_eq!(r.code, 0, "cp into a directory must not gate the dir: {}", r.err);
+    assert_eq!(std::fs::read_to_string(dir.path().join("d/src.txt")).unwrap(), "data");
+}
+
+#[tokio::test]
+async fn mv_overwrite_under_latch_requires_confirm() {
+    let dir = tempdir();
+    std::fs::write(dir.path().join("src.txt"), "fresh").expect("write");
+    std::fs::write(dir.path().join("dst.txt"), "old").expect("write");
+    let mock = Arc::new(MockTrash::default());
+    let kernel = kernel_with_trash(dir.path(), &mock);
+
+    run(&kernel, "set -o latch").await;
+    let r = run(&kernel, "mv src.txt dst.txt").await;
+    assert_eq!(r.code, 2, "mv onto an existing file gates: {}", r.err);
+    assert!(r.err.contains("--confirm="));
+    assert_eq!(std::fs::read_to_string(dir.path().join("dst.txt")).unwrap(), "old");
+    assert!(dir.path().join("src.txt").exists(), "src must survive a gated mv");
+
+    let nonce = latch_data_str(&r, "nonce");
+    let r2 = run(&kernel, &format!("mv --confirm=\"{nonce}\" src.txt dst.txt")).await;
+    assert_eq!(r2.code, 0, "confirmed mv succeeds: {}", r2.err);
+    assert_eq!(std::fs::read_to_string(dir.path().join("dst.txt")).unwrap(), "fresh");
+    assert!(!dir.path().join("src.txt").exists(), "src removed after the move");
+}
+
+#[tokio::test]
+async fn mv_overwrite_under_trash_snapshots_prior_bytes() {
+    let dir = tempdir();
+    std::fs::write(dir.path().join("src.txt"), "fresh").expect("write");
+    std::fs::write(dir.path().join("dst.txt"), "old").expect("write");
+    let mock = Arc::new(MockTrash::default());
+    let kernel = kernel_with_trash(dir.path(), &mock);
+
+    run(&kernel, "set -o trash").await;
+    let r = run(&kernel, "mv src.txt dst.txt").await;
+    assert_eq!(r.code, 0, "err: {}", r.err);
+    let snaps = mock.snapshots();
+    assert_eq!(snaps.len(), 1, "snapshot of the prior destination: {snaps:?}");
+    assert_eq!(snaps[0].1, b"old");
+    assert_eq!(std::fs::read_to_string(dir.path().join("dst.txt")).unwrap(), "fresh");
+}
+
+#[tokio::test]
+async fn dd_of_overwrite_under_latch_requires_confirm() {
+    let dir = tempdir();
+    std::fs::write(dir.path().join("in.bin"), "fresh").expect("write");
+    std::fs::write(dir.path().join("out.bin"), "old").expect("write");
+    let mock = Arc::new(MockTrash::default());
+    let kernel = kernel_with_trash(dir.path(), &mock);
+
+    run(&kernel, "set -o latch").await;
+    let r = run(&kernel, "dd if=in.bin of=out.bin").await;
+    assert_eq!(r.code, 2, "dd of= onto an existing file gates: {}", r.err);
+    assert!(r.err.contains("confirm="));
+    assert_eq!(std::fs::read_to_string(dir.path().join("out.bin")).unwrap(), "old");
+
+    // dd's latch hint uses its key=value idiom: `dd ... confirm="<nonce>"`.
+    let nonce = latch_data_str(&r, "nonce");
+    let r2 = run(&kernel, &format!("dd if=in.bin of=out.bin confirm=\"{nonce}\"")).await;
+    assert_eq!(r2.code, 0, "confirmed dd succeeds: {}", r2.err);
+    assert_eq!(std::fs::read_to_string(dir.path().join("out.bin")).unwrap(), "fresh");
+}

--- a/docs/EMBEDDING.md
+++ b/docs/EMBEDDING.md
@@ -135,10 +135,13 @@ in-memory VFS growth), `.with_skip_validation(bool)`, `.with_initial_vars(map)`
 
 #### Destructive-op rails: reading the latch nonce
 
-With `.with_latch(true)`, a destructive op (`rm`, and the overwrite gate behind
-`tee` / `patch` / `sed -i`) does not run on first call — it returns an
-`ExecResult` with **exit code 2** and a confirmation nonce. The re-run is the
-same argv plus `--confirm=<nonce>`. The output contract:
+With `.with_latch(true)`, a destructive op (`rm`'s delete, and the truncating
+overwrite behind `tee` / `patch` / `sed -i` / `write` / `cp` / `mv` / `dd of=`)
+does not run on first call — it returns an `ExecResult` with **exit code 2** and a
+confirmation nonce. The re-run is the same argv plus `--confirm=<nonce>` (`dd` uses
+its `confirm=<nonce>` key=value idiom). Copying or moving *into* a directory, and
+recursive `cp -r`/`mv` of a tree, gate only the named destination, not per-child
+overwrites. The output contract:
 
 - **`ExecResult.err`** (which a frontend routes to stderr) carries the
   human-readable prompt;

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -480,8 +480,12 @@ the stderr text. Where it lands depends on the output format:
               "hint": "...", "ttl": 60 } }
   ```
 
-The same contract holds for the overwrite gate (`tee`, `patch`, `sed -i`): exit 2,
-human prompt on the `err` channel, nonce on `.data` (nested under `--json`).
+The same contract holds for the truncating-overwrite gate (`tee`, `patch`,
+`sed -i`, `write`, `cp`, `mv`, `dd of=`): exit 2, human prompt on the `err`
+channel, nonce on `.data` (nested under `--json`). `dd` confirms with its
+`confirm=<nonce>` key=value idiom rather than `--confirm=`; copying or moving
+*into* a directory (and recursive `cp -r`/`mv` of a tree) gates the named
+destination, not each child file.
 
 The `kaish-trash` builtin manages trashed files: `list`, `restore`, `empty`, `config`.
 

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -186,37 +186,47 @@ Still open (deferred — bigger than a builtin fix, each its own focused PR):
     (`eval.rs`, non-kernel embedders only) still doesn't expand — it has no `HOME`
     source on the trait; left as-is until an embedder needs the sync `[[ ]]` path.
 
-### Write-model gate — DONE; two residuals
-**`tee` + `patch` + `sed -i` all gated** (`feat/mutation-write-gate` →
-`feat/patch-write-gate` → `feat/sed-in-place`): pure `decide_mutation_action →
-{TrashFirst, Latch, Proceed}` + `ExecContext::gate_overwrites`/
-`snapshot_for_overwrite` (copies prior content via `TrashBackend::trash_bytes`,
-leaving the file in place) + family-wide `--confirm=<nonce>`, one nonce per command.
-`sed -i` edits one-or-more files in place (no operands → loud error). Latch+trash
-stay ON in overlay mode; `tee -a` append / new file / `patch --dry-run` don't gate.
+### Write-model gate — DONE (full family); residuals
+**Gated: `rm` (delete) + `tee`/`patch`/`sed -i`/`write`/`cp`/`mv`/`dd of=` (truncating
+overwrite)** (`feat/complete-write-model-gate` finished the last four, which had
+bypassed the gate entirely). Pure `decide_mutation_action → {TrashFirst, Latch,
+Proceed}` — now **size-aware** (a prior file over `trash_max_size` can't be snapshotted
+so it falls through to latch/proceed, like `rm`) — plus `ExecContext::gate_overwrites`
+(snapshots prior content via `TrashBackend::trash_bytes` **and returns those bytes**) and
+the binary-safe `cas_overwrite`/`overwrite_checked` (re-read + compare prior bytes; no
+`String` `PatchOp`) used by the byte-oriented writers. `rm` and the overwrite gate share
+`is_trash_excluded` (the `/tmp`,`/v` list) so it can't drift. Family-wide
+`--confirm=<nonce>`, one nonce per command (`dd` uses its `confirm=<nonce>` key=value
+idiom). New file / append (`tee -a`) / `patch --dry-run` / copy-or-move *into* a
+directory don't gate. Latch+trash stay ON in overlay mode.
 
 Residuals:
+- **cp/mv recursive & into-directory overwrites are ungated.** The gate covers the
+  *named* destination when it already exists as a file (the direct `cp/mv SRC FILE`
+  clobber). A recursive `cp -r`/`mv` merging into an existing directory (per-child
+  writes in `copy_dir_recursive`/`move_dir_recursive`) and a `SRC DIR/` that overwrites
+  `DIR/SRC` are NOT gated — neither truncates the named target. The real fix is up-front
+  enumeration of every clobbered child so one nonce can scope them; deferred.
+- **`mv` overwrite has no CAS** (gate-snapshot + latch only). The same-mount path is an
+  atomic `rename` (no read→write window to guard) and the cross-mount path is
+  unlink+write; the trash snapshot is the recovery. Fine as-is — recorded for symmetry.
 - **`sed -i.bak` backup suffix.** Not supported: kaish's lexer splits `-i.bak` at
   the dot (dot-prefixed barewords), and the kernel value-flag binder consumes the
   *next* token greedily, so GNU's glued-optional-suffix isn't modelable post-lexing.
   The trash snapshot already gives a recoverable copy, so this is convenience, not
   safety. Needs lexer/binder work (or a bespoke pre-clap argv pass à la `set.rs`).
-- **Atomicity (whole family).** `tee`/`patch`/`sed -i` overwrite via
-  `backend.write(Overwrite)` (`patch`/`sed -i` use a CAS `Replace`), not write-temp-
-  then-atomic-rename, so a crash mid-write can truncate. The fix surfaces an atomic-
-  replace capability question on the `Filesystem` trait — do it once for the whole
-  family, not per-builtin.
-- **TOCTOU window B — snapshot/CAS double-read (P3).** Gated `patch`/`sed -i` read
-  the file twice: `gate_overwrites → snapshot_for_overwrite` reads state A and copies
-  it to trash, then the builtin re-reads state B for its transform and binds the CAS
-  `expected` to **B**. The read#2→write window is CAS-protected (a change there fails
-  loud), but a concurrent change A→B in the snapshot→read#2 gap leaves the trash
-  holding the *stale* A while B→C is written — recovery is one version behind, and CAS
-  doesn't catch it because `expected` is the later read. **Fixable cheaply:** have
-  `gate_overwrites` return the snapshotted bytes per TrashFirst target and let the
-  builtin transform *those* and set `expected` to *those* — one read, snapshot ==
-  expected, only the CAS-guarded read→write window remains. Contained API change to
-  the three callers.
+- **Atomicity (whole family).** Overwrites use `backend.write(Overwrite)` (`patch`/`sed
+  -i` a CAS `Replace`; the byte writers `cas_overwrite`), not write-temp-then-atomic-
+  rename, so a crash mid-write can truncate. `cas_overwrite` detects a *concurrent
+  change* but is **not** crash-atomic. The fix surfaces an atomic-replace capability
+  question on the `Filesystem` trait — do it once for the whole family, not per-builtin.
+- **TOCTOU window B — snapshot/CAS double-read (P3).** `gate_overwrites` now returns the
+  snapshotted bytes and the byte-oriented writers (`tee`/`write`/`dd`/`cp`) CAS against
+  *those* (one read), so window B is closed for them. `patch`/`sed -i` still read twice
+  (their transform re-reads and binds `expected` to the later read), so a concurrent
+  change A→B in the snapshot→read#2 gap leaves the trash holding the *stale* A while
+  B→C is written — recovery one version behind, CAS doesn't catch it. Migrating
+  `patch`/`sed -i` to transform the *returned* snapshot bytes (now available) closes it.
 - **TOCTOU window A — existence-check race (P3).** `decide_mutation_action` keys on
   `exists` at gate time; a path absent then returns `Proceed` (no snapshot, no latch).
   If it's created before the builtin's `write`, it's clobbered ungated. Inherent with


### PR DESCRIPTION
Closes the four non-regression gaps the pre-0.10.0 kaibo review (`cast=deepseek`) found in the write-model gate. All four fixed before the tag, per maintainer request.

## The four fixes
1. **`write` / `dd` / `cp` / `mv` now gate truncating overwrites** (they bypassed the gate entirely). Default-off — only active under `set -o latch` / `set -o trash`, so no behavior change by default. Each gains `--confirm=<nonce>`; `dd` uses its `confirm=<nonce>` key=value idiom. Only the **named** destination is gated; copying/moving *into* a directory and recursive `cp -r`/`mv` per-child overwrites stay ungated (documented residual — not a single-file truncation).
2. **`tee` (and the newly-gated `write`/`dd`/`cp`) now compare-and-swap.** `gate_overwrites` returns the prior bytes it snapshots; a new **binary-safe** `cas_overwrite` (re-read + compare raw bytes) guards the write. This is byte-safe where the `String`-based `PatchOp::Replace` CAS that `patch`/`sed -i` use would *regress* binary content (the backend's `patch()` does `String::from_utf8`). `mv` keeps snapshot+latch only — its same-mount path is an atomic `rename`.
3. **The gate honors `trash_max_size`.** `decide_mutation_action` is size-aware: a prior file too big to snapshot falls through to latch/proceed, mirroring `rm`.
4. **Killed the drift.** `rm` and the overwrite gate shared a duplicated `/tmp`,`/v` exclusion list (exactly how #3 slipped in) — now one `is_trash_excluded`.

## Why CAS via a context helper, not `PatchOp` or a trait method
`PatchOp::Replace` is `String`-based and would break binary `tee`/`write`/`dd`. A `Filesystem`-trait atomic-replace primitive is the "right" long-term fix but is a risky 3-backend change right before a release — and the existing `patch`/`sed -i` CAS is *also* not OS-atomic (read-check-write inside the backend method). So `cas_overwrite` gives the same conflict-detection at the same protection level, binary-safe, no trait change. **Crash-atomicity stays the documented deferred residual.**

## Tests (TDD)
- 9 kernel-routed cases in `latch_trash_tests.rs`: `write`/`cp`/`mv`/`dd` under latch (exit-2 + confirm round-trip) and trash (prior-bytes snapshot), new-file/into-dir non-gating, and too-big-to-trash → latch fall-through.
- 3 `overwrite_checked` CAS unit tests (reject concurrent change / write on match / no-CAS without expectation) + a size-cap unit test for `decide_mutation_action`.

## Gates
`cargo test --all` ✅ · `cargo clippy --all --all-targets` ✅ (0 warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)