### PR TITLE
chore: bump to v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ breaking entries are marked **BREAKING**.
 
 ## [Unreleased]
 
+## [0.10.0] - 2026-06-29
+
 ### Added
 - **`grep --ftype <NAME>` / `--ftype-not <NAME>`** — filter the recursive (`-r`)
   walk to (or away from) a named file type, e.g. `grep -r needle . --ftype rust`
@@ -629,7 +631,8 @@ Initial public release of **kaish** (会sh) — a predictable Bourne-like shell 
 - **REPL** (`kaish-repl`) with multi-line input, completion, and history; **MCP server** (`kaish-mcp`) exposing `kaish_execute` with help resources and structured + plain-text content blocks.
 - **`KernelClient` trait** + `EmbeddedClient` for in-process embedding; topic-based help system; `kaish-wasi` `wasm32-wasip1` target.
 
-[Unreleased]: https://github.com/tobert/kaish/compare/v0.9.1...HEAD
+[Unreleased]: https://github.com/tobert/kaish/compare/v0.10.0...HEAD
+[0.10.0]: https://github.com/tobert/kaish/compare/v0.9.1...v0.10.0
 [0.9.1]: https://github.com/tobert/kaish/compare/v0.9.0...v0.9.1
 [0.9.0]: https://github.com/tobert/kaish/compare/v0.8.4...v0.9.0
 [0.8.4]: https://github.com/tobert/kaish/compare/v0.8.3...v0.8.4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -965,7 +965,7 @@ dependencies = [
 
 [[package]]
 name = "kaish-client"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -979,7 +979,7 @@ dependencies = [
 
 [[package]]
 name = "kaish-glob"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "async-trait",
  "ignore",
@@ -991,14 +991,14 @@ dependencies = [
 
 [[package]]
 name = "kaish-help"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "kaish-types",
 ]
 
 [[package]]
 name = "kaish-kernel"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "ariadne",
@@ -1054,7 +1054,7 @@ dependencies = [
 
 [[package]]
 name = "kaish-repl"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1074,7 +1074,7 @@ dependencies = [
 
 [[package]]
 name = "kaish-tool-api"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "async-trait",
  "clap",
@@ -1084,7 +1084,7 @@ dependencies = [
 
 [[package]]
 name = "kaish-tools-host"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "async-trait",
  "clap",
@@ -1095,7 +1095,7 @@ dependencies = [
 
 [[package]]
 name = "kaish-types"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "base64",
  "schemars",
@@ -1107,7 +1107,7 @@ dependencies = [
 
 [[package]]
 name = "kaish-vfs"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "async-trait",
  "getrandom 0.3.4",
@@ -1118,7 +1118,7 @@ dependencies = [
 
 [[package]]
 name = "kaish-wasi"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "kaish-kernel",
  "kaish-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.9.1"
+version = "0.10.0"
 edition = "2024"
 rust-version = "1.85"
 authors = ["Amy Tobey <tobert@gmail.com>"]

--- a/crates/kaish-client/Cargo.toml
+++ b/crates/kaish-client/Cargo.toml
@@ -13,7 +13,7 @@ categories.workspace = true
 readme = "../../README.md"
 
 [dependencies]
-kaish-kernel = { path = "../kaish-kernel", version = "0.9.1" }
+kaish-kernel = { path = "../kaish-kernel", version = "0.10.0" }
 
 # Async runtime
 tokio = { workspace = true }

--- a/crates/kaish-help/Cargo.toml
+++ b/crates/kaish-help/Cargo.toml
@@ -13,7 +13,7 @@ categories.workspace = true
 readme = "../../README.md"
 
 [dependencies]
-kaish-types = { path = "../kaish-types", version = "0.9.1" }
+kaish-types = { path = "../kaish-types", version = "0.10.0" }
 
 [lints]
 workspace = true

--- a/crates/kaish-kernel/Cargo.toml
+++ b/crates/kaish-kernel/Cargo.toml
@@ -14,11 +14,11 @@ readme = "../../README.md"
 exclude = ["tests/snapshots/"]
 
 [dependencies]
-kaish-glob = { path = "../kaish-glob", version = "0.9.1" }
-kaish-types = { path = "../kaish-types", version = "0.9.1", features = [] }
-kaish-help = { path = "../kaish-help", version = "0.9.1" }
-kaish-tool-api = { path = "../kaish-tool-api", version = "0.9.1" }
-kaish-vfs = { path = "../kaish-vfs", version = "0.9.1", features = ["memory", "overlay"] }
+kaish-glob = { path = "../kaish-glob", version = "0.10.0" }
+kaish-types = { path = "../kaish-types", version = "0.10.0", features = [] }
+kaish-help = { path = "../kaish-help", version = "0.10.0" }
+kaish-tool-api = { path = "../kaish-tool-api", version = "0.10.0" }
+kaish-vfs = { path = "../kaish-vfs", version = "0.10.0", features = ["memory", "overlay"] }
 
 # Async runtime — minimal base; `localfs` adds tokio/fs, `subprocess` adds
 # tokio/process + tokio/rt-multi-thread (see [features]).
@@ -83,7 +83,7 @@ jaq-json = { workspace = true }
 # Optional deps, each pulled in by its capability feature:
 #   kaish-tools-host → host, trash/directories → os-integration,
 #   tiktoken-rs → tokens.
-kaish-tools-host = { path = "../kaish-tools-host", version = "0.9.1", optional = true }
+kaish-tools-host = { path = "../kaish-tools-host", version = "0.10.0", optional = true }
 trash = { workspace = true, optional = true }
 directories = { workspace = true, optional = true }
 tiktoken-rs = { workspace = true, optional = true }

--- a/crates/kaish-repl/Cargo.toml
+++ b/crates/kaish-repl/Cargo.toml
@@ -19,8 +19,8 @@ path = "src/main.rs"
 [dependencies]
 # The REPL is the full interactive human shell: it needs every capability
 # (external commands + job control, git, host introspection, tokens, trash).
-kaish-kernel = { path = "../kaish-kernel", version = "0.9.1", features = ["full"] }
-kaish-client = { path = "../kaish-client", version = "0.9.1" }
+kaish-kernel = { path = "../kaish-kernel", version = "0.10.0", features = ["full"] }
+kaish-client = { path = "../kaish-client", version = "0.10.0" }
 
 # Line editing
 rustyline = { workspace = true }

--- a/crates/kaish-tool-api/Cargo.toml
+++ b/crates/kaish-tool-api/Cargo.toml
@@ -12,7 +12,7 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-kaish-types = { path = "../kaish-types", version = "0.9.1", features = [] }
+kaish-types = { path = "../kaish-types", version = "0.10.0", features = [] }
 
 async-trait = { workspace = true }
 clap = { workspace = true }

--- a/crates/kaish-tools-host/Cargo.toml
+++ b/crates/kaish-tools-host/Cargo.toml
@@ -12,8 +12,8 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-kaish-types = { path = "../kaish-types", version = "0.9.1", features = [] }
-kaish-tool-api = { path = "../kaish-tool-api", version = "0.9.1" }
+kaish-types = { path = "../kaish-types", version = "0.10.0", features = [] }
+kaish-tool-api = { path = "../kaish-tool-api", version = "0.10.0" }
 
 async-trait = { workspace = true }
 clap = { workspace = true }

--- a/crates/kaish-vfs/Cargo.toml
+++ b/crates/kaish-vfs/Cargo.toml
@@ -12,7 +12,7 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-kaish-types = { path = "../kaish-types", version = "0.9.1", features = [] }
+kaish-types = { path = "../kaish-types", version = "0.10.0", features = [] }
 async-trait = { workspace = true }
 # DevFs's /dev/urandom pulls from the OS CSPRNG. Pure (no tokio); works on
 # Unix/macOS/WASI.


### PR DESCRIPTION
Version bump + changelog stamp for the **0.10.0** release.

## What's in this PR (mechanical)
- Root workspace `version` → `0.10.0` and all 14 inter-crate `path + version` pins bumped from `0.9.1` (verified: every `0.9.1` in a `Cargo.toml` was a version we own; `cargo check --all` resolves clean).
- `CHANGELOG.md`: `## [Unreleased]` renamed to `## [0.10.0] - 2026-06-29`, fresh empty `## [Unreleased]` added above, compare links updated.

## Release contents (reviewed pre-bump)
Everything since `v0.9.1`:
- **Added** — write-model gate now covers every truncating overwrite (`tee`/`patch`/`sed -i`/`write`/`cp`/`mv`/`dd of=`); `file` builtin + `kaish-glob::filetype` magic-byte detection; `sed -i` in-place edit; grep/glob `--ftype`/`--ftype-not`/`--ftype-list`/`--max-count`/`--hidden`; `Kernel::execute_argv`; validator advisory `W006`.
- **Changed** — **BREAKING** `cp -p` removed; jq integral-number formatting + key insertion-order (jaq-core 3 / jaq-json 2).
- **Removed** — **BREAKING** `test` builtin and `[` command.
- **Fixed** — mid-scan `ls`, `--json` nonce preservation, sed `-e <num>` / `s///0`, unterminated `$((`, printf `%c`, tilde file-tests, `<<-` tabs, export-in-function scope, binary `write` from `$()`, jq null-index.

## Review trail
- **Phase 4 — kaibo (`cast=deepseek`)**: holistic pass over the full release surface → *"safe to release — no silent-corruption bugs, no undocumented breakage."* Confirmed CAS binary-safety + consistent gate routing, `file` reads through the VFS with no panics, `sed -i` per-file batch semantics, `execute_argv` convergence with the string door, and clean `test`/`[` + `cp -p` removals. P3/P4 residuals (sed-i/patch snapshot TOCTOU window) already tracked in `docs/issues.md`.
- **Docs consistency**: 86 tools, README table matches registry one-for-one; `file` listed, `test`/`[` gone except deliberate "unsupported" notes.
- **Changelog reconciliation**: all 13 user-facing commits since v0.9.1 accounted for.

The bump diff itself is mechanical — this is a light check that the pins all moved together and the changelog stamped cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)