### PR TITLE
feat(types): typed LatchRequest accessor for the confirmation latch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ breaking entries are marked **BREAKING**.
 
 ## [Unreleased]
 
+### Added
+- **`ExecResult::latch_request()` + `LatchRequest` (kaish-types)** — typed
+  embedder seam for the confirmation latch: decodes a latched result (exit 2 +
+  nonce payload) into `{nonce, command, paths, hint, ttl}` so an embedder can
+  apply preapproval policy or a model review before re-running with
+  `--confirm=<nonce>`, instead of string-matching the error or digging `.data`
+  by key. Returns `None` for plain (non-latch) exit-2 results.
+
 ## [0.10.0] - 2026-06-29
 
 ### Added

--- a/crates/kaish-kernel/src/interpreter.rs
+++ b/crates/kaish-kernel/src/interpreter.rs
@@ -38,5 +38,5 @@ mod scope;
 
 pub use control_flow::ControlFlow;
 pub use eval::{eval_expr, expand_tilde, strip_leading_tabs, value_to_bool, value_to_exit_code, value_to_string, value_to_string_with_tilde, EvalError, EvalResult, Evaluator, Executor, HeredocAssembler, NoOpExecutor};
-pub use result::{apply_output_format, hex_dump, json_to_value, value_to_json, EntryType, ExecResult, OutputData, OutputFormat, OutputNode, OutputPayload};
+pub use result::{apply_output_format, hex_dump, json_to_value, value_to_json, EntryType, ExecResult, LatchRequest, OutputData, OutputFormat, OutputNode, OutputPayload};
 pub use scope::Scope;

--- a/crates/kaish-kernel/src/interpreter/result.rs
+++ b/crates/kaish-kernel/src/interpreter/result.rs
@@ -5,4 +5,6 @@
 
 pub use kaish_types::bytes::hex_dump;
 pub use kaish_types::output::{apply_output_format, EntryType, OutputData, OutputFormat, OutputNode};
-pub use kaish_types::result::{json_to_value, value_to_json, ExecResult, OutputPayload};
+pub use kaish_types::result::{
+    json_to_value, value_to_json, ExecResult, LatchRequest, OutputPayload,
+};

--- a/crates/kaish-kernel/src/tools/builtin/rm.rs
+++ b/crates/kaish-kernel/src/tools/builtin/rm.rs
@@ -450,6 +450,16 @@ mod tests {
         }
         // File should still exist
         assert!(ctx.backend.exists(Path::new("/file.txt")).await);
+
+        // The typed accessor must decode the same payload — this ties the
+        // kernel-side `latch_result` construction to `LatchRequest` so the keys
+        // can't drift apart silently. (Embedders hook this seam.)
+        let req = result.latch_request().expect("a latch request from exit-2 + nonce data");
+        assert_eq!(req.command, "rm");
+        assert_eq!(req.paths, vec!["/file.txt".to_string()]);
+        assert_eq!(req.ttl, 60);
+        assert!(req.hint.contains("--confirm="));
+        assert!(!req.nonce.is_empty());
     }
 
     #[tokio::test]

--- a/crates/kaish-kernel/src/tools/context.rs
+++ b/crates/kaish-kernel/src/tools/context.rs
@@ -737,13 +737,21 @@ impl ExecContext {
         let mut result = ExecResult::failure(2, format!(
             "{command}: confirmation required ({reason}){authorized}\nTo confirm, run: {hint}\nNonce expires in {ttl} seconds."
         ));
-        result.data = Some(Value::Json(serde_json::json!({
-            "nonce": nonce,
-            "command": command,
-            "paths": paths,
-            "hint": hint,
-            "ttl": ttl,
-        })));
+        // The struct is the single source of truth for the payload shape; the
+        // typed accessor `ExecResult::latch_request` deserializes exactly this.
+        let request = crate::interpreter::LatchRequest {
+            nonce,
+            command: command.to_string(),
+            paths: paths.iter().map(|p| (*p).to_string()).collect(),
+            hint,
+            ttl,
+        };
+        // Infallible: every field is String/Vec<String>/u64 (see NonceStore for
+        // the same allow on a genuinely-unreachable error).
+        #[allow(clippy::expect_used)]
+        let payload = serde_json::to_value(&request)
+            .expect("LatchRequest serializes infallibly (String/Vec<String>/u64)");
+        result.data = Some(Value::Json(payload));
         result
     }
 

--- a/crates/kaish-kernel/tests/execute_argv_tests.rs
+++ b/crates/kaish-kernel/tests/execute_argv_tests.rs
@@ -226,10 +226,16 @@ async fn latch_round_trips_through_argv_door() {
         "file must survive the latch gate"
     );
 
-    let nonce = match gated.data.as_ref().expect("latch result carries .data") {
-        Value::Json(j) => j["nonce"].as_str().expect("nonce string in .data").to_string(),
-        other => panic!("expected Value::Json latch data, got {other:?}"),
-    };
+    // Read the latch through the typed accessor — this exercises the real
+    // kernel→rm→latch_result production path and closes the producer/consumer
+    // loop, so a drift between the payload keys and `LatchRequest` fails here.
+    let req = gated
+        .latch_request()
+        .expect("a gated rm result decodes to a LatchRequest");
+    assert_eq!(req.command, "rm");
+    assert_eq!(req.paths, vec!["precious.txt".to_string()]);
+    assert_eq!(req.ttl, 60);
+    let nonce = req.nonce;
 
     // Confirm through the argv door: `rm --confirm=<nonce> precious.txt`.
     let confirmed = kernel

--- a/crates/kaish-types/src/result.rs
+++ b/crates/kaish-types/src/result.rs
@@ -55,6 +55,32 @@ impl<'de> serde::Deserialize<'de> for OutputPayload {
     }
 }
 
+/// A pending confirmation-latch request, decoded from a latched [`ExecResult`].
+///
+/// When the confirmation latch (`set -o latch`) gates a destructive operation,
+/// the kernel returns exit code 2 and attaches this payload to
+/// [`ExecResult::data`] as JSON. Embedders recover it as a typed struct via
+/// [`ExecResult::latch_request`] instead of reaching into the JSON by key — the
+/// seam an embedder hooks to apply preapproval policy or a model review before
+/// approving the operation.
+///
+/// To approve, re-run the *same argv* with `--confirm=<nonce>` (the `hint`
+/// shows the exact form). The nonce is command- and path-scoped, so it cannot
+/// authorize a different command or a path outside `paths`.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct LatchRequest {
+    /// Confirmation nonce — pass back as `--confirm=<nonce>` on the same command.
+    pub nonce: String,
+    /// The canonical command being gated (e.g. `"rm"`, `"kaish-trash empty"`).
+    pub command: String,
+    /// The resolved paths the operation would touch. Empty for command-only ops.
+    pub paths: Vec<String>,
+    /// A ready-to-run confirmation command string (informational).
+    pub hint: String,
+    /// Seconds until the nonce expires.
+    pub ttl: u64,
+}
+
 /// Returned when a binary result is asked to behave as text.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BinaryNotText {
@@ -422,6 +448,27 @@ impl ExecResult {
         self.code == 0
     }
 
+    /// Decode a confirmation-latch request from this result, if it is one.
+    ///
+    /// Returns `Some` only when the result is a latch gate: exit code 2 carrying
+    /// the structured nonce payload the latch system attaches to `.data`. This
+    /// is the typed seam an embedder hooks to apply preapproval policy or a
+    /// model review before re-running the command with `--confirm=<nonce>` —
+    /// instead of string-matching the error or digging the JSON by key. A plain
+    /// usage error (also exit 2, but no nonce payload) returns `None`.
+    ///
+    /// Call this on the raw result from `execute()`, before any `--json` output
+    /// formatting (which re-nests `.data` under an error envelope).
+    pub fn latch_request(&self) -> Option<LatchRequest> {
+        if self.code != 2 {
+            return None;
+        }
+        match self.data.as_ref()? {
+            Value::Json(payload) => serde_json::from_value(payload.clone()).ok(),
+            _ => None,
+        }
+    }
+
     /// Set content type hint, returning self for chaining.
     pub fn with_content_type(mut self, ct: impl Into<String>) -> Self {
         self.content_type = Some(ct.into());
@@ -742,6 +789,68 @@ mod tests {
         // Even JSON-shaped text is NOT auto-parsed — .data stays None.
         let json_result = ExecResult::with_output(OutputData::text(r#"{"key": 1}"#));
         assert!(json_result.data.is_none());
+    }
+
+    fn latch_payload(paths: &[&str]) -> Value {
+        Value::Json(serde_json::json!({
+            "nonce": "a3f7b2c1",
+            "command": "rm",
+            "paths": paths,
+            "hint": "rm --confirm=\"a3f7b2c1\" important.dat",
+            "ttl": 60,
+        }))
+    }
+
+    #[test]
+    fn latch_request_decodes_latch_result() {
+        let mut result = ExecResult::failure(2, "rm: confirmation required (latch enabled)");
+        result.data = Some(latch_payload(&["important.dat"]));
+
+        let req = result.latch_request().expect("a latch request");
+        assert_eq!(req.nonce, "a3f7b2c1");
+        assert_eq!(req.command, "rm");
+        assert_eq!(req.paths, vec!["important.dat".to_string()]);
+        assert_eq!(req.ttl, 60);
+        assert!(req.hint.contains("--confirm"));
+    }
+
+    #[test]
+    fn latch_request_handles_command_only_empty_paths() {
+        let mut result = ExecResult::failure(2, "kaish-trash empty: confirmation required");
+        result.data = Some(Value::Json(serde_json::json!({
+            "nonce": "deadbeef",
+            "command": "kaish-trash empty",
+            "paths": [],
+            "hint": "kaish-trash empty --confirm=deadbeef",
+            "ttl": 60,
+        })));
+
+        let req = result.latch_request().expect("a latch request");
+        assert_eq!(req.command, "kaish-trash empty");
+        assert!(req.paths.is_empty());
+    }
+
+    #[test]
+    fn latch_request_none_for_success() {
+        // Same payload shape, but exit 0 is not a latch gate.
+        let mut result = ExecResult::success("");
+        result.data = Some(latch_payload(&["important.dat"]));
+        assert!(result.latch_request().is_none());
+    }
+
+    #[test]
+    fn latch_request_none_for_usage_error() {
+        // A plain exit-2 usage error carries no nonce payload.
+        let result = ExecResult::failure(2, "rm: unknown flag --bogus");
+        assert!(result.latch_request().is_none());
+    }
+
+    #[test]
+    fn latch_request_none_for_unrelated_data() {
+        // Exit 2 with some other structured data is not a latch request.
+        let mut result = ExecResult::failure(2, "boom");
+        result.data = Some(Value::Json(serde_json::json!({"count": 3})));
+        assert!(result.latch_request().is_none());
     }
 
     #[test]

--- a/crates/kaish-types/src/result.rs
+++ b/crates/kaish-types/src/result.rs
@@ -68,6 +68,7 @@ impl<'de> serde::Deserialize<'de> for OutputPayload {
 /// shows the exact form). The nonce is command- and path-scoped, so it cannot
 /// authorize a different command or a path outside `paths`.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct LatchRequest {
     /// Confirmation nonce — pass back as `--confirm=<nonce>` on the same command.
     pub nonce: String,

--- a/docs/EMBEDDING.md
+++ b/docs/EMBEDDING.md
@@ -154,6 +154,23 @@ overwrites. The output contract:
     "paths": ["important.dat"], "hint": "...", "ttl": 60 }
   ```
 
+  From Rust, prefer the typed accessor over reaching into `.data` by key:
+
+  ```rust
+  // Returns Some(LatchRequest { nonce, command, paths, hint, ttl }) only for a
+  // latch gate (exit 2 + nonce payload); None for a plain usage error.
+  if let Some(req) = result.latch_request() {
+      // apply preapproval policy / model review over (req.command, req.paths) …
+      // approve → re-run the same argv with `--confirm=<req.nonce>`.
+  }
+  ```
+
+  This is the seam to hook embedder-side policy: check a preapproval allowlist or
+  ask a model to review the resolved `(command, paths)` before re-running. The
+  kernel owns the *mechanism* (issuing/validating the path- and command-scoped
+  nonce); the embedder owns the *judgment*. Call it on the raw result, before any
+  `--json` formatting.
+
   If you executed with `--json` (`OutputFormat::Json`), this is a non-zero exit
   with a diagnostic, so the result is wrapped in the standard JSON error envelope
   and the nonce payload is nested one level down, under `data`:

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -96,6 +96,20 @@ Still open:
   a malformed `$()` inside a `${VAR:-default}` *default word* still falls back to
   literal (two infallible Expr-returning call sites; rare edge).
 
+### Optional latch around subprocess spawn (allowlist + future model review)
+The confirmation latch covers the in-process write-model (`rm` + the truncating
+overwrite family), but an external `/bin/rm` on `PATH` bypasses it entirely — the
+gate lives in the builtin. For an embedder using the latch as a safety hook
+(kaijutsu catching latches to apply preapproval policy / a model review — the
+`ExecResult::latch_request()` seam, landed), the subprocess door is the hole.
+Proposal: an opt-in latch around *every* `subprocess` spawn, gated by an
+embedder-supplied **allowlist** (commands that run without confirmation); anything
+off the list returns the standard exit-2 + nonce so the embedder can approve via
+the same `latch_request()` path. Later: a hook for static checks + a model review
+of the argv (mirrors Claude Code "auto" mode). Mechanism in the kernel, judgment
+in the embedder — same split as the write-model latch. Until then, the airtight
+config is `subprocess` off (read-only / no-spawn build). (P2)
+
 ### `kaish-multicall` binary (deferred from the `execute_argv` work)
 `execute_argv` — the argv-native peer of `execute(&str)` — **landed** (see
 devlog); the load-bearing half is done. The cheap second half is still open: a


### PR DESCRIPTION
## What

Adds `ExecResult::latch_request() -> Option<LatchRequest>` (kaish-types) — a typed
accessor that decodes a latched result (exit code 2 + nonce payload on `.data`) into
`LatchRequest { nonce, command, paths, hint, ttl }`. Returns `None` for plain
(non-latch) exit-2 results.

## Why

Amy's framing: Claude Code's best-loved safety hook catches a dangerous recursive
force-delete with a regex on the command line. kaish can do better — when the
confirmation latch gates a destructive op, the kernel already *knows* the canonical
command and the **resolved** paths, and hands back a structured signal. This accessor
is the typed seam an embedder (kaijutsu) hooks to apply preapproval rules or a model
review before approving the op, instead of string-matching the error or digging `.data`
by key.

(Fitting note: the first `gh pr create` for this very PR was blocked by Claude Code's
regex hook firing on the literal delete string *inside this prose* — a textbook false
positive, and exactly the brittleness the typed seam replaces.)

Design split kept deliberate:
- **Kernel owns the mechanism** — issues/validates the command- and path-scoped nonce,
  stays predictable and policy-free.
- **Embedder owns the judgment** — rules / model calls happen at the `ExecResult`
  boundary, so slow non-deterministic I/O never enters the kernel's execution path. (A
  kernel-installed `LatchPolicy` callback was considered and rejected for that reason.)

## Tests

- Unit tests in `kaish-types` (decode, command-only empty paths, and the three `None`
  cases: success, usage error, unrelated data).
- A kernel-routed `rm` latch test asserts `latch_request()` decodes the real
  `latch_result` payload — ties the JSON construction to the struct so keys can't drift.
- `cargo test --all` green, `cargo clippy --all --all-targets` clean.

## Docs

- `EMBEDDING.md` "Destructive-op rails" now recommends the accessor as the canonical read.
- `CHANGELOG.md` Unreleased/Added.
- Follow-up filed in `docs/issues.md` (P2): an **optional latch around subprocess spawn**
  with an allowlist (and later static-check + model review), since an external delete
  binary on `PATH` bypasses the in-process gate. The airtight config today is
  `subprocess` off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
