### PR TITLE
docs: track interpreter stack/memory work on GitHub Issues

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,7 +141,11 @@ Tests live in `crates/kaish-kernel/tests/`. Snapshots in `crates/kaish-kernel/te
   `docs/composable-help.md`.
 - `docs/issues.md` — open work only (P1–P4). `docs/devlog.md` — a durable narrative
   from the agent's perspective; write your story there. Keep history out of
-  `issues.md` so it stays cheap to read for actual open work.
+  `issues.md` so it stays cheap to read for actual open work. **Write the devlog
+  entry late — just before signoff or opening a PR**, so it carries with the PR
+  and reflects the work as actually landed. Don't write it early or mid-flight:
+  the decisions aren't settled yet, and an entry written ahead of the change it
+  describes goes stale before it ships.
 
 **Keep in sync:** When adding builtins or changing syntax, update the relevant help files.
 The builtin list in `help builtins` is generated dynamically from tool schemas.

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -7,6 +7,11 @@ and `git log` (commits, SHAs) are canonical. This is the story.
 
 Newest themes first within each area; dates are when the work landed.
 
+Write entries **late** — just before signoff or opening a PR — so they carry with
+the PR and describe the work as it actually landed. Not early, not mid-flight: the
+decisions aren't settled yet, and an entry written ahead of its change goes stale
+before it ships.
+
 ---
 
 ## Interpreter stack-depth analysis → first GitHub Issues (2026-06-30)

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -9,6 +9,44 @@ Newest themes first within each area; dates are when the work landed.
 
 ---
 
+## Interpreter stack-depth analysis → first GitHub Issues (2026-06-30)
+
+A question — "what pushes up the interpreter's need for stack space over time?" —
+turned into a map of the async statement engine and three filed issues. The shape
+of the answer is worth keeping: stack cost here is **call-chain depth × fat async
+frames**, not data.
+
+- The real statement engine is the async kernel in `kernel.rs` (not the sync
+  `Evaluator` in `interpreter/eval.rs`, which only does arithmetic/test
+  sub-eval). Its core is a set of mutually-recursive `Box::pin`-returning
+  functions — `execute_stmt_flow`, `eval_expr_async`, `eval_string_part(s)_async`,
+  `eval_test_async`. Rust async recursion *requires* boxing, and each boxed level
+  keeps every live local across every `.await`, so frames are heavy.
+- The deepest cycle is command substitution: `Expr::CommandSubst(Vec<Stmt>)`
+  re-enters `execute_block_capturing` → `execute_stmt_flow`, stacking two boxed
+  futures per `$( … )` nesting level. Recursive shell functions
+  (`execute_user_tool`) and `.kai`→`.kai` sourcing (`try_execute_script`) deepen
+  the *same* thread stack the same way. None of these is depth-guarded — only
+  alias re-entry (`<10`) and the lexer (`MAX_PAREN_DEPTH = 256`) are.
+- Per command, the dispatch chain (`execute_pipeline` → runner → `dispatch_command`
+  → `execute_command_depth`) carries a ~30-field `ExecContext` that's copied twice
+  in `dispatch_command`, plus `#[tracing::instrument]` future bloat on the hot
+  frames.
+- Runtimes are plain `Runtime::new()` (no custom stack). The foreground root future
+  runs on the `block_on` thread; forked work (pipeline stages, scatter, background)
+  hops to tokio worker threads with the default ~2 MB stack — so the same script
+  has less headroom inside a pipe than in the foreground.
+
+Filed as [#46](https://github.com/tobert/kaish/issues/46) (depth guard — a loud
+error beats a silent `SIGSEGV`), [#47](https://github.com/tobert/kaish/issues/47)
+(explicit, uniform worker-thread stack size), and
+[#48](https://github.com/tobert/kaish/issues/48) (a profile-first memory/allocation
+pass — suspected low cost with occasional peaks, not urgent). These are the first
+issues we've put on GitHub instead of [issues.md](issues.md): an experiment ahead of
+announcing kaibo, where outside agents and people will want a public tracker.
+`devlog.md` stays in-repo and ships with the code — these repos also teach how a
+project gets sculpted.
+
 ## `execute_argv` — argv-native kernel entry point (landed 2026-06-29)
 
 `execute(&str)` is *string-native*: it lexes and parses its input. A caller that

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -9,6 +9,12 @@ Path note: the 0.8.0 crate split moved some cited files — `vfs/local.rs` →
 Priorities: **P1** high-leverage features/diagnostics · **P2** focused refactors
 & real bugs · **P3** scheduler and infra · **P4** eventually.
 
+> **Some work now lives on GitHub Issues** — an experiment as we get ready to
+> announce kaibo. Don't double-track these here. Interpreter stack/memory work:
+> [#46](https://github.com/tobert/kaish/issues/46) (recursion depth guard),
+> [#47](https://github.com/tobert/kaish/issues/47) (explicit worker-thread stack
+> size), [#48](https://github.com/tobert/kaish/issues/48) (allocation/memory pass).
+
 ---
 
 ## P1 — High-leverage features and diagnostics


### PR DESCRIPTION
## What

A "what pushes up our interpreter's need for stack space over time?" question turned into a map of the async statement engine. Records the analysis in `devlog.md` and points `issues.md` at three newly-filed GitHub Issues. Also adds a devlog **timing convention**.

This is the **first time we've used GitHub Issues instead of `issues.md`** — an experiment ahead of announcing kaibo, where outside agents and people will want a public tracker. `devlog.md` stays in-repo and ships with the code (these repos also teach how a project gets sculpted).

## The finding

Stack cost in the interpreter is **call-chain depth × fat boxed-async frames**, not data:

- The async statement engine (`kernel.rs`) is mutually-recursive `Box::pin` functions; each level keeps every live local across every `.await`.
- Deepest, **unguarded** path: command substitution `$(...)` re-enters `execute_block_capturing` → `execute_stmt_flow` (two boxed futures per nesting level); recursive functions and `.kai`→`.kai` sourcing deepen the same stack. Only alias re-entry (`<10`) and the lexer (`MAX_PAREN_DEPTH=256`) are capped.
- Forked work (pipes, scatter, background) runs on tokio worker threads with the default ~2 MB stack vs. the foreground `block_on` thread.

## Issues filed

- #46 — recursion depth guard (a loud error beats a silent `SIGSEGV`)
- #47 — explicit, uniform tokio worker-thread stack size
- #48 — profile-first memory/allocation pass (suspected low cost, occasional peaks)

## Devlog timing convention

Write devlog entries **late** — just before signoff or opening a PR — so the entry **carries with the PR** and reflects the work as actually landed. Not early or mid-flight: the decisions aren't settled yet, and an entry written ahead of its change goes stale before it ships. Added to CLAUDE.md (Documentation) and the `devlog.md` header.

## Changes

- `docs/issues.md` — note + links so we don't double-track the stack/memory items.
- `docs/devlog.md` — the analysis narrative, plus the timing guidance in the header.
- `CLAUDE.md` — the devlog timing convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)