### PR TITLE
feat(types): Kernel::classify_command for embedder script preflight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ breaking entries are marked **BREAKING**.
   apply preapproval policy or a model review before re-running with
   `--confirm=<nonce>`, instead of string-matching the error or digging `.data`
   by key. Returns `None` for plain (non-latch) exit-2 results.
+- **`Kernel::classify_command(name) -> CommandKind` (kaish-types)** — supported,
+  single-source-of-truth command classifier for embedders preflighting a script
+  (e.g. a consent gate that walks the public AST and blocks until external
+  commands are approved). Buckets a name into `Builtin` / `UserTool` / `Special`
+  / `Dynamic` / `External`, mirroring the interpreter's real resolution order so
+  the embedder never forks kaish's rules. `CommandKind::escapes_kernel()` flags
+  the `External`/`Dynamic` cases a gate must scrutinize.
 
 ## [0.10.0] - 2026-06-29
 

--- a/crates/kaish-kernel/src/kernel.rs
+++ b/crates/kaish-kernel/src/kernel.rs
@@ -47,7 +47,7 @@ static KERNEL_COUNTER: AtomicU64 = AtomicU64::new(1);
 use async_trait::async_trait;
 
 use crate::ast::{Arg, Command, Expr, FileTestOp, Stmt, StringPart, TestExpr, ToolDef, Value, BinaryOp};
-pub use kaish_types::ExecuteOptions;
+pub use kaish_types::{CommandKind, ExecuteOptions};
 use crate::backend::{BackendError, KernelBackend};
 use kaish_glob::glob_match;
 use crate::dispatch::{CommandDispatcher, PipelinePosition};
@@ -5028,6 +5028,31 @@ impl Kernel {
         self.tools.schemas()
     }
 
+    /// Classify how the kernel will resolve a command name.
+    ///
+    /// This is the supported, single source of truth for command resolution that
+    /// embedders should call instead of re-deriving the rules. Walk a parsed
+    /// script (`kaish_kernel::parser::parse` → `Stmt::Command` nodes) and call
+    /// this per command name to bucket each into builtin / user-function /
+    /// special-form / dynamic / external — for example a consent gate that blocks
+    /// a script until external commands are approved.
+    ///
+    /// The classification mirrors the interpreter's real resolution order
+    /// (`execute_command_depth`): special-forms (`true`/`false`/`source`/`.`)
+    /// first, then user functions (which shadow builtins), then builtins, then a
+    /// `PATH` lookup. A name that is a variable or command-substitution expansion
+    /// (`$cmd`, `$(pick)`) classifies as [`CommandKind::Dynamic`] because it can't
+    /// be resolved statically.
+    ///
+    /// Note: this does not expand aliases — pass the post-alias name if the
+    /// embedder has resolved one. The safe direction of any imprecision is
+    /// `External`/`Dynamic`, never a false "internal".
+    pub async fn classify_command(&self, name: &str) -> CommandKind {
+        let is_user_tool = self.user_tools.read().await.contains_key(name);
+        let is_builtin = self.tools.contains(name);
+        crate::validator::classify_command_name(name, is_builtin, is_user_tool)
+    }
+
     // --- Jobs ---
 
     /// Get job manager.
@@ -8193,5 +8218,74 @@ AFTER="yes"'"#)
             result.err
         );
         assert_eq!(result.text_out().trim(), "subproc");
+    }
+
+    #[tokio::test]
+    async fn test_classify_command_builtin() {
+        let kernel = Kernel::transient().expect("failed to create kernel");
+        assert_eq!(kernel.classify_command("cat").await, CommandKind::Builtin);
+        assert_eq!(kernel.classify_command("grep").await, CommandKind::Builtin);
+    }
+
+    #[tokio::test]
+    async fn test_classify_command_special_forms() {
+        let kernel = Kernel::transient().expect("failed to create kernel");
+        for name in ["true", "false", "source", "."] {
+            assert_eq!(
+                kernel.classify_command(name).await,
+                CommandKind::Special,
+                "{name} should be a special-form",
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_classify_command_dynamic() {
+        let kernel = Kernel::transient().expect("failed to create kernel");
+        assert_eq!(kernel.classify_command("$cmd").await, CommandKind::Dynamic);
+        assert_eq!(
+            kernel.classify_command("$(pick)").await,
+            CommandKind::Dynamic
+        );
+    }
+
+    #[tokio::test]
+    async fn test_classify_command_external() {
+        let kernel = Kernel::transient().expect("failed to create kernel");
+        // Not a builtin, user function, or special-form → escapes to PATH.
+        assert_eq!(
+            kernel.classify_command("definitely_not_a_kaish_builtin").await,
+            CommandKind::External
+        );
+        // `readonly` is *not* a kaish special-form despite the validator's
+        // warning heuristic — at runtime it resolves to an external command, so
+        // a consent gate must see it as External (regression guard against the
+        // validator/runtime divergence).
+        assert_eq!(
+            kernel.classify_command("readonly").await,
+            CommandKind::External
+        );
+        assert!(kernel.classify_command("readonly").await.escapes_kernel());
+    }
+
+    #[tokio::test]
+    async fn test_classify_command_user_tool_shadows_builtin() {
+        let kernel = Kernel::transient().expect("failed to create kernel");
+        kernel
+            .execute(r#"greet() { echo "hi" }"#)
+            .await
+            .expect("function definition failed");
+        assert_eq!(
+            kernel.classify_command("greet").await,
+            CommandKind::UserTool
+        );
+
+        // A user function named after a builtin classifies as UserTool, matching
+        // the interpreter's user-tools-first resolution.
+        kernel
+            .execute(r#"cat() { echo "shadowed" }"#)
+            .await
+            .expect("function definition failed");
+        assert_eq!(kernel.classify_command("cat").await, CommandKind::UserTool);
     }
 }

--- a/crates/kaish-kernel/src/kernel.rs
+++ b/crates/kaish-kernel/src/kernel.rs
@@ -2828,21 +2828,18 @@ impl Kernel {
 
     #[tracing::instrument(level = "info", skip(self, args, alias_depth), fields(command = %name), err)]
     async fn execute_command_depth(&self, name: &str, args: &[Arg], alias_depth: u8) -> Result<ExecResult> {
-        // Special built-ins. The *gate* is `RUNTIME_SPECIAL_FORMS` (the single
-        // source of truth shared with `classify_command`, via
-        // `is_runtime_special_form`); the inner match is per-form behavior. This
-        // makes it structurally impossible to short-circuit a name the classifier
-        // doesn't also treat as `Special` — adding a form means adding it to the
-        // const, which the drift-guard test then forces to have behavior here.
-        if crate::validator::is_runtime_special_form(name) {
-            match name {
-                "true" => return Ok(ExecResult::success("")),
-                "false" => return Ok(ExecResult::failure(1, "")),
-                "source" | "." => return self.execute_source(args).await,
-                other => unreachable!(
-                    "RUNTIME_SPECIAL_FORMS member {other:?} has no execution behavior"
-                ),
-            }
+        // Special built-ins. `SpecialForm::from_name` is the single source of
+        // truth (shared with `classify_command` via `is_runtime_special_form`),
+        // and this match on the enum is *exhaustive* — adding a special-form is a
+        // compile error until both the name mapping and the behavior here are
+        // updated. A name that is not a special-form falls through to alias /
+        // `/v/bin/` / user-tool / builtin / `PATH` resolution unchanged.
+        if let Some(form) = crate::validator::SpecialForm::from_name(name) {
+            return match form {
+                crate::validator::SpecialForm::True => Ok(ExecResult::success("")),
+                crate::validator::SpecialForm::False => Ok(ExecResult::failure(1, "")),
+                crate::validator::SpecialForm::Source => self.execute_source(args).await,
+            };
         }
 
         // Alias expansion (with recursion limit)
@@ -8389,24 +8386,35 @@ AFTER="yes"'"#)
     async fn classify_command_matches_executor() {
         let kernel = Kernel::transient().expect("failed to create kernel");
 
-        // (1) Special-forms. The shared `RUNTIME_SPECIAL_FORMS` const gates both
-        // the classifier and the executor's short-circuit, so a member added to
-        // one side is added to both. Running every member here also trips the
-        // executor's `unreachable!` if a const member ever lacks behavior — and
-        // because the executor *gates* on the const, it cannot short-circuit a
-        // name the const omits (so the reverse direction is structural, not
-        // testable: there is nothing to test).
-        for &name in crate::validator::RUNTIME_SPECIAL_FORMS {
+        // (1) Special-forms. `SpecialForm::from_name` is the single source of
+        // truth: classify reports Special via it, and the executor matches the
+        // enum exhaustively, so const↔behavior parity is compile-enforced (a new
+        // form won't build until both sides handle it). This test pins the other
+        // half — that each form classifies Special AND actually short-circuits at
+        // runtime rather than escaping to `PATH`. Every form is executed (not just
+        // `true`/`false`): an external miss in this PATH-less kernel would be exit
+        // 127, so a non-127 result that matches the form's own behavior proves the
+        // short-circuit fired.
+        for name in ["true", "false", "source", "."] {
             assert_eq!(
                 kernel.classify_command(name).await,
                 CommandKind::Special,
-                "{name} is in RUNTIME_SPECIAL_FORMS but didn't classify Special",
+                "{name} should classify Special",
             );
         }
-        // `true`/`false` short-circuit to fixed exit codes; an external miss in
-        // this PATH-less kernel would be 127, so these pin the short-circuit.
         assert_eq!(kernel.execute("true").await.expect("run true").code, 0);
         assert_eq!(kernel.execute("false").await.expect("run false").code, 1);
+        // `source`/`.` short-circuit to execute_source, which (no filename) fails
+        // with its own message — exit 1, never the 127 of an unresolved external.
+        for name in ["source", "."] {
+            let r = kernel.execute(name).await.expect("run source form");
+            assert_ne!(r.code, 127, "{name} fell through to PATH instead of source");
+            assert!(
+                r.err.contains("source: missing filename"),
+                "{name} did not route to execute_source: {:?}",
+                r.err,
+            );
+        }
 
         // (2) Builtin: classify Builtin AND the executor runs the builtin.
         assert_eq!(kernel.classify_command("echo").await, CommandKind::Builtin);

--- a/crates/kaish-kernel/src/kernel.rs
+++ b/crates/kaish-kernel/src/kernel.rs
@@ -2828,12 +2828,21 @@ impl Kernel {
 
     #[tracing::instrument(level = "info", skip(self, args, alias_depth), fields(command = %name), err)]
     async fn execute_command_depth(&self, name: &str, args: &[Arg], alias_depth: u8) -> Result<ExecResult> {
-        // Special built-ins
-        match name {
-            "true" => return Ok(ExecResult::success("")),
-            "false" => return Ok(ExecResult::failure(1, "")),
-            "source" | "." => return self.execute_source(args).await,
-            _ => {}
+        // Special built-ins. The *gate* is `RUNTIME_SPECIAL_FORMS` (the single
+        // source of truth shared with `classify_command`, via
+        // `is_runtime_special_form`); the inner match is per-form behavior. This
+        // makes it structurally impossible to short-circuit a name the classifier
+        // doesn't also treat as `Special` — adding a form means adding it to the
+        // const, which the drift-guard test then forces to have behavior here.
+        if crate::validator::is_runtime_special_form(name) {
+            match name {
+                "true" => return Ok(ExecResult::success("")),
+                "false" => return Ok(ExecResult::failure(1, "")),
+                "source" | "." => return self.execute_source(args).await,
+                other => unreachable!(
+                    "RUNTIME_SPECIAL_FORMS member {other:?} has no execution behavior"
+                ),
+            }
         }
 
         // Alias expansion (with recursion limit)
@@ -8365,6 +8374,70 @@ AFTER="yes"'"#)
         assert_eq!(
             kernel.classify_command("${CMD}").await,
             CommandKind::Dynamic
+        );
+    }
+
+    /// Drift guard: `classify_command` must agree with what the executor
+    /// (`execute_command_depth`) actually resolves. The classifier duplicates the
+    /// interpreter's resolution rules (special-form set, user-tools-before-builtins
+    /// precedence, alias expansion); without this test those copies could diverge
+    /// silently — the exact failure class `classify_command` exists to prevent,
+    /// just moved inside the kernel. Each case asserts the classification AND
+    /// observes the real resolution, so a future change to one side without the
+    /// other fails here.
+    #[tokio::test]
+    async fn classify_command_matches_executor() {
+        let kernel = Kernel::transient().expect("failed to create kernel");
+
+        // (1) Special-forms. The shared `RUNTIME_SPECIAL_FORMS` const gates both
+        // the classifier and the executor's short-circuit, so a member added to
+        // one side is added to both. Running every member here also trips the
+        // executor's `unreachable!` if a const member ever lacks behavior — and
+        // because the executor *gates* on the const, it cannot short-circuit a
+        // name the const omits (so the reverse direction is structural, not
+        // testable: there is nothing to test).
+        for &name in crate::validator::RUNTIME_SPECIAL_FORMS {
+            assert_eq!(
+                kernel.classify_command(name).await,
+                CommandKind::Special,
+                "{name} is in RUNTIME_SPECIAL_FORMS but didn't classify Special",
+            );
+        }
+        // `true`/`false` short-circuit to fixed exit codes; an external miss in
+        // this PATH-less kernel would be 127, so these pin the short-circuit.
+        assert_eq!(kernel.execute("true").await.expect("run true").code, 0);
+        assert_eq!(kernel.execute("false").await.expect("run false").code, 1);
+
+        // (2) Builtin: classify Builtin AND the executor runs the builtin.
+        assert_eq!(kernel.classify_command("echo").await, CommandKind::Builtin);
+        let r = kernel.execute("echo hi").await.expect("run echo");
+        assert!(r.ok() && r.text_out().trim() == "hi", "echo builtin didn't run");
+
+        // (3) User function shadows a builtin: classify UserTool AND the executor
+        // runs the function body, not the `cat` builtin.
+        kernel
+            .execute(r#"cat() { echo SHADOWED }"#)
+            .await
+            .expect("define cat()");
+        assert_eq!(kernel.classify_command("cat").await, CommandKind::UserTool);
+        let r = kernel.execute("cat").await.expect("run shadowed cat");
+        assert_eq!(
+            r.text_out().trim(),
+            "SHADOWED",
+            "executor ran the builtin instead of the shadowing function",
+        );
+
+        // (4) Alias whose head is external: classify External AND the executor
+        // resolves through the alias to a missing external (not a builtin).
+        kernel
+            .execute("alias x='/nonexistent/binary'")
+            .await
+            .expect("define alias x");
+        assert_eq!(kernel.classify_command("x").await, CommandKind::External);
+        let r = kernel.execute("x").await.expect("run alias x");
+        assert!(
+            !r.ok(),
+            "alias to a missing external should fail, not resolve internally",
         );
     }
 }

--- a/crates/kaish-kernel/src/kernel.rs
+++ b/crates/kaish-kernel/src/kernel.rs
@@ -5039,18 +5039,58 @@ impl Kernel {
     ///
     /// The classification mirrors the interpreter's real resolution order
     /// (`execute_command_depth`): special-forms (`true`/`false`/`source`/`.`)
-    /// first, then user functions (which shadow builtins), then builtins, then a
-    /// `PATH` lookup. A name that is a variable or command-substitution expansion
-    /// (`$cmd`, `$(pick)`) classifies as [`CommandKind::Dynamic`] because it can't
+    /// short-circuit first, then **aliases are expanded** (bounded recursion,
+    /// re-checking special-forms each step, exactly as execution does), then user
+    /// functions (which shadow builtins), then builtins, then a `PATH` lookup. A
+    /// name that is a variable or command-substitution expansion (`$cmd`,
+    /// `$(pick)`, `${x}`) classifies as [`CommandKind::Dynamic`] because it can't
     /// be resolved statically.
     ///
-    /// Note: this does not expand aliases — pass the post-alias name if the
-    /// embedder has resolved one. The safe direction of any imprecision is
-    /// `External`/`Dynamic`, never a false "internal".
+    /// Aliases are resolved against the kernel's current alias table, so an
+    /// `alias cat=/bin/something` makes `cat` classify as `External` — the same
+    /// thing it would actually run. The safe direction of any residual imprecision
+    /// is `External`/`Dynamic`, never a false "internal": the `/v/bin/` prefix and
+    /// `.kai`/backend-tool resolution are reported `External` even though some of
+    /// those resolve in-process, so a consent gate over-gates rather than letting
+    /// a `PATH` escape slip through.
     pub async fn classify_command(&self, name: &str) -> CommandKind {
-        let is_user_tool = self.user_tools.read().await.contains_key(name);
-        let is_builtin = self.tools.contains(name);
-        crate::validator::classify_command_name(name, is_builtin, is_user_tool)
+        // Resolve the command head the way `execute_command_depth` does: a
+        // special-form short-circuits before any alias lookup, otherwise expand
+        // aliases (bounded, recursive) and re-check from the top. A dynamic name
+        // can't be resolved at all.
+        let mut name = name.to_string();
+        let mut alias_depth = 0u8;
+        loop {
+            if !crate::validator::is_static_command_name(&name) {
+                return CommandKind::Dynamic;
+            }
+            if crate::validator::is_runtime_special_form(&name) {
+                return CommandKind::Special;
+            }
+            if alias_depth >= 10 {
+                break;
+            }
+            let alias_value = {
+                let ctx = self.exec_ctx.read().await;
+                ctx.aliases.get(&name).cloned()
+            };
+            // Expand to the alias's head command. An empty alias value (no head)
+            // is ignored by execution, so resolution continues with this name.
+            match alias_value
+                .as_deref()
+                .and_then(|v| v.split_whitespace().next())
+            {
+                Some(head) => {
+                    name = head.to_string();
+                    alias_depth += 1;
+                }
+                None => break,
+            }
+        }
+
+        let is_user_tool = self.user_tools.read().await.contains_key(&name);
+        let is_builtin = self.tools.contains(&name);
+        crate::validator::classify_command_name(&name, is_builtin, is_user_tool)
     }
 
     // --- Jobs ---
@@ -8287,5 +8327,44 @@ AFTER="yes"'"#)
             .await
             .expect("function definition failed");
         assert_eq!(kernel.classify_command("cat").await, CommandKind::UserTool);
+    }
+
+    #[tokio::test]
+    async fn test_classify_command_alias_to_external_is_external() {
+        let kernel = Kernel::transient().expect("failed to create kernel");
+        // An alias whose head is an external binary must NOT report as the
+        // builtin it shadows — execution expands the alias, so a consent gate
+        // would otherwise be told an external command is internal.
+        kernel
+            .execute("alias cat='/usr/bin/whatever'")
+            .await
+            .expect("alias failed");
+        assert_eq!(kernel.classify_command("cat").await, CommandKind::External);
+        assert!(kernel.classify_command("cat").await.escapes_kernel());
+    }
+
+    #[tokio::test]
+    async fn test_classify_command_alias_to_builtin() {
+        let kernel = Kernel::transient().expect("failed to create kernel");
+        kernel.execute("alias g=grep").await.expect("alias failed");
+        assert_eq!(kernel.classify_command("g").await, CommandKind::Builtin);
+    }
+
+    #[tokio::test]
+    async fn test_classify_command_alias_to_special_form() {
+        let kernel = Kernel::transient().expect("failed to create kernel");
+        kernel.execute("alias t=true").await.expect("alias failed");
+        assert_eq!(kernel.classify_command("t").await, CommandKind::Special);
+    }
+
+    #[tokio::test]
+    async fn test_classify_command_braced_var_is_dynamic() {
+        let kernel = Kernel::transient().expect("failed to create kernel");
+        // The string API can be handed a `${VAR}` head; it must not be mistaken
+        // for an external named literally "${VAR}".
+        assert_eq!(
+            kernel.classify_command("${CMD}").await,
+            CommandKind::Dynamic
+        );
     }
 }

--- a/crates/kaish-kernel/src/lib.rs
+++ b/crates/kaish-kernel/src/lib.rs
@@ -64,7 +64,7 @@ pub use backend::{
 };
 pub use dispatch::{CommandDispatcher, PipelinePosition};
 pub use ignore_config::{IgnoreConfig, IgnoreScope};
-pub use kernel::{ExecuteOptions, Kernel, KernelConfig, VfsMountMode};
+pub use kernel::{CommandKind, ExecuteOptions, Kernel, KernelConfig, VfsMountMode};
 pub use output_limit::OutputLimitConfig;
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/crates/kaish-kernel/src/validator/mod.rs
+++ b/crates/kaish-kernel/src/validator/mod.rs
@@ -31,7 +31,6 @@ mod walker;
 pub use issue::{IssueCode, Severity, Span, ValidationIssue};
 pub use scope_tracker::ScopeTracker;
 pub use walker::{build_tool_args_for_validation, Validator};
-pub(crate) use walker::{classify_command_name, is_runtime_special_form, is_static_command_name};
-// Only the drift-guard test consumes the list form directly.
-#[cfg(all(test, feature = "subprocess"))]
-pub(crate) use walker::RUNTIME_SPECIAL_FORMS;
+pub(crate) use walker::{
+    classify_command_name, is_runtime_special_form, is_static_command_name, SpecialForm,
+};

--- a/crates/kaish-kernel/src/validator/mod.rs
+++ b/crates/kaish-kernel/src/validator/mod.rs
@@ -31,4 +31,4 @@ mod walker;
 pub use issue::{IssueCode, Severity, Span, ValidationIssue};
 pub use scope_tracker::ScopeTracker;
 pub use walker::{build_tool_args_for_validation, Validator};
-pub(crate) use walker::classify_command_name;
+pub(crate) use walker::{classify_command_name, is_runtime_special_form, is_static_command_name};

--- a/crates/kaish-kernel/src/validator/mod.rs
+++ b/crates/kaish-kernel/src/validator/mod.rs
@@ -31,3 +31,4 @@ mod walker;
 pub use issue::{IssueCode, Severity, Span, ValidationIssue};
 pub use scope_tracker::ScopeTracker;
 pub use walker::{build_tool_args_for_validation, Validator};
+pub(crate) use walker::classify_command_name;

--- a/crates/kaish-kernel/src/validator/mod.rs
+++ b/crates/kaish-kernel/src/validator/mod.rs
@@ -32,3 +32,6 @@ pub use issue::{IssueCode, Severity, Span, ValidationIssue};
 pub use scope_tracker::ScopeTracker;
 pub use walker::{build_tool_args_for_validation, Validator};
 pub(crate) use walker::{classify_command_name, is_runtime_special_form, is_static_command_name};
+// Only the drift-guard test consumes the list form directly.
+#[cfg(all(test, feature = "subprocess"))]
+pub(crate) use walker::RUNTIME_SPECIAL_FORMS;

--- a/crates/kaish-kernel/src/validator/walker.rs
+++ b/crates/kaish-kernel/src/validator/walker.rs
@@ -550,8 +550,17 @@ pub(crate) fn is_static_command_name(name: &str) -> bool {
     !name.starts_with('$') && !name.contains("$(") && !name.contains("${")
 }
 
-/// Interpreter special-forms — handled directly in `execute_command_depth`,
-/// never resolved through the tool registry or `PATH`.
+/// Interpreter special-forms — the command names `execute_command_depth`
+/// short-circuits before any alias/registry/`PATH` lookup.
+///
+/// **Single source of truth:** the executor's special-form `match` arms must
+/// cover exactly these names. A drift-guard test
+/// (`classify_special_forms_match_executor`) asserts each name here actually
+/// short-circuits at runtime and that `execute_command_depth` has no special
+/// arm this list omits, so the two can't silently diverge.
+pub(crate) const RUNTIME_SPECIAL_FORMS: &[&str] = &["true", "false", "source", "."];
+
+/// Whether `name` is an interpreter special-form (see [`RUNTIME_SPECIAL_FORMS`]).
 ///
 /// This is deliberately **narrower** than `is_special_command` below: that set
 /// is a validator warning heuristic (it suppresses "command not found" for names
@@ -561,7 +570,7 @@ pub(crate) fn is_static_command_name(name: &str) -> bool {
 /// would in fact escape to `PATH` (e.g. `readonly` resolves to an external
 /// command at runtime). See `Kernel::classify_command`.
 pub(crate) fn is_runtime_special_form(name: &str) -> bool {
-    matches!(name, "true" | "false" | "source" | ".")
+    RUNTIME_SPECIAL_FORMS.contains(&name)
 }
 
 /// Classify a command name the way the interpreter resolves it, given whether

--- a/crates/kaish-kernel/src/validator/walker.rs
+++ b/crates/kaish-kernel/src/validator/walker.rs
@@ -541,8 +541,13 @@ impl<'a> Validator<'a> {
 }
 
 /// Check if a command name is static (not a variable expansion).
+///
+/// The parser only ever produces a literal `Command.name`, so for the AST-walk
+/// path this is always true; the `${…}` / `$(…)` guards matter for the
+/// string-accepting `Kernel::classify_command` API, where a dynamic name
+/// classifies as [`CommandKind::Dynamic`] rather than a misleading `External`.
 pub(crate) fn is_static_command_name(name: &str) -> bool {
-    !name.starts_with('$') && !name.contains("$(")
+    !name.starts_with('$') && !name.contains("$(") && !name.contains("${")
 }
 
 /// Interpreter special-forms — handled directly in `execute_command_depth`,

--- a/crates/kaish-kernel/src/validator/walker.rs
+++ b/crates/kaish-kernel/src/validator/walker.rs
@@ -553,24 +553,47 @@ pub(crate) fn is_static_command_name(name: &str) -> bool {
 /// Interpreter special-forms — the command names `execute_command_depth`
 /// short-circuits before any alias/registry/`PATH` lookup.
 ///
-/// **Single source of truth:** the executor's special-form `match` arms must
-/// cover exactly these names. A drift-guard test
-/// (`classify_special_forms_match_executor`) asserts each name here actually
-/// short-circuits at runtime and that `execute_command_depth` has no special
-/// arm this list omits, so the two can't silently diverge.
-pub(crate) const RUNTIME_SPECIAL_FORMS: &[&str] = &["true", "false", "source", "."];
-
-/// Whether `name` is an interpreter special-form (see [`RUNTIME_SPECIAL_FORMS`]).
+/// **Single source of truth, compile-enforced.** `from_name` is the only place a
+/// name becomes "special", and the executor matches this enum *exhaustively*, so
+/// adding a form is a compile error until both the name mapping here and the
+/// execution behavior in `execute_command_depth` are updated — the two cannot
+/// silently diverge, and there's no `unreachable!` to panic at runtime.
+/// `classify_command` reports every special form as `CommandKind::Special` via
+/// [`is_runtime_special_form`].
 ///
-/// This is deliberately **narrower** than `is_special_command` below: that set
-/// is a validator warning heuristic (it suppresses "command not found" for names
-/// like `readonly`/`:` that the validator chooses not to flag), whereas this
-/// reflects what the interpreter *actually* short-circuits. Keeping them
+/// This set is deliberately **narrower** than `is_special_command` below: that
+/// set is a validator warning heuristic (it suppresses "command not found" for
+/// names like `readonly`/`:` that the validator chooses not to flag), whereas
+/// this reflects what the interpreter *actually* short-circuits. Keeping them
 /// separate avoids `classify_command` mislabelling a name as internal when it
 /// would in fact escape to `PATH` (e.g. `readonly` resolves to an external
 /// command at runtime). See `Kernel::classify_command`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SpecialForm {
+    /// `true` — always succeeds (exit 0).
+    True,
+    /// `false` — always fails (exit 1).
+    False,
+    /// `source` / `.` — execute a script in the current shell.
+    Source,
+}
+
+impl SpecialForm {
+    /// The single mapping from a command name to a special-form, or `None` if the
+    /// name is resolved normally (alias/registry/`PATH`).
+    pub(crate) fn from_name(name: &str) -> Option<Self> {
+        match name {
+            "true" => Some(Self::True),
+            "false" => Some(Self::False),
+            "source" | "." => Some(Self::Source),
+            _ => None,
+        }
+    }
+}
+
+/// Whether `name` is an interpreter special-form (see [`SpecialForm`]).
 pub(crate) fn is_runtime_special_form(name: &str) -> bool {
-    RUNTIME_SPECIAL_FORMS.contains(&name)
+    SpecialForm::from_name(name).is_some()
 }
 
 /// Classify a command name the way the interpreter resolves it, given whether

--- a/crates/kaish-kernel/src/validator/walker.rs
+++ b/crates/kaish-kernel/src/validator/walker.rs
@@ -10,6 +10,7 @@ use crate::kernel::{bind_glued_short_value, push_repeatable_value};
 use crate::scheduler::{is_bool_type, schema_param_lookup};
 use crate::validator::issue::Span;
 use crate::tools::{ToolArgs, ToolRegistry, ToolSchema};
+use kaish_types::CommandKind;
 
 use super::issue::{IssueCode, ValidationIssue};
 use super::scope_tracker::ScopeTracker;
@@ -540,8 +541,47 @@ impl<'a> Validator<'a> {
 }
 
 /// Check if a command name is static (not a variable expansion).
-fn is_static_command_name(name: &str) -> bool {
+pub(crate) fn is_static_command_name(name: &str) -> bool {
     !name.starts_with('$') && !name.contains("$(")
+}
+
+/// Interpreter special-forms — handled directly in `execute_command_depth`,
+/// never resolved through the tool registry or `PATH`.
+///
+/// This is deliberately **narrower** than `is_special_command` below: that set
+/// is a validator warning heuristic (it suppresses "command not found" for names
+/// like `readonly`/`:` that the validator chooses not to flag), whereas this
+/// reflects what the interpreter *actually* short-circuits. Keeping them
+/// separate avoids `classify_command` mislabelling a name as internal when it
+/// would in fact escape to `PATH` (e.g. `readonly` resolves to an external
+/// command at runtime). See `Kernel::classify_command`.
+pub(crate) fn is_runtime_special_form(name: &str) -> bool {
+    matches!(name, "true" | "false" | "source" | ".")
+}
+
+/// Classify a command name the way the interpreter resolves it, given whether
+/// the registry and user-tool table contain it. Shared by the validator's
+/// triage and `Kernel::classify_command` so the two never diverge.
+pub(crate) fn classify_command_name(
+    name: &str,
+    is_builtin: bool,
+    is_user_tool: bool,
+) -> CommandKind {
+    if !is_static_command_name(name) {
+        return CommandKind::Dynamic;
+    }
+    if is_runtime_special_form(name) {
+        return CommandKind::Special;
+    }
+    // User functions are checked before builtins in `execute_command_depth`, so
+    // a user function shadows a builtin of the same name.
+    if is_user_tool {
+        return CommandKind::UserTool;
+    }
+    if is_builtin {
+        return CommandKind::Builtin;
+    }
+    CommandKind::External
 }
 
 /// Check if a command is a special built-in that we don't validate.

--- a/crates/kaish-types/src/command.rs
+++ b/crates/kaish-types/src/command.rs
@@ -1,0 +1,50 @@
+//! Command classification — how the kernel will resolve a command name.
+//!
+//! `CommandKind` is the typed answer to "what will kaish actually run for this
+//! name?" It exists so embedders (kaijutsu's consent gate, kaibo) can walk a
+//! parsed script and bucket each command node without re-implementing kaish's
+//! resolution rules. Re-deriving those rules in the embedder forks kaish's
+//! command-resolution truth: the day the kernel refines how a name resolves, a
+//! hand-rolled copy silently disagrees with what kaish will actually execute —
+//! a security-relevant divergence for anything gating external commands.
+
+/// The category the kernel resolves a command name into.
+///
+/// Returned by `Kernel::classify_command`. The classification mirrors the
+/// interpreter's real resolution order (`execute_command_depth`), not the
+/// validator's warning heuristics — it answers "what will run", which is what a
+/// consent gate needs.
+///
+/// The safe direction of any imprecision is to *over*-report `External`: an
+/// embedder gating external commands should never see something classified as
+/// internal that in fact escapes to `PATH`.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CommandKind {
+    /// A built-in tool run in-process (e.g. `cat`, `grep`, `jq`).
+    Builtin,
+    /// A user-defined function (`fn name { … }`) — shadows a builtin of the same
+    /// name, matching the interpreter's user-tools-first resolution.
+    UserTool,
+    /// An interpreter special-form handled directly, never resolved through the
+    /// registry or `PATH`: `true`, `false`, `source`, `.`.
+    Special,
+    /// The name can't be resolved statically because it's a variable or
+    /// command-substitution expansion (`$cmd`, `$(pick)`). The embedder must
+    /// treat it conservatively.
+    Dynamic,
+    /// Not a builtin, user function, or special-form: kaish will look it up as a
+    /// `.kai` script or external binary on `PATH`. This is the bucket a consent
+    /// gate cares about.
+    External,
+}
+
+impl CommandKind {
+    /// True when the name escapes the kernel to a `PATH` lookup (`External`) or
+    /// can't be resolved statically (`Dynamic`) — the two cases an external-command
+    /// consent gate must scrutinize.
+    pub fn escapes_kernel(self) -> bool {
+        matches!(self, CommandKind::External | CommandKind::Dynamic)
+    }
+}

--- a/crates/kaish-types/src/lib.rs
+++ b/crates/kaish-types/src/lib.rs
@@ -6,6 +6,7 @@
 
 pub mod backend;
 pub mod bytes;
+pub mod command;
 pub mod dir_entry;
 pub mod job;
 pub mod kernel;
@@ -17,6 +18,7 @@ pub mod value;
 // Flat re-exports for convenience
 pub use backend::*;
 pub use bytes::{bytes_to_envelope, envelope_to_bytes, hex_dump};
+pub use command::*;
 pub use dir_entry::*;
 pub use job::*;
 pub use kernel::*;

--- a/docs/EMBEDDING.md
+++ b/docs/EMBEDDING.md
@@ -471,6 +471,43 @@ processes). Two gates:
   lookups return "command not found" and `exec`/`spawn` error.
   `KernelConfig::isolated()` sets this by default.
 
+### Preflighting a script for external commands
+
+To gate a script for consent (e.g. block until external commands are approved),
+classify each command node *before* executing. Walk the parsed AST and ask the
+kernel how it will resolve each name — don't re-derive the rules, or your gate
+silently disagrees with what kaish actually runs the day resolution changes:
+
+```rust
+use kaish_kernel::{parser, ast::Stmt, CommandKind};
+
+let program = parser::parse(src)              // public parser + AST
+    .map_err(|_errors| /* surface parse errors */ ())?;
+for stmt in &program.statements {
+    if let Stmt::Command(cmd) = stmt {        // walk however your policy needs
+        let kind = kernel.classify_command(&cmd.name).await;
+        if kind.escapes_kernel() {
+            // External or Dynamic — escapes to PATH (or can't be resolved
+            // statically). Gate it.
+        }
+        // Builtin / UserTool / Special run in-process under the VFS and
+        // capability model.
+    }
+}
+```
+
+`CommandKind` is `#[non_exhaustive]`, so a `match` needs a wildcard arm — and the
+safe default for an unrecognized kind is to gate it. `escapes_kernel()` captures
+the two buckets a consent gate scrutinizes without spelling out the variants.
+
+`classify_command` mirrors the interpreter's real resolution order, so a name
+like `readonly` (no kaish builtin; resolves to an external binary) reports
+`External`, not a false "internal". The safe direction of any imprecision is
+`External`/`Dynamic` — it never under-reports a `PATH` escape as internal. The
+classifier does not expand aliases; pass the post-alias name if your embedder
+resolves one. The consent UX and the block-the-script loop are embedder policy —
+the kernel supplies only the classification.
+
 ## Path Composition with XDG Primitives
 
 kaish exports XDG base directory primitives so embedders can compose their
@@ -581,8 +618,8 @@ match on those, not on `completed`.
 The `kaish_kernel` crate root re-exports the embedding surface:
 
 - **Core**: `Kernel`, `KernelConfig`, `VfsMountMode`, `ExecuteOptions`,
-  `KernelBackend`, `LocalBackend`, `Tool`, `ToolRegistry`, `ExecContext`,
-  `OutputLimitConfig`
+  `CommandKind`, `KernelBackend`, `LocalBackend`, `Tool`, `ToolRegistry`,
+  `ExecContext`, `OutputLimitConfig`
 - **Jobs**: `BoundedStream`, `StreamStats`, `drain_to_stream`,
   `DEFAULT_STREAM_MAX_SIZE`, `JobFs`
 - **Paths**: `home_dir`, `xdg_data_home`, `xdg_config_home`,

--- a/docs/EMBEDDING.md
+++ b/docs/EMBEDDING.md
@@ -500,12 +500,13 @@ for stmt in &program.statements {
 safe default for an unrecognized kind is to gate it. `escapes_kernel()` captures
 the two buckets a consent gate scrutinizes without spelling out the variants.
 
-`classify_command` mirrors the interpreter's real resolution order, so a name
-like `readonly` (no kaish builtin; resolves to an external binary) reports
-`External`, not a false "internal". The safe direction of any imprecision is
-`External`/`Dynamic` — it never under-reports a `PATH` escape as internal. The
-classifier does not expand aliases; pass the post-alias name if your embedder
-resolves one. The consent UX and the block-the-script loop are embedder policy —
+`classify_command` mirrors the interpreter's real resolution order — including
+**alias expansion** — so a name like `readonly` (no kaish builtin; resolves to an
+external binary) reports `External`, and an `alias cat=/bin/something` makes `cat`
+report `External` too, the same thing it would actually run. The safe direction of
+any residual imprecision is `External`/`Dynamic` — it never under-reports a `PATH`
+escape as internal (`/v/bin/cat` and `.kai`/backend tools over-report as
+`External`). The consent UX and the block-the-script loop are embedder policy —
 the kernel supplies only the classification.
 
 ## Path Composition with XDG Primitives

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -45,6 +45,16 @@ deliberately mirrors the **interpreter's** real special-forms
 `External`, not be told it's internal. The validator↔runtime mismatch is now
 filed as a P3 (the validator probably shouldn't suppress those warnings).
 
+A deepseek review (kaibo) caught the one real under-reporting hole: execution
+expands **aliases** before the registry/PATH lookup, so `alias cat=/bin/evil`
+would have classified as `Builtin` while running external — the dangerous
+direction for a consent gate, and there was no public alias API for the embedder
+to compensate. `classify_command` now expands aliases internally, mirroring
+`execute_command_depth`'s bounded recursion (special-forms re-checked each step),
+so it reports `External` there too. `/v/bin/cat` and `.kai`/backend tools still
+over-report as `External` (the safe direction — over-gate, never leak a `PATH`
+escape). Added a `${VAR}` → `Dynamic` guard for the string-API surface.
+
 Deferred, same reasoning as the `kaish-edit` crate: the `PreflightReport`, the AST
 walk, and the consent loop are embedder policy (kaijutsu owns them), and a
 `Kernel::preflight(src)` convenience waits for a second consumer. Docs: a

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -57,16 +57,21 @@ escape). Added a `${VAR}` → `Dynamic` guard for the string-API surface.
 
 **Staying in sync with the executor.** The classifier duplicates the
 interpreter's resolution rules, which is the same silent-divergence risk the
-feature exists to kill — just moved inside the kernel. Two guards keep it honest:
-(1) *membership* never drifts because classify reads the live registry and
-user-tool tables, not a copy; (2) the *special-form set* is now one
-`RUNTIME_SPECIAL_FORMS` const that **gates** `execute_command_depth` itself (an
-outer `if` over the const wrapping the per-form `match`, with `unreachable!` on a
-const member lacking behavior), so the executor structurally cannot short-circuit
-a name the classifier doesn't also call `Special`. A `classify_command_matches_executor`
-drift test then pins the remaining duplicated rules (precedence, alias expansion)
-by classifying *and* observing the real resolution for each kind. Add a
-resolution step to the executor without teaching classify, and that test fails.
+feature exists to kill — just moved inside the kernel. Three guards keep it
+honest: (1) *membership* never drifts because classify reads the live registry
+and user-tool tables, not a copy; (2) the *special-form set* is a single
+`SpecialForm` enum whose `from_name` is the only place a name becomes "special" —
+classify reports it via `is_runtime_special_form`, and `execute_command_depth`
+matches the enum **exhaustively**, so adding a form is a *compile error* until
+both the name mapping and the behavior are updated (the first cut used a const +
+`unreachable!`, but a deepseek round-2 review flagged that as a runtime panic the
+drift test didn't actually exercise — the enum makes it compile-enforced and
+drops the panic); (3) a `classify_command_matches_executor` drift test pins the
+rules that *can't* be compile-enforced (user-vs-builtin precedence, alias
+expansion) by classifying *and* observing the real resolution for each kind, and
+now executes every special form (incl. `source`/`.`), not just `true`/`false`.
+Add a resolution step to the executor without teaching classify, and either it
+won't compile or that test fails.
 
 Deferred, same reasoning as the `kaish-edit` crate: the `PreflightReport`, the AST
 walk, and the consent loop are embedder policy (kaijutsu owns them), and a

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -14,6 +14,42 @@ before it ships.
 
 ---
 
+## `classify_command`: a supported command classifier for embedder preflight (2026-06-30)
+
+Follow-on to the typed latch accessor (#45). kaijutsu wants to gate kaish's
+destructive/external operations for consent — walk a script, find the command
+nodes that escape to `PATH`, and block until they're approved. It can already do
+most of that with the public surface (`parser::parse`, the `ast`, `tool_schemas`,
+`has_function`). The one thing it *can't* do without forking kaish's truth is
+classify a command name the way the interpreter resolves it — the two rules that
+decide that (`is_static_command_name`, the special-form set) were private helpers
+in the validator. If kaijutsu hardcodes copies, the day kaish refines name
+resolution its consent gate silently disagrees with what kaish actually runs.
+That's the silent-divergence failure class, and here it's security-relevant.
+
+So we added `Kernel::classify_command(name) -> CommandKind` (`Builtin` /
+`UserTool` / `Special` / `Dynamic` / `External`, plus `escapes_kernel()` for the
+two buckets a gate scrutinizes). `CommandKind` lives in `kaish-types` (pure data,
+`#[non_exhaustive]` so a future variant doesn't break embedders — and the safe
+default for an unknown kind is to gate it). The classification core is one shared
+`classify_command_name` in `validator/walker.rs`; the kernel computes the two
+booleans and delegates, so there's a single source of truth.
+
+The sharp bit was discovered empirically: the validator's `is_special_command`
+set (`true`/`false`/`:`/`readonly`/`local`) is **not** what the interpreter
+actually short-circuits. At runtime `readonly` resolves to an *external* command
+(exit 127), `:` is a parse error, `local` is parser-level. The validator uses that
+broad set only to suppress a "command not found" warning. `classify_command`
+deliberately mirrors the **interpreter's** real special-forms
+(`true`/`false`/`source`/`.`) instead — a consent gate must see `readonly` as
+`External`, not be told it's internal. The validator↔runtime mismatch is now
+filed as a P3 (the validator probably shouldn't suppress those warnings).
+
+Deferred, same reasoning as the `kaish-edit` crate: the `PreflightReport`, the AST
+walk, and the consent loop are embedder policy (kaijutsu owns them), and a
+`Kernel::preflight(src)` convenience waits for a second consumer. Docs: a
+"Preflighting a script for external commands" recipe in EMBEDDING.md.
+
 ## Interpreter stack-depth analysis → first GitHub Issues (2026-06-30)
 
 A question — "what pushes up the interpreter's need for stack space over time?" —

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -55,6 +55,19 @@ so it reports `External` there too. `/v/bin/cat` and `.kai`/backend tools still
 over-report as `External` (the safe direction — over-gate, never leak a `PATH`
 escape). Added a `${VAR}` → `Dynamic` guard for the string-API surface.
 
+**Staying in sync with the executor.** The classifier duplicates the
+interpreter's resolution rules, which is the same silent-divergence risk the
+feature exists to kill — just moved inside the kernel. Two guards keep it honest:
+(1) *membership* never drifts because classify reads the live registry and
+user-tool tables, not a copy; (2) the *special-form set* is now one
+`RUNTIME_SPECIAL_FORMS` const that **gates** `execute_command_depth` itself (an
+outer `if` over the const wrapping the per-form `match`, with `unreachable!` on a
+const member lacking behavior), so the executor structurally cannot short-circuit
+a name the classifier doesn't also call `Special`. A `classify_command_matches_executor`
+drift test then pins the remaining duplicated rules (precedence, alias expansion)
+by classifying *and* observing the real resolution for each kind. Add a
+resolution step to the executor without teaching classify, and that test fails.
+
 Deferred, same reasoning as the `kaish-edit` crate: the `PreflightReport`, the AST
 walk, and the consent loop are embedder policy (kaijutsu owns them), and a
 `Kernel::preflight(src)` convenience waits for a second consumer. Docs: a

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -116,6 +116,30 @@ of the argv (mirrors Claude Code "auto" mode). Mechanism in the kernel, judgment
 in the embedder — same split as the write-model latch. Until then, the airtight
 config is `subprocess` off (read-only / no-spawn build). (P2)
 
+### Script preflight: `classify_command` landed; report + `preflight()` deferred
+`Kernel::classify_command(name) -> CommandKind` **landed** (mirrors the
+interpreter's resolution order; the two private validator predicates are promoted
+behind it via the shared `classify_command_name` in `validator/walker.rs`). That
+gives an embedder (kaijutsu's consent gate) the kernel half: walk the public AST,
+classify each command node, gate `External`/`Dynamic`. Two follow-ups stay
+deferred until a second consumer wants them — same reasoning as the deferred
+`kaish-edit` crate:
+- **`PreflightReport` + the AST walk + the consent loop are embedder policy**, not
+  kernel work. kaijutsu owns them. (advice, not an issue)
+- **`Kernel::preflight(src) -> Report` convenience** — a kernel-side walk that
+  bundles classification per command node. Defer until a 2nd embedder wants the
+  shared version. (P3)
+- **Validator/runtime special-form divergence (found building this).** The
+  validator's `is_special_command` set (`true`/`false`/`:`/`readonly`/`local`)
+  suppresses the "command not found" warning for names that don't actually resolve
+  in-process: `readonly` runs as an *external* command (exit 127 at runtime), `:`
+  is a parse error, `local` is parser-level. `classify_command` deliberately uses
+  the **narrower** runtime set (`true`/`false`/`source`/`.`) so a consent gate
+  isn't lied to. The validator's warning heuristic is now the odd one out — it
+  should probably warn on `readonly`/`:` (they aren't kaish commands), or route
+  through `classify_command_name`. Low urgency (warning-only), but it's a real
+  validator↔runtime mismatch. (P3)
+
 ### `kaish-multicall` binary (deferred from the `execute_argv` work)
 `execute_argv` — the argv-native peer of `execute(&str)` — **landed** (see
 devlog); the load-bearing half is done. The cheap second half is still open: a


### PR DESCRIPTION
## What

Adds `Kernel::classify_command(name) -> CommandKind` — a supported, single-source-of-truth command classifier — plus the `CommandKind` enum in `kaish-types`. Follow-on to the typed latch accessor (#45).

## Why

kaijutsu wants to gate kaish's destructive/external operations for consent: walk a parsed script, find the command nodes that escape to `PATH`, and block until they're approved. The public surface already covers most of the preflight (`parser::parse`, the `ast`, `tool_schemas`, `has_function`). The one missing piece is classifying a command name *the way the interpreter resolves it* — and the two rules that decide that (`is_static_command_name` + the special-form set) were private helpers in the validator.

If an embedder hardcodes copies of those rules, it forks kaish's command-resolution truth: the day kaish refines name resolution, the consent gate silently disagrees with what kaish actually runs. That's the silent-divergence failure class, and here it's security-relevant.

## API

```rust
let kind = kernel.classify_command(&cmd.name).await; // Builtin | UserTool | Special | Dynamic | External
if kind.escapes_kernel() { /* External or Dynamic — gate it */ }
```

- `CommandKind` is pure data in `kaish-types`, `#[non_exhaustive]` so a future variant doesn't break embedders — and the safe default for an unknown kind is to gate it.
- The classification core is one shared `classify_command_name` in `validator/walker.rs`; the kernel computes the registry/user-tool booleans and delegates. Single source of truth — the validator's `is_static_command_name` is now the same predicate.

## The sharp bit (a decision worth flagging)

`classify_command` mirrors the **interpreter's** real special-forms (`true`/`false`/`source`/`.`), *not* the validator's broader `is_special_command` heuristic (`true`/`false`/`:`/`readonly`/`local`). That broad set turns out to be stale vs. runtime — empirically:

- `readonly` → resolves to an **external** command (exit 127)
- `:` → parse error (can't be a command name)
- `local` → parser-level assignment (never a `Command` node)

The validator uses the broad set only to suppress a "command not found" warning. A consent gate must see `readonly` as `External`, not be told it's internal — so classify uses the narrow runtime set. The validator↔runtime mismatch (the validator suppresses a real warning) is filed as a P3 in `docs/issues.md`.

## Deferred (embedder policy / second-consumer rule, same as the `kaish-edit` crate)

The `PreflightReport`, the AST walk, the consent loop, and a `Kernel::preflight(src)` convenience all stay in the embedder until a second consumer wants the shared version.

## Tests

5 new tests through `kernel.classify_command(...)`: builtin, the four special-forms, dynamic (`$cmd`/`$(pick)`), external (incl. the `readonly`-is-External regression guard), and user-function-shadows-builtin.

## Docs

- EMBEDDING.md: "Preflighting a script for external commands" recipe + exported-types entry
- CHANGELOG (Unreleased / Added), devlog, issues.md

Gates: `cargo test --all` clean; `cargo clippy --all --all-targets --all-features` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)