### PR TITLE
fix(kernel): pass --help through to owned-output tools (#51)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@ breaking entries are marked **BREAKING**.
   `--confirm=<nonce>`, instead of string-matching the error or digging `.data`
   by key. Returns `None` for plain (non-latch) exit-2 results.
 
+### Fixed
+- **`--help`/`-h` now passes through to `with_owned_output()` tools** — the
+  kernel's generic help router no longer intercepts it for tools that re-parse
+  their own argv, so a leaf request like `tool subcmd --help` reaches the tool
+  and renders its subcommand help instead of the top-level whole-tool help. This
+  also retires the per-tool workaround of advertising a synthetic root `help`
+  param. Plain tools are unaffected.
+
 ## [0.10.0] - 2026-06-29
 
 ### Added

--- a/crates/kaish-kernel/src/kernel.rs
+++ b/crates/kaish-kernel/src/kernel.rs
@@ -2939,14 +2939,20 @@ impl Kernel {
         let schema = tool.schema();
         let tool_args = self.build_args_async(args, Some(&schema)).await?;
 
-        // --help / -h: show help unless the tool's schema claims that flag
+        // --help / -h: show the generic whole-tool help, unless either the tool's
+        // root schema claims that flag OR the tool owns its output. Owned-output
+        // tools re-parse their own argv and route their own `--help` — including
+        // leaf/subcommand help — through their internal (clap) parser, so the root
+        // schema can't express "this leaf claims help" and intercepting here would
+        // render top-level help and return before `execute()` ever sees the
+        // request (#51). Pass it through and let the tool render its own help.
         let schema_claims = |flag: &str| -> bool {
             let bare = flag.trim_start_matches('-');
             schema.params.iter().any(|p| p.matches_flag(flag) || p.matches_flag(bare))
         };
-        let wants_help =
-            (tool_args.flags.contains("help") && !schema_claims("help"))
-            || (tool_args.flags.contains("h") && !schema_claims("-h"));
+        let wants_help = !schema.owns_output
+            && ((tool_args.flags.contains("help") && !schema_claims("help"))
+                || (tool_args.flags.contains("h") && !schema_claims("-h")));
         if wants_help {
             let help_topic = crate::help::HelpTopic::Tool(name.to_string());
             let ctx = self.exec_ctx.read().await;

--- a/crates/kaish-kernel/tests/owned_output_help_tests.rs
+++ b/crates/kaish-kernel/tests/owned_output_help_tests.rs
@@ -1,0 +1,125 @@
+//! Regression tests for #51: the kernel's generic `--help` router must NOT
+//! intercept `--help`/`-h` for tools that own their output and re-parse their
+//! own argv (`with_owned_output()`).
+//!
+//! Such a tool routes its own help — including leaf/subcommand help — through
+//! its internal parser. Intercepting at the kernel layer renders the generic
+//! whole-tool help and returns *before* `execute()`, so the tool can never show
+//! its subcommand help. The fix: when `schema.owns_output` is set, pass `--help`
+//! through to the tool. Plain tools must still get the generic router.
+
+// Test-fixture code: unwrap/expect on known-good setup is the idiom here.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use kaish_kernel::tools::{ToolArgs, ToolCtx, ToolSchema};
+use kaish_kernel::vfs::{MemoryFs, VfsRouter};
+use kaish_kernel::{Kernel, KernelBackend, KernelConfig, LocalBackend, Tool};
+use kaish_types::ExecResult;
+
+/// An owned-output tool that renders its OWN help when it sees `--help`/`-h`.
+/// The sentinel text proves `execute()` was reached rather than the kernel's
+/// generic `HelpTopic::Tool` router short-circuiting first.
+struct OwnedTool;
+
+#[async_trait]
+impl Tool for OwnedTool {
+    fn name(&self) -> &str {
+        "owned"
+    }
+
+    fn schema(&self) -> ToolSchema {
+        ToolSchema::new("owned", "owned-output test tool").with_owned_output()
+    }
+
+    async fn execute(&self, args: ToolArgs, _ctx: &mut dyn ToolCtx) -> ExecResult {
+        if args.flags.contains("help") || args.flags.contains("h") {
+            // A real owned-output tool would render leaf-aware clap help here.
+            return ExecResult::success("OWNED-HELP-RENDERED");
+        }
+        ExecResult::success("OWNED-RAN")
+    }
+}
+
+/// A plain tool (does NOT own output). The kernel's generic `--help` router
+/// should still intercept, so its `execute()` sentinel must never appear.
+struct PlainTool;
+
+#[async_trait]
+impl Tool for PlainTool {
+    fn name(&self) -> &str {
+        "plain"
+    }
+
+    fn schema(&self) -> ToolSchema {
+        ToolSchema::new("plain", "plain test tool")
+    }
+
+    async fn execute(&self, _args: ToolArgs, _ctx: &mut dyn ToolCtx) -> ExecResult {
+        ExecResult::success("PLAIN-RAN")
+    }
+}
+
+fn kernel_with_tools() -> Arc<Kernel> {
+    let mut vfs = VfsRouter::new();
+    vfs.mount("/", MemoryFs::new());
+    let backend: Arc<dyn KernelBackend> = Arc::new(LocalBackend::new(Arc::new(vfs)));
+    Kernel::with_backend(backend, KernelConfig::isolated(), |_| {}, |tools| {
+        tools.register(OwnedTool);
+        tools.register(PlainTool);
+    })
+    .expect("with_backend kernel")
+    .into_arc()
+}
+
+/// The bug: `--help` on an owned-output tool must reach `execute()` so the tool
+/// renders its own (leaf-aware) help, not the kernel's generic top-level help.
+#[tokio::test]
+async fn owned_output_tool_receives_help_flag() {
+    let kernel = kernel_with_tools();
+    let result = kernel.execute("owned sub --help").await.expect("execute");
+    assert_eq!(
+        result.text_out().trim(),
+        "OWNED-HELP-RENDERED",
+        "owned-output tool didn't receive --help; the kernel intercepted it",
+    );
+}
+
+/// `-h` short form, same expectation.
+#[tokio::test]
+async fn owned_output_tool_receives_h_flag() {
+    let kernel = kernel_with_tools();
+    let result = kernel.execute("owned -h").await.expect("execute");
+    assert_eq!(result.text_out().trim(), "OWNED-HELP-RENDERED");
+}
+
+/// Sanity: without a help flag the owned tool runs normally.
+#[tokio::test]
+async fn owned_output_tool_runs_without_help() {
+    let kernel = kernel_with_tools();
+    let result = kernel.execute("owned").await.expect("execute");
+    assert_eq!(result.text_out().trim(), "OWNED-RAN");
+}
+
+/// Regression guard: a plain tool's `--help` is STILL intercepted by the kernel
+/// router, so `execute()` (and its sentinel) is never reached.
+#[tokio::test]
+async fn plain_tool_help_is_still_intercepted() {
+    let kernel = kernel_with_tools();
+    let result = kernel.execute("plain --help").await.expect("execute");
+    assert_ne!(
+        result.text_out().trim(),
+        "PLAIN-RAN",
+        "plain tool's --help should be intercepted by the kernel, not run execute()",
+    );
+}
+
+/// Sanity: the plain tool runs normally without a help flag.
+#[tokio::test]
+async fn plain_tool_runs_without_help() {
+    let kernel = kernel_with_tools();
+    let result = kernel.execute("plain").await.expect("execute");
+    assert_eq!(result.text_out().trim(), "PLAIN-RAN");
+}

--- a/crates/kaish-kernel/tests/owned_output_help_tests.rs
+++ b/crates/kaish-kernel/tests/owned_output_help_tests.rs
@@ -43,6 +43,38 @@ impl Tool for OwnedTool {
     }
 }
 
+/// An owned-output tool with a real subcommand *tree* — the exact shape from
+/// #51 (`kj context create --help`). `with_owned_output()` marks the whole tree,
+/// so a leaf help request must still reach `execute()` rather than being
+/// intercepted at the root.
+struct OwnedTree;
+
+#[async_trait]
+impl Tool for OwnedTree {
+    fn name(&self) -> &str {
+        "ownedtree"
+    }
+
+    fn schema(&self) -> ToolSchema {
+        ToolSchema::new("ownedtree", "owned-output subcommand tree")
+            .subcommand(
+                ToolSchema::new("context", "context commands")
+                    .subcommand(ToolSchema::new("create", "create a context")),
+            )
+            .with_owned_output()
+    }
+
+    async fn execute(&self, args: ToolArgs, _ctx: &mut dyn ToolCtx) -> ExecResult {
+        // The kernel gate is what's under test: an owned-output tool with a
+        // subcommand tree must still see `--help` at execute() so its own parser
+        // can render the *leaf* help the root schema can't describe.
+        if args.flags.contains("help") || args.flags.contains("h") {
+            return ExecResult::success("OWNEDTREE-HELP-RENDERED");
+        }
+        ExecResult::success("OWNEDTREE-RAN")
+    }
+}
+
 /// A plain tool (does NOT own output). The kernel's generic `--help` router
 /// should still intercept, so its `execute()` sentinel must never appear.
 struct PlainTool;
@@ -68,6 +100,7 @@ fn kernel_with_tools() -> Arc<Kernel> {
     let backend: Arc<dyn KernelBackend> = Arc::new(LocalBackend::new(Arc::new(vfs)));
     Kernel::with_backend(backend, KernelConfig::isolated(), |_| {}, |tools| {
         tools.register(OwnedTool);
+        tools.register(OwnedTree);
         tools.register(PlainTool);
     })
     .expect("with_backend kernel")
@@ -103,16 +136,40 @@ async fn owned_output_tool_runs_without_help() {
     assert_eq!(result.text_out().trim(), "OWNED-RAN");
 }
 
+/// The #51 shape: a leaf help request on an owned-output subcommand tree
+/// (`ownedtree context create --help`) must reach `execute()`, not stop at the
+/// root and render top-level help.
+#[tokio::test]
+async fn owned_output_subcommand_tree_receives_leaf_help() {
+    let kernel = kernel_with_tools();
+    let result = kernel
+        .execute("ownedtree context create --help")
+        .await
+        .expect("execute");
+    assert_eq!(
+        result.text_out().trim(),
+        "OWNEDTREE-HELP-RENDERED",
+        "leaf --help didn't reach the owned-output subcommand tree",
+    );
+}
+
 /// Regression guard: a plain tool's `--help` is STILL intercepted by the kernel
-/// router, so `execute()` (and its sentinel) is never reached.
+/// router — `execute()` (and its sentinel) is never reached, and the generic
+/// whole-tool help actually renders (not just "something other than the
+/// sentinel"). Asserting the rendered content keeps this from passing for the
+/// wrong reason if the help system ever breaks.
 #[tokio::test]
 async fn plain_tool_help_is_still_intercepted() {
     let kernel = kernel_with_tools();
     let result = kernel.execute("plain --help").await.expect("execute");
-    assert_ne!(
-        result.text_out().trim(),
-        "PLAIN-RAN",
+    let text = result.text_out();
+    assert!(
+        !text.contains("PLAIN-RAN"),
         "plain tool's --help should be intercepted by the kernel, not run execute()",
+    );
+    assert!(
+        text.contains("plain — plain test tool"),
+        "expected the generic whole-tool help to render; got {text:?}",
     );
 }
 

--- a/docs/EMBEDDING.md
+++ b/docs/EMBEDDING.md
@@ -417,7 +417,10 @@ Notes:
   stdin, and cancellation without depending on kernel internals.
 - If your tool renders its own output (including handling `--json`
   itself), mark the schema `.with_owned_output()` — the kernel then passes
-  `--json` through instead of re-rendering your `ExecResult`.
+  `--json` through instead of re-rendering your `ExecResult`. It also passes
+  `--help`/`-h` through: an owned-output tool re-parses its own argv, so the
+  kernel's generic whole-tool help router stands aside and lets the tool render
+  its own help (including leaf/subcommand help its internal parser knows about).
 
 ### Patient tools: suspending the script timeout
 

--- a/docs/EMBEDDING.md
+++ b/docs/EMBEDDING.md
@@ -421,6 +421,10 @@ Notes:
   `--help`/`-h` through: an owned-output tool re-parses its own argv, so the
   kernel's generic whole-tool help router stands aside and lets the tool render
   its own help (including leaf/subcommand help its internal parser knows about).
+  This makes `--help`/`-h` handling **your** responsibility — unlike `--json`,
+  there is no post-execute safety net. If you re-parse with clap this is
+  automatic (clap emits help on `--help`); a hand-rolled parser must handle it
+  explicitly, or `--help` will fall into your default action.
 
 ### Patient tools: suspending the script timeout
 

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -14,6 +14,31 @@ before it ships.
 
 ---
 
+## `--help` passthrough for owned-output tools (#51, 2026-06-30)
+
+The kernel intercepts `--help`/`-h` in `dispatch_command` and renders the generic
+whole-tool help before the tool runs — fine for ordinary builtins, wrong for a
+tool that owns its output and re-parses its own argv (`with_owned_output()`,
+typically a `schema_tree_from_clap` subcommand tree). For those, a leaf request
+like `tool subcmd --help` never reached the tool, so its *subcommand* help could
+never render; the user got top-level help that read like a missing-verb fallback.
+The interception keyed only on the *root* schema's params, so a subcommand-aware
+tool had no way to say "this leaf claims help."
+
+Fix is the issue's preferred option 1: when `schema.owns_output` is set, don't
+intercept — pass `--help` through to `execute()`. These tools already handle
+their own argv and output rendering, and their internal clap parser renders
+better leaf help than `HelpTopic::Tool` would. One condition (`!schema.owns_output`)
+on the existing `wants_help`; plain tools are untouched. This also retires the
+downstream workaround (kaijutsu's `kj` advertising a synthetic root `help` param
+just to dodge the interception). Found while building the `kj` subcommand tree in
+kaijutsu; the inconsistency was that bare `help` (a positional) reached the tool
+while `--help` (a flag) didn't, purely as an artifact of where interception sat.
+
+Own PR, off main — kept separate from the `classify_command` work (#50): different
+concern, different changelog group (`Fixed` vs `Added`), and #50 was already
+review-clean.
+
 ## Interpreter stack-depth analysis → first GitHub Issues (2026-06-30)
 
 A question — "what pushes up the interpreter's need for stack space over time?" —


### PR DESCRIPTION
Fixes #51.

## Problem

The kernel's `--help`/`-h` router in `dispatch_command` intercepts help on **any** tool whose *root* schema doesn't claim that flag, rendering the generic whole-tool help and returning *before* `execute()`. For a tool that owns its output and re-parses its own argv (`with_owned_output()`, typically a `schema_tree_from_clap` subcommand tree), a leaf request like `tool subcmd --help` never reaches the tool, so its **subcommand** help can never render — the user gets top-level help that reads like a missing-verb fallback. The check only inspected the root schema's params, so a subcommand-aware tool had no way to say "this leaf claims help."

The tell: bare `help` (a positional) reached the tool while `--help` (a flag) didn't, purely as an artifact of where interception sat.

## Fix

Issue's preferred **option 1**: when `schema.owns_output` is set, don't intercept — pass `--help` through to `execute()` and let the tool's own (clap) parser render help, including leaf help `HelpTopic::Tool` can't reach. One `!schema.owns_output` condition on the existing `wants_help`; plain tools are untouched. This also retires the downstream workaround of advertising a synthetic root `help` param just to dodge interception.

## Tests (TDD)

New `owned_output_help_tests.rs`:
- `with_owned_output()` fixture asserts `--help` and `-h` reach `execute()` (both **red** before the fix — they got generic `HelpTopic::Tool` output)
- a plain fixture asserts interception still fires (regression guard)
- run-without-help sanity for both

Gates: `cargo test --all` clean; `cargo clippy --all --all-targets` / `--all-features` clean.

Independent of #50 (off `main`); kept separate by concern and changelog group (`Fixed` vs `Added`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)