### PR TITLE
feat(builtins): fromjson/tojson — the JSON ingress/egress bridge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,18 @@ breaking entries are marked **BREAKING**.
   builtin may return someday.
 
 ### Added
+- **`fromjson` / `tojson` builtins** — the JSON ingress/egress bridge for the
+  value model. `fromjson` parses exactly one JSON document (from an argument or
+  stdin) into a structured value in `.data`; empty input or trailing garbage is
+  a loud line:column error, never a silent `null`, and an object shaped like the
+  internal base64 byte-envelope stays a plain record (never silently decoded to
+  bytes). `tojson` serializes one value to JSON text (compact, or `--pretty`) —
+  the "serialize explicitly first" escape hatch for `export CFG_JSON=$(tojson
+  $cfg)`; binary values are refused loudly. Both are pure data (present in every
+  capability build). `fromjson "$(tojson $x)"` round-trips `$x` structurally.
+- **`json_to_value_no_envelope` (kaish-types)** — envelope-free JSON→`Value`
+  conversion for external JSON, so byte-envelope-shaped objects are never
+  silently decoded to `Value::Bytes`.
 - **`ExecResult::latch_request()` + `LatchRequest` (kaish-types)** — typed
   embedder seam for the confirmation latch: decodes a latched result (exit 2 +
   nonce payload) into `{nonce, command, paths, hint, ttl}` so an embedder can

--- a/crates/kaish-kernel/src/tools/builtin/fromjson.rs
+++ b/crates/kaish-kernel/src/tools/builtin/fromjson.rs
@@ -1,0 +1,121 @@
+//! fromjson — parse one JSON document into a structured kaish value.
+//!
+//! The JSON *ingress* half of the value model's text boundary (the egress half
+//! is [`super::tojson`]). Reads a single JSON document from a positional string
+//! argument or stdin, and lands the result in `.data` so it can be captured or
+//! iterated: `cfg=$(curl -s api/config | fromjson)`.
+//!
+//! Non-negotiables (see `docs/arrays-and-hashes.md`):
+//! - **Envelope-free.** External JSON is converted with
+//!   [`kaish_types::json_to_value_no_envelope`] — a base64 byte-envelope-shaped
+//!   object stays a plain record, never silently becomes `Value::Bytes`.
+//! - **One document, one value.** The whole input is exactly one JSON document;
+//!   empty input or trailing garbage is a loud error with line:column, never a
+//!   silent `null`. (Contrast `$(… | jq .)`, which array-wraps a multi-value
+//!   stream.)
+//! - **Same unwrap law as native access.** JSON scalars unwrap to native
+//!   `Value` variants; objects/arrays stay `Value::Json`.
+//!
+//! # Examples
+//!
+//! ```kaish
+//! cfg=$(curl -s api/config | fromjson)   # from a pipe
+//! v=$(fromjson "$text")                  # from a string argument
+//! echo ${cfg[port]}                      # (native access, once it lands)
+//! ```
+
+use async_trait::async_trait;
+use clap::{CommandFactory, Parser};
+
+use crate::ast::Value;
+use crate::interpreter::ExecResult;
+use crate::tools::{schema_from_clap, ExecContext, GlobalFlags, Tool, ToolArgs, ToolCtx, ToolSchema};
+
+/// fromjson tool: parse one JSON document into a structured value.
+pub struct FromJson;
+
+/// clap-derived argv layer for fromjson.
+#[derive(Parser, Debug)]
+#[command(name = "fromjson", about = "Parse one JSON document into a value")]
+struct FromJsonArgs {
+    #[command(flatten)]
+    global: GlobalFlags,
+
+    /// JSON text to parse (or pipe it on stdin). Hidden sink — the real value
+    /// is read off `args.positional` per the Value-typed positional rule.
+    #[arg(hide = true)]
+    input: Vec<String>,
+}
+
+#[async_trait]
+impl Tool for FromJson {
+    fn name(&self) -> &str {
+        "fromjson"
+    }
+
+    fn schema(&self) -> ToolSchema {
+        schema_from_clap(
+            &FromJsonArgs::command(),
+            "fromjson",
+            "Parse one JSON document into a structured value (in .data)",
+            [
+                ("Parse a string", "fromjson '{\"name\": \"amy\"}'"),
+                ("Parse a pipe", "curl -s api/config | fromjson"),
+                ("Capture for access", "cfg=$(fromjson \"$text\")"),
+            ],
+        )
+    }
+
+    async fn execute(&self, args: ToolArgs, ctx: &mut dyn ToolCtx) -> ExecResult {
+        let Some(ctx) = ctx.as_any_mut().downcast_mut::<ExecContext>() else {
+            return ExecResult::failure(1, "internal error: kernel builtin requires ExecContext");
+        };
+        let parsed = match FromJsonArgs::try_parse_from(
+            std::iter::once("fromjson".to_string()).chain(args.to_argv()),
+        ) {
+            Ok(p) => p,
+            Err(e) => return ExecResult::failure(2, format!("fromjson: {e}")),
+        };
+        parsed.global.apply(ctx);
+
+        // Input text: an explicit positional argument wins; otherwise stdin.
+        let input = match args.positional.first() {
+            Some(Value::String(s)) => s.clone(),
+            Some(Value::Bytes(b)) => match std::str::from_utf8(b) {
+                Ok(s) => s.to_string(),
+                Err(_) => {
+                    return ExecResult::failure(1, "fromjson: input is binary, not text")
+                }
+            },
+            // An already-structured value: re-serialize its JSON text so
+            // `fromjson` is idempotent on values that are already typed.
+            Some(other) => kaish_types::value_to_json(other).to_string(),
+            None => match ctx.read_stdin_to_text().await {
+                Ok(Some(s)) => s,
+                Ok(None) => {
+                    return ExecResult::failure(
+                        1,
+                        "fromjson: no input (pass a JSON string or pipe stdin)",
+                    )
+                }
+                Err(e) => return ExecResult::failure(2, format!("fromjson: {e}")),
+            },
+        };
+
+        if input.trim().is_empty() {
+            return ExecResult::failure(1, "fromjson: empty input (expected one JSON document)");
+        }
+
+        // One document, one value: serde_json::from_str rejects trailing garbage
+        // ("trailing characters"), and its Display already carries "at line L
+        // column C" — a loud, positioned error, never a silent null.
+        let json: serde_json::Value = match serde_json::from_str(&input) {
+            Ok(j) => j,
+            Err(e) => return ExecResult::failure(1, format!("fromjson: invalid JSON: {e}")),
+        };
+
+        // Envelope-free: an envelope-shaped object stays a record, never Bytes.
+        let value = kaish_types::json_to_value_no_envelope(json);
+        ExecResult::success_data(value)
+    }
+}

--- a/crates/kaish-kernel/src/tools/builtin/mod.rs
+++ b/crates/kaish-kernel/src/tools/builtin/mod.rs
@@ -32,6 +32,7 @@ mod export;
 #[cfg(feature = "subprocess")]
 mod fg;
 mod file;
+mod fromjson;
 mod glob;
 mod find;
 pub(crate) mod format_string;
@@ -80,6 +81,7 @@ mod tac;
 mod tail;
 mod tee;
 mod timeout;
+mod tojson;
 #[cfg(feature = "tokens")]
 mod tokens;
 mod touch;
@@ -151,6 +153,7 @@ pub fn register_builtins(registry: &mut ToolRegistry) {
     #[cfg(feature = "subprocess")]
     registry.register(fg::Fg);
     registry.register(file::File);
+    registry.register(fromjson::FromJson);
     registry.register(glob::Glob);
     registry.register(find::Find);
     registry.register(gather::Gather);
@@ -201,6 +204,7 @@ pub fn register_builtins(registry: &mut ToolRegistry) {
     registry.register(timeout::Timeout);
     #[cfg(feature = "tokens")]
     registry.register(tokens::Tokens);
+    registry.register(tojson::ToJson);
     registry.register(touch::Touch);
     registry.register(tr::Tr);
     registry.register(tree::Tree);

--- a/crates/kaish-kernel/src/tools/builtin/tojson.rs
+++ b/crates/kaish-kernel/src/tools/builtin/tojson.rs
@@ -1,0 +1,111 @@
+//! tojson — serialize a kaish value to a JSON document.
+//!
+//! The JSON *egress* half of the value model's text boundary (the ingress half
+//! is [`super::fromjson`]). Takes one value and emits its JSON text — the
+//! "serialize explicitly first" escape hatch for putting structured data in an
+//! OS environment variable (which `export` refuses to do silently):
+//! `export CFG_JSON=$(tojson $cfg)`.
+//!
+//! - **One value positional**, read off `args.positional` per the Value-typed
+//!   rule (`to_argv()` stringifies, so the clap sink is validation-only).
+//! - **Compact by default**, `--pretty` for files/humans.
+//! - **Text out, no `.data`** — the whole point is a JSON *string*; setting
+//!   `.data` would make `$(tojson …)` round-trip straight back to a value.
+//! - **`Value::Bytes` is a loud error** — bytes are not JSON.
+//!
+//! # Examples
+//!
+//! ```kaish
+//! export CFG_JSON=$(tojson $cfg)     # the export-error escape hatch
+//! tojson --pretty $cfg | tee config.json
+//! tojson hello                       # "hello"  (a scalar is valid JSON)
+//! ```
+
+use async_trait::async_trait;
+use clap::{CommandFactory, Parser};
+
+use crate::ast::Value;
+use crate::interpreter::ExecResult;
+use crate::tools::{schema_from_clap, ExecContext, GlobalFlags, Tool, ToolArgs, ToolCtx, ToolSchema};
+
+/// tojson tool: serialize a value to a JSON document.
+pub struct ToJson;
+
+/// clap-derived argv layer for tojson.
+#[derive(Parser, Debug)]
+#[command(name = "tojson", about = "Serialize a value to a JSON document")]
+struct ToJsonArgs {
+    /// Pretty-print with two-space indentation (default is compact).
+    #[arg(long)]
+    pretty: bool,
+
+    #[command(flatten)]
+    global: GlobalFlags,
+
+    /// The value to serialize. Hidden sink — the real value is read off
+    /// `args.positional` per the Value-typed positional rule.
+    #[arg(hide = true)]
+    value: Vec<String>,
+}
+
+#[async_trait]
+impl Tool for ToJson {
+    fn name(&self) -> &str {
+        "tojson"
+    }
+
+    fn schema(&self) -> ToolSchema {
+        schema_from_clap(
+            &ToJsonArgs::command(),
+            "tojson",
+            "Serialize a value to a JSON document (text out)",
+            [
+                ("Serialize a value", "tojson $cfg"),
+                ("Pretty-print to a file", "tojson --pretty $cfg | tee config.json"),
+                ("Escape hatch for export", "export CFG_JSON=$(tojson $cfg)"),
+                ("A scalar is valid JSON", "tojson hello"),
+            ],
+        )
+    }
+
+    async fn execute(&self, args: ToolArgs, ctx: &mut dyn ToolCtx) -> ExecResult {
+        let Some(ctx) = ctx.as_any_mut().downcast_mut::<ExecContext>() else {
+            return ExecResult::failure(1, "internal error: kernel builtin requires ExecContext");
+        };
+        let parsed = match ToJsonArgs::try_parse_from(
+            std::iter::once("tojson".to_string()).chain(args.to_argv()),
+        ) {
+            Ok(p) => p,
+            Err(e) => return ExecResult::failure(2, format!("tojson: {e}")),
+        };
+        parsed.global.apply(ctx);
+
+        let value = match args.positional.first() {
+            Some(v) => v,
+            None => {
+                return ExecResult::failure(1, "tojson: no value (pass a value to serialize)")
+            }
+        };
+
+        // Bytes are not JSON — refuse loudly rather than emit a base64 envelope
+        // that would silently masquerade as the data.
+        if let Value::Bytes(b) = value {
+            return ExecResult::failure(
+                1,
+                format!("tojson: cannot serialize {} bytes of binary — use base64", b.len()),
+            );
+        }
+
+        let json = kaish_types::value_to_json(value);
+        let text = if parsed.pretty {
+            serde_json::to_string_pretty(&json)
+        } else {
+            serde_json::to_string(&json)
+        };
+        match text {
+            // Text out only — no .data, so $(tojson …) captures the JSON string.
+            Ok(s) => ExecResult::success(s),
+            Err(e) => ExecResult::failure(1, format!("tojson: {e}")),
+        }
+    }
+}

--- a/crates/kaish-kernel/tests/json_bridge_tests.rs
+++ b/crates/kaish-kernel/tests/json_bridge_tests.rs
@@ -1,0 +1,178 @@
+//! End-to-end tests for the JSON ingress/egress bridge: `fromjson` / `tojson`.
+//!
+//! These drive real command strings through `kernel.execute()` (never a
+//! builtin's `.execute()` directly) so the full dispatch chain runs, and they
+//! use `KernelConfig::isolated()` — no localfs — because the pair is pure data
+//! and must work in every capability build.
+//!
+//! The load-bearing guarantees under test (see `docs/arrays-and-hashes.md`):
+//! - **Envelope-free**: an envelope-shaped object from external JSON stays a
+//!   record, never silently becomes bytes.
+//! - **One document, one value**: empty input and trailing garbage are loud
+//!   errors, never a silent null.
+//! - **Roundtrip law**: `fromjson "$(tojson $x)"` reproduces `$x` structurally.
+
+// Test-fixture code: unwrap/expect on known-good setup is the idiom here.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::sync::Arc;
+
+use kaish_kernel::{Kernel, KernelConfig};
+
+async fn setup() -> Arc<Kernel> {
+    Kernel::new(KernelConfig::isolated().with_skip_validation(true))
+        .expect("failed to create kernel")
+        .into_arc()
+}
+
+async fn run(k: &Kernel, script: &str) -> (String, i64, String) {
+    let r = k.execute(script).await.expect("kernel execute");
+    (r.text_out().trim().to_string(), r.code, r.err.clone())
+}
+
+// ── fromjson: parsing ──────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn fromjson_parses_object_preserving_key_order() {
+    let k = setup().await;
+    let (out, code, _) = run(&k, r#"fromjson '{"name":"amy","age":40}'"#).await;
+    assert_eq!(code, 0);
+    // preserve_order is on workspace-wide, so key order survives.
+    assert_eq!(out, r#"{"name":"amy","age":40}"#);
+}
+
+#[tokio::test]
+async fn fromjson_unwraps_scalars() {
+    let k = setup().await;
+    assert_eq!(run(&k, "fromjson 42").await.0, "42");
+    assert_eq!(run(&k, "fromjson true").await.0, "true");
+    assert_eq!(run(&k, "fromjson null").await.0, "null");
+    // A JSON string round-trips as a quoted JSON string.
+    assert_eq!(run(&k, r#"fromjson '"hi"'"#).await.0, r#""hi""#);
+}
+
+#[tokio::test]
+async fn fromjson_reads_stdin() {
+    let k = setup().await;
+    let (out, code, _) = run(&k, r#"echo '{"a":1}' | fromjson"#).await;
+    assert_eq!(code, 0);
+    assert_eq!(out, r#"{"a":1}"#);
+}
+
+// ── fromjson: loud errors, never a silent null ─────────────────────────────
+
+#[tokio::test]
+async fn fromjson_empty_input_is_loud() {
+    let k = setup().await;
+    let (_, code, err) = run(&k, "fromjson ''").await;
+    assert_ne!(code, 0);
+    assert!(err.contains("empty"), "err: {err}");
+}
+
+#[tokio::test]
+async fn fromjson_trailing_garbage_is_loud_with_position() {
+    let k = setup().await;
+    let (_, code, err) = run(&k, r#"fromjson '{"a":1} extra'"#).await;
+    assert_ne!(code, 0);
+    assert!(err.contains("invalid JSON"), "err: {err}");
+    // serde_json's Display carries the line/column of the failure.
+    assert!(err.contains("line") && err.contains("column"), "err: {err}");
+}
+
+#[tokio::test]
+async fn fromjson_malformed_is_loud() {
+    let k = setup().await;
+    let (_, code, err) = run(&k, "fromjson '{not json}'").await;
+    assert_ne!(code, 0);
+    assert!(err.contains("invalid JSON"), "err: {err}");
+}
+
+#[tokio::test]
+async fn fromjson_no_input_is_loud() {
+    let k = setup().await;
+    let (_, code, err) = run(&k, "fromjson").await;
+    assert_ne!(code, 0);
+    assert!(err.contains("no input"), "err: {err}");
+}
+
+// ── The envelope-free hazard ───────────────────────────────────────────────
+
+#[tokio::test]
+async fn fromjson_never_decodes_a_bytes_envelope() {
+    // External JSON shaped exactly like the internal base64 byte envelope must
+    // NOT silently become Value::Bytes. If it did, `tojson` would reject it as
+    // binary; because it stays a record, `tojson` re-serializes the object.
+    let k = setup().await;
+    let (out, code, err) = run(
+        &k,
+        r#"x=$(fromjson '{"_type":"bytes","encoding":"base64","data":"AQID","len":3}'); tojson $x"#,
+    )
+    .await;
+    assert_eq!(code, 0, "envelope-shaped object should stay a record; err: {err}");
+    assert!(out.contains(r#""_type""#), "out: {out}");
+    assert!(out.contains(r#""bytes""#), "out: {out}");
+}
+
+// ── tojson: serialize ──────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn tojson_serializes_a_captured_value() {
+    let k = setup().await;
+    let (out, code, _) = run(&k, r#"x=$(fromjson '{"name":"amy"}'); tojson $x"#).await;
+    assert_eq!(code, 0);
+    assert_eq!(out, r#"{"name":"amy"}"#);
+}
+
+#[tokio::test]
+async fn tojson_scalar_is_valid_json() {
+    let k = setup().await;
+    assert_eq!(run(&k, "tojson hello").await.0, r#""hello""#);
+}
+
+#[tokio::test]
+async fn tojson_pretty_indents() {
+    let k = setup().await;
+    let (out, code, _) = run(&k, r#"x=$(fromjson '{"a":1}'); tojson --pretty $x"#).await;
+    assert_eq!(code, 0);
+    assert!(out.contains("\n"), "pretty output should have newlines: {out}");
+    assert!(out.contains("  \"a\""), "pretty output should indent: {out}");
+}
+
+#[tokio::test]
+async fn tojson_no_value_is_loud() {
+    let k = setup().await;
+    let (_, code, err) = run(&k, "tojson").await;
+    assert_ne!(code, 0);
+    assert!(err.contains("no value"), "err: {err}");
+}
+
+#[tokio::test]
+async fn tojson_refuses_binary() {
+    // `/w==` decodes to a single 0xFF byte — invalid UTF-8, so base64 -d yields
+    // a Bytes value. tojson must refuse it loudly, not emit a base64 envelope.
+    let k = setup().await;
+    let (_, code, err) = run(&k, "x=$(echo '/w==' | base64 -d); tojson $x").await;
+    assert_ne!(code, 0);
+    assert!(err.contains("bytes") || err.contains("binary"), "err: {err}");
+}
+
+// ── The roundtrip law ──────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn roundtrip_law_holds_structurally() {
+    let k = setup().await;
+    // fromjson -> tojson reproduces the input document (top-level, order kept).
+    let (out, code, _) =
+        run(&k, r#"x=$(fromjson '{"n":3,"tags":["a","b"]}'); tojson $x"#).await;
+    assert_eq!(code, 0);
+    assert_eq!(out, r#"{"n":3,"tags":["a","b"]}"#);
+
+    // fromjson(tojson(x)) == x, pinned by serializing both and comparing text.
+    let (rt, code, _) = run(
+        &k,
+        r#"x=$(fromjson '{"n":3,"tags":["a","b"]}'); y=$(fromjson "$(tojson $x)"); tojson $y"#,
+    )
+    .await;
+    assert_eq!(code, 0);
+    assert_eq!(rt, r#"{"n":3,"tags":["a","b"]}"#);
+}

--- a/crates/kaish-kernel/tests/json_sweep_tests.rs
+++ b/crates/kaish-kernel/tests/json_sweep_tests.rs
@@ -108,6 +108,7 @@ const CASES: &[Case] = &[
     Case { name: "false", setup: &[], cmd: "false --json", expect: Expect::FailsClean(1) },
     Case { name: "file", setup: &[], cmd: "file tmp/data.json --json", expect: Expect::Array },
     Case { name: "find", setup: &[], cmd: "find src -name '*.rs' --json", expect: Expect::Array },
+    Case { name: "fromjson", setup: &[], cmd: r#"fromjson '{"a":1}' --json"#, expect: Expect::Object },
     // scatter/gather own their output (`owns_output`): `--json` passes
     // through untouched and `--format json` is the structured form.
     Case { name: "gather", setup: &[], cmd: "seq 1 2 | scatter --as N | echo $N | gather --format json", expect: Expect::Array },
@@ -167,6 +168,7 @@ const CASES: &[Case] = &[
     Case { name: "tail", setup: &[], cmd: "tail -n 1 tmp/app.log --json", expect: Expect::Array },
     Case { name: "tee", setup: &[], cmd: "echo hi | tee out.txt --json", expect: Expect::String },
     Case { name: "timeout", setup: &[], cmd: "timeout 5 echo hi --json", expect: Expect::String },
+    Case { name: "tojson", setup: &[], cmd: "tojson hello --json", expect: Expect::String },
     Case { name: "tokens", setup: &[], cmd: "echo hello | tokens --json", expect: Expect::Array },
     Case { name: "touch", setup: &[], cmd: "touch new.txt --json", expect: Expect::Empty },
     Case { name: "tr", setup: &[], cmd: "printf 'abc' | tr a x --json", expect: Expect::String },

--- a/crates/kaish-types/src/result.rs
+++ b/crates/kaish-types/src/result.rs
@@ -506,6 +506,35 @@ pub fn json_to_value(json: serde_json::Value) -> Value {
     }
 }
 
+/// Convert serde_json::Value to our AST Value **without** bytes-envelope sniffing.
+///
+/// External JSON (from `fromjson`, or native access traversal) must never
+/// silently become a `Value::Bytes` just because an object happens to match the
+/// base64 envelope shape (`{"_type":"bytes",…}`). That auto-decode is a feature
+/// of *internal* round-tripping only — it would be a silent, surprising
+/// conversion on untrusted input. Otherwise this is the same unwrap law as
+/// [`json_to_value`]: JSON scalars unwrap to native `Value` variants, and only
+/// objects/arrays stay `Value::Json`.
+pub fn json_to_value_no_envelope(json: serde_json::Value) -> Value {
+    match json {
+        serde_json::Value::Null => Value::Null,
+        serde_json::Value::Bool(b) => Value::Bool(b),
+        serde_json::Value::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                Value::Int(i)
+            } else if let Some(f) = n.as_f64() {
+                Value::Float(f)
+            } else {
+                Value::String(n.to_string())
+            }
+        }
+        serde_json::Value::String(s) => Value::String(s),
+        // Objects and arrays stay structured — an envelope-shaped object is a
+        // plain record here, not decoded to bytes.
+        serde_json::Value::Object(_) | serde_json::Value::Array(_) => Value::Json(json),
+    }
+}
+
 /// Convert our AST Value to serde_json::Value for serialization.
 pub fn value_to_json(value: &Value) -> serde_json::Value {
     match value {
@@ -722,6 +751,35 @@ mod tests {
         // A plain object is NOT mistaken for bytes.
         let obj = serde_json::json!({"name": "amy"});
         assert!(matches!(json_to_value(obj), Value::Json(_)));
+    }
+
+    #[test]
+    fn no_envelope_never_decodes_bytes() {
+        // The envelope-free path is what external JSON (fromjson, access) uses:
+        // an object matching the byte-envelope shape stays a plain record, it is
+        // NOT silently decoded to Value::Bytes.
+        let envelope = crate::bytes::bytes_to_envelope(&[1u8, 2, 3]);
+        // The sniffing path DOES decode it (internal round-trip).
+        assert!(matches!(json_to_value(envelope.clone()), Value::Bytes(_)));
+        // The envelope-free path leaves it structured.
+        assert!(matches!(
+            json_to_value_no_envelope(envelope),
+            Value::Json(serde_json::Value::Object(_))
+        ));
+    }
+
+    #[test]
+    fn no_envelope_shares_unwrap_law_for_scalars() {
+        // Scalars unwrap identically to json_to_value; only the object arm differs.
+        assert_eq!(json_to_value_no_envelope(serde_json::json!(42)), Value::Int(42));
+        assert_eq!(json_to_value_no_envelope(serde_json::json!(1.5)), Value::Float(1.5));
+        assert_eq!(json_to_value_no_envelope(serde_json::json!(true)), Value::Bool(true));
+        assert_eq!(json_to_value_no_envelope(serde_json::json!("hi")), Value::String("hi".into()));
+        assert_eq!(json_to_value_no_envelope(serde_json::json!(null)), Value::Null);
+        assert!(matches!(
+            json_to_value_no_envelope(serde_json::json!([1, 2])),
+            Value::Json(serde_json::Value::Array(_))
+        ));
     }
 
     #[test]

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -14,6 +14,39 @@ before it ships.
 
 ---
 
+## JSON bridge: fromjson / tojson land ahead of the grammar (2026-07-01)
+
+First implementation step of the collections effort, and deliberately the one
+that touches no lexer or parser. `fromjson`/`tojson` are the value model's text
+boundary — the pair the arrays-and-hashes doc sketched as "prototype early." They
+exercise the whole value-model plumbing (structured `$()`, `.data`, typed
+positionals, assignment capture) end to end, so building them first de-risks the
+boundary semantics and pins the error copy before the big grammar PR.
+
+Two integration points were verified against HEAD before writing a line, because
+they decide whether the pair is useful *before* native access exists: (1)
+command-substitution already prefers a result's `.data` (`kernel.rs:3716`), so
+`cfg=$(… | fromjson)` captures the structured `Value`; (2) a variable holding a
+`Value::Json` expands straight into `args.positional` as that typed value
+(`kernel.rs:3285`), so `tojson $cfg` reads a real value off the positional, not a
+stringified copy. Both held — the pair works today, with access arriving later.
+
+The load-bearing decision is **envelope-free conversion**. The internal
+`json_to_value` auto-decodes any object matching the base64 byte-envelope shape
+into `Value::Bytes` — correct for internal round-tripping, a silent-corruption
+trap for *external* JSON that happens to match. Added
+`json_to_value_no_envelope` (kaish-types) and routed `fromjson` through it; the
+hazard is pinned by a test that feeds an envelope-shaped document through
+`fromjson | tojson` and asserts it re-serializes as a record, not as refused
+binary. `fromjson` is one-doc-one-value (serde's trailing-garbage rejection does
+the work; empty input is a separate loud error), and its parse errors carry
+serde's line:column. `tojson` is text-out-only — setting `.data` would make
+`$(tojson $x)` round-trip straight back to a value and defeat the export escape
+hatch — and refuses `Value::Bytes` loudly rather than emit an envelope. The
+roundtrip law (`fromjson "$(tojson $x)"` ≡ `$x`) is test-pinned. Both are pure
+data: registered unconditionally, verified under `--no-default-features`, and
+tested through `KernelConfig::isolated()` (no localfs).
+
 ## Arrays & hashes design revision: the brackets are ours (2026-07-01)
 
 The 2026-06-05 collections proposal came back for review a month later and left

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -313,6 +313,22 @@ dominating at ~5.4K). Do this before the collections fragments land — they're 
 feature that will test it. See [arrays-and-hashes.md](arrays-and-hashes.md)
 "Help & teaching delivery".
 
+**Envelope-free must hold through downstream `.data` consumers (2026-07-01, from
+the json-bridge deepseek review):** `fromjson` converts external JSON with
+`json_to_value_no_envelope` (envelope-free at ingress), but two consumers still
+re-sniff the byte-envelope on `Value::Json` sub-values via the sniffing
+`json_to_value`: the `for` loop's array-element spread (`kernel.rs:2177`) and
+`jq`'s single-value output (`jq_native.rs:689`). So `for i in $(fromjson
+'[{"_type":"bytes",…}]')` silently decodes an envelope-shaped array element to
+`Value::Bytes` — the exact silent conversion the guarantee forbids, just one hop
+downstream. Pre-existing (these sites predate the bridge and were written for
+internal round-tripping, where re-decoding is correct). **Fold into step-2
+read-side traversal**, which is all about envelope-free access: switch these to
+`json_to_value_no_envelope` (verify no internal builtin relies on a `.data` array
+element round-tripping to bytes — `dd` emits `out_bytes`, not `.data` arrays, so
+it looks safe) and add the `for i in $(fromjson '[envelope]')` + `fromjson | jq
+'.'` regression tests the bridge PR deliberately left out of scope.
+
 ### Split `kernel.rs::execute_stmt_flow`
 `kernel.rs:1463`–~1913 is a 16-arm async match (kernel.rs is ~6,838 lines); each
 arm reaches into `scope`/`exec_ctx`/`user_tools` RwLocks, and `For`/`While`/`Case`


### PR DESCRIPTION
First implementation step of the arrays & hashes effort ([design](docs/arrays-and-hashes.md)), deliberately the one with **zero grammar work**. `fromjson`/`tojson` are the value model's text boundary — the pair the design sketched as "prototype early." Building them first exercises the whole value-model plumbing (structured `$()`, `.data`, typed positionals, assignment capture) end to end, de-risks the boundary semantics, and pins the error copy before the grammar PR.

## What lands

- **`fromjson`** — parses exactly one JSON document (from an argument or stdin) into a structured value in `.data`. `cfg=$(curl -s api/config | fromjson)`.
- **`tojson`** — serializes one value to JSON text (compact, or `--pretty`). The "serialize explicitly first" escape hatch for `export CFG_JSON=$(tojson $cfg)`.
- **`json_to_value_no_envelope`** (kaish-types) — envelope-free JSON→`Value` conversion.

## Decisions

- **Envelope-free ingress.** External JSON shaped like the internal base64 byte-envelope (`{"_type":"bytes",…}`) must **never** silently become `Value::Bytes` — a silent-corruption trap. `fromjson` routes through the new envelope-free conversion; pinned by a test that runs an envelope-shaped doc through `fromjson | tojson` and asserts it re-serializes as a **record**, not refused as binary.
- **One doc, one value.** Empty input and trailing garbage are loud errors, never a silent `null`; parse errors carry serde's line:column.
- **`tojson` is text-out only** — setting `.data` would make `$(tojson $x)` round-trip straight back to a value and defeat the export hatch. `Value::Bytes` is refused loudly rather than emitting an envelope.
- **Pure data** — both registered unconditionally, present in every capability build (confirmed under `--no-default-features`), tested through `KernelConfig::isolated()` (no localfs).

The roundtrip law `fromjson "$(tojson $x)"` ≡ `$x` is test-pinned.

## Why it works before native access exists

Two integration points verified against HEAD: `$()` prefers a result's `.data` (`kernel.rs:3716`), so `cfg=$(… | fromjson)` captures the `Value`; and a `Value::Json` var expands straight into `args.positional` typed (`kernel.rs:3285`), so `tojson $cfg` reads a real value off the positional.

## Tests / gates

- `tests/json_bridge_tests.rs` (14, kernel-routed), kaish-types unit tests, two `json_sweep_tests` cases.
- `cargo test --all` and `cargo clippy --all --all-targets` both clean.

## Review

Reviewed with kaibo (cast deepseek): all four intended guarantees pass. One out-of-scope finding — two pre-existing `.data` consumers (for-loop array spread, jq single-value) still re-sniff the envelope via the sniffing `json_to_value` — deferred to `docs/issues.md`, to fold into step-2 read-side traversal (envelope-free access).

🤖 Generated with [Claude Code](https://claude.com/claude-code)