### PR TITLE
feat(interpreter): native collection read access — ${xs[0]}, ${r[key]}, slices, nested paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,18 @@ breaking entries are marked **BREAKING**.
   builtin may return someday.
 
 ### Added
+- **Native collection read access** — `${xs[0]}`, `${r[key]}`, `${r[$k]}`,
+  `${r["weird-key"]}`, `${xs[-1]}` (negative index), `${xs[0:2]}` (end-exclusive
+  slice → a list), and chained `${a[b][c]}`, over any `Value::Json` (e.g. from
+  `fromjson` or `$()`). Brackets only — a bareword subscript is a literal key, a
+  `$var` is dynamic, integers index lists; a subscript that lands on a JSON
+  scalar unwraps to a native value (so `[[ ${cfg[healthy]} == false ]]` and
+  `$(( ${cfg[port]} + 1 ))` are typed). `${#…}` now returns element count for a
+  list and key count for a record (string length unchanged). Every bad access is
+  a loud error, never a silent empty: dotted access (`${r.key}` → use `[key]`),
+  out-of-bounds index, missing record key, a string key on a list, an integer
+  index on a record, and subscripting a scalar. Literal construction
+  (`xs=[a b c]`) and record iteration are not in this slice.
 - **`fromjson` / `tojson` builtins** — the JSON ingress/egress bridge for the
   value model. `fromjson` parses exactly one JSON document (from an argument or
   stdin) into a structured value in `.data`; empty input or trailing garbage is

--- a/crates/kaish-kernel/src/arithmetic.rs
+++ b/crates/kaish-kernel/src/arithmetic.rs
@@ -269,6 +269,10 @@ impl<'a> ArithParser<'a> {
                     }
 
                     let name = self.parse_identifier()?;
+                    // Collection subscript path: `${p[port]}`, `${a[b][0]}`.
+                    if self.peek() == Some('[') {
+                        return self.eval_braced_path(&name);
+                    }
                     if self.peek() != Some('}') {
                         bail!("expected '}}' after variable name in arithmetic");
                     }
@@ -335,20 +339,67 @@ impl<'a> ArithParser<'a> {
         }
 
         // Regular variable lookup
-        match self.scope.get(name) {
-            Some(Value::Int(n)) => Ok(*n),
-            Some(Value::String(s)) => {
+        match self.scope.get(name).cloned() {
+            Some(value) => self.value_to_arith(&value, name),
+            None => Ok(0), // Unset variables default to 0 in arithmetic
+        }
+    }
+
+    /// Resolve a subscripted variable path (`${p[port]}`) and coerce to an
+    /// integer. Reuses the real path resolver, so scalar unwrap and the loud
+    /// path errors are identical to `${p[port]}` outside arithmetic.
+    fn eval_braced_path(&mut self, root: &str) -> Result<i64> {
+        let mut brackets = String::new();
+        while self.peek() == Some('[') {
+            brackets.push('[');
+            self.advance(); // consume '['
+            let mut depth = 1;
+            while depth > 0 {
+                match self.advance() {
+                    Some('[') => {
+                        depth += 1;
+                        brackets.push('[');
+                    }
+                    Some(']') => {
+                        depth -= 1;
+                        brackets.push(']');
+                    }
+                    Some(c) => brackets.push(c),
+                    None => bail!("unterminated subscript in arithmetic"),
+                }
+            }
+        }
+        if self.peek() != Some('}') {
+            bail!("expected '}}' after subscripted variable in arithmetic");
+        }
+        self.advance(); // consume '}'
+
+        let raw = format!("${{{root}{brackets}}}");
+        let path = crate::parser::parse_varpath(&raw);
+        let value = self.scope.resolve_path(&path).map_err(|e| match e {
+            crate::interpreter::PathError::UndefinedRoot(_) => {
+                anyhow::anyhow!("undefined variable in arithmetic: {root}")
+            }
+            crate::interpreter::PathError::Invalid(msg) => anyhow::anyhow!(msg),
+        })?;
+        self.value_to_arith(&value, root)
+    }
+
+    /// Coerce a resolved value to an integer for arithmetic.
+    fn value_to_arith(&self, value: &Value, name: &str) -> Result<i64> {
+        match value {
+            Value::Int(n) => Ok(*n),
+            Value::String(s) => {
                 // Try to parse string as integer
                 s.parse().with_context(|| format!(
                     "variable '{}' has non-numeric value: {:?}", name, s
                 ))
             }
-            Some(Value::Float(f)) => Ok(*f as i64),
-            Some(Value::Bool(b)) => Ok(if *b { 1 } else { 0 }),
-            Some(Value::Null) => Ok(0), // Unset variables default to 0 in arithmetic
-            Some(Value::Json(_)) => anyhow::bail!("variable '{}' is JSON, not a number", name),
-            Some(Value::Bytes(_)) => anyhow::bail!("variable '{}' is binary data, not a number", name),
-            None => Ok(0), // Unset variables default to 0 in arithmetic
+            Value::Float(f) => Ok(*f as i64),
+            Value::Bool(b) => Ok(if *b { 1 } else { 0 }),
+            Value::Null => Ok(0), // null coerces to 0 in arithmetic
+            Value::Json(_) => anyhow::bail!("variable '{}' is JSON, not a number", name),
+            Value::Bytes(_) => anyhow::bail!("variable '{}' is binary data, not a number", name),
         }
     }
 }

--- a/crates/kaish-kernel/src/ast/sexpr.rs
+++ b/crates/kaish-kernel/src/ast/sexpr.rs
@@ -413,6 +413,14 @@ pub fn format_varpath(path: &VarPath) -> String {
         .iter()
         .map(|seg| match seg {
             VarSegment::Field(name) => name.clone(),
+            VarSegment::Index(i) => format!("[{i}]"),
+            VarSegment::Key(k) => format!("[{k}]"),
+            VarSegment::Dynamic(v) => format!("[${v}]"),
+            VarSegment::Slice(a, b) => format!(
+                "[{}:{}]",
+                a.map(|n| n.to_string()).unwrap_or_default(),
+                b.map(|n| n.to_string()).unwrap_or_default()
+            ),
         })
         .collect::<Vec<_>>()
         .join(".")

--- a/crates/kaish-kernel/src/ast/types.rs
+++ b/crates/kaish-kernel/src/ast/types.rs
@@ -383,11 +383,12 @@ pub enum TestCmpOp {
 // Value lives in kaish-types.
 pub use kaish_types::Value;
 
-/// Variable reference path: `${VAR}` or `${VAR.field}`.
+/// Variable reference path: `${VAR}`, `${VAR[0]}`, `${r[key]}`, `${a[b][c]}`.
 ///
-/// `$?` resolves to the previous command's exit code as an int. Field access
-/// on `$?` is rejected by the validator (use `kaish-last` for structured data).
-/// Array indexing is not supported — use `jq` for JSON processing.
+/// The first segment is always the root variable name (`Field`); the rest are
+/// bracket subscripts. `$?` resolves to the previous command's exit code as an
+/// int (bare only — `${?.field}` is rejected). Access is brackets-only: a
+/// dotted `${VAR.field}` resolves to a loud error suggesting `${VAR[field]}`.
 #[derive(Debug, Clone, PartialEq)]
 pub struct VarPath {
     pub segments: Vec<VarSegment>,
@@ -403,11 +404,24 @@ impl VarPath {
 }
 
 /// A segment in a variable path.
+///
+/// The first segment of a path is the root name, carried as `Field`. Every
+/// later segment is a bracket subscript. A `Field` in a non-root position
+/// represents a dotted `.field` access, which — kaish being brackets-only —
+/// resolves to a loud error with the bracket form in the message.
 #[derive(Debug, Clone, PartialEq)]
 pub enum VarSegment {
-    /// Field access: `.field` or initial name
-    /// Only supported for special variables like `$?`
+    /// The root variable name, or (illegally, past the root) a dotted `.field`.
     Field(String),
+    /// Integer subscript `[0]` / `[-1]` — indexes a list (negative from the end).
+    Index(i64),
+    /// Literal key `[bareword]` or `["quoted key"]` — keys a record.
+    Key(String),
+    /// Dynamic subscript `[$var]` — the named variable's value is the key
+    /// (record) or index (list) at resolution time. Holds the variable name.
+    Dynamic(String),
+    /// Slice `[a:b]` — end-exclusive, yields a list. Either bound may be omitted.
+    Slice(Option<i64>, Option<i64>),
 }
 
 /// Part of an interpolated string.

--- a/crates/kaish-kernel/src/dispatch.rs
+++ b/crates/kaish-kernel/src/dispatch.rs
@@ -197,7 +197,7 @@ impl BackendDispatcher {
                     Expr::Literal(Value::String(s)) => Some(s.clone()),
                     Expr::Literal(Value::Int(i)) => Some(i.to_string()),
                     Expr::Literal(Value::Float(f)) => Some(f.to_string()),
-                    Expr::VarRef(path) => ctx.scope.resolve_path(path).map(|v| crate::interpreter::value_to_string(&v)),
+                    Expr::VarRef(path) => ctx.scope.resolve_path(path).ok().map(|v| crate::interpreter::value_to_string(&v)),
                     _ => None,
                 },
                 Arg::ShortFlag(f) => Some(format!("-{f}")),

--- a/crates/kaish-kernel/src/interpreter.rs
+++ b/crates/kaish-kernel/src/interpreter.rs
@@ -37,6 +37,6 @@ mod result;
 mod scope;
 
 pub use control_flow::ControlFlow;
-pub use eval::{eval_expr, expand_tilde, strip_leading_tabs, value_to_bool, value_to_exit_code, value_to_string, value_to_string_with_tilde, EvalError, EvalResult, Evaluator, Executor, HeredocAssembler, NoOpExecutor};
+pub use eval::{eval_expr, expand_tilde, strip_leading_tabs, value_to_bool, value_to_exit_code, value_length, value_to_string, value_to_string_with_tilde, EvalError, EvalResult, Evaluator, Executor, HeredocAssembler, NoOpExecutor};
 pub use result::{apply_output_format, hex_dump, json_to_value, value_to_json, EntryType, ExecResult, LatchRequest, OutputData, OutputFormat, OutputNode, OutputPayload};
-pub use scope::Scope;
+pub use scope::{PathError, Scope};

--- a/crates/kaish-kernel/src/interpreter/eval.rs
+++ b/crates/kaish-kernel/src/interpreter/eval.rs
@@ -397,9 +397,15 @@ impl<'a, E: Executor> Evaluator<'a, E> {
 
     /// Evaluate a variable reference.
     fn eval_var_ref(&mut self, path: &VarPath) -> EvalResult<Value> {
-        self.scope
-            .resolve_path(path)
-            .ok_or_else(|| EvalError::InvalidPath(format_path(path)))
+        match self.scope.resolve_path(path) {
+            Ok(v) => Ok(v),
+            // Undefined root keeps the existing path-shaped error.
+            Err(super::scope::PathError::UndefinedRoot(_)) => {
+                Err(EvalError::InvalidPath(format_path(path)))
+            }
+            // A loud path error carries its own actionable message.
+            Err(super::scope::PathError::Invalid(msg)) => Err(EvalError::InvalidPath(msg)),
+        }
     }
 
     /// Evaluate a positional parameter ($0-$9).
@@ -426,10 +432,7 @@ impl<'a, E: Executor> Evaluator<'a, E> {
     /// Evaluate variable string length (${#VAR}).
     fn eval_var_length(&self, name: &str) -> EvalResult<Value> {
         match self.scope.get(name) {
-            Some(value) => {
-                let s = value_to_string(value);
-                Ok(Value::Int(s.len() as i64))
-            }
+            Some(value) => Ok(Value::Int(value_length(value))),
             None => Ok(Value::Int(0)), // Unset variable has length 0
         }
     }
@@ -461,9 +464,14 @@ impl<'a, E: Executor> Evaluator<'a, E> {
             match part {
                 StringPart::Literal(s) => result.push_str(s),
                 StringPart::Var(path) => {
-                    // Unset variables expand to empty string (bash-compatible)
-                    if let Some(value) = self.scope.resolve_path(path) {
-                        result.push_str(&value_to_string(&value));
+                    match self.scope.resolve_path(path) {
+                        Ok(value) => result.push_str(&value_to_string(&value)),
+                        // Unset variables expand to empty string (bash-compatible).
+                        Err(super::scope::PathError::UndefinedRoot(_)) => {}
+                        // A loud path error is surfaced, never swallowed to empty.
+                        Err(super::scope::PathError::Invalid(msg)) => {
+                            return Err(EvalError::InvalidPath(msg))
+                        }
                     }
                 }
                 StringPart::VarWithDefault { name, default } => {
@@ -570,6 +578,18 @@ pub fn value_to_exit_code(value: &Value) -> anyhow::Result<i64> {
         Value::Null | Value::Json(_) | Value::Bytes(_) => {
             anyhow::bail!("numeric argument required (got {:?})", value)
         }
+    }
+}
+
+/// Length of a value for `${#…}`: element count for a list, key count for a
+/// record, and the byte length of the string form for any scalar (unchanged
+/// for non-collections). The single source of truth for the three `${#…}`
+/// evaluation sites (sync + the two async ones).
+pub fn value_length(value: &Value) -> i64 {
+    match value {
+        Value::Json(serde_json::Value::Array(a)) => a.len() as i64,
+        Value::Json(serde_json::Value::Object(o)) => o.len() as i64,
+        other => value_to_string(other).len() as i64,
     }
 }
 
@@ -713,6 +733,14 @@ fn format_path(path: &VarPath) -> String {
                     result.push('.');
                 }
                 result.push_str(name);
+            }
+            VarSegment::Index(idx) => result.push_str(&format!("[{idx}]")),
+            VarSegment::Key(k) => result.push_str(&format!("[{k}]")),
+            VarSegment::Dynamic(v) => result.push_str(&format!("[${v}]")),
+            VarSegment::Slice(a, b) => {
+                let s = a.map(|n| n.to_string()).unwrap_or_default();
+                let e = b.map(|n| n.to_string()).unwrap_or_default();
+                result.push_str(&format!("[{s}:{e}]"));
             }
         }
     }

--- a/crates/kaish-kernel/src/interpreter/scope.rs
+++ b/crates/kaish-kernel/src/interpreter/scope.rs
@@ -8,9 +8,136 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
+use kaish_types::json_to_value_no_envelope;
+
 use crate::ast::{Value, VarPath, VarSegment};
 
+use super::eval::value_to_string;
 use super::result::ExecResult;
+
+/// Why a variable path failed to resolve.
+///
+/// The distinction is load-bearing: an undefined *root* is soft (expression
+/// position surfaces an error, string interpolation expands to empty, matching
+/// bash), while any deeper path failure is **loud** — subscripting a scalar, an
+/// out-of-bounds index, a missing record key, a dotted (non-bracket) segment,
+/// or a bad slice. A loud error is surfaced everywhere, including inside
+/// strings; it is NEVER silently swallowed to an empty expansion.
+#[derive(Debug, Clone, PartialEq)]
+pub enum PathError {
+    /// The root variable is not in scope.
+    UndefinedRoot(String),
+    /// A loud path error, message ready to display.
+    Invalid(String),
+}
+
+/// A human-readable type name for a value, for path error messages.
+fn type_name(value: &Value) -> &'static str {
+    match value {
+        Value::Null => "null",
+        Value::Bool(_) => "a boolean",
+        Value::Int(_) => "an integer",
+        Value::Float(_) => "a float",
+        Value::String(_) => "a string",
+        Value::Json(serde_json::Value::Array(_)) => "a list",
+        Value::Json(serde_json::Value::Object(_)) => "a record",
+        Value::Json(_) => "a scalar",
+        Value::Bytes(_) => "binary data",
+    }
+}
+
+/// A dynamic subscript value usable as a list index: an integer, or a string
+/// that parses as one (`k=1; ${xs[$k]}`).
+fn value_as_index(value: &Value) -> Option<i64> {
+    match value {
+        Value::Int(i) => Some(*i),
+        Value::String(s) => s.parse::<i64>().ok(),
+        _ => None,
+    }
+}
+
+/// Index into a list. Negative indices count from the end; out of bounds is a
+/// loud error, and an integer subscript on a record is an error (keys are
+/// strings — the design's "integers index lists" rule).
+fn index_into(json: &serde_json::Value, i: i64, root: &str) -> Result<Value, PathError> {
+    let arr = match json {
+        serde_json::Value::Array(a) => a,
+        serde_json::Value::Object(_) => {
+            return Err(PathError::Invalid(format!(
+                "${{{root}[{i}]}}: integer index on a record — record keys are strings, use ${{{root}[\"{i}\"]}}"
+            )))
+        }
+        _ => {
+            return Err(PathError::Invalid(format!(
+                "${{{root}[{i}]}}: not a collection"
+            )))
+        }
+    };
+    let len = arr.len() as i64;
+    let idx = if i < 0 { len + i } else { i };
+    if idx < 0 || idx >= len {
+        return Err(PathError::Invalid(format!(
+            "${{{root}[{i}]}}: index out of bounds (list length {len})"
+        )));
+    }
+    Ok(json_to_value_no_envelope(arr[idx as usize].clone()))
+}
+
+/// Look up a record key. A missing key is a loud error (use `[[ k in $r ]]` to
+/// test presence); a bareword/string key on a list is an error.
+fn key_into(json: &serde_json::Value, key: &str, root: &str) -> Result<Value, PathError> {
+    match json {
+        serde_json::Value::Object(map) => match map.get(key) {
+            Some(v) => Ok(json_to_value_no_envelope(v.clone())),
+            None => Err(PathError::Invalid(format!(
+                "${{{root}[{key}]}}: no such key"
+            ))),
+        },
+        serde_json::Value::Array(_) => Err(PathError::Invalid(format!(
+            "${{{root}[{key}]}}: string key on a list — use an integer index"
+        ))),
+        _ => Err(PathError::Invalid(format!(
+            "${{{root}[{key}]}}: not a collection"
+        ))),
+    }
+}
+
+/// Slice a list, end-exclusive. Bounds clamp; negatives count from the end; an
+/// inverted or empty range yields an empty list. Slicing a record is an error.
+/// The result stays a list (`Value::Json`), never unwrapped.
+fn slice_into(
+    json: &serde_json::Value,
+    start: Option<i64>,
+    end: Option<i64>,
+    root: &str,
+) -> Result<Value, PathError> {
+    let arr = match json {
+        serde_json::Value::Array(a) => a,
+        serde_json::Value::Object(_) => {
+            return Err(PathError::Invalid(format!(
+                "${{{root}[..]}}: cannot slice a record"
+            )))
+        }
+        _ => {
+            return Err(PathError::Invalid(format!(
+                "${{{root}[..]}}: not a collection"
+            )))
+        }
+    };
+    let len = arr.len() as i64;
+    let norm = |b: i64| -> i64 {
+        let b = if b < 0 { len + b } else { b };
+        b.clamp(0, len)
+    };
+    let s = start.map(norm).unwrap_or(0);
+    let e = end.map(norm).unwrap_or(len);
+    let slice = if s >= e {
+        Vec::new()
+    } else {
+        arr[s as usize..e as usize].to_vec()
+    };
+    Ok(Value::Json(serde_json::Value::Array(slice)))
+}
 
 /// Variable scope with nested frames and last-result tracking.
 ///
@@ -348,43 +475,106 @@ impl Scope {
         names
     }
 
-    /// Resolve a variable path like `${VAR}` or `${VAR.field}`.
+    /// Resolve a variable path: `${VAR}`, `${xs[0]}`, `${r[key]}`, `${a[b][c]}`.
     ///
-    /// Returns None if the path cannot be resolved.
-    /// `$?` resolves to the previous command's exit code as an int;
-    /// field access on `$?` is rejected by the validator before reaching here.
-    pub fn resolve_path(&self, path: &VarPath) -> Option<Value> {
-        if path.segments.is_empty() {
-            return None;
-        }
+    /// The first segment is the root name; the rest are bracket subscripts,
+    /// walked left to right into the root's `Value::Json`. A subscript landing
+    /// on a JSON scalar unwraps to a native `Value` (envelope-free); a subscript
+    /// landing on a collection stays `Value::Json`. `$?` resolves to the
+    /// previous command's exit code (bare only).
+    ///
+    /// Errors distinguish an undefined root (soft) from a loud path error (see
+    /// [`PathError`]).
+    pub fn resolve_path(&self, path: &VarPath) -> Result<Value, PathError> {
+        let Some(VarSegment::Field(root_name)) = path.segments.first() else {
+            // Empty path, or a first segment the parser never emits as root.
+            return Err(PathError::UndefinedRoot(String::new()));
+        };
 
-        // Get the root variable name
-        let VarSegment::Field(root_name) = &path.segments[0];
-
-        // Special case: $? (last result)
+        // Special case: $? (last result) — bare only.
         if root_name == "?" {
-            return self.resolve_result_path(&path.segments[1..]);
+            if path.segments.len() == 1 {
+                return Ok(Value::Int(self.last_result.code));
+            }
+            return Err(PathError::Invalid(
+                "$? is the POSIX exit code, not a collection — use `kaish-last` for structured data"
+                    .to_string(),
+            ));
         }
 
-        // For regular variables, only simple access is supported
-        if path.segments.len() > 1 {
-            return None; // No nested field access for regular variables
-        }
+        let root = self
+            .get(root_name)
+            .cloned()
+            .ok_or_else(|| PathError::UndefinedRoot(root_name.clone()))?;
 
-        self.get(root_name).cloned()
+        // Walk the subscripts (none for a bare `${VAR}`).
+        let mut current = root;
+        for seg in &path.segments[1..] {
+            current = self.apply_segment(&current, seg, root_name)?;
+        }
+        Ok(current)
     }
 
-    /// Resolve path segments on the last result ($?).
-    ///
-    /// `$?` alone returns the exit code as an integer (POSIX-shaped).
-    /// Field access on `$?` was removed — the validator rejects it with
-    /// a pointer to `kaish-last`, which exposes the previous command's
-    /// structured data (or stdout) as text.
-    fn resolve_result_path(&self, segments: &[VarSegment]) -> Option<Value> {
-        if segments.is_empty() {
-            return Some(Value::Int(self.last_result.code));
+    /// Apply one subscript to a value during path traversal.
+    fn apply_segment(
+        &self,
+        value: &Value,
+        seg: &VarSegment,
+        root: &str,
+    ) -> Result<Value, PathError> {
+        // A non-root `Field` is a dotted `.field` access. Brackets-only: this is
+        // always a loud error regardless of the value's type, with the fix in
+        // the message.
+        if let VarSegment::Field(name) = seg {
+            // Generic (not a full-path reconstruction, which would drop earlier
+            // subscripts and mislead on nested dotted access): brackets-only.
+            return Err(PathError::Invalid(format!(
+                "${{{root}…}}: kaish uses bracket access, not dots — write the key as a subscript: [{name}]"
+            )));
         }
-        None
+
+        // Everything else needs a collection.
+        let json = match value {
+            Value::Json(j) => j,
+            other => {
+                return Err(PathError::Invalid(format!(
+                    "${{{root}…}}: cannot subscript {} — it is not a collection",
+                    type_name(other)
+                )))
+            }
+        };
+
+        match seg {
+            VarSegment::Index(i) => index_into(json, *i, root),
+            VarSegment::Key(k) => key_into(json, k, root),
+            VarSegment::Slice(start, end) => slice_into(json, *start, *end, root),
+            VarSegment::Dynamic(var) => {
+                // The variable's value is the subscript; the container type
+                // decides whether it's an index or a key.
+                let key_val = self.get(var).ok_or_else(|| {
+                    PathError::Invalid(format!("${{{root}[${var}]}}: ${var} is not set"))
+                })?;
+                match json {
+                    serde_json::Value::Array(_) => {
+                        let idx = value_as_index(key_val).ok_or_else(|| {
+                            PathError::Invalid(format!(
+                                "${{{root}[${var}]}}: a list index must be an integer, got \"{}\"",
+                                value_to_string(key_val)
+                            ))
+                        })?;
+                        index_into(json, idx, root)
+                    }
+                    serde_json::Value::Object(_) => {
+                        key_into(json, &value_to_string(key_val), root)
+                    }
+                    _ => Err(PathError::Invalid(format!(
+                        "${{{root}[${var}]}}: not a collection"
+                    ))),
+                }
+            }
+            // Field handled above.
+            VarSegment::Field(_) => unreachable!("dotted segment handled above"),
+        }
     }
 
     /// Check if a variable exists in any frame.
@@ -477,7 +667,7 @@ mod tests {
         let path = VarPath::simple("NAME");
         assert_eq!(
             scope.resolve_path(&path),
-            Some(Value::String("Alice".into()))
+            Ok(Value::String("Alice".into()))
         );
     }
 
@@ -489,14 +679,14 @@ mod tests {
         let path = VarPath {
             segments: vec![VarSegment::Field("?".into())],
         };
-        assert_eq!(scope.resolve_path(&path), Some(Value::Int(127)));
+        assert_eq!(scope.resolve_path(&path), Ok(Value::Int(127)));
     }
 
     #[test]
     fn resolve_last_result_field_access_is_rejected() {
         // Field access on $? was removed — use `kaish-last` for structured data.
-        // The resolver returns None; the validator catches it earlier with a
-        // specific error code so users see actionable diagnostics.
+        // The resolver now returns a loud error; the validator also catches it
+        // earlier with a specific error code for actionable diagnostics.
         let mut scope = Scope::new();
         scope.set_last_result(ExecResult::success_with_data(
             "1",
@@ -509,22 +699,38 @@ mod tests {
                 VarSegment::Field("data".into()),
             ],
         };
-        assert_eq!(scope.resolve_path(&path), None);
+        assert!(matches!(
+            scope.resolve_path(&path),
+            Err(PathError::Invalid(_))
+        ));
     }
 
     #[test]
-    fn resolve_invalid_path_returns_none() {
+    fn resolve_dotted_access_on_scalar_is_a_loud_error() {
         let mut scope = Scope::new();
         scope.set("X", Value::Int(42));
 
-        // Cannot do field access on an int
+        // Dotted access `${X.invalid}` — brackets-only, so it's a loud error.
         let path = VarPath {
             segments: vec![
                 VarSegment::Field("X".into()),
                 VarSegment::Field("invalid".into()),
             ],
         };
-        assert_eq!(scope.resolve_path(&path), None);
+        assert!(matches!(
+            scope.resolve_path(&path),
+            Err(PathError::Invalid(_))
+        ));
+    }
+
+    #[test]
+    fn resolve_undefined_root_is_soft() {
+        let scope = Scope::new();
+        let path = VarPath::simple("NOPE");
+        assert!(matches!(
+            scope.resolve_path(&path),
+            Err(PathError::UndefinedRoot(_))
+        ));
     }
 
     #[test]

--- a/crates/kaish-kernel/src/kernel.rs
+++ b/crates/kaish-kernel/src/kernel.rs
@@ -51,7 +51,7 @@ pub use kaish_types::{CommandKind, ExecuteOptions};
 use crate::backend::{BackendError, KernelBackend};
 use kaish_glob::glob_match;
 use crate::dispatch::{CommandDispatcher, PipelinePosition};
-use crate::interpreter::{apply_output_format, eval_expr, expand_tilde, json_to_value, value_to_bool, value_to_string, ControlFlow, ExecResult, Scope};
+use crate::interpreter::{apply_output_format, eval_expr, expand_tilde, json_to_value, value_to_bool, value_length, value_to_string, ControlFlow, ExecResult, PathError, Scope};
 use crate::parser::parse;
 use crate::scheduler::{is_bool_type, schema_param_lookup, select_leaf, stderr_stream, BoundedStream, JobManager, PipelineRunner, StderrReceiver};
 #[cfg(feature = "subprocess")]
@@ -2807,12 +2807,25 @@ impl Kernel {
             Expr::Literal(Value::Bool(b)) => b.to_string(),
             Expr::Literal(Value::Null) => "null".to_string(),
             Expr::VarRef(path) => {
-                let name = path.segments.iter()
-                    .map(|seg| match seg {
-                        crate::ast::VarSegment::Field(f) => f.clone(),
-                    })
-                    .collect::<Vec<_>>()
-                    .join(".");
+                let mut name = String::new();
+                for (i, seg) in path.segments.iter().enumerate() {
+                    match seg {
+                        crate::ast::VarSegment::Field(f) => {
+                            if i > 0 {
+                                name.push('.');
+                            }
+                            name.push_str(f);
+                        }
+                        crate::ast::VarSegment::Index(idx) => name.push_str(&format!("[{idx}]")),
+                        crate::ast::VarSegment::Key(k) => name.push_str(&format!("[{k}]")),
+                        crate::ast::VarSegment::Dynamic(v) => name.push_str(&format!("[${v}]")),
+                        crate::ast::VarSegment::Slice(a, b) => name.push_str(&format!(
+                            "[{}:{}]",
+                            a.map(|n| n.to_string()).unwrap_or_default(),
+                            b.map(|n| n.to_string()).unwrap_or_default()
+                        )),
+                    }
+                }
                 format!("${{{}}}", name)
             }
             Expr::Interpolated(_) => "\"...\"".to_string(),
@@ -3638,8 +3651,13 @@ impl Kernel {
             Expr::Literal(value) => Ok(value.clone()),
             Expr::VarRef(path) => {
                 let scope = self.scope.read().await;
-                scope.resolve_path(path)
-                    .ok_or_else(|| anyhow::anyhow!("undefined variable"))
+                match scope.resolve_path(path) {
+                    Ok(v) => Ok(v),
+                    Err(PathError::UndefinedRoot(_)) => {
+                        Err(anyhow::anyhow!("undefined variable"))
+                    }
+                    Err(PathError::Invalid(msg)) => Err(anyhow::anyhow!(msg)),
+                }
             }
             Expr::Interpolated(parts) => {
                 let mut result = String::new();
@@ -3761,7 +3779,7 @@ impl Kernel {
             Expr::VarLength(name) => {
                 let scope = self.scope.read().await;
                 match scope.get(name) {
-                    Some(value) => Ok(Value::Int(value_to_string(value).len() as i64)),
+                    Some(value) => Ok(Value::Int(value_length(value))),
                     None => Ok(Value::Int(0)),
                 }
             }
@@ -3895,8 +3913,10 @@ impl Kernel {
                 StringPart::Var(path) => {
                     let scope = self.scope.read().await;
                     match scope.resolve_path(path) {
-                        Some(value) => Ok(value_to_string(&value)),
-                        None => Ok(String::new()), // Unset vars expand to empty
+                        Ok(value) => Ok(value_to_string(&value)),
+                        // Unset vars expand to empty; loud path errors surface.
+                        Err(PathError::UndefinedRoot(_)) => Ok(String::new()),
+                        Err(PathError::Invalid(msg)) => Err(anyhow::anyhow!(msg)),
                     }
                 }
                 StringPart::VarWithDefault { name, default } => {
@@ -3917,7 +3937,7 @@ impl Kernel {
             StringPart::VarLength(name) => {
                 let scope = self.scope.read().await;
                 match scope.get(name) {
-                    Some(value) => Ok(value_to_string(value).len().to_string()),
+                    Some(value) => Ok(value_length(value).to_string()),
                     None => Ok("0".to_string()),
                 }
             }

--- a/crates/kaish-kernel/src/parser.rs
+++ b/crates/kaish-kernel/src/parser.rs
@@ -133,15 +133,70 @@ fn find_default_separator_in_content(content: &str) -> Option<usize> {
 
 /// Parse a raw `${...}` string into a VarPath.
 ///
-/// Handles paths like `${VAR}` and `${VAR.field}`. Array indexing is not supported.
-fn parse_varpath(raw: &str) -> VarPath {
-    let segments_strs = lexer::parse_var_ref(raw).unwrap_or_default();
-    let segments = segments_strs
+/// The first segment is the root variable name; each `[...]` segment the lexer
+/// produced becomes the corresponding subscript (`Index`/`Key`/`Dynamic`/
+/// `Slice`). A dotted segment (`${a.b}`) is kept as a non-root `Field` so
+/// resolution can emit the brackets-only error — the lexer already split it out.
+pub(crate) fn parse_varpath(raw: &str) -> VarPath {
+    let segment_strs = lexer::parse_var_ref(raw).unwrap_or_default();
+    let segments = segment_strs
         .into_iter()
-        .filter(|s| !s.starts_with('['))  // Skip index segments
-        .map(VarSegment::Field)
+        .enumerate()
+        .map(|(i, s)| {
+            if i == 0 {
+                // The root name (or the special `?`).
+                VarSegment::Field(s)
+            } else if let Some(inner) = s.strip_prefix('[').and_then(|s| s.strip_suffix(']')) {
+                parse_subscript(inner)
+            } else {
+                // A dotted `.field` — carried through as a Field so resolution
+                // produces the "use ${name[field]}" error (brackets only).
+                VarSegment::Field(s)
+            }
+        })
         .collect();
     VarPath { segments }
+}
+
+/// Parse the interior of a `[...]` subscript into a `VarSegment`.
+///
+/// Classification is syntactic (the container's runtime type decides list-vs-
+/// record at resolution): `$var` → dynamic; a quoted string → literal key;
+/// `int:int` (either side optional) → slice; a bare integer → index; anything
+/// else → a literal bareword key.
+fn parse_subscript(inner: &str) -> VarSegment {
+    // Dynamic: `[$var]`.
+    if let Some(var) = inner.strip_prefix('$') {
+        return VarSegment::Dynamic(var.to_string());
+    }
+    // Quoted key: `["weird key"]` or `['weird key']`.
+    if inner.len() >= 2
+        && ((inner.starts_with('"') && inner.ends_with('"'))
+            || (inner.starts_with('\'') && inner.ends_with('\'')))
+    {
+        return VarSegment::Key(inner[1..inner.len() - 1].to_string());
+    }
+    // Slice: `a:b` where each side is empty or a valid integer. A colon that
+    // isn't a numeric slice falls through to a bareword key (`["a:b"]` covers
+    // colon-bearing keys explicitly).
+    if let Some((lhs, rhs)) = inner.split_once(':') {
+        let bound = |s: &str| -> Option<Option<i64>> {
+            if s.is_empty() {
+                Some(None)
+            } else {
+                s.parse::<i64>().ok().map(Some)
+            }
+        };
+        if let (Some(start), Some(end)) = (bound(lhs), bound(rhs)) {
+            return VarSegment::Slice(start, end);
+        }
+    }
+    // Integer index: `[0]`, `[-1]`.
+    if let Ok(i) = inner.parse::<i64>() {
+        return VarSegment::Index(i);
+    }
+    // Bareword literal key: `[name]`, `[content-type]`.
+    VarSegment::Key(inner.to_string())
 }
 
 /// Drop `Stmt::Empty` (bare newlines/semicolons) from a parsed `$()` body so an
@@ -2870,7 +2925,9 @@ mod tests {
             Stmt::Command(cmd) => match &cmd.args[0] {
                 Arg::Positional(Expr::VarRef(path)) => {
                     assert_eq!(path.segments.len(), 1);
-                    let VarSegment::Field(name) = &path.segments[0];
+                    let VarSegment::Field(name) = &path.segments[0] else {
+                        panic!("expected root field, got {:?}", path.segments[0]);
+                    };
                     assert_eq!(name, "MESSAGE");
                 }
                 other => panic!("expected varref, got {:?}", other),
@@ -2885,9 +2942,16 @@ mod tests {
         match &result.statements[0] {
             Stmt::Command(cmd) => match &cmd.args[0] {
                 Arg::Positional(Expr::VarRef(path)) => {
+                    // A dotted `${RESULT.data}` keeps both as Field — the root
+                    // and a dotted segment (resolution turns the latter into the
+                    // brackets-only error).
                     assert_eq!(path.segments.len(), 2);
-                    let VarSegment::Field(a) = &path.segments[0];
-                    let VarSegment::Field(b) = &path.segments[1];
+                    let VarSegment::Field(a) = &path.segments[0] else {
+                        panic!("expected field, got {:?}", path.segments[0]);
+                    };
+                    let VarSegment::Field(b) = &path.segments[1] else {
+                        panic!("expected field, got {:?}", path.segments[1]);
+                    };
                     assert_eq!(a, "RESULT");
                     assert_eq!(b, "data");
                 }
@@ -2898,16 +2962,19 @@ mod tests {
     }
 
     #[test]
-    fn value_varref_index_ignored() {
-        // Index segments are no longer supported - they're filtered out by parse_varpath
+    fn value_varref_index_parsed() {
+        // Bracket subscripts are now parsed into typed segments (native
+        // collection access), not filtered out.
         let result = parse("echo ${ITEMS[0]}").unwrap();
         match &result.statements[0] {
             Stmt::Command(cmd) => match &cmd.args[0] {
                 Arg::Positional(Expr::VarRef(path)) => {
-                    // Index segment [0] is skipped, only ITEMS remains
-                    assert_eq!(path.segments.len(), 1);
-                    let VarSegment::Field(name) = &path.segments[0];
+                    assert_eq!(path.segments.len(), 2);
+                    let VarSegment::Field(name) = &path.segments[0] else {
+                        panic!("expected root field, got {:?}", path.segments[0]);
+                    };
                     assert_eq!(name, "ITEMS");
+                    assert_eq!(path.segments[1], VarSegment::Index(0));
                 }
                 other => panic!("expected varref, got {:?}", other),
             },
@@ -3097,7 +3164,9 @@ mod tests {
                     match &parts[1] {
                         StringPart::Var(path) => {
                             assert_eq!(path.segments.len(), 1);
-                            let VarSegment::Field(name) = &path.segments[0];
+                            let VarSegment::Field(name) = &path.segments[0] else {
+                                panic!("expected root field, got {:?}", path.segments[0]);
+                            };
                             assert_eq!(name, "NAME");
                         }
                         other => panic!("expected var, got {:?}", other),

--- a/crates/kaish-kernel/src/scheduler/pipeline.rs
+++ b/crates/kaish-kernel/src/scheduler/pipeline.rs
@@ -937,14 +937,17 @@ pub fn build_tool_args(args: &[Arg], ctx: &ExecContext, schema: Option<&ToolSche
 pub(crate) fn eval_simple_expr(expr: &Expr, ctx: &ExecContext) -> Option<Value> {
     match expr {
         Expr::Literal(value) => Some(eval_literal(value, ctx)),
-        Expr::VarRef(path) => ctx.scope.resolve_path(path),
+        // This reduced sync path coalesces any resolution failure to None
+        // (undefined or a loud path error alike); the async kernel paths carry
+        // the loud collection-access errors.
+        Expr::VarRef(path) => ctx.scope.resolve_path(path).ok(),
         Expr::Interpolated(parts) => {
             let mut result = String::new();
             for part in parts {
                 match part {
                     crate::ast::StringPart::Literal(s) => result.push_str(s),
                     crate::ast::StringPart::Var(path) => {
-                        if let Some(value) = ctx.scope.resolve_path(path) {
+                        if let Ok(value) = ctx.scope.resolve_path(path) {
                             result.push_str(&value_to_string(&value));
                         }
                     }
@@ -1045,7 +1048,7 @@ fn eval_string_parts_sync(parts: &[crate::ast::StringPart], ctx: &ExecContext) -
         match part {
             crate::ast::StringPart::Literal(s) => result.push_str(s),
             crate::ast::StringPart::Var(path) => {
-                if let Some(value) = ctx.scope.resolve_path(path) {
+                if let Ok(value) = ctx.scope.resolve_path(path) {
                     result.push_str(&value_to_string(&value));
                 }
             }

--- a/crates/kaish-kernel/tests/collection_access_tests.rs
+++ b/crates/kaish-kernel/tests/collection_access_tests.rs
@@ -1,0 +1,288 @@
+//! Read-side traversal for native collections: `${xs[0]}`, `${r[key]}`,
+//! `${r[$k]}`, `${r["weird-key"]}`, `${xs[-1]}`, `${xs[0:2]}`, `${a[b][c]}`,
+//! and `${#…}` length. See docs/arrays-and-hashes.md.
+//!
+//! Values are constructed with `fromjson` (the JSON ingress bridge) so these
+//! tests exercise the ACCESS surface before the literal-construction grammar
+//! exists. Kernel-routed via `KernelConfig::isolated()` (pure data, no localfs).
+
+// Test-fixture code: unwrap/expect on known-good setup is the idiom here.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::sync::Arc;
+
+use kaish_kernel::{Kernel, KernelConfig};
+
+async fn setup() -> Arc<Kernel> {
+    Kernel::new(KernelConfig::isolated().with_skip_validation(true))
+        .expect("failed to create kernel")
+        .into_arc()
+}
+
+/// Run a script; return (trimmed stdout, exit code, stderr).
+async fn run(k: &Kernel, script: &str) -> (String, i64, String) {
+    let r = k.execute(script).await.expect("kernel execute");
+    (r.text_out().trim().to_string(), r.code, r.err.clone())
+}
+
+// ── List indexing ──────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn list_index_positive() {
+    let k = setup().await;
+    let (out, code, err) =
+        run(&k, r#"x=$(fromjson '["apple","banana","cherry"]'); echo ${x[0]}"#).await;
+    assert_eq!(code, 0, "err: {err}");
+    assert_eq!(out, "apple");
+}
+
+#[tokio::test]
+async fn list_index_negative() {
+    let k = setup().await;
+    let (out, code, err) =
+        run(&k, r#"x=$(fromjson '["apple","banana","cherry"]'); echo ${x[-1]}"#).await;
+    assert_eq!(code, 0, "err: {err}");
+    assert_eq!(out, "cherry");
+}
+
+#[tokio::test]
+async fn list_slice_yields_list() {
+    let k = setup().await;
+    // end-exclusive; yields a list, which echo renders as compact JSON.
+    let (out, code, err) =
+        run(&k, r#"x=$(fromjson '["apple","banana","cherry"]'); echo ${x[0:2]}"#).await;
+    assert_eq!(code, 0, "err: {err}");
+    assert_eq!(out, r#"["apple","banana"]"#);
+}
+
+// ── Record keys ────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn record_bareword_key_is_literal() {
+    let k = setup().await;
+    let (out, code, err) =
+        run(&k, r#"u=$(fromjson '{"name":"amy","role":"maintainer"}'); echo ${u[name]}"#).await;
+    assert_eq!(code, 0, "err: {err}");
+    assert_eq!(out, "amy");
+}
+
+#[tokio::test]
+async fn record_dynamic_key() {
+    let k = setup().await;
+    let (out, code, err) = run(
+        &k,
+        r#"u=$(fromjson '{"name":"amy"}'); k=name; echo ${u[$k]}"#,
+    )
+    .await;
+    assert_eq!(code, 0, "err: {err}");
+    assert_eq!(out, "amy");
+}
+
+#[tokio::test]
+async fn record_quoted_key() {
+    let k = setup().await;
+    let (out, code, err) = run(
+        &k,
+        r#"r=$(fromjson '{"content-type":"text/plain"}'); echo ${r["content-type"]}"#,
+    )
+    .await;
+    assert_eq!(code, 0, "err: {err}");
+    assert_eq!(out, "text/plain");
+}
+
+// ── Nested / chained subscripts ────────────────────────────────────────────
+
+#[tokio::test]
+async fn nested_list_in_record() {
+    let k = setup().await;
+    let (out, code, err) = run(
+        &k,
+        r#"n=$(fromjson '{"tags":["a","b","c"]}'); echo ${n[tags][1]}"#,
+    )
+    .await;
+    assert_eq!(code, 0, "err: {err}");
+    assert_eq!(out, "b");
+}
+
+#[tokio::test]
+async fn nested_record_scalar_unwraps_bool() {
+    let k = setup().await;
+    // ${n[meta][active]} lands on a JSON bool → unwraps to native, prints "true".
+    let (out, code, err) = run(
+        &k,
+        r#"n=$(fromjson '{"meta":{"active":true}}'); echo ${n[meta][active]}"#,
+    )
+    .await;
+    assert_eq!(code, 0, "err: {err}");
+    assert_eq!(out, "true");
+}
+
+#[tokio::test]
+async fn deep_record_path() {
+    let k = setup().await;
+    let (out, code, err) = run(
+        &k,
+        r#"s=$(fromjson '{"web":{"port":8080}}'); echo ${s[web][port]}"#,
+    )
+    .await;
+    assert_eq!(code, 0, "err: {err}");
+    assert_eq!(out, "8080");
+}
+
+// ── Length ${#…} ───────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn length_of_list_is_element_count() {
+    let k = setup().await;
+    let (out, code, err) =
+        run(&k, r#"x=$(fromjson '["a","b","c"]'); echo ${#x}"#).await;
+    assert_eq!(code, 0, "err: {err}");
+    assert_eq!(out, "3");
+}
+
+#[tokio::test]
+async fn length_of_record_is_key_count() {
+    let k = setup().await;
+    let (out, code, err) =
+        run(&k, r#"u=$(fromjson '{"name":"amy","role":"m","age":40}'); echo ${#u}"#).await;
+    assert_eq!(code, 0, "err: {err}");
+    assert_eq!(out, "3");
+}
+
+#[tokio::test]
+async fn length_of_string_stays_char_count() {
+    // Scalars keep today's behavior — ${#s} is string length, not a collection.
+    let k = setup().await;
+    let (out, code, err) = run(&k, r#"s=hello; echo ${#s}"#).await;
+    assert_eq!(code, 0, "err: {err}");
+    assert_eq!(out, "5");
+}
+
+// ── Scalar unwrap enables typed ops ────────────────────────────────────────
+
+#[tokio::test]
+async fn unwrapped_bool_compares_typed() {
+    let k = setup().await;
+    let (out, code, err) = run(
+        &k,
+        r#"c=$(fromjson '{"healthy":false}'); if [[ ${c[healthy]} == false ]]; then echo down; fi"#,
+    )
+    .await;
+    assert_eq!(code, 0, "err: {err}");
+    assert_eq!(out, "down");
+}
+
+#[tokio::test]
+async fn unwrapped_number_does_arithmetic() {
+    let k = setup().await;
+    let (out, code, err) = run(
+        &k,
+        r#"p=$(fromjson '{"port":8080}'); echo $(( ${p[port]} + 1 ))"#,
+    )
+    .await;
+    assert_eq!(code, 0, "err: {err}");
+    assert_eq!(out, "8081");
+}
+
+// ── In-string interpolation ────────────────────────────────────────────────
+
+#[tokio::test]
+async fn access_inside_double_quoted_string() {
+    let k = setup().await;
+    let (out, code, err) = run(
+        &k,
+        r#"u=$(fromjson '{"name":"amy"}'); echo "${u[name]} lives here""#,
+    )
+    .await;
+    assert_eq!(code, 0, "err: {err}");
+    assert_eq!(out, "amy lives here");
+}
+
+// ── Loud errors (brackets-only; no silent surprises) ───────────────────────
+
+#[tokio::test]
+async fn dotted_access_is_a_loud_error_with_bracket_hint() {
+    let k = setup().await;
+    let (_, code, err) =
+        run(&k, r#"u=$(fromjson '{"name":"amy"}'); echo ${u.name}"#).await;
+    assert_ne!(code, 0, "dotted access must be an error");
+    assert!(err.contains("[name]"), "error should suggest the bracket form: {err}");
+}
+
+#[tokio::test]
+async fn subscript_on_scalar_is_a_loud_error() {
+    // Scalars never auto-coerce to collections.
+    let k = setup().await;
+    let (_, code, err) = run(&k, r#"s=hello; echo ${s[0]}"#).await;
+    assert_ne!(code, 0, "subscripting a scalar must be an error");
+    assert!(err.contains("not a collection"), "got: {err}");
+}
+
+#[tokio::test]
+async fn out_of_bounds_index_is_a_loud_error() {
+    let k = setup().await;
+    let (_, code, err) = run(&k, r#"x=$(fromjson '["a","b"]'); echo ${x[9]}"#).await;
+    assert_ne!(code, 0, "out-of-bounds index must be an error");
+    assert!(err.contains("out of bounds"), "got: {err}");
+}
+
+#[tokio::test]
+async fn missing_record_key_is_a_loud_error() {
+    // A missing key is loud, not a silent empty (use `[[ k in $r ]]` to test
+    // presence). Decision recorded in docs/arrays-and-hashes.md.
+    let k = setup().await;
+    let (_, code, err) =
+        run(&k, r#"u=$(fromjson '{"name":"amy"}'); echo ${u[nope]}"#).await;
+    assert_ne!(code, 0, "missing key must be an error");
+    assert!(err.contains("no such key"), "got: {err}");
+}
+
+#[tokio::test]
+async fn string_key_on_a_list_is_a_loud_error() {
+    let k = setup().await;
+    let (_, code, err) =
+        run(&k, r#"x=$(fromjson '["a","b"]'); echo ${x[web]}"#).await;
+    assert_ne!(code, 0, "a string key on a list must be an error");
+    assert!(err.contains("integer index"), "got: {err}");
+}
+
+#[tokio::test]
+async fn integer_index_on_a_record_is_a_loud_error() {
+    // "integers index lists" — a bare integer subscript on a record is an error.
+    let k = setup().await;
+    let (_, code, err) =
+        run(&k, r#"u=$(fromjson '{"name":"amy"}'); echo ${u[0]}"#).await;
+    assert_ne!(code, 0, "an integer index on a record must be an error");
+    assert!(err.contains("record keys are strings"), "got: {err}");
+}
+
+#[tokio::test]
+async fn nested_dynamic_key_through_a_path() {
+    // `${services[$k][port]}` — a dynamic key mid-path, then a literal key.
+    let k = setup().await;
+    let (out, code, err) = run(
+        &k,
+        r#"s=$(fromjson '{"web":{"port":8080},"api":{"port":9000}}'); k=api; echo ${s[$k][port]}"#,
+    )
+    .await;
+    assert_eq!(code, 0, "err: {err}");
+    assert_eq!(out, "9000");
+}
+
+#[tokio::test]
+async fn undefined_root_in_expression_is_an_error() {
+    // Undefined root is soft in strings (empty) but an error in expression
+    // position — assert the expression-position behavior here.
+    let k = setup().await;
+    let (_, code, _) = run(&k, r#"echo ${nope[0]}"#).await;
+    assert_ne!(code, 0, "undefined root subscript in expr position must error");
+}
+
+#[tokio::test]
+async fn undefined_root_in_string_is_empty() {
+    // Back-compat: an unset variable expands to empty inside a string.
+    let k = setup().await;
+    let (out, code, err) = run(&k, r#"echo "x=${nope}y""#).await;
+    assert_eq!(code, 0, "err: {err}");
+    assert_eq!(out, "x=y");
+}

--- a/crates/kaish-repl/tests/integration.rs
+++ b/crates/kaish-repl/tests/integration.rs
@@ -489,8 +489,8 @@ fn error_invalid_path() {
         echo ${X.field}
     "#);
     let joined = outputs.join("\n");
-    // Should error on field access of int
-    assert!(joined.contains("ERROR") || joined.contains("undefined"));
+    // Dotted access is brackets-only — a loud error suggesting the bracket form.
+    assert!(joined.contains("bracket"), "got: {joined}");
 }
 
 #[test]
@@ -500,8 +500,8 @@ fn error_invalid_field_access() {
         echo ${NUM.field}
     "#);
     let joined = outputs.join("\n");
-    // Should error on field access of non-object
-    assert!(joined.contains("ERROR") || joined.contains("undefined"));
+    // Dotted access is brackets-only — a loud error suggesting the bracket form.
+    assert!(joined.contains("bracket"), "got: {joined}");
 }
 
 // ============================================================================

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -14,6 +14,55 @@ before it ships.
 
 ---
 
+## Native collection read access: the bracket path resolver (2026-07-01)
+
+Step 2 of the collections effort — reading into a value with `${xs[0]}`,
+`${r[key]}`, `${r[$k]}`, `${r["weird-key"]}`, `${xs[-1]}`, `${xs[0:2]}`, chained
+`${a[b][c]}`, and `${#…}` list/record length. Deliberately *before* the
+literal-grammar gate: it only consumes `${…}` segments the lexer already splits,
+so no value/argv bifurcation and no glob-merge change — the read side was
+"half-built" and this finishes it.
+
+A reconnaissance pass (Explore agent) charted the machinery and surfaced the
+shape of the work: the lexer already hands out `["VAR","[0]","[k]"]`, but
+`parse_varpath` was *filtering every bracket segment out* (so `${x[0]}` silently
+returned the whole value — a latent silent bug the red test baseline caught
+immediately), and `resolve_path` rejected anything multi-segment. The clean
+insight that shaped the design: dynamic keys are just `$var`, resolved through
+`scope.get`, and `resolve_path` is a `Scope` method — so the **entire traversal,
+dynamic keys included, lives in `resolve_path`**, and all four var-ref eval sites
+(sync + async, expression + string) get collection access for free with no
+evaluator plumbing.
+
+The load-bearing decision was the error channel. `resolve_path` went from
+`Option<Value>` to `Result<Value, PathError>` with a two-variant split that the
+whole no-silent-fallback directive rides on: `UndefinedRoot` is **soft** (an
+error in expression position, empty inside a string — bash-compatible, preserving
+every existing `"${UNSET}"` → empty), while `Invalid` (subscript on a scalar,
+out-of-bounds, missing key, dotted access, string-key-on-list, integer-index-on-
+record) is **loud everywhere, including inside double-quoted strings** — never
+swallowed to empty. That distinction is exactly why the four primary eval sites
+each match both arms explicitly; the three reduced *sync* pipeline sites keep
+their pre-existing best-effort coalescing (a known narrow gap, filed P3).
+
+Access unwraps at the boundary through `json_to_value_no_envelope` (the same
+envelope-free law `fromjson` uses — an envelope-shaped sub-object stays a record,
+never becomes bytes), so `[[ ${cfg[healthy]} == false ]]` is a typed bool compare
+and `$(( ${cfg[port]} + 1 ))` just works — the latter needed teaching the
+arithmetic mini-parser's `${…}` branch to collect bracket runs and reuse
+`parse_varpath` + `resolve_path` rather than choking at the first `[`.
+
+Brackets-only is enforced by making a dotted `${u.name}` a loud error suggesting
+the bracket form (the lexer still splits `.field`, so a non-root `Field` segment
+*is* the dotted case). Semantic calls, all consistent with the loud-errors ethos:
+missing key errors (not bash's silent empty — `[[ k in $r ]]` is the presence
+test), integer index on a record errors ("integers index lists"), a dynamic
+string key works as a list index if it parses as one. Deepseek review confirmed
+the core (envelope-free at every level, panic-free bounds math, correct arithmetic
+bracket balancing) and turned up only the two low-priority follow-ups now in
+issues.md. Twenty-four kernel-routed tests, built on `fromjson` to construct the
+values the literal grammar can't yet.
+
 ## JSON bridge: fromjson / tojson land ahead of the grammar (2026-07-01)
 
 First implementation step of the collections effort, and deliberately the one

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -313,6 +313,27 @@ dominating at ~5.4K). Do this before the collections fragments land — they're 
 feature that will test it. See [arrays-and-hashes.md](arrays-and-hashes.md)
 "Help & teaching delivery".
 
+**Collection read-access follow-ups (2026-07-01, from the read-access deepseek
+review; verified locally):**
+- **P3 — reduced sync arg path coalesces a loud path error to skip.** The four
+  primary eval sites surface `PathError::Invalid` loudly (verified: `echo`,
+  assignment, `$(( ))`, and `"${…}"` interpolation all error on a bad subscript),
+  but the reduced *sync* pipeline path (`eval_simple_expr` /
+  `eval_string_parts_sync`, `pipeline.rs:943/950/1051`) coalesces any resolution
+  failure to None/skip — so a bad subscript inside a scatter/gather worker's arg
+  could silently drop the arg instead of erroring. Narrow (the common paths are
+  loud) and consistent with the pre-existing undefined-var behavior there, but a
+  silent-fallback to close: give those sync helpers an error channel (or route
+  them through the async resolver) when the scatter/gather arg path is next
+  touched.
+- **P4 — a `]` inside a quoted subscript key is mishandled.** The lexer's bracket
+  collector (`lexer.rs` `parse_var_ref`) scans to the first `]` with no quote
+  awareness, so `${r["weird]key"]}` doesn't resolve the intended key. It does NOT
+  silently corrupt (it errors — "failed to evaluate assignment"), but the error
+  is cryptic. Fix: make the bracket collector quote-aware, or emit a clear
+  "quote-bearing key with `]`" diagnostic. (Same root cause bounds the empty
+  subscript `${r[]}` → `Key("")` oddity — reject in the validator if we care.)
+
 **Envelope-free must hold through downstream `.data` consumers (2026-07-01, from
 the json-bridge deepseek review):** `fromjson` converts external JSON with
 `json_to_value_no_envelope` (envelope-free at ingress), but two consumers still


### PR DESCRIPTION
Step 2 of the arrays & hashes effort ([design](docs/arrays-and-hashes.md)) — reading into a value with bracket subscripts. Deliberately **before** the literal-grammar gate: it only consumes the `${…}` segments the lexer already splits, so no value/argv bifurcation and no glob-merge change. The read side was "half-built"; this finishes it. Values come from `fromjson` (#54) or `$()` — literal construction (`xs=[a b c]`) and record iteration are later slices.

## What lands

`${xs[0]}` · `${r[key]}` · `${r[$k]}` (dynamic) · `${r["weird-key"]}` (quoted) · `${xs[-1]}` (negative) · `${xs[0:2]}` (end-exclusive slice → a list) · chained `${a[b][c]}` · `${#…}` (list element count / record key count).

- **Parser** turns each `${…}` bracket segment into a typed `VarSegment` (`Index`/`Key`/`Dynamic`/`Slice`); a dotted `${a.b}` stays a non-root `Field` so resolution emits the brackets-only error.
- **`Scope::resolve_path`** does the whole traversal — dynamic keys included, since they're just `scope.get`, so all four var-ref eval sites (sync + async, expression + interpolation) get access for free.
- **Leaf unwrap** uses `json_to_value_no_envelope` (envelope-free — an envelope-shaped sub-object stays a record). Scalars unwrap to native `Value`, so `[[ ${cfg[healthy]} == false ]]` is a typed compare and `$(( ${cfg[port]} + 1 ))` works (the arithmetic mini-parser now reuses `parse_varpath` + `resolve_path`).
- **`${#…}`** consolidated to one `value_length` helper (was three duplicated `.len()` sites), then extended to collections.

## The load-bearing decision: the error channel

`resolve_path` went `Option<Value>` → `Result<Value, PathError>` with a split the no-silent-fallback directive rides on:
- **`UndefinedRoot` is soft** — an error in expression position, empty inside a string (bash-compatible; every existing `"${UNSET}"` → empty is preserved).
- **`Invalid` is loud everywhere, including inside double-quoted strings** — subscript on a scalar, out-of-bounds, missing key, dotted access, string-key-on-list, integer-index-on-record. Never swallowed to empty.

Missing key is loud **by design** (`[[ k in $r ]]` is the presence test) — kaish's crash-over-corruption ethos, not bash's silent empty.

## Tests / gates

24 kernel-routed tests (`collection_access_tests.rs`), built on `fromjson` to construct values the literal grammar can't yet. `cargo test --all` (3900+) and `cargo clippy --all --all-targets` both clean.

## Review

Reviewed with kaibo (cast deepseek): core confirmed — envelope-free at every level, panic-free bounds math, correct arithmetic bracket balancing, soft/loud honored at all four primary sites. Two low-priority follow-ups filed in `docs/issues.md` and verified locally (severity refined from the review): a reduced *sync* pipeline arg path coalesces a path error to skip (narrow — the common paths are all loud); a `]` inside a quoted key is mishandled (errors cryptically, does **not** silently corrupt).

Collections help / LANGUAGE.md is **deferred to step 3** (gated on the panel re-test), per the design's sequencing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)