### PR TITLE
feat(help): importance-ranked onboarding tiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ breaking entries are marked **BREAKING**.
 ## [Unreleased]
 
 ### Changed
+- **Agent onboarding composes in importance order** — the always-on instruction
+  block an embedder ships (`Recipe::agent_onboarding`) now renders its Foundations
+  fragments by an explicit importance rank (most-critical rules first), so the
+  client model meets the load-bearing rules even when it skims or truncates. A
+  size-budget test keeps the always-on spine lean.
+- **BREAKING:** `kaish-help`'s `Fragment` gains a public `rank: u8` field (`0` =
+  most important; `UNRANKED` default preserves registry order) plus a
+  `Fragment::ranked()` builder. Constructing a `Fragment` literal directly now
+  requires the field (a compile error, not silent) — the `en()`/`syntax_section()`
+  builders set it for you, so registry authors are unaffected.
 - **`help limits` no longer claims `[]` array syntax will never exist** — the
   brackets are reserved by kaish (`[[ ]]` today, native list literals per the
   arrays-and-hashes design). The `[` command stays banned permanently; a `test`

--- a/crates/kaish-help/src/compose.rs
+++ b/crates/kaish-help/src/compose.rs
@@ -96,6 +96,11 @@ pub enum Depth {
 /// Default (and canonical-complete) content locale.
 pub const DEFAULT_LOCALE: &str = "en";
 
+/// The importance rank of an unranked fragment: sorts last, so a fragment with
+/// no explicit rank keeps its registry position relative to other unranked
+/// fragments. Only the always-on onboarding spine assigns explicit ranks.
+pub const UNRANKED: u8 = u8::MAX;
+
 /// A unit of content, addressed by (concept, key, variant, locale).
 pub struct Fragment {
     /// Concept this fragment belongs to.
@@ -110,12 +115,28 @@ pub struct Fragment {
     pub locale: &'static str,
     /// `None` = shared (default); `Some(_)` = audience-specific divergence.
     pub audience: Option<Audience>,
+    /// Importance rank for the always-on onboarding block: `0` is the most
+    /// important, and composition renders fragments **in ascending rank** so the
+    /// client model meets the critical rules first even under skimming or
+    /// truncation. Fragments at [`UNRANKED`] (the default) keep registry order.
+    /// The rank is a property of the `(concept, key, variant)` slot, so it is
+    /// locale-agnostic — a translation of a fragment inherits the same rank.
+    pub rank: u8,
     /// Optional section heading for reference rendering (e.g. `"Quoting"`).
     /// `None` for inline fragments (the Foundations spine renders under its
     /// concept header instead). Used by [`render_syntax_reference`].
     pub title: Option<&'static str>,
     /// Markdown body.
     pub body: &'static str,
+}
+
+impl Fragment {
+    /// Attach an importance `rank` (0 = most important) to a fragment, for the
+    /// always-on onboarding block. `const` so it composes in the static registry:
+    /// `en(...).ranked(2)`.
+    pub const fn ranked(self, rank: u8) -> Fragment {
+        Fragment { rank, ..self }
+    }
 }
 
 /// What to compose. Build one directly, or use a [`Recipe`].
@@ -209,10 +230,16 @@ fn select_for_concept<'f>(concept: Concept, selector: &Selector) -> Vec<&'f Frag
         }
     }
 
-    order
+    let mut result: Vec<&Fragment> = order
         .iter()
         .filter_map(|slot| chosen.get(slot).copied())
-        .collect()
+        .collect();
+    // Render in importance order: ascending rank, ties preserving registry
+    // position (a stable sort). Unranked fragments (`UNRANKED`) sort last and so
+    // keep their registry order among themselves — a no-op for any concept whose
+    // fragments are all unranked (Syntax, Model), which keeps `syntax.md` stable.
+    result.sort_by_key(|f| f.rank);
+    result
 }
 
 /// Compose canonical kaish guidance into a single markdown document.
@@ -425,13 +452,40 @@ mod tests {
     }
 
     #[test]
-    fn fragments_render_in_registry_order_not_alphabetical() {
+    fn onboarding_renders_in_importance_rank_order() {
         let out = compose(&Recipe::agent_onboarding(), &no_content());
         let nws = out.find("No word splitting").expect("has no-word-splitting");
         let fail = out.find("Fail loud").expect("has crash-not-corrupt");
         assert!(
             nws < fail,
-            "registry order should lead with no-word-splitting, not alphabetical:\n{out}"
+            "the most-important rule (no-word-splitting, rank 0) must lead:\n{out}"
+        );
+        // Rank overrides registry position: structured-substitution (rank 2)
+        // appears *before* structured-output (rank 5) even though the registry
+        // lists structured-output first — proof the rank sort is doing work.
+        let subst = out.find("carries structured data").expect("has structured-substitution");
+        let output = out.find("Structured output").expect("has structured-output");
+        assert!(
+            subst < output,
+            "rank must reorder ahead of registry position:\n{out}"
+        );
+    }
+
+    /// The always-on onboarding block (the fragment spine, without the
+    /// embedder-supplied builtin index) has a budget: it is composed in
+    /// importance order and must stay lean so the critical rules survive
+    /// skimming/truncation. Bumping this ceiling should be a deliberate choice —
+    /// prefer moving verbose, low-rank content into a `help` topic and pointing
+    /// at it from the tail.
+    #[test]
+    fn onboarding_spine_stays_within_budget() {
+        const BUDGET: usize = 3500;
+        let out = compose(&Recipe::agent_onboarding(), &no_content());
+        assert!(
+            out.len() <= BUDGET,
+            "always-on onboarding spine is {} chars (budget {BUDGET}) — trim or defer \
+             low-rank content to a help topic:\n{out}",
+            out.len()
         );
     }
 

--- a/crates/kaish-help/src/fragments.rs
+++ b/crates/kaish-help/src/fragments.rs
@@ -10,9 +10,11 @@
 //! Bodies are inline `&'static str` for now; when i18n lands they move to
 //! per-locale files keyed by (concept, key, variant).
 
-use crate::compose::{Audience, Concept, Depth, Fragment, Variant, DEFAULT_LOCALE};
+use crate::compose::{Audience, Concept, Depth, Fragment, Variant, DEFAULT_LOCALE, UNRANKED};
 
-/// Shorthand for an inline English fragment (no section heading).
+/// Shorthand for an inline English fragment (no section heading). Unranked by
+/// default; the always-on onboarding spine attaches an importance rank with
+/// [`Fragment::ranked`].
 const fn en(
     concept: Concept,
     key: &'static str,
@@ -28,6 +30,7 @@ const fn en(
         depth,
         locale: DEFAULT_LOCALE,
         audience,
+        rank: UNRANKED,
         title: None,
         body,
     }
@@ -44,6 +47,7 @@ const fn syntax_section(key: &'static str, title: &'static str, body: &'static s
         depth: Depth::Reference,
         locale: DEFAULT_LOCALE,
         audience: None,
+        rank: UNRANKED,
         title: Some(title),
         body,
     }
@@ -80,7 +84,8 @@ pub const FRAGMENTS: &[Fragment] = &[
         "**No word splitting.** `$VAR` is always a single value — a variable holding \
          spaces stays one argument. Use `split` when you actually want to split on \
          whitespace, a delimiter, or a regex.",
-    ),
+    )
+    .ranked(0),
     en(
         Concept::Foundations,
         "no-word-splitting",
@@ -100,7 +105,8 @@ pub const FRAGMENTS: &[Fragment] = &[
          unless quoted — kaish never pastes adjacent unquoted tokens. To build one \
          word from text plus interpolation, wrap the whole thing in double quotes: \
          `\"$dir/file.txt\"`, `\"out-$(date +%s).log\"`.",
-    ),
+    )
+    .ranked(1),
     en(
         Concept::Foundations,
         "quote-to-join",
@@ -120,7 +126,8 @@ pub const FRAGMENTS: &[Fragment] = &[
         None,
         "**Structured output.** Every builtin can emit machine-readable data with \
          `--json` (`ls --json`, `ps --json`, `kaish-vars --json`).",
-    ),
+    )
+    .ranked(5),
     en(
         Concept::Foundations,
         "structured-output",
@@ -137,7 +144,8 @@ pub const FRAGMENTS: &[Fragment] = &[
         None,
         "**Newline-split substitution.** `for x in $(cmd)` splits on newlines only — \
          one iteration per line; whitespace within a line never splits.",
-    ),
+    )
+    .ranked(3),
     en(
         Concept::Foundations,
         "structured-substitution",
@@ -146,7 +154,8 @@ pub const FRAGMENTS: &[Fragment] = &[
         None,
         "`$(cmd)` carries structured data: `for i in $(seq 1 5)` iterates five values, \
          not split text.",
-    ),
+    )
+    .ranked(2),
     en(
         Concept::Foundations,
         "glob-strict",
@@ -155,7 +164,8 @@ pub const FRAGMENTS: &[Fragment] = &[
         None,
         "**Strict globs.** `*.txt` expands to matching files; zero matches is an \
          error, not a silent pass-through.",
-    ),
+    )
+    .ranked(4),
     en(
         Concept::Foundations,
         "pre-validation",
@@ -164,7 +174,8 @@ pub const FRAGMENTS: &[Fragment] = &[
         None,
         "**Pre-validation.** kaish validates the whole command before running it — \
          syntax errors are caught up front, so a command never half-runs.",
-    ),
+    )
+    .ranked(6),
     en(
         Concept::Foundations,
         "crash-not-corrupt",
@@ -173,7 +184,8 @@ pub const FRAGMENTS: &[Fragment] = &[
         None,
         "**Fail loud, not silent.** kaish prefers to error over corrupting data; \
          destructive operations can require a confirmation nonce via `set -o latch`.",
-    ),
+    )
+    .ranked(7),
     en(
         Concept::Foundations,
         "json-orchestration",
@@ -182,7 +194,8 @@ pub const FRAGMENTS: &[Fragment] = &[
         Some(Audience::Agent),
         "When orchestrating tools, prefer `--json` piped through `jq` — consuming \
          structured data beats scraping text output.",
-    ),
+    )
+    .ranked(8),
     en(
         Concept::Foundations,
         "overlay-mode",
@@ -200,7 +213,8 @@ pub const FRAGMENTS: &[Fragment] = &[
          transaction. `kaish-vfs commit` MUST run in the same call as the writes — if \
          you commit in a later call the transaction from the write call was already \
          discarded.",
-    ),
+    )
+    .ranked(9),
     // ---- Syntax reference (single source for content/en/syntax.md) -----------
     syntax_section(
         "variables",

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -14,6 +14,37 @@ before it ships.
 
 ---
 
+## Importance-ranked onboarding tiers (2026-07-01)
+
+Step 3 of the collections effort splits in two: the tier *mechanism* (pure infra,
+this entry) and the collections *fragments* (which describe not-yet-built syntax,
+so they wait on a ship-vs-panel scoping call). The mechanism landed first because
+issues.md wanted it "before the collections fragments land — they're the feature
+that will test it."
+
+The always-on instruction block an embedder ships was an undifferentiated blob in
+registry order; nothing capped its size and nothing guaranteed the load-bearing
+rules came first. Now `Fragment` carries an importance `rank` (0 = most important;
+`UNRANKED` default keeps registry order), and `select_for_concept` stable-sorts by
+it — a deliberate no-op for any all-`UNRANKED` concept, so `syntax.md`
+(`render_syntax_reference`, which doesn't even go through that path) and the REPL
+welcome stay byte-identical. The ~10 Foundations Summary fragments got explicit
+ranks 0..9, ordered by what an agent needs to write *correct* kaish first
+(no-word-splitting, quote-to-join, then substitution/iteration, then capability
+and safety guarantees, with the verbose overlay-mode trailing). A char-budget test
+now keeps the spine lean.
+
+Two implementation notes worth keeping: `const fn ranked(self, rank) -> Fragment {
+Fragment { rank, ..self } }` relies on functional record update in const context
+(stable since Rust 1.83; MSRV is 1.85), which let the rank attach in the static
+registry without a builder-signature change touching every call site — only the
+ranked fragments changed. And the sort key must stay `rank` alone: adding `key`
+would alphabetize equal-rank fragments and reorder the Model concept the REPL
+welcome depends on. Deepseek review confirmed the no-op-for-unranked claim and
+flagged one latent case (Reference-depth Foundations would separate a Contrast
+from its Rule — inert today, filed P4) and the public-field break (loud compile
+error, marked BREAKING).
+
 ## Native collection read access: the bracket path resolver (2026-07-01)
 
 Step 2 of the collections effort — reading into a value with `${xs[0]}`,

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -300,6 +300,17 @@ depth. Worth dedicated kernel-routed suites.
 those repos). **Phase 5:** i18n scaffolding + first `ja` fragments. Full design:
 [composable-help.md](composable-help.md).
 
+**P4 — rank the Reference/Contrast fragments before a Reference-depth Foundations
+consumer ships (2026-07-01, from the tier-mechanism review).** `select_for_concept`
+stable-sorts by `rank`, and `UNRANKED` (the default on Contrast/Example/Reference
+fragments) sorts last. No shipping recipe renders Foundations at Reference depth,
+so this is inert today — but if a `help foundations`-style topic ever composes
+Foundations at Reference depth, an UNRANKED Contrast would render *after* the
+ranked Rules instead of beside its Rule sibling. The sort key can't include
+`key`/`variant` (that would reorder the REPL's Model concept, which relies on
+registry order for equal ranks), so the fix is to give each Contrast/Reference
+fragment the same rank as its Rule counterpart when such a consumer is built.
+
 **Importance-ranked onboarding tiers (2026-07-01, from the arrays-and-hashes
 review):** restructure `agent_onboarding()` composition into ~200–300-char ranks in
 descending importance — the first rank carries the most critical rules so the client


### PR DESCRIPTION
Step 3a of the arrays & hashes effort ([design](docs/arrays-and-hashes.md) "Help & teaching delivery"; [issues.md](docs/issues.md) "Importance-ranked onboarding tiers"). This is the tier **mechanism** — pure `kaish-help` infra. The collections **fragments** it will carry are a follow-up (they describe not-yet-built syntax, so they wait on a ship-vs-panel scoping call).

## Why

The always-on instruction block an embedder ships (`Recipe::agent_onboarding`, consumed by kaibo/kaijutsu) was an undifferentiated blob in registry order — nothing led with the load-bearing rules, nothing capped its size. Now it composes **most-critical-first**, so the client model meets the rules that matter even when it skims or truncates.

## What

- `Fragment` gains `rank: u8` (`0` = most important; `UNRANKED` default keeps registry order). `select_for_concept` **stable-sorts by rank** — a deliberate no-op for any all-`UNRANKED` concept, so `syntax.md` (`render_syntax_reference`, which doesn't use that path) and the REPL welcome stay byte-identical. The sort key is `rank` alone by necessity: adding `key` would alphabetize equal-rank fragments and reorder the Model concept the REPL welcome depends on.
- The ~10 Foundations Summary fragments get explicit ranks `0..9`, ordered by what an agent needs to write *correct* kaish first: no-word-splitting → quote-to-join → substitution/iteration → glob/`--json` capability → validation/fail-loud guarantees → agent-only power tools (jq orchestration, overlay). **Ranks are content judgment — easy to tune; the composed block is in the description below for review.**
- `const fn ranked(self, rank) -> Fragment { Fragment { rank, ..self } }` uses const functional-update (stable since Rust 1.83; MSRV 1.85), so the rank attaches in the static registry without a builder-signature change rippling to every call site.
- A char-budget test (3500, spine only — the embedder-supplied builtin index is excluded) keeps it lean; a rank-order test pins that rank overrides registry position.

## Composed onboarding block (for review of the ordering)

```
No word splitting → Quote to join → $(cmd) carries structured data →
Newline-split substitution → Strict globs → Structured output →
Pre-validation → Fail loud → jq orchestration → Overlay mode
```
(2265 chars, fragment spine only.)

## Breaking

`Fragment`'s new public field is a breaking change to the `kaish-help` API — but a **loud** one (a direct struct literal fails to compile with "missing field `rank`"). The `en()`/`syntax_section()` builders set it, so registry authors are unaffected. Marked `**BREAKING:**` in the changelog.

## Gates / review

`cargo test --all` + `cargo clippy --all --all-targets` clean. Reviewed with kaibo (deepseek): no-op-for-unranked confirmed across `render_syntax_reference`/REPL/locale-dedup; one latent Reference-depth case filed P4 (no shipping recipe triggers it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)