### PR TITLE
fix(collections): close five silent-corruption traps in read access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,25 @@ breaking entries are marked **BREAKING**.
   the `External`/`Dynamic` cases a gate must scrutinize.
 
 ### Fixed
+- **Collection read-access silent-corruption traps** (found by the collections
+  milestone review) — five cases that returned a plausible wrong answer instead of
+  erroring, all now loud:
+  - Comparing a list/record to a scalar with `==`/`!=` (e.g. `[[ $list == x ]]`)
+    was silently `false`; it is now a loud error hinting at `in`/`jq` (a JSON
+    scalar still unwraps and compares typed).
+  - `export`ing a structured value to a subprocess silently JSON-serialized it
+    into the child's environment; it is now refused, pointing at `export
+    CFG=$(tojson $CFG)`.
+  - A `fromjson` array element shaped like the internal byte-envelope was silently
+    decoded to binary during `for`/`jq` iteration; it now stays a record.
+  - `${#…}` in the scatter/gather sync path returned the string byte-length
+    instead of the element/key count (`${#xs}` on a 3-element list gave `7`);
+    `${#…}` on binary now counts bytes.
+  - A negative slice *end* (`${xs[0:-1]}`) was misread as a `:-default` and
+    mangled to `1]`; the `:-` scanners are now subscript-aware. Length or default
+    on a *subscripted* path (`${#u[tags]}`, `${cfg[port]:-8080}`) — which silently
+    returned `0` / the default — is now a loud "bind it first" error pending full
+    path-aware support.
 - **`--help`/`-h` now passes through to `with_owned_output()` tools** — the
   kernel's generic help router no longer intercepts it for tools that re-parse
   their own argv, so a leaf request like `tool subcmd --help` reaches the tool

--- a/crates/kaish-kernel/src/dispatch.rs
+++ b/crates/kaish-kernel/src/dispatch.rs
@@ -232,7 +232,14 @@ impl BackendDispatcher {
         // process's OS env. Frontends that want OS-env passthrough (REPL, MCP)
         // populate it via KernelConfig::initial_vars at construction.
         cmd.env_clear();
-        for (var_name, value) in ctx.scope.exported_vars() {
+        let exported = ctx.scope.exported_vars();
+        // A structured value can't cross the process boundary; refuse rather than
+        // silently JSON-serialize it into the child's environment. Kept in sync
+        // with the production spawn site in kernel.rs::try_execute_external.
+        if let Some(msg) = crate::interpreter::structured_export_error(&exported) {
+            return Some(ExecResult::failure(1, msg));
+        }
+        for (var_name, value) in exported {
             cmd.env(var_name, crate::interpreter::value_to_string(&value));
         }
 

--- a/crates/kaish-kernel/src/interpreter.rs
+++ b/crates/kaish-kernel/src/interpreter.rs
@@ -37,6 +37,6 @@ mod result;
 mod scope;
 
 pub use control_flow::ControlFlow;
-pub use eval::{eval_expr, expand_tilde, strip_leading_tabs, value_to_bool, value_to_exit_code, value_length, value_to_string, value_to_string_with_tilde, EvalError, EvalResult, Evaluator, Executor, HeredocAssembler, NoOpExecutor};
-pub use result::{apply_output_format, hex_dump, json_to_value, value_to_json, EntryType, ExecResult, LatchRequest, OutputData, OutputFormat, OutputNode, OutputPayload};
+pub use eval::{eval_expr, expand_tilde, name_is_subscripted, strip_leading_tabs, structured_export_error, subscripted_default_error, subscripted_length_error, value_to_bool, value_to_exit_code, value_length, value_to_string, value_to_string_with_tilde, EvalError, EvalResult, Evaluator, Executor, HeredocAssembler, NoOpExecutor};
+pub use result::{apply_output_format, hex_dump, json_to_value, json_to_value_no_envelope, value_to_json, EntryType, ExecResult, LatchRequest, OutputData, OutputFormat, OutputNode, OutputPayload};
 pub use scope::{PathError, Scope};

--- a/crates/kaish-kernel/src/interpreter/eval.rs
+++ b/crates/kaish-kernel/src/interpreter/eval.rs
@@ -119,6 +119,10 @@ pub enum EvalError {
     ArithmeticError(String),
     /// Invalid regex pattern.
     RegexError(String),
+    /// A collection (list/record) was compared to a scalar with `==`/`!=`, or a
+    /// collection form (`${#…}`, `${…:-default}`) was used on a subscripted path
+    /// before that path support landed. Carries a full teaching message.
+    Unsupported(String),
 }
 
 impl fmt::Display for EvalError {
@@ -133,6 +137,7 @@ impl fmt::Display for EvalError {
             EvalError::NoExecutor => write!(f, "no executor available for command substitution"),
             EvalError::ArithmeticError(msg) => write!(f, "arithmetic error: {msg}"),
             EvalError::RegexError(msg) => write!(f, "regex error: {msg}"),
+            EvalError::Unsupported(msg) => write!(f, "{msg}"),
         }
     }
 }
@@ -316,8 +321,8 @@ impl<'a, E: Executor> Evaluator<'a, E> {
                 let right_val = self.eval(right)?;
 
                 match op {
-                    TestCmpOp::Eq => values_equal(&left_val, &right_val),
-                    TestCmpOp::NotEq => !values_equal(&left_val, &right_val),
+                    TestCmpOp::Eq => values_equal(&left_val, &right_val)?,
+                    TestCmpOp::NotEq => !(values_equal(&left_val, &right_val)?),
                     TestCmpOp::Match => {
                         // Regex match — propagate compile errors loudly (no silent false).
                         match regex_match(&left_val, &right_val, false)? {
@@ -431,6 +436,9 @@ impl<'a, E: Executor> Evaluator<'a, E> {
 
     /// Evaluate variable string length (${#VAR}).
     fn eval_var_length(&self, name: &str) -> EvalResult<Value> {
+        if name_is_subscripted(name) {
+            return Err(subscripted_length_error(name));
+        }
         match self.scope.get(name) {
             Some(value) => Ok(Value::Int(value_length(value))),
             None => Ok(Value::Int(0)), // Unset variable has length 0
@@ -440,6 +448,9 @@ impl<'a, E: Executor> Evaluator<'a, E> {
     /// Evaluate variable with default (${VAR:-default}).
     /// Returns the variable value if set and non-empty, otherwise evaluates the default parts.
     fn eval_var_with_default(&mut self, name: &str, default: &[StringPart]) -> EvalResult<Value> {
+        if name_is_subscripted(name) {
+            return Err(subscripted_default_error(name));
+        }
         match self.scope.get(name) {
             Some(value) => {
                 let s = value_to_string(value);
@@ -589,8 +600,54 @@ pub fn value_length(value: &Value) -> i64 {
     match value {
         Value::Json(serde_json::Value::Array(a)) => a.len() as i64,
         Value::Json(serde_json::Value::Object(o)) => o.len() as i64,
+        // Binary length is the byte count, not the length of the text placeholder.
+        Value::Bytes(b) => b.len() as i64,
         other => value_to_string(other).len() as i64,
     }
+}
+
+/// A name inside `${#name}` or `${name:-default}` that carries a `[...]`
+/// subscript. Length-of-path and default-on-path aren't wired through the path
+/// resolver yet (they land with the collections lvalue/resolver work), so these
+/// forms take a bare-name lookup that misses the subscript. Detect it and fail
+/// loudly with a "bind first" hint instead of returning the silent wrong answer
+/// (`0` for length, always-default for defaults) they produced before.
+pub fn name_is_subscripted(name: &str) -> bool {
+    name.contains('[')
+}
+
+/// Loud error for `${#path}` on a subscripted name (see [`name_is_subscripted`]).
+pub fn subscripted_length_error(name: &str) -> EvalError {
+    let root = name.split('[').next().unwrap_or(name);
+    EvalError::Unsupported(format!(
+        "${{#{name}}}: length of a subscripted path isn't supported yet — bind it first: `x=${{{name}}}; ${{#x}}` (root `{root}` alone works: `${{#{root}}}`)"
+    ))
+}
+
+/// Loud error for `${path:-default}` on a subscripted name (see [`name_is_subscripted`]).
+pub fn subscripted_default_error(name: &str) -> EvalError {
+    EvalError::Unsupported(format!(
+        "${{{name}:-…}}: a default on a subscripted path isn't supported yet — bind it first: `x=${{{name}}}; ${{x:-…}}`"
+    ))
+}
+
+/// Reject exporting a structured value into an OS env var. A list/record can't
+/// cross the process boundary, and kaish will not silently JSON-serialize it into
+/// the child's environment. Returns a loud "serialize first" message naming the
+/// offending variable, or `None` if every exported value is a scalar. Both
+/// external-spawn sites (`kernel.rs`, `dispatch.rs`) call this before `cmd.env`.
+pub fn structured_export_error(vars: &[(String, Value)]) -> Option<String> {
+    for (name, value) in vars {
+        if let Value::Json(j) = value {
+            if matches!(j, serde_json::Value::Array(_) | serde_json::Value::Object(_)) {
+                let kind = if j.is_array() { "list" } else { "record" };
+                return Some(format!(
+                    "cannot export '{name}': it holds a {kind}, which can't be an OS environment variable — serialize it explicitly first, e.g. `export {name}=$(tojson ${name})`"
+                ));
+            }
+        }
+    }
+    None
 }
 
 pub fn value_to_string(value: &Value) -> String {
@@ -772,21 +829,35 @@ fn is_truthy(value: &Value) -> bool {
 /// `[[ "01" == 1 ]]` returned true via parse-as-int while `[[ "01" == "1" ]]`
 /// returned false. Users wanting numeric equality across stringified
 /// numbers should use `-eq`, which coerces via `numeric_compare`.
-fn values_equal(left: &Value, right: &Value) -> bool {
+fn values_equal(left: &Value, right: &Value) -> EvalResult<bool> {
     match (left, right) {
-        (Value::Null, Value::Null) => true,
-        (Value::Bool(a), Value::Bool(b)) => a == b,
-        (Value::Int(a), Value::Int(b)) => a == b,
-        (Value::Float(a), Value::Float(b)) => (a - b).abs() < f64::EPSILON,
+        (Value::Null, Value::Null) => Ok(true),
+        (Value::Bool(a), Value::Bool(b)) => Ok(a == b),
+        (Value::Int(a), Value::Int(b)) => Ok(a == b),
+        (Value::Float(a), Value::Float(b)) => Ok((a - b).abs() < f64::EPSILON),
         (Value::Int(a), Value::Float(b)) | (Value::Float(b), Value::Int(a)) => {
-            (*a as f64 - b).abs() < f64::EPSILON
+            Ok((*a as f64 - b).abs() < f64::EPSILON)
         }
-        (Value::String(a), Value::String(b)) => a == b,
-        (Value::Json(a), Value::Json(b)) => a == b,
-        (Value::Bytes(a), Value::Bytes(b)) => a == b,
-        // Mixed types (most commonly String vs Int/Float from a quoted variable
+        (Value::String(a), Value::String(b)) => Ok(a == b),
+        (Value::Json(a), Value::Json(b)) => Ok(a == b),
+        (Value::Bytes(a), Value::Bytes(b)) => Ok(a == b),
+        // A collection (list/record) compared to a scalar is a loud error, never
+        // silently false: brackets-only access means `$list` here is the whole
+        // structure. Silent-false is exactly the trap `in` exists to close.
+        // (A JSON *scalar* is unwrapped at the value boundary, so it never reaches
+        // here as `Json`; only Array/Object do.)
+        (Value::Json(j), other) | (other, Value::Json(j))
+            if matches!(j, serde_json::Value::Array(_) | serde_json::Value::Object(_)) =>
+        {
+            let kind = if j.is_array() { "list" } else { "record" };
+            Err(EvalError::Unsupported(format!(
+                "cannot compare a {kind} to a {other_kind} with ==/!= — test membership with `[[ x in $coll ]]`, or compare structures with `jq`",
+                other_kind = type_name(other),
+            )))
+        }
+        // Mixed scalars (most commonly String vs Int/Float from a quoted variable
         // against a numeric literal): fall back to string equality.
-        _ => value_to_string(left) == value_to_string(right),
+        _ => Ok(value_to_string(left) == value_to_string(right)),
     }
 }
 
@@ -1527,5 +1598,88 @@ mod tests {
         let expr = Expr::Interpolated(parts);
         let result = eval_expr(&expr, &mut scope).unwrap();
         assert_eq!(result, Value::String("-hello-".into()));
+    }
+
+    // ── Overnight-review fixes (2026-07-02) ────────────────────────────────
+
+    #[test]
+    fn values_equal_scalars_still_work() {
+        assert_eq!(
+            values_equal(&Value::String("x".into()), &Value::String("x".into())),
+            Ok(true)
+        );
+        // Mixed scalar fallthrough (String vs Int) stays string-equality.
+        assert_eq!(
+            values_equal(&Value::String("42".into()), &Value::Int(42)),
+            Ok(true)
+        );
+    }
+
+    #[test]
+    fn values_equal_collection_vs_scalar_is_loud() {
+        let list = Value::Json(serde_json::json!(["a", "b"]));
+        let record = Value::Json(serde_json::json!({"k": 1}));
+        assert!(
+            matches!(values_equal(&list, &Value::String("banana".into())), Err(EvalError::Unsupported(_))),
+            "list vs scalar must be a loud error, never silently false"
+        );
+        // Order-independent: scalar on the left too.
+        assert!(matches!(
+            values_equal(&Value::String("x".into()), &record),
+            Err(EvalError::Unsupported(_))
+        ));
+    }
+
+    #[test]
+    fn values_equal_collection_vs_collection_is_structural() {
+        // Two collections still compare structurally (records order-insensitive).
+        let a = Value::Json(serde_json::json!({"a": 1, "b": 2}));
+        let b = Value::Json(serde_json::json!({"b": 2, "a": 1}));
+        assert_eq!(values_equal(&a, &b), Ok(true));
+    }
+
+    #[test]
+    fn value_length_of_bytes_is_byte_count() {
+        assert_eq!(value_length(&Value::Bytes(vec![1, 2, 3])), 3);
+    }
+
+    #[test]
+    fn structured_export_error_flags_collections_passes_scalars() {
+        // Scalars are fine.
+        let scalars = vec![
+            ("A".to_string(), Value::String("x".into())),
+            ("B".to_string(), Value::Int(1)),
+        ];
+        assert!(structured_export_error(&scalars).is_none());
+        // A record is refused with a `tojson` hint.
+        let with_record = vec![(
+            "CFG".to_string(),
+            Value::Json(serde_json::json!({"port": 8080})),
+        )];
+        let msg = structured_export_error(&with_record).expect("record must be refused");
+        assert!(msg.contains("CFG") && msg.contains("tojson"), "got: {msg}");
+        // A list too.
+        let with_list = vec![("XS".to_string(), Value::Json(serde_json::json!([1, 2])))];
+        assert!(structured_export_error(&with_list).is_some());
+    }
+
+    #[test]
+    fn subscripted_name_guards_fire() {
+        assert!(name_is_subscripted("u[tags]"));
+        assert!(!name_is_subscripted("plain"));
+        // The sync eval path surfaces the loud "bind first" error (not silent 0).
+        let mut scope = Scope::new();
+        let err = eval_expr(&Expr::VarLength("u[tags]".into()), &mut scope).unwrap_err();
+        assert!(matches!(err, EvalError::Unsupported(_)), "got: {err}");
+        // And the default-on-path form too.
+        let err = eval_expr(
+            &Expr::VarWithDefault {
+                name: "cfg[port]".into(),
+                default: vec![StringPart::Literal("8080".into())],
+            },
+            &mut scope,
+        )
+        .unwrap_err();
+        assert!(matches!(err, EvalError::Unsupported(_)), "got: {err}");
     }
 }

--- a/crates/kaish-kernel/src/interpreter/result.rs
+++ b/crates/kaish-kernel/src/interpreter/result.rs
@@ -6,5 +6,6 @@
 pub use kaish_types::bytes::hex_dump;
 pub use kaish_types::output::{apply_output_format, EntryType, OutputData, OutputFormat, OutputNode};
 pub use kaish_types::result::{
-    json_to_value, value_to_json, ExecResult, LatchRequest, OutputPayload,
+    json_to_value, json_to_value_no_envelope, value_to_json, ExecResult, LatchRequest,
+    OutputPayload,
 };

--- a/crates/kaish-kernel/src/kernel.rs
+++ b/crates/kaish-kernel/src/kernel.rs
@@ -51,7 +51,7 @@ pub use kaish_types::{CommandKind, ExecuteOptions};
 use crate::backend::{BackendError, KernelBackend};
 use kaish_glob::glob_match;
 use crate::dispatch::{CommandDispatcher, PipelinePosition};
-use crate::interpreter::{apply_output_format, eval_expr, expand_tilde, json_to_value, value_to_bool, value_length, value_to_string, ControlFlow, ExecResult, PathError, Scope};
+use crate::interpreter::{apply_output_format, eval_expr, expand_tilde, json_to_value_no_envelope, value_to_bool, value_length, value_to_string, ControlFlow, ExecResult, PathError, Scope};
 use crate::parser::parse;
 use crate::scheduler::{is_bool_type, schema_param_lookup, select_leaf, stderr_stream, BoundedStream, JobManager, PipelineRunner, StderrReceiver};
 #[cfg(feature = "subprocess")]
@@ -2174,7 +2174,11 @@ impl Kernel {
                         // when builtins emit .data — seq, jq, cut, find, …)
                         Value::Json(serde_json::Value::Array(arr)) => {
                             for elem in arr {
-                                items.push(json_to_value(elem));
+                                // Envelope-free: an element that happens to be
+                                // envelope-shaped (e.g. from `fromjson`) is
+                                // external data, not an internal bytes round-trip,
+                                // so it must NOT be re-decoded to Value::Bytes.
+                                items.push(json_to_value_no_envelope(elem));
                             }
                         }
                         // Strings from $(cmd): empty → 0 iterations,
@@ -3777,6 +3781,9 @@ impl Kernel {
                 Ok(Value::Int(scope.arg_count() as i64))
             }
             Expr::VarLength(name) => {
+                if crate::interpreter::name_is_subscripted(name) {
+                    return Err(anyhow::anyhow!("{}", crate::interpreter::subscripted_length_error(name)));
+                }
                 let scope = self.scope.read().await;
                 match scope.get(name) {
                     Some(value) => Ok(Value::Int(value_length(value))),
@@ -3784,6 +3791,9 @@ impl Kernel {
                 }
             }
             Expr::VarWithDefault { name, default } => {
+                if crate::interpreter::name_is_subscripted(name) {
+                    return Err(anyhow::anyhow!("{}", crate::interpreter::subscripted_default_error(name)));
+                }
                 let scope = self.scope.read().await;
                 let use_default = match scope.get(name) {
                     Some(value) => value_to_string(value).is_empty(),
@@ -3920,6 +3930,9 @@ impl Kernel {
                     }
                 }
                 StringPart::VarWithDefault { name, default } => {
+                    if crate::interpreter::name_is_subscripted(name) {
+                        return Err(anyhow::anyhow!("{}", crate::interpreter::subscripted_default_error(name)));
+                    }
                     let scope = self.scope.read().await;
                     let use_default = match scope.get(name) {
                         Some(value) => value_to_string(value).is_empty(),
@@ -3935,6 +3948,9 @@ impl Kernel {
                     }
                 }
             StringPart::VarLength(name) => {
+                if crate::interpreter::name_is_subscripted(name) {
+                    return Err(anyhow::anyhow!("{}", crate::interpreter::subscripted_length_error(name)));
+                }
                 let scope = self.scope.read().await;
                 match scope.get(name) {
                     Some(value) => Ok(value_length(value).to_string()),
@@ -4584,7 +4600,13 @@ impl Kernel {
         cmd.env_clear();
         {
             let scope = self.scope.read().await;
-            for (var_name, value) in scope.exported_vars() {
+            let exported = scope.exported_vars();
+            // A structured value can't cross the process boundary; refuse rather
+            // than silently JSON-serialize it into the child's environment.
+            if let Some(msg) = crate::interpreter::structured_export_error(&exported) {
+                return Err(anyhow::anyhow!(msg));
+            }
+            for (var_name, value) in exported {
                 cmd.env(var_name, value_to_string(&value));
             }
         }

--- a/crates/kaish-kernel/src/parser.rs
+++ b/crates/kaish-kernel/src/parser.rs
@@ -83,6 +83,7 @@ fn unquote_default_word(word: &str) -> String {
 fn find_default_separator(raw: &str) -> Option<usize> {
     let bytes = raw.as_bytes();
     let mut depth = 0;
+    let mut bracket_depth = 0;
     let mut i = 0;
 
     while i < bytes.len() {
@@ -96,8 +97,21 @@ fn find_default_separator(raw: &str) -> Option<usize> {
             i += 1;
             continue;
         }
-        // Only find :- at the top level (depth == 1 means we're inside the outer ${...})
-        if depth == 1 && i + 1 < bytes.len() && bytes[i] == b':' && bytes[i + 1] == b'-' {
+        // Track `[...]` so a `:-` inside a subscript (e.g. the negative slice end
+        // in `${xs[0:-1]}`) is NOT mistaken for a default separator.
+        if bytes[i] == b'[' {
+            bracket_depth += 1;
+        } else if bytes[i] == b']' && bracket_depth > 0 {
+            bracket_depth -= 1;
+        }
+        // Only find :- at the top level (depth == 1 means we're inside the outer
+        // ${...}) and outside any subscript.
+        if depth == 1
+            && bracket_depth == 0
+            && i + 1 < bytes.len()
+            && bytes[i] == b':'
+            && bytes[i + 1] == b'-'
+        {
             return Some(i);
         }
         i += 1;
@@ -109,6 +123,7 @@ fn find_default_separator(raw: &str) -> Option<usize> {
 fn find_default_separator_in_content(content: &str) -> Option<usize> {
     let bytes = content.as_bytes();
     let mut depth = 0;
+    let mut bracket_depth = 0;
     let mut i = 0;
 
     while i < bytes.len() {
@@ -122,8 +137,20 @@ fn find_default_separator_in_content(content: &str) -> Option<usize> {
             i += 1;
             continue;
         }
-        // Find :- at the top level (depth == 0)
-        if depth == 0 && i + 1 < bytes.len() && bytes[i] == b':' && bytes[i + 1] == b'-' {
+        // Track `[...]` so a `:-` inside a subscript (e.g. the negative slice end
+        // in `${xs[0:-1]}`) is NOT mistaken for a default separator.
+        if bytes[i] == b'[' {
+            bracket_depth += 1;
+        } else if bytes[i] == b']' && bracket_depth > 0 {
+            bracket_depth -= 1;
+        }
+        // Find :- at the top level (depth == 0) and outside any subscript.
+        if depth == 0
+            && bracket_depth == 0
+            && i + 1 < bytes.len()
+            && bytes[i] == b':'
+            && bytes[i + 1] == b'-'
+        {
             return Some(i);
         }
         i += 1;

--- a/crates/kaish-kernel/src/scheduler/pipeline.rs
+++ b/crates/kaish-kernel/src/scheduler/pipeline.rs
@@ -966,7 +966,10 @@ pub(crate) fn eval_simple_expr(expr: &Expr, ctx: &ExecContext) -> Option<Value> 
                     }
                     crate::ast::StringPart::VarLength(name) => {
                         let len = match ctx.scope.get(name) {
-                            Some(value) => value_to_string(value).len(),
+                            // Element/key count for collections, byte count for
+                            // binary — the same helper the async/interp paths use
+                            // (not the string byte-length of a rendered value).
+                            Some(value) => crate::interpreter::value_length(value) as usize,
                             None => 0,
                         };
                         result.push_str(&len.to_string());
@@ -1067,7 +1070,9 @@ fn eval_string_parts_sync(parts: &[crate::ast::StringPart], ctx: &ExecContext) -
             }
             crate::ast::StringPart::VarLength(name) => {
                 let len = match ctx.scope.get(name) {
-                    Some(value) => value_to_string(value).len(),
+                    // Element/key count for collections, byte count for binary —
+                    // the same helper the async/interp paths use.
+                    Some(value) => crate::interpreter::value_length(value) as usize,
                     None => 0,
                 };
                 result.push_str(&len.to_string());

--- a/crates/kaish-kernel/src/tools/builtin/jq_native.rs
+++ b/crates/kaish-kernel/src/tools/builtin/jq_native.rs
@@ -677,16 +677,19 @@ fn value_as_string(v: &serde_json::Value) -> Option<String> {
 ///   CommandSubst arm in the kernel hands a JSON array to the for-loop
 ///   regardless of the `-r` / `-c` rendering flags.
 fn build_exec_result(run: JqRun) -> ExecResult {
-    use crate::interpreter::json_to_value;
+    use crate::interpreter::json_to_value_no_envelope;
     let JqRun { text, mut values } = run;
     if values.is_empty() {
         return ExecResult::with_output(OutputData::text(text));
     }
     // Single-value output: keep `.data` as the underlying scalar/object so
     // `jq '.name'` continues to expose a non-array value via `kaish-last`.
+    // Envelope-free: jq operates on external JSON, so an envelope-shaped object
+    // stays a plain record and is never silently re-decoded to Value::Bytes
+    // (matches the 2+-value path below, which hands raw serde values through).
     if values.len() == 1 {
         if let Some(only) = values.pop() {
-            return ExecResult::success_with_data(text, json_to_value(only));
+            return ExecResult::success_with_data(text, json_to_value_no_envelope(only));
         }
     }
     ExecResult::success_with_data(text, Value::Json(serde_json::Value::Array(values)))

--- a/crates/kaish-kernel/tests/collection_access_tests.rs
+++ b/crates/kaish-kernel/tests/collection_access_tests.rs
@@ -286,3 +286,100 @@ async fn undefined_root_in_string_is_empty() {
     assert_eq!(code, 0, "err: {err}");
     assert_eq!(out, "x=y");
 }
+
+// ── Overnight-review fixes (2026-07-02): silent-collection traps ────────────
+
+// `[[ ]]` eval errors surface as `Err` from `kernel.execute()` — the same LOUD
+// contract the regex-match fix established (see regex_match_error_tests.rs), not a
+// silent false. So these assert on the Err, not an exit code.
+
+#[tokio::test]
+async fn collection_vs_scalar_equality_is_a_loud_error() {
+    // `[[ $list == banana ]]` must NOT be silently false — it's the trap `in`
+    // exists to close. See docs/arrays-and-hashes.md (comparison decision).
+    let k = setup().await;
+    let result = k
+        .execute(r#"x=$(fromjson '["a","b"]'); if [[ $x == banana ]]; then echo hit; fi"#)
+        .await;
+    assert!(result.is_err(), "comparing a list to a scalar must be a loud error");
+    let msg = format!("{:#}", result.unwrap_err());
+    assert!(msg.contains("membership") || msg.contains(" in "), "should hint at `in`: {msg}");
+}
+
+#[tokio::test]
+async fn whole_list_vs_scalar_inequality_is_a_loud_error() {
+    // `!=` must be loud too (it's `!(values_equal ?)`, so the error propagates).
+    let k = setup().await;
+    let result = k
+        .execute(r#"x=$(fromjson '["a","b"]'); if [[ $x != banana ]]; then echo hit; fi"#)
+        .await;
+    assert!(result.is_err(), "!= with a list and a scalar must be a loud error");
+    assert!(format!("{:#}", result.unwrap_err()).contains("list"), "should name the list type");
+}
+
+#[tokio::test]
+async fn whole_record_vs_scalar_is_a_loud_error() {
+    let k = setup().await;
+    // `$u` alone is the whole record; comparing it to a scalar must be loud.
+    let result = k
+        .execute(r#"u=$(fromjson '{"name":"amy"}'); if [[ $u == amy ]]; then echo hit; fi"#)
+        .await;
+    assert!(result.is_err(), "comparing a whole record to a scalar must be a loud error");
+    assert!(format!("{:#}", result.unwrap_err()).contains("record"), "should name the record type");
+}
+
+#[tokio::test]
+async fn negative_slice_end_is_not_mistaken_for_a_default() {
+    // `${xs[0:-1]}` — the `:-` is a slice bound, not a `:-default` separator.
+    let k = setup().await;
+    let (out, code, err) =
+        run(&k, r#"x=$(fromjson '["a","b","c"]'); echo ${x[0:-1]}"#).await;
+    assert_eq!(code, 0, "err: {err}");
+    assert_eq!(out, r#"["a","b"]"#);
+}
+
+#[tokio::test]
+async fn default_on_a_subscripted_path_is_a_loud_error_not_the_default() {
+    // `${cfg[port]:-8080}` must not silently return 8080 while a real value
+    // exists — length/default on a path isn't wired yet, so it's loud with a
+    // "bind first" hint (never silent-wrong-output).
+    let k = setup().await;
+    let (_, code, err) = run(
+        &k,
+        r#"cfg=$(fromjson '{"port":9000}'); echo ${cfg[port]:-8080}"#,
+    )
+    .await;
+    assert_ne!(code, 0, "default-on-path must be loud, not silently the default");
+    assert!(err.contains("bind it first"), "should hint at binding first: {err}");
+}
+
+#[tokio::test]
+async fn length_of_a_subscripted_path_is_a_loud_error_not_zero() {
+    // `${#u[tags]}` must not silently print 0 (bare-name lookup miss) — loud with
+    // a "bind first" hint until nested length lands.
+    let k = setup().await;
+    let (_, code, err) = run(
+        &k,
+        r#"u=$(fromjson '{"tags":["a","b"]}'); echo "${#u[tags]}""#,
+    )
+    .await;
+    assert_ne!(code, 0, "length-of-path must be loud, not silent 0");
+    assert!(err.contains("bind it first"), "should hint at binding first: {err}");
+}
+
+#[tokio::test]
+async fn for_loop_over_envelope_shaped_elements_stays_a_record() {
+    // A `fromjson` array element that happens to be envelope-shaped is external
+    // data — it must NOT be silently re-decoded to binary during iteration.
+    let k = setup().await;
+    // The `$(fromjson …)` CommandSubst form is the real iteration idiom (a bare
+    // `for x in $xs` is rejected by the validator, E012).
+    let (out, code, err) = run(
+        &k,
+        r#"for x in $(fromjson '[{"_type":"bytes","encoding":"base64","data":"AQID","len":3}]'); do echo ${x[_type]}; done"#,
+    )
+    .await;
+    assert_eq!(code, 0, "err: {err}");
+    // Envelope-free: the element is still a record, so `[_type]` reads "bytes".
+    assert_eq!(out, "bytes");
+}

--- a/crates/kaish-kernel/tests/external_command_tests.rs
+++ b/crates/kaish-kernel/tests/external_command_tests.rs
@@ -94,6 +94,29 @@ async fn external_resolution_is_hermetic_no_os_path_fallback() {
 }
 
 #[tokio::test]
+async fn exporting_a_structured_value_to_a_subprocess_is_a_loud_error() {
+    // A list/record can't cross the process boundary; the external spawn refuses
+    // rather than silently JSON-serializing it into the child's environment.
+    // `printenv` is a real external (see the hermetic test above), so this
+    // exercises the production spawn-site guard in try_execute_external.
+    let kernel = repl_kernel();
+    let result = kernel
+        .execute(r#"export CFG=$(fromjson '{"port":8080}'); printenv CFG"#)
+        .await;
+    // The guard surfaces as an Err from execute (or a failed ExecResult); either
+    // way it must be loud and hint at serializing with `tojson` first.
+    let msg = match result {
+        Ok(r) => {
+            assert_ne!(r.code, 0, "exporting a record to a subprocess must fail: {r:?}");
+            r.err
+        }
+        Err(e) => format!("{e:#}"),
+    };
+    assert!(msg.contains("tojson"), "should hint at serializing with tojson: {msg}");
+    assert!(msg.contains("CFG"), "should name the offending variable: {msg}");
+}
+
+#[tokio::test]
 async fn external_command_not_found() {
     let kernel = repl_kernel();
     let result = kernel

--- a/docs/arrays-and-hashes.md
+++ b/docs/arrays-and-hashes.md
@@ -259,12 +259,17 @@ for the record.
   `eval.rs:747` — correct by accident; make it correct by design), and `$(( ${cfg[port]} + 1 ))`
   just works. One model, no "JSON-flavored scalars" second species.
 
-- **Comparison semantics for collections.** *(Added 2026-07-01.)* `==`/`!=` between two
-  collections is **structural JSON equality** (records order-insensitive — `serde_json::Map`
-  equality; lists order-sensitive). A collection compared to a scalar is a **loud error** with a
-  hint ("use `in` for membership; jq for structural queries") — `[[ $list == banana ]]` being
-  silently false is exactly the trap `in` exists to close. Ordering operators (`<`, `-lt`, …) on
-  collections are errors.
+- **Comparison semantics for collections.** *(Added 2026-07-01; collection-vs-scalar landed
+  2026-07-02.)* `==`/`!=` between two collections is **structural JSON equality** (records
+  order-insensitive — `serde_json::Map` equality; lists order-sensitive). A collection compared
+  to a scalar is a **loud error** with a hint ("use `in` for membership; jq for structural
+  queries") — `[[ $list == banana ]]` being silently false is exactly the trap `in` exists to
+  close. Ordering operators (`<`, `-lt`, …) on collections are errors. **Implemented**:
+  `values_equal` (`eval.rs`) now returns `EvalResult<bool>` and yields `EvalError::Unsupported`
+  for the collection-vs-scalar case; it surfaces as a loud `Err` from `kernel.execute()`, the
+  same LOUD contract as the `=~` regex-error fix (a JSON *scalar* is unwrapped at the value
+  boundary, so only Array/Object reach the guard). Pulled forward ahead of `in`/membership
+  because read-access already lets collections reach `[[ ]]`.
 
 - **Assignment lvalues — bracket paths, loud errors, no autovivification.** *(Added
   2026-07-01.)* `name[seg][seg…]=value` writes into a collection in place:
@@ -321,9 +326,42 @@ for the record.
 - **Length is `${#…}`, not a `len` builtin.** `${#xs}` returns element count for a list and key
   count for a record — the existing `${#NAME}` param-expansion (LANGUAGE.md) extended to
   collections. One length form, no nested `len $(keys $r)` trap. Strings keep today's behavior.
-  *(Correction 2026-07-01: this is no longer "one spot" — there are now **three** duplicated
-  call sites: `kernel.rs:3761` (`Expr::VarLength`), `kernel.rs:3917` (in-string), and
-  `eval.rs:427` (sync path). Consolidate before extending.)*
+  *(Correction 2026-07-01: this is no longer "one spot" — there are now duplicated call sites in
+  `kernel.rs` (`Expr::VarLength` + in-string), `eval.rs` (sync), and `scheduler/pipeline.rs`
+  (reduced sync). Consolidate before extending.)* **Partly landed 2026-07-02**: all sites now
+  route length through the shared `value_length` helper (the `scheduler/pipeline.rs` sync path
+  previously returned the *string* byte-length — `${#xs}` on `[1,2,3]` gave `7`, not `3`), and
+  `value_length` counts `Value::Bytes` by byte length rather than the placeholder-string length.
+
+- **Length/default on a *subscripted path* — loud placeholder now, path-aware with the resolver.**
+  *(Spec gap the 2026-07-02 review surfaced; resolved as "loud, not silent". Default semantics
+  decided 2026-07-02.)* `${#u[tags]}` and `${cfg[port]:-8080}` were never given semantics, and the
+  code fell into silent-wrong-output: `${#u[tags]}` printed `0` (bare-name lookup of the literal
+  `"u[tags]"`) and `${cfg[port]:-8080}` **always** returned the default (the `:-` scanner + a
+  literal `scope.get`). Root cause: the `VarLength(String)` / `VarWithDefault{name:String}` AST
+  nodes carry a bare name and never reach the path resolver. **Interim (landed 2026-07-02):** the
+  two `:-` scanners are now bracket-aware so a genuine slice like `${xs[0:-1]}` (negative end) is
+  no longer misread as a default; a subscripted name in either form is a **loud "bind it first"
+  error** (`x=${u[tags]}; ${#x}`), never the silent wrong answer — until the nodes carry a
+  `VarPath` and resolve through the shared read resolver (folds into the bind/walk extraction; see
+  Implementation notes).
+
+  **Decided — `${path:-default}` is lenient on *absence*, loud on *misuse*.** When path support
+  lands, `${cfg[port]:-8080}` returns the value if the key is present and non-empty, else the
+  default — for an **unset root, a missing key, an out-of-bounds index, or an empty value**. The
+  `:-` operator *is* the absence affordance (matching every model's bash prior — `${x:-d}` has
+  always handled absence), so erroring on a missing key would defeat its purpose. Strictness stays
+  available *per expression* by not writing `:-`: bare `${cfg[port]}` is loud-on-absence (already
+  shipped), so the call site picks assert-vs-default by whether it types `:-`. **But `:-` does not
+  suppress a *shape* error** — a string key on a list, an integer index on a record, or
+  subscripting a scalar is "you're accessing it wrong," not "it's absent," and stays loud. This
+  needs the resolver to classify its failure as **absence vs shape**: today `PathError` lumps
+  missing-key and shape errors into one `Invalid` variant, so splitting them is a #6 resolver job
+  (`Bind` tags the error class; `:-` catches only absence). Complementary tools, not substitutes:
+  `${r[k]}` asserts (loud), `${r[k]:-d}` defaults (lenient on absence), `[[ k in $r ]]` is the
+  boolean check for branching (native form coming with membership; `jq 'has("k")'` works today).
+  **No global `set -o strict` for now** — the `:-`-free form already is the strict form; a mode
+  that makes even `:-` shout on missing-key is a small future bolt-on if a real need appears.
 
 - **String path interpolation is `${path}`; no auto-interpolation.** Inside a string, brace the
   subscripted path to bound it — `"${user[name]}"`, `"${user[tags][0]}"`, `"${user[$k]}"` —
@@ -350,12 +388,15 @@ for the record.
   glob `[[ $s == *sub* ]]`, or `case`). We're already extending the language; keeping substring
   on the sh muscle-memory path avoids overloading `in` and conflicting with `=~`.
 
-- **`export` of a structured value is an error.** You cannot put a list/record in an OS env var;
-  kaish will **not** silently JSON-serialize it. Today it does, at spawn time
-  (`kernel.rs:4561` and its synced test-only twin `dispatch.rs:231`; `export.rs:164` also
-  quote-stringifies for display) — flip to error at both spawn sites. If you want JSON in the
+- **`export` of a structured value is an error.** *(Landed 2026-07-02.)* You cannot put a
+  list/record in an OS env var; kaish will **not** silently JSON-serialize it. Both external-spawn
+  sites (`kernel.rs::try_execute_external` and its synced test-only twin
+  `dispatch.rs::try_external`) now call `structured_export_error` before `cmd.env(...)` and refuse
+  loudly, naming the variable and pointing at `export CFG=$(tojson $CFG)`. If you want JSON in the
   environment, serialize explicitly first. Surfacing this boundary loudly is the point — the
-  structured data model is otherwise invisible at the process edge.
+  structured data model is otherwise invisible at the process edge. *(`export.rs` display
+  formatting of a structured value at declaration time is untouched — the boundary that matters is
+  the process edge, and that's where the guard sits.)*
 
 - **Commas optional in BOTH lists and records.** `[1 2 3]` ≡ `[1, 2, 3]`; `{a: 1, b: 2}` ≡
   `{a: 1 b: 2}`. Records were shown comma-separated and lists space-separated, which would make
@@ -544,18 +585,21 @@ paths relative to `crates/kaish-kernel/src`).
 - **POSIX-name tightening for assignment LHS** happens in the assignment/env-prefix parser or
   validator — NOT the lexer: the `Ident` regex (`lexer.rs:596`, `[a-zA-Z_][a-zA-Z0-9_.@-]*`) is
   shared with command names (`some-tool`) and must keep accepting those.
-- **`${#…}` length**: three duplicated sites (`kernel.rs:3761`, `kernel.rs:3917`,
-  `eval.rs:427`), all `value_to_string(value).len()`. Consolidate to one helper, then
-  type-dispatch on `Value::Json` (array len / object key count).
+- **`${#…}` length**: consolidated 2026-07-02 onto the shared `value_length` helper across all
+  four sites (`kernel.rs` `Expr::VarLength` + in-string, `eval.rs` sync, `scheduler/pipeline.rs`
+  reduced sync — the last of which was still `value_to_string(value).len()`). The remaining length
+  work is *nested* length (`${#u[tags]}`): the `VarLength(String)` node carries a bare name, so it
+  can't reach a subscript — it's a loud "bind first" error until the node carries a `VarPath` (do
+  it with the resolver extraction below).
 - **`[[ in ]]`** routes through the existing async test path (`eval_test_async`,
   `kernel.rs:3821-3886`) so it is VFS/backend-aware. `TestExpr` (`ast/types.rs:304-318`) gains
   `In`/`NotIn`; RHS shape-dispatches on `Value::Json` (array → element membership; object → key
   membership; string RHS → error). The RHS must accept a list/record **literal**, not just a
   `$var` — Haiku produced `[[ $a not in [dog] ]]` (mind the glued-GlobWord case).
-- **Typed comparison**: `values_equal` (`eval.rs:747-763`) currently drops `Json(Bool)` vs
-  `Bool` to the stringify fallback. With boundary unwrap most cases become native-typed;
-  add the structural-equality arm for collection/collection and the loud error for
-  collection/scalar.
+- **Typed comparison**: DONE 2026-07-02 — `values_equal` (`eval.rs`) now returns
+  `EvalResult<bool>`, has the structural-equality arm for collection/collection (via
+  `serde_json::Value` `PartialEq`, records order-insensitive under `preserve_order`), and the
+  loud `EvalError::Unsupported` for collection/scalar. Boundary unwrap keeps scalar cases native.
 - **`for` over records**: the for-loop already iterates `Value::Json(Array)` element-wise
   (`kernel.rs:2130-2212`); add an `Object` arm yielding keys (insertion order). Add the soft
   W-code for bareword `keys`/`values` in a for-head.
@@ -566,9 +610,30 @@ paths relative to `crates/kaish-kernel/src`).
   don't either — `bind` is only called for assignments, for-vars, and function params). New
   pattern following `ScopeTracker::bind` (`scope_tracker.rs:81`): register `push`'s first arg as
   a var-target; undefined target → E-code; defined-but-not-a-list → runtime error.
-- **`export` structured error**: guard before `cmd.env(...)` at both spawn sites
-  (`kernel.rs:4561`, test-only twin `dispatch.rs:231` — the hermetic two-spawn-site rule) and in
-  `export.rs:164` display formatting.
+- **`export` structured error**: DONE 2026-07-02 — `structured_export_error` guards before
+  `cmd.env(...)` at both spawn sites (`kernel.rs::try_execute_external`, test-only twin
+  `dispatch.rs::try_external` — the hermetic two-spawn-site rule). `export.rs` declaration-time
+  display was deliberately left as-is (the process edge is the boundary that matters).
+- **Two-phase bind/walk resolver (the load-bearing extraction the write side needs).** *(Flagged
+  by the 2026-07-02 review as the single most important thing before the grammar; NOT yet done —
+  design with Amy first.)* Today `Scope::apply_segment` fuses three jobs — classify a segment
+  against the container (index-vs-key, negative-index normalization, every loud message), walk one
+  hop, and unwrap the child via `json_to_value_no_envelope` (cloning each subtree, so
+  `for k in $u; ${u[$k]}` is O(n²)). The lvalue navigator needs `&mut` serde-tree navigation and
+  can't reuse that walker, so building it separately duplicates the classification logic under
+  `&mut` — and read/write then drift on exactly the semantics that must never drift (`${a[-1]}`
+  read vs `a[-1]=x` write). Proposed split: **Bind** `(VarPath, &Scope) → Result<Vec<ConcreteStep>,
+  PathError>` (owns `value_as_index`, negative math, and every message; `arithmetic.rs` stops
+  hand-collecting brackets and calls this — fixing the quoted-key whitespace bug for free) + a
+  **Walk** over `&serde_json::Value` (unwrap at leaf only) with a later `&mut` twin sharing Bind
+  verbatim. Converting `VarLength`/`VarWithDefault` to carry a `VarPath` (root of the deferred
+  nested-length / default-on-path forms above) folds in here — and `Bind` is where the
+  **absence-vs-shape error classification** lives that `${path:-default}` needs (`:-` catches the
+  absence class — unset root / missing key / out-of-bounds / empty — but not a shape error; see
+  the default-semantics decision above). That means splitting today's single `PathError::Invalid`
+  into an absence variant and a shape/type variant, which Bind returns. Deep-path error messages
+  should thread the traversed prefix (today `${services[web][prot]}` errors as the fabricated flat
+  `${services[prot]}`), which is free once Bind owns the path.
 - **`...` spread**: new lexer token; no existing `..`/`...` handling to collide with. Scope it
   to `[ ]` value context only.
 

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -345,21 +345,83 @@ review; verified locally):**
   "quote-bearing key with `]`" diagnostic. (Same root cause bounds the empty
   subscript `${r[]}` → `Key("")` oddity — reject in the validator if we care.)
 
-**Envelope-free must hold through downstream `.data` consumers (2026-07-01, from
-the json-bridge deepseek review):** `fromjson` converts external JSON with
-`json_to_value_no_envelope` (envelope-free at ingress), but two consumers still
-re-sniff the byte-envelope on `Value::Json` sub-values via the sniffing
-`json_to_value`: the `for` loop's array-element spread (`kernel.rs:2177`) and
-`jq`'s single-value output (`jq_native.rs:689`). So `for i in $(fromjson
-'[{"_type":"bytes",…}]')` silently decodes an envelope-shaped array element to
-`Value::Bytes` — the exact silent conversion the guarantee forbids, just one hop
-downstream. Pre-existing (these sites predate the bridge and were written for
-internal round-tripping, where re-decoding is correct). **Fold into step-2
-read-side traversal**, which is all about envelope-free access: switch these to
-`json_to_value_no_envelope` (verify no internal builtin relies on a `.data` array
-element round-tripping to bytes — `dd` emits `out_bytes`, not `.data` arrays, so
-it looks safe) and add the `for i in $(fromjson '[envelope]')` + `fromjson | jq
-'.'` regression tests the bridge PR deliberately left out of scope.
+**~~Envelope-free must hold through downstream `.data` consumers~~ FIXED
+2026-07-02** (`fix/collections-silent-traps`). The `for`-loop array-element spread
+(`kernel.rs:2177`) and `jq`'s single-value output (`jq_native.rs:689`) both
+re-sniffed the byte-envelope via the sniffing `json_to_value`, so `for i in
+$(fromjson '[{"_type":"bytes",…}]')` silently decoded an envelope-shaped element
+to `Value::Bytes`. Both now use `json_to_value_no_envelope` (jq's 2+-value path
+already handed raw serde through, so this makes the single-value path match).
+Regression test: `collection_access_tests::for_loop_over_envelope_shaped_elements_stays_a_record`.
+The `fromjson | jq '.'` roundtrip case remains untested — add if it recurs.
+
+**Overnight milestone review — collections read-access (2026-07-02, gemini-pro +
+fable-5 batches; every finding verified against the local build).** Cross-model
+consensus. **The silent-corruption cluster (#1–#5) FIXED 2026-07-02**
+(`fix/collections-silent-traps`, failing-first tests each); the structural item
+(#6) and the small tail remain open.
+
+- **~~`${cfg[port]:-8080}` always returned the default; `${xs[0:-1]}` → `1]`~~ FIXED**
+  (fable A1). Both `:-` scanners (`find_default_separator`/`_in_content`, `parser.rs`)
+  are now bracket-aware, so a `:-` *inside* a subscript (negative slice end) is no
+  longer read as a default separator — `${xs[0:-1]}` slices correctly. A genuine `:-`
+  *after* a subscript (`${cfg[port]:-8080}`, name still carries `[port]`) now trips a
+  **loud "bind it first" error** instead of silently returning the default. (Full
+  path-aware default semantics defer to #6 — the `VarWithDefault.name`→`VarPath`
+  conversion.)
+- **~~`${#u[tags]}` silently `0`; `${#xs}` byte-length not element count in sync~~ FIXED**
+  (fable A2 + gemini #3). `scheduler/pipeline.rs`'s two reduced-sync sites now use
+  `value_length` (they were `value_to_string(value).len()` → `${#xs}` on `[1,2,3]`
+  gave `7`); `value_length` counts `Value::Bytes` by byte length. `${#u[tags]}` (a
+  subscripted name) is now a **loud "bind it first" error**, not silent `0` — full
+  nested length defers to #6.
+- **~~collection-vs-scalar `==`/`!=` silently `false`~~ FIXED** (gemini #1 / fable A4).
+  `values_equal` now returns `EvalResult<bool>` and yields `EvalError::Unsupported`
+  for the collection-vs-scalar case (surfaces as a loud `Err` from `execute`, same
+  contract as the `=~` regex fix). Pulled forward ahead of `in`/membership. `!=`
+  propagates the same error.
+- **~~`export` of a structured value silently JSON-serialized~~ FIXED** (gemini #2).
+  `structured_export_error` guards before `cmd.env(...)` at both spawn sites
+  (`kernel.rs::try_execute_external` + test-only twin `dispatch.rs::try_external`),
+  naming the var and pointing at `export CFG=$(tojson $CFG)`.
+- **~~for-loop / jq envelope re-sniff~~ FIXED** — see the "Envelope-free" entry above
+  (folded together; `kernel.rs:2177` + `jq_native.rs:689` now `_no_envelope`).
+
+- **OPEN, STRUCTURAL (awaiting Amy) — #6: extract a two-phase bind/walk resolver
+  before lvalues** (fable's "single most important thing before the grammar"). Full
+  design captured in [arrays-and-hashes.md](arrays-and-hashes.md) Implementation notes
+  ("Two-phase bind/walk resolver"). In short: `Scope::apply_segment` fuses classify +
+  walk + per-hop `clone()`+unwrap (O(n²) for `for k in $u; ${u[$k]}`); the write side
+  needs `&mut` serde navigation and can't reuse it, so building lvalues on it
+  duplicates the classification/message logic under `&mut` and read/write drift.
+  Split into **Bind** `(VarPath, &Scope) → Result<Vec<ConcreteStep>, PathError>` +
+  **Walk** over `&serde_json::Value`. Converting `VarLength`/`VarWithDefault` to carry
+  a `VarPath` (unblocks nested `${#path}` and default-on-path from #1/#2) folds in
+  here, as does arithmetic's hand-collected brackets (fixes fable A3) and
+  full-path-prefix error messages. **Do not start without a design pass with Amy.**
+- **DECIDED (2026-07-02) — `${path:-default}` semantics for #6:** `:-` is **lenient on
+  absence** (unset root, missing key, out-of-bounds, empty → the default) but **loud on
+  shape errors** (string key on a list, int index on a record, subscript-on-scalar).
+  Rationale: `:-` *is* the absence affordance; strictness stays available per-expression
+  via the `:-`-free bare form (`${r[k]}`, already loud); `[[ k in $r ]]`/`jq has()` cover
+  the boolean-branch case. No global `set -o strict` for now. Implementation dependency:
+  #6's `Bind` must split today's single `PathError::Invalid` into **absence** vs
+  **shape** so `:-` can catch only absence — full writeup in arrays-and-hashes.md
+  ("Length/default on a subscripted path" + the resolver Implementation note). `${#path}`
+  stays loud "bind first" until path-aware (no default-style leniency question there).
+- **OPEN — reduced sync path still coalesces** (unchanged, see the separate P3 entry
+  above): the subscripted-name loud guard lands in `eval.rs` (sync) + `kernel.rs`
+  (async), but `scheduler/pipeline.rs`'s `eval_string_parts_sync` has no error channel,
+  so a subscripted `${#u[tags]}` there is still silent-0. Rides the P3 error-channel
+  work when the scatter/gather arg path is next touched.
+- **OPEN — P3/P4 tail** (verified, non-blocking): `fromjson` on an already-typed value
+  stringifies-then-reparses and loses `Value::Bytes` (gemini #4 — short-circuit typed
+  values); async `VarRef` "undefined variable" omits the name (`kernel.rs:eval_expr_async`)
+  while the sync path includes it; missing-key errors could list available keys;
+  `${.a}`/`${a.}` empty dot segments resolve as `${a}` silently. Help-tier: rank is an
+  *instance* property but documented as a *slot* property — a locale translation
+  forgetting `.ranked(n)` silently reorders that locale's onboarding (add a cross-locale
+  rank-parity test) — refines the Reference/Contrast P4 above.
 
 ### Split `kernel.rs::execute_stmt_flow`
 `kernel.rs:1463`–~1913 is a 16-arm async match (kernel.rs is ~6,838 lines); each

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -422,6 +422,15 @@ consensus. **The silent-corruption cluster (#1–#5) FIXED 2026-07-02**
   *instance* property but documented as a *slot* property — a locale translation
   forgetting `.ranked(n)` silently reorders that locale's onboarding (add a cross-locale
   rank-parity test) — refines the Reference/Contrast P4 above.
+- **OPEN — expression-position `${#u[tags]}` gives a poor message** (kaibo deepseek review of
+  #57, 2026-07-02; verified). *In-string* `"${#u[tags]}"` gets the nice "bind it first" guard,
+  but *expression-position* `echo ${#u[tags]}` never becomes a `VarLength` node: the lexer regex
+  `Token::VarLength` (`\$\{#[a-zA-Z_][a-zA-Z0-9_]*\}`, `lexer.rs`) excludes `[`, so it falls to
+  `VarRef` with root `#u` → loud, but the message is the bare "undefined variable" (also missing
+  the name, per the async-VarRef item above), not the length hint. **Loud, not silent — no
+  correctness bug.** Fix rides #6: when `VarLength`/`VarWithDefault` carry a `VarPath`, also widen
+  the lexer `VarLength` regex (or route `#`-prefixed `VarRef` through the length path) so the
+  subscripted form reaches the guard/resolver in expression position too.
 
 ### Split `kernel.rs::execute_stmt_flow`
 `kernel.rs:1463`–~1913 is a 16-arm async match (kernel.rs is ~6,838 lines); each


### PR DESCRIPTION
## What & why

The collections read-access milestone review (gemini-pro + fable-5 overnight batches — cross-model consensus, every finding reproduced against the local build) surfaced a cluster of cases that returned a *plausible wrong answer* instead of erroring: the silent-corruption class kaish exists to prevent. This PR closes all five, each with a failing-first test, and settles the one design question they raised.

## The five traps (all now loud or correct)

| Trap | Was (silent) | Now |
|---|---|---|
| `[[ $list == x ]]` | silently `false` | loud `Err` (same contract as the `=~` regex fix), hints at `in`/`jq`; JSON scalar still unwraps & compares typed |
| `export CFG=$list` to a subprocess | JSON-serialized into child env | refused at both spawn sites, points at `export CFG=$(tojson $CFG)` |
| `for x in $(fromjson '[{envelope}]')` | element decoded to `Value::Bytes` | stays a record (`json_to_value_no_envelope`; jq single-value too) |
| `${#xs}` in scatter/gather sync path | rendered-string byte length (`7` for a 3-list) | element/key count via shared `value_length`; `Value::Bytes` counts bytes |
| `${xs[0:-1]}` / `${cfg[port]:-8080}` / `${#u[tags]}` | `1]` / silent default / silent `0` | slice works (bracket-aware `:-` scanner); subscripted length/default → loud "bind it first" |

The comparison error surfaces as an `Err` from `execute` — verified to be the established LOUD contract (see `regex_match_error_tests.rs`), not an ad-hoc choice.

## Decision settled here

`${path:-default}` semantics (previously an open spec gap): **`:-` is lenient on *absence*** (unset root, missing key, out-of-bounds, empty value → default) **but loud on *shape* errors** (string key on a list, int index on a record, subscript-on-scalar). Rationale: `:-` *is* the absence affordance (matching every model's bash prior); strictness stays available per-expression via the `:-`-free bare form (`${r[k]}`, already loud); `[[ k in $r ]]` / `jq has()` cover the boolean-branch case. No global `set -o strict`. Recorded in `docs/arrays-and-hashes.md` + `docs/issues.md`.

## Deliberately *not* in this PR

The structural follow-up (fable's "single most important thing before the grammar"): a **two-phase bind/walk resolver** shared by read + lvalue write, which also makes the subscripted `${#…}`/`:-` forms path-aware and splits `PathError::Invalid` into absence-vs-shape (the classification `:-` leniency needs). It's written up as the next step in `arrays-and-hashes.md` Implementation notes and awaits a design pass before the grammar/lvalue work begins. `VarLength`/`VarWithDefault` → `VarPath` folds into it.

## Tests / gates

- New failing-first tests in `collection_access_tests.rs` (7) and `external_command_tests.rs` (1: export guard through a real spawn), plus unit tests in `eval.rs`.
- `cargo test --all` green; `cargo clippy --all --all-targets` clean.
- Verified end-to-end in the real `./target/debug/kaish` binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)