### PR TITLE
feat(collections): typeof builtin + [[ -list ]]/[[ -record ]] shape guards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,10 +78,10 @@ breaking entries are marked **BREAKING**.
   work. `[[ -list $x ]]` / `[[ -record $x ]]` test the operand's *value*
   shape directly (like `-z`/`-n`, not a path stat like `-f`/`-d`) — the common
   guard idiom is `if [[ -record $data ]]; then ... elif [[ -list $data ]];
-  then ... fi` before committing to `keys`/`values`/a `for` loop. Both
-  operators deliberately never error on an unset variable or the wrong shape
-  (false, same as `-f` on a nonexistent path). `typeof` is pure data, present
-  in every capability build.
+  then ... fi` before committing to `keys`/`values`/a `for` loop. A
+  defined-but-wrong-shaped value is `false`; a bare unset `$var` is an
+  undefined-variable error (like `-z`/`-n`), so a typo isn't silently false.
+  `typeof` is pure data, present in every capability build.
 - **`json_to_value_no_envelope` (kaish-types)** — envelope-free JSON→`Value`
   conversion for external JSON, so byte-envelope-shaped objects are never
   silently decoded to `Value::Bytes`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,18 @@ breaking entries are marked **BREAKING**.
   result in `.data` for `$()` capture/iteration, and are pure data (present in
   every capability build). A non-collection argument (scalar, bytes, unset) is a
   loud error naming the actual type.
+- **Shape guard — `typeof` builtin + `[[ -list ]]` / `[[ -record ]]` test
+  operators** — the antidote to the "API sometimes returns an object instead
+  of a list" trap. `typeof $x` returns the exact type name (`list`, `record`,
+  `string`, `number`, `bool`, `null`, or `bytes`; no int/float split) in text
+  output and `.data`, so `t=$(typeof $x)` and `case $(typeof $x) in ...` both
+  work. `[[ -list $x ]]` / `[[ -record $x ]]` test the operand's *value*
+  shape directly (like `-z`/`-n`, not a path stat like `-f`/`-d`) — the common
+  guard idiom is `if [[ -record $data ]]; then ... elif [[ -list $data ]];
+  then ... fi` before committing to `keys`/`values`/a `for` loop. Both
+  operators deliberately never error on an unset variable or the wrong shape
+  (false, same as `-f` on a nonexistent path). `typeof` is pure data, present
+  in every capability build.
 - **`json_to_value_no_envelope` (kaish-types)** — envelope-free JSON→`Value`
   conversion for external JSON, so byte-envelope-shaped objects are never
   silently decoded to `Value::Bytes`.

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ everywhere, a `jq` that always uses the same filter syntax, an `awk` that never 
 |----------|-------|
 | **Text** | awk, base64, cut, diff, grep, head, sed, sort, split, tac, tail, tr, uniq, wc, xxd |
 | **Files** | basename, cat, cd, checksum, cmp, cp, dd, dirname, file, find, glob, ln, ls, mkdir, mktemp, mv, patch, pwd, readlink, realpath, rm, stat, tee, touch, tree, write |
-| **JSON** | fromjson, jq, keys, tojson, values |
+| **JSON** | fromjson, jq, keys, tojson, typeof, values |
 | **System** | alias, bg, date, echo, env, exec, export, fg, help, hostname, jobs, kill, printf, ps, read, seq, set, sleep, spawn, timeout, tokens, uname, unalias, unset, wait, which |
 | **Parallel** | scatter, gather |
 | **Meta** | assert, false, true |

--- a/crates/kaish-help/content/en/syntax.md
+++ b/crates/kaish-help/content/en/syntax.md
@@ -153,9 +153,9 @@ cmd1 || cmd2              # cmd2 if cmd1 fails
 ```sh
 # File: -f (file) -d (dir) -e (exists) -r (readable) -w (writable) -x (executable)
 # String: -z (empty) -n (non-empty) == != =~ (regex) !~ (not regex)
-# Shape guard: -list -record — the value's shape, not a path stat; never
-#   errors on an unset variable or the wrong shape (false, like -f on a
-#   missing path). Pairs with the typeof builtin.
+# Shape guard: -list -record — the value's shape, not a path stat. A
+#   defined-but-wrong-shaped value is false; a bare unset $var errors (like
+#   -z), so a typo isn't silently false. Pairs with the typeof builtin.
 # Numeric: -gt -lt -ge -le
 # Logic: && || !
 # Membership: in (list→element, record→key) / not in — RHS must be a collection

--- a/crates/kaish-help/content/en/syntax.md
+++ b/crates/kaish-help/content/en/syntax.md
@@ -68,6 +68,14 @@ done
 [[ name in $u ]]                                   # record has key?
 [[ 1 in $(keys $xs) ]]                             # index in bounds?
 
+# SHAPE GUARD — an API sometimes returns a list, sometimes a record; check
+# before committing to keys/values/for. typeof + [[ -list ]] / [[ -record ]]:
+if [[ -record $data ]]; then
+  for k in $(keys $data); do echo $k; done
+elif [[ -list $data ]]; then
+  for x in $(values $data); do echo $x; done
+fi
+
 tojson $u                 # serialize back to JSON text (--pretty to indent)
 ```
 
@@ -145,6 +153,9 @@ cmd1 || cmd2              # cmd2 if cmd1 fails
 ```sh
 # File: -f (file) -d (dir) -e (exists) -r (readable) -w (writable) -x (executable)
 # String: -z (empty) -n (non-empty) == != =~ (regex) !~ (not regex)
+# Shape guard: -list -record — the value's shape, not a path stat; never
+#   errors on an unset variable or the wrong shape (false, like -f on a
+#   missing path). Pairs with the typeof builtin.
 # Numeric: -gt -lt -ge -le
 # Logic: && || !
 # Membership: in (list→element, record→key) / not in — RHS must be a collection
@@ -154,6 +165,8 @@ cmd1 || cmd2              # cmd2 if cmd1 fails
 [[ $s =~ "\.rs$" ]]
 [[ banana in $fruits ]]
 [[ tmp not in $services ]]
+[[ -list $x ]]
+[[ -record $x ]]
 ```
 
 ## Control Flow

--- a/crates/kaish-help/src/fragments.rs
+++ b/crates/kaish-help/src/fragments.rs
@@ -300,6 +300,14 @@ done
 [[ name in $u ]]                                   # record has key?
 [[ 1 in $(keys $xs) ]]                             # index in bounds?
 
+# SHAPE GUARD — an API sometimes returns a list, sometimes a record; check
+# before committing to keys/values/for. typeof + [[ -list ]] / [[ -record ]]:
+if [[ -record $data ]]; then
+  for k in $(keys $data); do echo $k; done
+elif [[ -list $data ]]; then
+  for x in $(values $data); do echo $x; done
+fi
+
 tojson $u                 # serialize back to JSON text (--pretty to indent)
 ```"#,
     ),
@@ -382,6 +390,9 @@ cmd1 || cmd2              # cmd2 if cmd1 fails
         r#"```sh
 # File: -f (file) -d (dir) -e (exists) -r (readable) -w (writable) -x (executable)
 # String: -z (empty) -n (non-empty) == != =~ (regex) !~ (not regex)
+# Shape guard: -list -record — the value's shape, not a path stat; never
+#   errors on an unset variable or the wrong shape (false, like -f on a
+#   missing path). Pairs with the typeof builtin.
 # Numeric: -gt -lt -ge -le
 # Logic: && || !
 # Membership: in (list→element, record→key) / not in — RHS must be a collection
@@ -391,6 +402,8 @@ cmd1 || cmd2              # cmd2 if cmd1 fails
 [[ $s =~ "\.rs$" ]]
 [[ banana in $fruits ]]
 [[ tmp not in $services ]]
+[[ -list $x ]]
+[[ -record $x ]]
 ```"#,
     ),
     syntax_section(

--- a/crates/kaish-help/src/fragments.rs
+++ b/crates/kaish-help/src/fragments.rs
@@ -390,9 +390,9 @@ cmd1 || cmd2              # cmd2 if cmd1 fails
         r#"```sh
 # File: -f (file) -d (dir) -e (exists) -r (readable) -w (writable) -x (executable)
 # String: -z (empty) -n (non-empty) == != =~ (regex) !~ (not regex)
-# Shape guard: -list -record — the value's shape, not a path stat; never
-#   errors on an unset variable or the wrong shape (false, like -f on a
-#   missing path). Pairs with the typeof builtin.
+# Shape guard: -list -record — the value's shape, not a path stat. A
+#   defined-but-wrong-shaped value is false; a bare unset $var errors (like
+#   -z), so a typo isn't silently false. Pairs with the typeof builtin.
 # Numeric: -gt -lt -ge -le
 # Logic: && || !
 # Membership: in (list→element, record→key) / not in — RHS must be a collection

--- a/crates/kaish-kernel/src/ast/sexpr.rs
+++ b/crates/kaish-kernel/src/ast/sexpr.rs
@@ -328,6 +328,8 @@ pub fn format_test_expr(test: &TestExpr) -> String {
             let op_str = match op {
                 StringTestOp::IsEmpty => "-z",
                 StringTestOp::IsNonEmpty => "-n",
+                StringTestOp::IsList => "-list",
+                StringTestOp::IsRecord => "-record",
             };
             format!("(string {} {})", op_str, format_expr(value))
         }

--- a/crates/kaish-kernel/src/ast/types.rs
+++ b/crates/kaish-kernel/src/ast/types.rs
@@ -346,6 +346,16 @@ pub enum StringTestOp {
     IsEmpty,
     /// `-n` - string is non-empty
     IsNonEmpty,
+    /// `-list` - value is a native list (`Value::Json(Array)`). Shape guard —
+    /// the antidote to the "API sometimes returns an object instead of a
+    /// list" trap (see `docs/arrays-and-hashes.md`, decision F). Evaluates
+    /// the operand's *value*, like `-z`/`-n`, not a path stat like `-f`/`-d`.
+    /// Never errors on an unset variable or wrong-shaped value — false,
+    /// same as `-f` on a nonexistent path.
+    IsList,
+    /// `-record` - value is a native record (`Value::Json(Object)`). See
+    /// [`StringTestOp::IsList`].
+    IsRecord,
 }
 
 /// Comparison operators for `[[ ]]` tests.
@@ -512,7 +522,27 @@ impl fmt::Display for StringTestOp {
         match self {
             StringTestOp::IsEmpty => write!(f, "-z"),
             StringTestOp::IsNonEmpty => write!(f, "-n"),
+            StringTestOp::IsList => write!(f, "-list"),
+            StringTestOp::IsRecord => write!(f, "-record"),
         }
+    }
+}
+
+impl StringTestOp {
+    /// Does `value` match this shape-guard operator? Only meaningful for
+    /// [`StringTestOp::IsList`] / [`StringTestOp::IsRecord`] — returns `false`
+    /// for `IsEmpty`/`IsNonEmpty` (callers evaluate those separately via
+    /// string-empty checks, not this predicate).
+    ///
+    /// Shared by both the sync (`interpreter/eval.rs`) and async
+    /// (`kernel.rs::eval_test_async`) `[[ ]]` evaluators so the two paths
+    /// can't diverge on the shape rule.
+    pub fn matches_shape(self, value: &Value) -> bool {
+        matches!(
+            (self, value),
+            (StringTestOp::IsList, Value::Json(serde_json::Value::Array(_)))
+                | (StringTestOp::IsRecord, Value::Json(serde_json::Value::Object(_)))
+        )
     }
 }
 

--- a/crates/kaish-kernel/src/ast/types.rs
+++ b/crates/kaish-kernel/src/ast/types.rs
@@ -350,8 +350,8 @@ pub enum StringTestOp {
     /// the antidote to the "API sometimes returns an object instead of a
     /// list" trap (see `docs/arrays-and-hashes.md`, decision F). Evaluates
     /// the operand's *value*, like `-z`/`-n`, not a path stat like `-f`/`-d`.
-    /// Never errors on an unset variable or wrong-shaped value — false,
-    /// same as `-f` on a nonexistent path.
+    /// A defined-but-wrong-shaped value is false; a bare unset `$var` is an
+    /// undefined-variable error (like `-z`/`-n`), so a typo isn't silently false.
     IsList,
     /// `-record` - value is a native record (`Value::Json(Object)`). See
     /// [`StringTestOp::IsList`].

--- a/crates/kaish-kernel/src/interpreter/eval.rs
+++ b/crates/kaish-kernel/src/interpreter/eval.rs
@@ -310,14 +310,26 @@ impl<'a, E: Executor> Evaluator<'a, E> {
                     }),
                 }
             }
-            TestExpr::StringTest { op, value } => {
-                let val = self.eval(value)?;
-                let s = value_to_string(&val);
-                match op {
-                    StringTestOp::IsEmpty => s.is_empty(),
-                    StringTestOp::IsNonEmpty => !s.is_empty(),
+            TestExpr::StringTest { op, value } => match op {
+                StringTestOp::IsEmpty | StringTestOp::IsNonEmpty => {
+                    let val = self.eval(value)?;
+                    let s = value_to_string(&val);
+                    match op {
+                        StringTestOp::IsEmpty => s.is_empty(),
+                        StringTestOp::IsNonEmpty => !s.is_empty(),
+                        StringTestOp::IsList | StringTestOp::IsRecord => unreachable!(),
+                    }
                 }
-            }
+                // Shape guard: never errors on an unset variable or a
+                // wrong-shaped value — false, same as `-f` on a nonexistent
+                // path. Deliberately does NOT propagate `self.eval`'s error
+                // with `?` (unlike -z/-n above), so `[[ -list $unset ]]`
+                // reads as false rather than aborting the script.
+                StringTestOp::IsList | StringTestOp::IsRecord => self
+                    .eval(value)
+                    .map(|val| op.matches_shape(&val))
+                    .unwrap_or(false),
+            },
             TestExpr::Comparison { left, op, right } => {
                 let left_val = self.eval(left)?;
                 let right_val = self.eval(right)?;

--- a/crates/kaish-kernel/src/interpreter/eval.rs
+++ b/crates/kaish-kernel/src/interpreter/eval.rs
@@ -320,15 +320,16 @@ impl<'a, E: Executor> Evaluator<'a, E> {
                         StringTestOp::IsList | StringTestOp::IsRecord => unreachable!(),
                     }
                 }
-                // Shape guard: never errors on an unset variable or a
-                // wrong-shaped value — false, same as `-f` on a nonexistent
-                // path. Deliberately does NOT propagate `self.eval`'s error
-                // with `?` (unlike -z/-n above), so `[[ -list $unset ]]`
-                // reads as false rather than aborting the script.
-                StringTestOp::IsList | StringTestOp::IsRecord => self
-                    .eval(value)
-                    .map(|val| op.matches_shape(&val))
-                    .unwrap_or(false),
+                // Shape guard: inspect the operand's type. Propagates eval
+                // errors like -z/-n — a bare `$unset` is an undefined-variable
+                // error, not a silent `false` (catching a typo beats reading
+                // "not a list"). The guard is meant to be used bare
+                // (`[[ -list $data ]]`); a defined-but-wrong-shaped value is
+                // simply false.
+                StringTestOp::IsList | StringTestOp::IsRecord => {
+                    let val = self.eval(value)?;
+                    op.matches_shape(&val)
+                }
             },
             TestExpr::Comparison { left, op, right } => {
                 let left_val = self.eval(left)?;

--- a/crates/kaish-kernel/src/kernel.rs
+++ b/crates/kaish-kernel/src/kernel.rs
@@ -3883,16 +3883,13 @@ impl Kernel {
                             | crate::ast::StringTestOp::IsRecord => unreachable!(),
                         })
                     }
-                    // Shape guard: never errors on an unset variable or a
-                    // wrong-shaped value — false, same as `-f` on a
-                    // nonexistent path. Must not diverge from the sync path
-                    // in interpreter/eval.rs.
+                    // Shape guard: propagates eval errors like -z/-n (a bare
+                    // `$unset` is an undefined-variable error, not a silent
+                    // false). A defined-but-wrong-shaped value is false. Must
+                    // not diverge from the sync path in interpreter/eval.rs.
                     crate::ast::StringTestOp::IsList | crate::ast::StringTestOp::IsRecord => {
-                        Ok(self
-                            .eval_expr_async(value)
-                            .await
-                            .map(|val| op.matches_shape(&val))
-                            .unwrap_or(false))
+                        let val = self.eval_expr_async(value).await?;
+                        Ok(op.matches_shape(&val))
                     }
                 },
                 TestExpr::Comparison { left, op, right } => {

--- a/crates/kaish-kernel/src/kernel.rs
+++ b/crates/kaish-kernel/src/kernel.rs
@@ -3872,14 +3872,29 @@ impl Kernel {
                         }),
                     })
                 }
-                TestExpr::StringTest { op, value } => {
-                    let val = self.eval_expr_async(value).await?;
-                    let s = value_to_string(&val);
-                    Ok(match op {
-                        crate::ast::StringTestOp::IsEmpty => s.is_empty(),
-                        crate::ast::StringTestOp::IsNonEmpty => !s.is_empty(),
-                    })
-                }
+                TestExpr::StringTest { op, value } => match op {
+                    crate::ast::StringTestOp::IsEmpty | crate::ast::StringTestOp::IsNonEmpty => {
+                        let val = self.eval_expr_async(value).await?;
+                        let s = value_to_string(&val);
+                        Ok(match op {
+                            crate::ast::StringTestOp::IsEmpty => s.is_empty(),
+                            crate::ast::StringTestOp::IsNonEmpty => !s.is_empty(),
+                            crate::ast::StringTestOp::IsList
+                            | crate::ast::StringTestOp::IsRecord => unreachable!(),
+                        })
+                    }
+                    // Shape guard: never errors on an unset variable or a
+                    // wrong-shaped value — false, same as `-f` on a
+                    // nonexistent path. Must not diverge from the sync path
+                    // in interpreter/eval.rs.
+                    crate::ast::StringTestOp::IsList | crate::ast::StringTestOp::IsRecord => {
+                        Ok(self
+                            .eval_expr_async(value)
+                            .await
+                            .map(|val| op.matches_shape(&val))
+                            .unwrap_or(false))
+                    }
+                },
                 TestExpr::Comparison { left, op, right } => {
                     // Evaluate operands async (handles $(cmd)), then compare sync
                     let left_val = self.eval_expr_async(left).await?;

--- a/crates/kaish-kernel/src/parser.rs
+++ b/crates/kaish-kernel/src/parser.rs
@@ -1880,6 +1880,8 @@ where
 /// Supports:
 /// - File tests: `[[ -f path ]]`, `[[ -d path ]]`, etc.
 /// - String tests: `[[ -z str ]]`, `[[ -n str ]]`
+/// - Shape-guard tests: `[[ -list x ]]`, `[[ -record x ]]` (see
+///   `docs/arrays-and-hashes.md`, decision F)
 /// - Comparisons: `[[ $X == "value" ]]`, `[[ $NUM -gt 5 ]]`
 /// - Compound: `[[ -f a && -d b ]]`, `[[ -z x || -n y ]]`, `[[ ! -f file ]]`
 ///
@@ -1899,10 +1901,14 @@ where
         Token::ShortFlag(s) if s == "x" => FileTestOp::Executable,
     };
 
-    // String test operators: -z, -n
+    // String test operators: -z, -n, plus the shape-guard operators -list /
+    // -record (value-typed tests, not path stats — same operand-evaluation
+    // path as -z/-n, unlike the file_test_op family above).
     let string_test_op = select! {
         Token::ShortFlag(s) if s == "z" => StringTestOp::IsEmpty,
         Token::ShortFlag(s) if s == "n" => StringTestOp::IsNonEmpty,
+        Token::ShortFlag(s) if s == "list" => StringTestOp::IsList,
+        Token::ShortFlag(s) if s == "record" => StringTestOp::IsRecord,
     };
 
     // Comparison operators: =, ==, !=, =~, !~, >, <, >=, <=, -gt, -lt, -ge, -le, -eq, -ne

--- a/crates/kaish-kernel/src/tools/builtin/mod.rs
+++ b/crates/kaish-kernel/src/tools/builtin/mod.rs
@@ -89,6 +89,10 @@ mod touch;
 mod tr;
 mod tree;
 mod true_false;
+// Module named `type_of`, not `typeof` — `typeof` is a reserved (but unused)
+// Rust keyword, so `mod typeof;` doesn't compile. The tool name is still the
+// plain string "typeof" (see `Tool::name`).
+mod type_of;
 mod uname;
 mod uniq;
 mod unset;
@@ -213,6 +217,7 @@ pub fn register_builtins(registry: &mut ToolRegistry) {
     registry.register(tree::Tree);
     registry.register(true_false::True);
     registry.register(true_false::False);
+    registry.register(type_of::TypeOf);
     registry.register(uname::Uname);
     registry.register(uniq::Uniq);
     registry.register(unset::Unset);

--- a/crates/kaish-kernel/src/tools/builtin/type_of.rs
+++ b/crates/kaish-kernel/src/tools/builtin/type_of.rs
@@ -1,0 +1,120 @@
+//! typeof — the shape guard: a value's type as a plain type name.
+//!
+//! Part of the native-collections shape-guard surface (see
+//! `docs/arrays-and-hashes.md`, decision F: "Ship a shape guard (`typeof` /
+//! `[[ -list ]]` / `[[ -record ]]`) — antidote to the keys-on-list footgun
+//! and the API-shape-variance trap"). `typeof $x` answers "what did this
+//! value actually turn out to be" before an agent commits to `keys`/`values`
+//! or a `for` loop over it — the trap this guards against is an API call
+//! that sometimes returns a list and sometimes returns a single record.
+//!
+//! Type names are deliberately coarse — `number` covers both `Int` and
+//! `Float` (no int/float split), matching jq/JSON's single numeric type.
+//! Pair with `[[ -list $x ]]` / `[[ -record $x ]]` for the common two-shape
+//! guard idiom without a `case` statement.
+//!
+//! Pure data transform — no OS, no VFS — so it belongs in every capability
+//! build, same footing as `fromjson`/`tojson`/`keys`/`values`.
+//!
+//! # Examples
+//!
+//! ```kaish
+//! t=$(typeof $x)                 # "list" | "record" | "string" | "number" | "bool" | "null" | "bytes"
+//! if [[ -record $data ]]; then
+//!   for k in $(keys $data); do echo $k; done
+//! elif [[ -list $data ]]; then
+//!   for x in $(values $data); do echo $x; done
+//! fi
+//! ```
+
+use async_trait::async_trait;
+use clap::{CommandFactory, Parser};
+
+use crate::ast::Value;
+use crate::interpreter::ExecResult;
+use crate::tools::{schema_from_clap, ExecContext, GlobalFlags, Tool, ToolArgs, ToolCtx, ToolSchema};
+
+/// typeof tool: a value's type as a plain type name — the shape guard.
+pub struct TypeOf;
+
+/// clap-derived argv layer for typeof.
+#[derive(Parser, Debug)]
+#[command(name = "typeof", about = "The value's type — the shape guard")]
+struct TypeOfArgs {
+    #[command(flatten)]
+    global: GlobalFlags,
+
+    /// The value. Hidden sink — the real value is read off
+    /// `args.positional` per the Value-typed positional rule.
+    #[arg(hide = true)]
+    value: Vec<String>,
+}
+
+/// The exact type name for the shape guard — `list`/`record`/`string`/
+/// `number`/`bool`/`null`/`bytes`. No int/float split (jq/JSON have one
+/// numeric type). `Value::Json` scalars are named precisely rather than
+/// lumped under a generic "json" bucket — they normally unwrap to native
+/// `Value`s at the access boundary, but this stays exhaustive in case one
+/// reaches here directly (e.g. via `fromjson` on a bare scalar).
+pub(crate) fn type_name(value: &Value) -> &'static str {
+    match value {
+        Value::Null => "null",
+        Value::Bool(_) => "bool",
+        Value::Int(_) | Value::Float(_) => "number",
+        Value::String(_) => "string",
+        Value::Json(serde_json::Value::Array(_)) => "list",
+        Value::Json(serde_json::Value::Object(_)) => "record",
+        Value::Json(serde_json::Value::Null) => "null",
+        Value::Json(serde_json::Value::Bool(_)) => "bool",
+        Value::Json(serde_json::Value::Number(_)) => "number",
+        Value::Json(serde_json::Value::String(_)) => "string",
+        Value::Bytes(_) => "bytes",
+    }
+}
+
+#[async_trait]
+impl Tool for TypeOf {
+    fn name(&self) -> &str {
+        "typeof"
+    }
+
+    fn schema(&self) -> ToolSchema {
+        schema_from_clap(
+            &TypeOfArgs::command(),
+            "typeof",
+            "The value's type — list/record/string/number/bool/null/bytes (in .data)",
+            [
+                ("Assign the type name", "t=$(typeof $x)"),
+                (
+                    "Shape guard idiom",
+                    "if [[ -record $data ]]; then echo record; elif [[ -list $data ]]; then echo list; fi",
+                ),
+                (
+                    "Dispatch on shape",
+                    "case $(typeof $x) in\n  list) ... ;;\n  record) ... ;;\nesac",
+                ),
+            ],
+        )
+    }
+
+    async fn execute(&self, args: ToolArgs, ctx: &mut dyn ToolCtx) -> ExecResult {
+        let Some(ctx) = ctx.as_any_mut().downcast_mut::<ExecContext>() else {
+            return ExecResult::failure(1, "internal error: kernel builtin requires ExecContext");
+        };
+        let parsed = match TypeOfArgs::try_parse_from(
+            std::iter::once("typeof".to_string()).chain(args.to_argv()),
+        ) {
+            Ok(p) => p,
+            Err(e) => return ExecResult::failure(2, format!("typeof: {e}")),
+        };
+        parsed.global.apply(ctx);
+
+        match args.positional.first() {
+            Some(value) => {
+                let name = type_name(value);
+                ExecResult::success_with_data(name, Value::String(name.to_string()))
+            }
+            None => ExecResult::failure(1, "typeof: no argument (expected a value)"),
+        }
+    }
+}

--- a/crates/kaish-kernel/tests/collection_access_tests.rs
+++ b/crates/kaish-kernel/tests/collection_access_tests.rs
@@ -848,26 +848,21 @@ async fn record_test_operator_false_on_a_scalar() {
 }
 
 #[tokio::test]
-async fn list_test_operator_false_on_unset_variable_no_error() {
-    // Shape guard never errors on type — false, same as `-f` on a
-    // nonexistent path. Deliberately diverges from `-z`/`-n`, which DO error
-    // on a bare unset `$var` (kaish's general strict-unset-variable rule) —
-    // the shape guard exists precisely so a caller can probe an unknown
-    // shape without pre-checking `-n`/`-z` first.
+async fn list_test_operator_on_unset_variable_is_a_loud_error() {
+    // A bare `$unset` is an undefined-variable error, consistent with every
+    // other bare-`$x` operator (`-z $unset` errors too) — a typo'd variable
+    // must not read as a silent `false`. A defined-but-wrong-shaped value is
+    // false; only *absence* is loud. The guard is used bare (`[[ -list $data ]]`).
     let k = setup().await;
-    let (out, code, err) =
-        run(&k, "if [[ -list $unset ]]; then echo T; else echo F; fi").await;
-    assert_eq!(code, 0, "err: {err}");
-    assert_eq!(out, "F");
+    let result = k.execute("if [[ -list $unset ]]; then echo T; fi").await;
+    assert!(result.is_err(), "-list on an unset variable must be a loud error");
 }
 
 #[tokio::test]
-async fn record_test_operator_false_on_unset_variable_no_error() {
+async fn record_test_operator_on_unset_variable_is_a_loud_error() {
     let k = setup().await;
-    let (out, code, err) =
-        run(&k, "if [[ -record $unset ]]; then echo T; else echo F; fi").await;
-    assert_eq!(code, 0, "err: {err}");
-    assert_eq!(out, "F");
+    let result = k.execute("if [[ -record $unset ]]; then echo T; fi").await;
+    assert!(result.is_err(), "-record on an unset variable must be a loud error");
 }
 
 #[tokio::test]

--- a/crates/kaish-kernel/tests/collection_access_tests.rs
+++ b/crates/kaish-kernel/tests/collection_access_tests.rs
@@ -678,3 +678,225 @@ async fn membership_bool_element() {
     assert_eq!(code, 0, "err: {err}");
     assert_eq!(out, "yes");
 }
+
+// ── Shape guard: `typeof` / `[[ -list ]]` / `[[ -record ]]` ────────────────
+// See docs/arrays-and-hashes.md, decision F: the antidote to the
+// keys-on-list footgun and the API-shape-variance trap (Teaching note #12).
+
+#[tokio::test]
+async fn typeof_on_a_list() {
+    let k = setup().await;
+    let (out, code, err) = run(&k, r#"x=$(fromjson '[1,2,3]'); typeof $x"#).await;
+    assert_eq!(code, 0, "err: {err}");
+    assert_eq!(out, "list");
+}
+
+#[tokio::test]
+async fn typeof_on_a_record() {
+    let k = setup().await;
+    let (out, code, err) = run(&k, r#"x=$(fromjson '{"a":1}'); typeof $x"#).await;
+    assert_eq!(code, 0, "err: {err}");
+    assert_eq!(out, "record");
+}
+
+#[tokio::test]
+async fn typeof_on_a_string() {
+    let k = setup().await;
+    let (out, code, err) = run(&k, "x=hello; typeof $x").await;
+    assert_eq!(code, 0, "err: {err}");
+    assert_eq!(out, "string");
+}
+
+#[tokio::test]
+async fn typeof_on_a_number() {
+    // No int/float split — both are "number" (jq/JSON have one numeric type).
+    let k = setup().await;
+    let (out_int, code_int, err_int) = run(&k, "x=5; typeof $x").await;
+    assert_eq!(code_int, 0, "err: {err_int}");
+    assert_eq!(out_int, "number");
+
+    let (out_float, code_float, err_float) = run(&k, "x=3.14; typeof $x").await;
+    assert_eq!(code_float, 0, "err: {err_float}");
+    assert_eq!(out_float, "number");
+}
+
+#[tokio::test]
+async fn typeof_on_a_bool() {
+    let k = setup().await;
+    let (out, code, err) = run(&k, "x=true; typeof $x").await;
+    assert_eq!(code, 0, "err: {err}");
+    assert_eq!(out, "bool");
+}
+
+#[tokio::test]
+async fn typeof_on_null() {
+    let k = setup().await;
+    let (out, code, err) = run(&k, r#"x=$(fromjson 'null'); typeof $x"#).await;
+    assert_eq!(code, 0, "err: {err}");
+    assert_eq!(out, "null");
+}
+
+#[tokio::test]
+async fn typeof_on_bytes() {
+    // xxd -r produces a raw Value::Bytes with no VFS/subprocess involved —
+    // safe under the isolated (NoLocal) kernel config.
+    let k = setup().await;
+    let (out, code, err) = run(&k, "x=$(echo ff | xxd -r -p); typeof $x").await;
+    assert_eq!(code, 0, "err: {err}");
+    assert_eq!(out, "bytes");
+}
+
+#[tokio::test]
+async fn typeof_no_argument_is_a_loud_error() {
+    let k = setup().await;
+    let (_, code, err) = run(&k, "typeof").await;
+    assert_ne!(code, 0, "typeof with no argument must be an error");
+    assert!(err.contains("no argument"), "got: {err}");
+}
+
+#[tokio::test]
+async fn typeof_in_a_case_statement() {
+    let k = setup().await;
+    let (out, code, err) = run(
+        &k,
+        r#"x=$(fromjson '[1,2,3]'); case $(typeof $x) in
+  list) echo "it's a list" ;;
+  record) echo "it's a record" ;;
+  *) echo "other" ;;
+esac"#,
+    )
+    .await;
+    assert_eq!(code, 0, "err: {err}");
+    assert_eq!(out, "it's a list");
+}
+
+#[tokio::test]
+async fn typeof_json_output() {
+    let k = setup().await;
+    let r = k
+        .execute(r#"x=$(fromjson '[1,2,3]'); typeof $x --json"#)
+        .await
+        .expect("kernel execute");
+    assert_eq!(r.code, 0, "err: {}", r.err);
+    // --json wraps the plain type name as a JSON string, not double-encoded.
+    assert_eq!(r.text_out().trim(), "\"list\"");
+}
+
+#[tokio::test]
+async fn list_test_operator_true_on_a_list() {
+    let k = setup().await;
+    let (out, code, err) = run(
+        &k,
+        r#"x=$(fromjson '[1,2,3]'); if [[ -list $x ]]; then echo T; else echo F; fi"#,
+    )
+    .await;
+    assert_eq!(code, 0, "err: {err}");
+    assert_eq!(out, "T");
+}
+
+#[tokio::test]
+async fn list_test_operator_false_on_a_record() {
+    let k = setup().await;
+    let (out, code, err) = run(
+        &k,
+        r#"x=$(fromjson '{"a":1}'); if [[ -list $x ]]; then echo T; else echo F; fi"#,
+    )
+    .await;
+    assert_eq!(code, 0, "err: {err}");
+    assert_eq!(out, "F");
+}
+
+#[tokio::test]
+async fn record_test_operator_true_on_a_record() {
+    let k = setup().await;
+    let (out, code, err) = run(
+        &k,
+        r#"x=$(fromjson '{"a":1}'); if [[ -record $x ]]; then echo T; else echo F; fi"#,
+    )
+    .await;
+    assert_eq!(code, 0, "err: {err}");
+    assert_eq!(out, "T");
+}
+
+#[tokio::test]
+async fn record_test_operator_false_on_a_list() {
+    let k = setup().await;
+    let (out, code, err) = run(
+        &k,
+        r#"x=$(fromjson '[1,2,3]'); if [[ -record $x ]]; then echo T; else echo F; fi"#,
+    )
+    .await;
+    assert_eq!(code, 0, "err: {err}");
+    assert_eq!(out, "F");
+}
+
+#[tokio::test]
+async fn list_test_operator_false_on_a_scalar() {
+    let k = setup().await;
+    let (out, code, err) = run(&k, "x=hello; if [[ -list $x ]]; then echo T; else echo F; fi").await;
+    assert_eq!(code, 0, "err: {err}");
+    assert_eq!(out, "F");
+}
+
+#[tokio::test]
+async fn record_test_operator_false_on_a_scalar() {
+    let k = setup().await;
+    let (out, code, err) =
+        run(&k, "x=hello; if [[ -record $x ]]; then echo T; else echo F; fi").await;
+    assert_eq!(code, 0, "err: {err}");
+    assert_eq!(out, "F");
+}
+
+#[tokio::test]
+async fn list_test_operator_false_on_unset_variable_no_error() {
+    // Shape guard never errors on type — false, same as `-f` on a
+    // nonexistent path. Deliberately diverges from `-z`/`-n`, which DO error
+    // on a bare unset `$var` (kaish's general strict-unset-variable rule) —
+    // the shape guard exists precisely so a caller can probe an unknown
+    // shape without pre-checking `-n`/`-z` first.
+    let k = setup().await;
+    let (out, code, err) =
+        run(&k, "if [[ -list $unset ]]; then echo T; else echo F; fi").await;
+    assert_eq!(code, 0, "err: {err}");
+    assert_eq!(out, "F");
+}
+
+#[tokio::test]
+async fn record_test_operator_false_on_unset_variable_no_error() {
+    let k = setup().await;
+    let (out, code, err) =
+        run(&k, "if [[ -record $unset ]]; then echo T; else echo F; fi").await;
+    assert_eq!(code, 0, "err: {err}");
+    assert_eq!(out, "F");
+}
+
+#[tokio::test]
+async fn shape_guard_idiom_end_to_end() {
+    // The documented guard idiom: check the shape before committing to
+    // `keys`/`values`/a `for` loop — the antidote to an API call that
+    // sometimes returns a list and sometimes returns a single record.
+    let k = setup().await;
+    let script = r#"
+data=$(fromjson '{"a":1,"b":2}')
+if [[ -record $data ]]; then
+  for k in $(keys $data); do echo "key:$k"; done
+elif [[ -list $data ]]; then
+  for x in $(values $data); do echo "val:$x"; done
+fi
+"#;
+    let (out, code, err) = run(&k, script).await;
+    assert_eq!(code, 0, "err: {err}");
+    assert_eq!(out, "key:a\nkey:b");
+
+    let script_list = r#"
+data=$(fromjson '["x","y"]')
+if [[ -record $data ]]; then
+  for k in $(keys $data); do echo "key:$k"; done
+elif [[ -list $data ]]; then
+  for x in $(values $data); do echo "val:$x"; done
+fi
+"#;
+    let (out_list, code_list, err_list) = run(&k, script_list).await;
+    assert_eq!(code_list, 0, "err: {err_list}");
+    assert_eq!(out_list, "val:x\nval:y");
+}

--- a/crates/kaish-kernel/tests/json_sweep_tests.rs
+++ b/crates/kaish-kernel/tests/json_sweep_tests.rs
@@ -175,6 +175,7 @@ const CASES: &[Case] = &[
     Case { name: "tr", setup: &[], cmd: "printf 'abc' | tr a x --json", expect: Expect::String },
     Case { name: "tree", setup: &[], cmd: "tree src --json", expect: Expect::Object },
     Case { name: "true", setup: &[], cmd: "true --json", expect: Expect::Empty },
+    Case { name: "typeof", setup: &["x=$(fromjson '[1,2,3]')"], cmd: "typeof $x --json", expect: Expect::String },
     Case { name: "unalias", setup: &["alias g=grep"], cmd: "unalias g --json", expect: Expect::Empty },
     Case { name: "uname", setup: &[], cmd: "uname --json", expect: Expect::String },
     Case { name: "uniq", setup: &[], cmd: r#"printf 'a\na\nb\n' | uniq --json"#, expect: Expect::String },

--- a/crates/kaish-kernel/tests/parser_tests.rs
+++ b/crates/kaish-kernel/tests/parser_tests.rs
@@ -468,6 +468,16 @@ fn parser_test_string_nonempty() {
 }
 
 #[test]
+fn parser_test_shape_guard_list() {
+    parse_and_snapshot("test_shape_guard_list", "[[ -list $x ]]");
+}
+
+#[test]
+fn parser_test_shape_guard_record() {
+    parse_and_snapshot("test_shape_guard_record", "[[ -record $x ]]");
+}
+
+#[test]
 fn parser_test_comparison_eq() {
     parse_and_snapshot("test_comparison_eq", r#"[[ $X == "value" ]]"#);
 }

--- a/crates/kaish-kernel/tests/snapshots/parser_tests__test_shape_guard_list.snap
+++ b/crates/kaish-kernel/tests/snapshots/parser_tests__test_shape_guard_list.snap
@@ -1,0 +1,5 @@
+---
+source: crates/kaish-kernel/tests/parser_tests.rs
+expression: sexpr
+---
+(test (string -list (varref x)))

--- a/crates/kaish-kernel/tests/snapshots/parser_tests__test_shape_guard_record.snap
+++ b/crates/kaish-kernel/tests/snapshots/parser_tests__test_shape_guard_record.snap
@@ -1,0 +1,5 @@
+---
+source: crates/kaish-kernel/tests/parser_tests.rs
+expression: sexpr
+---
+(test (string -record (varref x)))

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -137,6 +137,31 @@ Element equality uses the same rule as `==` (a numeric bareword matches a JSON
 number). Comparing a whole collection to a scalar with `==`/`!=` is a loud error
 — test membership with `in`, or compare structures with `jq`.
 
+### Shape guards — `typeof` / `[[ -list ]]` / `[[ -record ]]`
+
+An API call sometimes returns a list, sometimes a single record — the shape
+guard is the antidote: check the shape *before* committing to `keys`/`values`
+or a `for` loop over it.
+
+```sh
+typeof $x            # "list" | "record" | "string" | "number" | "bool" | "null" | "bytes"
+t=$(typeof $x)        # capture the type name
+[[ -list $x ]]        # true iff $x is a list
+[[ -record $x ]]      # true iff $x is a record
+
+# The guard idiom:
+if [[ -record $data ]]; then
+  for k in $(keys $data); do echo "$k = ${data[$k]}"; done
+elif [[ -list $data ]]; then
+  for x in $(values $data); do echo $x; done
+fi
+```
+
+`typeof` never splits int/float — both are `number`, matching jq/JSON's single
+numeric type. `[[ -list ]]` / `[[ -record ]]` evaluate the operand's *value*
+(like `-z`/`-n`), not a path stat (unlike `-f`/`-d`), and never error on an
+unset variable or the wrong shape — false, same as `-f` on a nonexistent path.
+
 ### Crossing the boundary
 
 A collection **displays** as compact JSON (`echo $xs` → `[10,20,30]`), but it
@@ -293,6 +318,12 @@ mkdir /tmp/work && cd /tmp/work && echo "ready"
 # String tests
 [[ -z $VAR ]]                   # empty
 [[ -n $VAR ]]                   # non-empty
+
+# Shape guards — see "Collections" → "Shape guards" above
+[[ -list $x ]]                  # is a native list
+[[ -record $x ]]                # is a native record
+# Value-typed like -z/-n (not a path stat like -f/-d); never errors on an
+# unset variable or the wrong shape — false, same as -f on a missing path.
 
 # Comparisons
 [[ $X == "value" ]]             # equality

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -159,8 +159,11 @@ fi
 
 `typeof` never splits int/float — both are `number`, matching jq/JSON's single
 numeric type. `[[ -list ]]` / `[[ -record ]]` evaluate the operand's *value*
-(like `-z`/`-n`), not a path stat (unlike `-f`/`-d`), and never error on an
-unset variable or the wrong shape — false, same as `-f` on a nonexistent path.
+(like `-z`/`-n`), not a path stat (unlike `-f`/`-d`). A defined-but-wrong-shaped
+value is false; a bare unset `$var` is an undefined-variable error (like
+`-z`/`-n`), so a typo doesn't read as a silent false. Use them bare
+(`[[ -list $data ]]`) — a quoted `"$data"` would test the collection's JSON
+*string*, not its value.
 
 ### Crossing the boundary
 
@@ -322,8 +325,8 @@ mkdir /tmp/work && cd /tmp/work && echo "ready"
 # Shape guards — see "Collections" → "Shape guards" above
 [[ -list $x ]]                  # is a native list
 [[ -record $x ]]                # is a native record
-# Value-typed like -z/-n (not a path stat like -f/-d); never errors on an
-# unset variable or the wrong shape — false, same as -f on a missing path.
+# Value-typed like -z/-n (not a path stat like -f/-d). Wrong shape → false;
+# a bare unset $var errors (like -z), so a typo isn't silently false.
 
 # Comparisons
 [[ $X == "value" ]]             # equality

--- a/docs/arrays-and-hashes.md
+++ b/docs/arrays-and-hashes.md
@@ -452,8 +452,9 @@ for the record.
     `[[ -record $x ]]`. The antidote to the keys-on-list footgun and the
     API-shape-variance trap (Teaching note #12). `typeof` is a pure-data builtin
     (`.data` + text out); the two test operators evaluate the operand's value
-    (like `-z`/`-n`, not a path stat like `-f`/`-d`) and never error on an unset
-    variable or the wrong shape — false, same as `-f` on a nonexistent path.
+    (like `-z`/`-n`, not a path stat like `-f`/`-d`). A defined-but-wrong-shaped
+    value is false; a bare unset `$var` is an undefined-variable error (like
+    `-z`/`-n`) so a typo isn't silently false. Use them bare.
 
 - **Commas optional in BOTH lists and records.** `[1 2 3]` ≡ `[1, 2, 3]`; `{a: 1, b: 2}` ≡
   `{a: 1 b: 2}`. Records were shown comma-separated and lists space-separated, which would make

--- a/docs/arrays-and-hashes.md
+++ b/docs/arrays-and-hashes.md
@@ -447,11 +447,13 @@ for the record.
     `=~`, `!~`, `-eq`/`-gt`/`-lt`/…, and ordering `<`/`>`. Decided as a matrix so no operator falls
     to a stringify path one at a time. (`==`/`!=` already loud; membership `in` is the *only* op
     that takes a collection RHS.)
-  - **(F) Ship a shape guard in the near term:** `typeof $x` (→ `list`/`record`/`string`/`number`/
-    `bool`/`null`/`bytes`) and/or `[[ -list $x ]]` / `[[ -record $x ]]`. It's the antidote to the
-    keys-on-list footgun and the API-shape-variance trap (Teaching note #12) — and "if it bites" is
-    too late, because the guard idiom won't exist to teach. Promote from "Out of scope" into the
-    first post-#6 cut.
+  - **(F) Ship a shape guard.** *(Resolved — shipped.)* `typeof $x` (→
+    `list`/`record`/`string`/`number`/`bool`/`null`/`bytes`) and `[[ -list $x ]]` /
+    `[[ -record $x ]]`. The antidote to the keys-on-list footgun and the
+    API-shape-variance trap (Teaching note #12). `typeof` is a pure-data builtin
+    (`.data` + text out); the two test operators evaluate the operand's value
+    (like `-z`/`-n`, not a path stat like `-f`/`-d`) and never error on an unset
+    variable or the wrong shape — false, same as `-f` on a nonexistent path.
 
 - **Commas optional in BOTH lists and records.** `[1 2 3]` ≡ `[1, 2, 3]`; `{a: 1, b: 2}` ≡
   `{a: 1 b: 2}`. Records were shown comma-separated and lists space-separated, which would make
@@ -792,9 +794,9 @@ taught a specific way** — get the examples wrong and even capable models fail.
     to the shipped idiom: `for x in $(values $data)` on a record yields the record's *field
     values* instead of iterating the one object. Still a silent type cascade, not an error. So
     the mitigation stands and is now more load-bearing: the docs must show a shape guard where
-    data shape isn't trusted, and a shape predicate (`typeof` / `[[ -list ]]` / `[[ -record ]]`)
-    should be promoted from "Out of scope if it bites" into the first cut — API-shape variance is
-    core agent work, and by the time it bites the guard idiom won't exist to teach.
+    data shape isn't trusted. *(Resolved — the shape predicate shipped: `typeof` /
+    `[[ -list ]]` / `[[ -record ]]`, decision F above. Docs cover the guard idiom in
+    `docs/LANGUAGE.md` "Shape guards" and the composable-help collections fragment.)*
 
 ## Help & teaching delivery
 
@@ -870,8 +872,6 @@ Points decided or flagged during the 2026-07-01 review:
 - **Slice lvalues** (`xs[0:2]=…`) — loud error, see lvalue rules. (`push` to a bracketed
   path IS in scope — see the push decision.)
 - Pair iteration (`for k v in $record`) — iterate keys, access values.
-- A shape/type predicate (`typeof` or `[[ -list / -record ]]`) — the missing guard for the
-  record-vs-list `for` trap (Teaching note #12); design if it bites in practice.
 - JSON ingress/egress builtins (`fromjson`/`tojson`) — sketched above and **prototyped
   early, ahead of the collections grammar** (they need no parser work); hard prerequisite
   for the jq-out-of-core possibility (see Open decisions).

--- a/docs/arrays-and-hashes.md
+++ b/docs/arrays-and-hashes.md
@@ -634,8 +634,10 @@ paths relative to `crates/kaish-kernel/src`).
   traversal + **scalar unwrap at the boundary**, slices, negative indices. Brackets-only means
   dotted segments in `${…}` become the targeted error path (with the bracket fix in the
   message), not a resolution path.
-- **Lvalues** touch five layers, but share the segment types and traversal skeleton with the
-  read side: (1) lexer — the glob-merge suppression before `=` above; (2) AST — `Assignment`
+- **Lvalues (the phase after #6)** touch five layers, but the navigation core is `walk_write` over
+  `&mut serde_json::Value` sharing #6's `resolve_step` verbatim (that sharing is the whole point of
+  #6 — read/write classification can't drift): (1) lexer — the glob-merge suppression before `=`
+  above; (2) AST — `Assignment`
   grows from `name: String` to an lvalue (root + segments); (3) parser — an `lvalue_parser`
   wired into `assignment_parser` (`parser.rs:1028-1058`) and `env_prefix_assign`
   (`parser.rs:952-970`, which must *reject* path lvalues); (4) interpreter — clone root, navigate
@@ -677,29 +679,59 @@ paths relative to `crates/kaish-kernel/src`).
   `cmd.env(...)` at both spawn sites (`kernel.rs::try_execute_external`, test-only twin
   `dispatch.rs::try_external` — the hermetic two-spawn-site rule). `export.rs` declaration-time
   display was deliberately left as-is (the process edge is the boundary that matters).
-- **Two-phase bind/walk resolver (the load-bearing extraction the write side needs).** *(Flagged
-  by the 2026-07-02 review as the single most important thing before the grammar; NOT yet done —
-  design with Amy first.)* Today `Scope::apply_segment` fuses three jobs — classify a segment
-  against the container (index-vs-key, negative-index normalization, every loud message), walk one
-  hop, and unwrap the child via `json_to_value_no_envelope` (cloning each subtree, so
-  `for k in $(keys $u); do … ${u[$k]}` is O(n²)). The lvalue navigator needs `&mut` serde-tree navigation and
-  can't reuse that walker, so building it separately duplicates the classification logic under
-  `&mut` — and read/write then drift on exactly the semantics that must never drift (`${a[-1]}`
-  read vs `a[-1]=x` write). Proposed split: **Bind** `(VarPath, &Scope) → Result<Vec<ConcreteStep>,
-  PathError>` (owns `value_as_index`, negative math, and every message; `arithmetic.rs` stops
-  hand-collecting brackets and calls this — fixing the quoted-key whitespace bug for free) + a
-  **Walk** over `&serde_json::Value` (unwrap at leaf only) with a later `&mut` twin sharing Bind
-  verbatim. Converting `VarLength`/`VarWithDefault` to carry a `VarPath` (root of the deferred
-  nested-length / default-on-path forms above) folds in here — and `Bind` is where the
-  **absence-vs-shape error classification** lives that `${path:-default}` needs. **Decided
-  (2026-07-02): `PathError` becomes three variants** — `UndefinedRoot` (unchanged, soft) ·
-  **`Absence`** (missing key, out-of-bounds index) · **`Shape`** (string key on a list, integer
-  index on a record, subscript-on-scalar). `${path:-default}` catches `UndefinedRoot` + `Absence`
-  and yields the default; `Shape` always stays loud (a wrong-type access is a bug, not an absence).
-  Empty-value → default is a *post*-resolution check (the path resolved fine, the value's just
-  empty — bash semantics), not a `PathError`. `Bind` returns the classified error. Deep-path error
-  messages should thread the traversed prefix (today `${services[web][prot]}` errors as the
-  fabricated flat `${services[prot]}`), which is free once Bind owns the path.
+### #6 — the shared per-hop resolver (design settled 2026-07-02)
+
+*The single most important thing before the literal/lvalue grammar. This is a read-side refactor
+that also unblocks the deferred `${#path}` / `${path:-default}` forms and arithmetic subscripts;
+lvalue **writes** are the phase after, but the resolver is shaped so they slot in.*
+
+**The problem.** Today `Scope::apply_segment` (`scope.rs:519`) fuses three jobs per hop — classify
+a segment against the container (index-vs-key, negative-index normalization, every loud message),
+walk one hop, and unwrap the child via `json_to_value_no_envelope(subtree.clone())` (the clone
+makes `for k in $(keys $u); do … ${u[$k]}` O(n²)). The lvalue navigator needs `&mut` serde-tree
+navigation and can't reuse that walker; built separately it would duplicate the classification
+logic under `&mut`, and read/write would drift on exactly the semantics that must never drift
+(`${a[-1]}` read vs `a[-1]=x` write).
+
+**The seam — a shared per-hop resolver, NOT a two-pass Bind→Walk.** The earlier "Bind
+`(VarPath,&Scope)→Vec<ConcreteStep>` then Walk" framing is wrong: classification is
+**container-dependent** — index-vs-key, negative-index normalization, and slice bounds all need the
+container *at that hop* (see the `Dynamic` arm at `scope.rs:551`, which inspects Array-vs-Object to
+decide index-vs-key). Only `$k`→value is Scope-only. So the shared unit is a **per-hop**
+`resolve_step(&container, segment, &scope) -> Result<Step, PathError>` where `Step` is a concrete
+`Index(usize)` / `Key(String)` / `Slice(range)` produced *after* seeing the container. Both a
+`walk_read(&serde_json::Value)` and (next phase) a `walk_write(&mut serde_json::Value)` call the
+same `resolve_step`; they differ **only** in `&` vs `&mut` descent and leaf handling. All the
+classification, negative math, and every error message live in `resolve_step`, once — which is what
+guarantees read and write can't diverge.
+
+**Decisions (all settled 2026-07-02):**
+- **Arithmetic bareword classification → parse-time.** `$(( xs[i] ))` reads variable `i`;
+  `${xs[i]}` is the literal key `"i"`. Resolved at PARSE time, per context: the arithmetic parser
+  emits a *variable* subscript segment, the interpolation parser a *key* segment, so `resolve_step`
+  stays context-free (no context flag threaded through). `arithmetic.rs` stops hand-collecting
+  brackets (also killing the quoted-key whitespace bug).
+- **`PathError` → three variants.** `UndefinedRoot` (soft in strings, loud in expr) · **`Absence`**
+  (missing key, out-of-bounds) · **`Shape`** (string-key-on-list, integer-index-on-record,
+  subscript-a-scalar, dotted-access). `${path:-default}` catches `UndefinedRoot` + `Absence` and
+  yields the default; `Shape` always stays loud (a wrong-type access is a bug, not absence).
+  Empty-string/`null` → default is a *post*-resolution check, not a `PathError`. **An unset dynamic
+  key** (`${r[$k]}` with `$k` itself unset) is `UndefinedRoot`-class — so `${r[$k]:-d}` defaults
+  when `$k` is unset (the *variable* is missing, not the key).
+- **`VarLength` / `VarWithDefault` → carry a `VarPath`.** AST change + the parser builds the path +
+  **widen the lexer `VarLength` regex** (`\$\{#[a-zA-Z_]\w*\}` → accept brackets) so `${#u[tags]}`
+  lexes in expression position, not just inside strings. This is what turns the current loud "bind
+  first" placeholders (`${#u[tags]}`, `${cfg[port]:-8080}`) into working path-aware forms.
+- **Scope of #6 = read side + deferred forms.** Lands: the shared `resolve_step` + `walk_read`, the
+  `VarPath` conversion, arithmetic subscripts, the `PathError` split, and full-path-prefix error
+  messages (`${services[web][prot]}` names the real path, free once the walker owns the path).
+  **Does NOT land lvalue writes** (`a[b]=x` grammar + `walk_write` + validator root-binding) — that
+  is the next phase, and `resolve_step` is designed to be its shared core.
+
+**Technical risk to prototype early:** `walk_read` returns a `&serde_json::Value` borrowed from the
+`Scope` read-guard, unwrapping to owned only at the leaf (this is what removes the O(n²) clone). The
+borrow must complete within the `RwLock` guard's lifetime — validate that borrow shape before
+building out.
 - **`...` spread**: new lexer token; no existing `..`/`...` handling to collide with. Scope it
   to `[ ]` value context only.
 


### PR DESCRIPTION
Decision **F** from the collections review: a shape guard, so agents can check a value's type before committing to `keys`/`values`/a `for` loop — the antidote to the "API sometimes returns an object instead of a list" trap (Teaching note #12).

## What

- **`typeof $x`** → the value's type as text + `.data` string: `list`, `record`, `string`, `number` (Int or Float — no split, matching JSON), `bool`, `null`, `bytes`. So `case $(typeof $x) in …`, `t=$(typeof $x)`, and `[[ $(typeof $x) == list ]]` all work. No-arg is a loud error. Pure-data (every capability build).
- **`[[ -list $x ]]` / `[[ -record $x ]]`** — value-type tests (evaluate the operand's value like `-z`/`-n`, not a path stat like `-f`/`-d`). A defined-but-wrong-shaped value is `false`.

```sh
if   [[ -record $data ]]; then handle_one $data
elif [[ -list $data ]];   then for x in $(values $data); do handle_one $x; done
fi
```

## One design decision worth your eye

The spec I handed the subagent said `[[ -list $unset ]]` should be `false`, "mirroring `-z`/`-n`." **That premise was wrong** — a bare `$unset` in `-z $unset` actually hard-errors (kaish's strict-undefined-variable rule). So I changed the shape guards to be **consistent with every other bare-`$x` operator: a defined-but-wrong-shaped value is `false`, but a bare unset `$var` is a loud undefined-variable error.** A typo'd variable reading as a silent "not a list" is exactly the silent-trap the shell exists to avoid, and the guard's real use (`[[ -list $data ]]` on an API result) always has the var set. Used bare — a quoted `"$data"` would test the collection's JSON *string*, not its value.

## Tests / docs

- 21 kernel-routed tests (typeof per shape + no-arg loud; `-list`/`-record` true/false/unset-error; the guard idiom end-to-end; `case`; `--json`) + 2 parser snapshots + the json_sweep drift case.
- CHANGELOG, LANGUAGE.md (Collections "Shape guards" + Test Expressions), help fragments (regenerated `syntax.md`, `sh` fences), README JSON row, arrays-and-hashes.md decision-F marked shipped.
- `cargo test --all` + `clippy --all --all-targets` + `insta --check` green; verified in the binary.

Built by a Sonnet subagent; unset-semantics correction + doc fixes by me. kaibo (deepseek) review running; findings folded before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Also folded in
- `docs/arrays-and-hashes.md`: recorded the **#6 shared per-hop resolver** design settled with Amy (corrects the earlier Bind→Walk framing; the four locked decisions — parse-time arithmetic classification, `PathError` three-variant, `VarLength`/`VarWithDefault`→`VarPath` + lexer widening, read-side scope with lvalue-write as the next phase). Doc-only; no code.
