### PR TITLE
feat(#6): shared per-hop path resolver — read side (PathError split, path-aware ${#…}/${…:-…}, arithmetic subscripts)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,21 @@ breaking entries are marked **BREAKING**.
   defined-but-wrong-shaped value is `false`; a bare unset `$var` is an
   undefined-variable error (like `-z`/`-n`), so a typo isn't silently false.
   `typeof` is pure data, present in every capability build.
+- **Path-aware `${#…}` length and `${…:-default}`** — both now accept a
+  subscripted path: `${#u[tags]}` is the element/key count of the nested value,
+  and `${cfg[port]:-8080}` defaults on the resolved path. The default follows
+  decision A — it fires on **absence** (unset root, missing key, out-of-bounds
+  index) and on an empty value (JSON `null` or empty string), but never on a
+  falsy-but-present value (`false`, `0`, `[]`, `{}`); a **shape** error (integer
+  index on a record, string key on a list, subscripting a scalar, dotted access)
+  stays loud even with `:-`. These were a loud "bind it first" placeholder
+  before.
+- **Bare subscripts in arithmetic — `$(( xs[i] ))`** — inside `$(( … ))` a
+  bracket's contents are a numeric expression, so a bareword subscript is the
+  **variable** `i` (the opposite of the interpolation form `${xs[i]}`, a literal
+  key). `xs[0]`, `xs[i]`, `xs[i + 1]`, `xs[-1]`, and chained `grid[i][j]` all
+  work; an out-of-bounds index is loud. Previously a bare subscript was dropped
+  and failed as "variable is JSON, not a number".
 - **`json_to_value_no_envelope` (kaish-types)** — envelope-free JSON→`Value`
   conversion for external JSON, so byte-envelope-shaped objects are never
   silently decoded to `Value::Bytes`.
@@ -115,10 +130,14 @@ breaking entries are marked **BREAKING**.
     instead of the element/key count (`${#xs}` on a 3-element list gave `7`);
     `${#…}` on binary now counts bytes.
   - A negative slice *end* (`${xs[0:-1]}`) was misread as a `:-default` and
-    mangled to `1]`; the `:-` scanners are now subscript-aware. Length or default
-    on a *subscripted* path (`${#u[tags]}`, `${cfg[port]:-8080}`) — which silently
-    returned `0` / the default — is now a loud "bind it first" error pending full
-    path-aware support.
+    mangled to `1]`; the `:-` scanners are now subscript-aware. (Length and
+    default on a *subscripted* path — `${#u[tags]}`, `${cfg[port]:-8080}` — were
+    briefly a loud "bind it first" error; they are now fully path-aware, see
+    Added.)
+- **`${x:-default}` no longer treats JSON `null` as present** — a variable
+  holding `null` stringified to the non-empty `"null"`, so `${x:-fallback}`
+  returned `null` instead of the default. `:-` now fires on `null` and empty
+  string (decision A), while `false`/`0`/`[]`/`{}` stay present values.
 - **`--help`/`-h` now passes through to `with_owned_output()` tools** — the
   kernel's generic help router no longer intercepts it for tools that re-parse
   their own argv, so a leaf request like `tool subcmd --help` reaches the tool

--- a/crates/kaish-kernel/src/arithmetic.rs
+++ b/crates/kaish-kernel/src/arithmetic.rs
@@ -13,7 +13,7 @@
 //! - Assignment within expressions (confusing)
 
 use crate::interpreter::Scope;
-use crate::ast::Value;
+use crate::ast::{Value, VarPath, VarSegment};
 use anyhow::{bail, Context, Result};
 
 /// Evaluate an arithmetic expression string.
@@ -289,6 +289,10 @@ impl<'a> ArithParser<'a> {
             Some(c) if c.is_ascii_alphabetic() || c == '_' => {
                 // Bare variable name (bash allows this in $(( )))
                 let var_name = self.parse_identifier()?;
+                if self.peek() == Some('[') {
+                    // Bare subscript path `xs[i]` — decision B.
+                    return self.eval_bare_subscript_path(&var_name);
+                }
                 self.get_var_value(&var_name)
             }
             Some(c) => bail!("unexpected character in arithmetic expression: {:?}", c),
@@ -386,6 +390,38 @@ impl<'a> ArithParser<'a> {
         self.value_to_arith(&value, root)
     }
 
+    /// Resolve a BARE subscripted path in arithmetic (`xs[i]`, `xs[0]`,
+    /// `xs[i+1]`, `xs[-1]`) and coerce to an integer.
+    ///
+    /// Decision B: inside `$(( … ))` a bracket's contents are a numeric
+    /// expression, so a bareword subscript is the VARIABLE `i` (evaluated here),
+    /// NOT the literal key — the exact opposite of the interpolation form
+    /// `${xs[i]}`, which stays a literal key via `eval_braced_path`. Each
+    /// subscript is evaluated as a nested arithmetic expression to an integer
+    /// index; chained subscripts (`grid[i][j]`) walk left to right.
+    fn eval_bare_subscript_path(&mut self, root: &str) -> Result<i64> {
+        let mut segments = vec![VarSegment::Field(root.to_string())];
+        while self.peek() == Some('[') {
+            self.advance(); // consume '['
+            let index = self.parse_comparison()?; // the inner is a numeric expr
+            self.skip_whitespace();
+            if self.peek() != Some(']') {
+                bail!("expected ']' to close subscript in arithmetic");
+            }
+            self.advance(); // consume ']'
+            segments.push(VarSegment::Index(index));
+        }
+        let path = VarPath { segments };
+        let value = self.scope.resolve_path(&path).map_err(|e| match e {
+            crate::interpreter::PathError::UndefinedRoot(_) => {
+                anyhow::anyhow!("undefined variable in arithmetic: {root}")
+            }
+            crate::interpreter::PathError::Absence(msg)
+            | crate::interpreter::PathError::Shape(msg) => anyhow::anyhow!(msg),
+        })?;
+        self.value_to_arith(&value, root)
+    }
+
     /// Coerce a resolved value to an integer for arithmetic.
     fn value_to_arith(&self, value: &Value, name: &str) -> Result<i64> {
         match value {
@@ -425,6 +461,64 @@ mod tests {
         assert_eq!(eval("42"), 42);
         assert_eq!(eval("0"), 0);
         assert_eq!(eval("12345"), 12345);
+    }
+
+    // ── Decision B: a bare subscript in arithmetic is a numeric expression ──
+    // `$(( xs[i] ))` reads variable `i` (the opposite of `${xs[i]}`, a literal
+    // key). Each bracket's inner is evaluated arithmetically to an index.
+
+    fn eval_with_scope(expr: &str, setup: impl FnOnce(&mut Scope)) -> Result<i64> {
+        let mut scope = Scope::new();
+        setup(&mut scope);
+        eval_arithmetic(expr, &scope)
+    }
+
+    #[test]
+    fn bare_subscript_index_is_a_variable() {
+        // xs = [10, 20, 30]; i = 1  →  xs[i] == 20
+        let r = eval_with_scope("xs[i]", |s| {
+            s.set("xs", Value::Json(serde_json::json!([10, 20, 30])));
+            s.set("i", Value::Int(1));
+        })
+        .expect("bare xs[i] should resolve via variable i");
+        assert_eq!(r, 20);
+    }
+
+    #[test]
+    fn bare_subscript_literal_index() {
+        let r = eval_with_scope("xs[0] + 1", |s| {
+            s.set("xs", Value::Json(serde_json::json!([10, 20, 30])));
+        })
+        .expect("xs[0] + 1");
+        assert_eq!(r, 11);
+    }
+
+    #[test]
+    fn bare_subscript_inner_is_an_expression() {
+        // xs[i + 1] with i = 0  →  xs[1] == 20
+        let r = eval_with_scope("xs[i + 1]", |s| {
+            s.set("xs", Value::Json(serde_json::json!([10, 20, 30])));
+            s.set("i", Value::Int(0));
+        })
+        .expect("xs[i + 1]");
+        assert_eq!(r, 20);
+    }
+
+    #[test]
+    fn bare_subscript_negative_index() {
+        let r = eval_with_scope("xs[-1]", |s| {
+            s.set("xs", Value::Json(serde_json::json!([10, 20, 30])));
+        })
+        .expect("xs[-1]");
+        assert_eq!(r, 30);
+    }
+
+    #[test]
+    fn bare_subscript_out_of_bounds_is_loud() {
+        let r = eval_with_scope("xs[9]", |s| {
+            s.set("xs", Value::Json(serde_json::json!([10, 20])));
+        });
+        assert!(r.is_err(), "out-of-bounds index must be a loud error");
     }
 
     #[test]

--- a/crates/kaish-kernel/src/arithmetic.rs
+++ b/crates/kaish-kernel/src/arithmetic.rs
@@ -380,7 +380,8 @@ impl<'a> ArithParser<'a> {
             crate::interpreter::PathError::UndefinedRoot(_) => {
                 anyhow::anyhow!("undefined variable in arithmetic: {root}")
             }
-            crate::interpreter::PathError::Invalid(msg) => anyhow::anyhow!(msg),
+            crate::interpreter::PathError::Absence(msg)
+            | crate::interpreter::PathError::Shape(msg) => anyhow::anyhow!(msg),
         })?;
         self.value_to_arith(&value, root)
     }

--- a/crates/kaish-kernel/src/ast/sexpr.rs
+++ b/crates/kaish-kernel/src/ast/sexpr.rs
@@ -297,10 +297,10 @@ pub fn format_expr(expr: &Expr) -> String {
         Expr::Positional(n) => format!("(positional {})", n),
         Expr::AllArgs => "(all-args)".to_string(),
         Expr::ArgCount => "(arg-count)".to_string(),
-        Expr::VarLength(name) => format!("(var-length {})", name),
-        Expr::VarWithDefault { name, default } => {
+        Expr::VarLength(path) => format!("(var-length {})", format_varpath(path)),
+        Expr::VarWithDefault { path, default } => {
             let default_parts: Vec<String> = default.iter().map(format_string_part).collect();
-            format!("(var-default {} ({}))", name, default_parts.join(" "))
+            format!("(var-default {} ({}))", format_varpath(path), default_parts.join(" "))
         }
         Expr::Arithmetic(expr_str) => format!("(arithmetic \"{}\")", expr_str),
         Expr::Command(cmd) => format_command(cmd),
@@ -380,11 +380,11 @@ fn format_string_part(part: &StringPart) -> String {
     match part {
         StringPart::Literal(s) => format!("\"{}\"", escape_for_display(s)),
         StringPart::Var(path) => format!("(varref {})", format_varpath(path)),
-        StringPart::VarWithDefault { name, default } => {
+        StringPart::VarWithDefault { path, default } => {
             let default_parts: Vec<String> = default.iter().map(format_string_part).collect();
-            format!("(vardefault {} ({}))", name, default_parts.join(" "))
+            format!("(vardefault {} ({}))", format_varpath(path), default_parts.join(" "))
         }
-        StringPart::VarLength(name) => format!("(varlength {})", name),
+        StringPart::VarLength(path) => format!("(varlength {})", format_varpath(path)),
         StringPart::Positional(n) => format!("(positional {})", n),
         StringPart::AllArgs => "(allargs)".to_string(),
         StringPart::ArgCount => "(argcount)".to_string(),

--- a/crates/kaish-kernel/src/ast/types.rs
+++ b/crates/kaish-kernel/src/ast/types.rs
@@ -283,11 +283,13 @@ pub enum Expr {
     AllArgs,
     /// Argument count: `$#`
     ArgCount,
-    /// Variable string length: `${#VAR}`
-    VarLength(String),
-    /// Variable with default: `${VAR:-default}` - use default if VAR is unset or empty
-    /// The default can contain nested variable expansions and command substitutions
-    VarWithDefault { name: String, default: Vec<StringPart> },
+    /// Variable string length: `${#VAR}` or `${#path[sub]}`
+    VarLength(VarPath),
+    /// Variable with default: `${VAR:-default}` / `${path[sub]:-default}` — use
+    /// default if the path is absent (unset root, missing key, out-of-bounds) or
+    /// empty. The default can contain nested variable expansions and command
+    /// substitutions.
+    VarWithDefault { path: VarPath, default: Vec<StringPart> },
     /// Arithmetic expansion: `$((expr))` - evaluates to integer
     Arithmetic(String),
     /// Command as condition: `if grep -q pattern file; then` - exit code determines truthiness
@@ -446,10 +448,11 @@ pub enum StringPart {
     Literal(String),
     /// Variable interpolation: `${VAR}` or `$VAR`
     Var(VarPath),
-    /// Variable with default: `${VAR:-default}` where default can contain nested expansions
-    VarWithDefault { name: String, default: Vec<StringPart> },
-    /// Variable string length: `${#VAR}`
-    VarLength(String),
+    /// Variable with default: `${VAR:-default}` / `${path[sub]:-default}` where
+    /// default can contain nested expansions
+    VarWithDefault { path: VarPath, default: Vec<StringPart> },
+    /// Variable string length: `${#VAR}` or `${#path[sub]}`
+    VarLength(VarPath),
     /// Positional parameter: `$0`, `$1`, ..., `$9`
     Positional(usize),
     /// All arguments: `$@`

--- a/crates/kaish-kernel/src/interpreter.rs
+++ b/crates/kaish-kernel/src/interpreter.rs
@@ -37,6 +37,6 @@ mod result;
 mod scope;
 
 pub use control_flow::ControlFlow;
-pub use eval::{eval_expr, expand_tilde, name_is_subscripted, strip_leading_tabs, structured_export_error, subscripted_default_error, subscripted_length_error, value_to_bool, value_to_exit_code, value_length, value_to_string, value_to_string_with_tilde, EvalError, EvalResult, Evaluator, Executor, HeredocAssembler, NoOpExecutor};
+pub use eval::{eval_expr, expand_tilde, resolve_default, resolve_length, strip_leading_tabs, structured_export_error, value_defaults_on_emptiness, value_to_bool, value_to_exit_code, value_length, value_to_string, value_to_string_with_tilde, EvalError, EvalResult, Evaluator, Executor, HeredocAssembler, NoOpExecutor};
 pub use result::{apply_output_format, hex_dump, json_to_value, json_to_value_no_envelope, value_to_json, EntryType, ExecResult, LatchRequest, OutputData, OutputFormat, OutputNode, OutputPayload};
 pub use scope::{PathError, Scope};

--- a/crates/kaish-kernel/src/interpreter/eval.rs
+++ b/crates/kaish-kernel/src/interpreter/eval.rs
@@ -245,8 +245,8 @@ impl<'a, E: Executor> Evaluator<'a, E> {
             Expr::Positional(n) => self.eval_positional(*n),
             Expr::AllArgs => self.eval_all_args(),
             Expr::ArgCount => self.eval_arg_count(),
-            Expr::VarLength(name) => self.eval_var_length(name),
-            Expr::VarWithDefault { name, default } => self.eval_var_with_default(name, default),
+            Expr::VarLength(path) => self.eval_var_length(path),
+            Expr::VarWithDefault { path, default } => self.eval_var_with_default(path, default),
             Expr::Arithmetic(expr_str) => self.eval_arithmetic(expr_str),
             Expr::Command(cmd) => self.eval_command(cmd),
             Expr::LastExitCode => self.eval_last_exit_code(),
@@ -461,37 +461,20 @@ impl<'a, E: Executor> Evaluator<'a, E> {
         Ok(Value::Int(self.scope.arg_count() as i64))
     }
 
-    /// Evaluate variable string length (${#VAR}).
-    fn eval_var_length(&self, name: &str) -> EvalResult<Value> {
-        if name_is_subscripted(name) {
-            return Err(subscripted_length_error(name));
-        }
-        match self.scope.get(name) {
-            Some(value) => Ok(Value::Int(value_length(value))),
-            None => Ok(Value::Int(0)), // Unset variable has length 0
-        }
+    /// Evaluate variable string length (`${#VAR}` / `${#path[sub]}`).
+    fn eval_var_length(&self, path: &VarPath) -> EvalResult<Value> {
+        resolve_length(self.scope, path)
+            .map(Value::Int)
+            .map_err(EvalError::InvalidPath)
     }
 
-    /// Evaluate variable with default (${VAR:-default}).
-    /// Returns the variable value if set and non-empty, otherwise evaluates the default parts.
-    fn eval_var_with_default(&mut self, name: &str, default: &[StringPart]) -> EvalResult<Value> {
-        if name_is_subscripted(name) {
-            return Err(subscripted_default_error(name));
-        }
-        match self.scope.get(name) {
-            Some(value) => {
-                let s = value_to_string(value);
-                if s.is_empty() {
-                    // Variable is set but empty, evaluate the default parts
-                    self.eval_interpolated(default)
-                } else {
-                    Ok(value.clone())
-                }
-            }
-            None => {
-                // Variable is unset, evaluate the default parts
-                self.eval_interpolated(default)
-            }
+    /// Evaluate a variable/path with a default (`${VAR:-default}`).
+    /// Yields the value if present and non-empty; on absence or emptiness
+    /// evaluates the default parts; a shape error stays loud (decision A).
+    fn eval_var_with_default(&mut self, path: &VarPath, default: &[StringPart]) -> EvalResult<Value> {
+        match resolve_default(self.scope, path).map_err(EvalError::InvalidPath)? {
+            Some(value) => Ok(value),
+            None => self.eval_interpolated(default),
         }
     }
 
@@ -514,12 +497,12 @@ impl<'a, E: Executor> Evaluator<'a, E> {
                         }
                     }
                 }
-                StringPart::VarWithDefault { name, default } => {
-                    let value = self.eval_var_with_default(name, default)?;
+                StringPart::VarWithDefault { path, default } => {
+                    let value = self.eval_var_with_default(path, default)?;
                     result.push_str(&value_to_string(&value));
                 }
-                StringPart::VarLength(name) => {
-                    let value = self.eval_var_length(name)?;
+                StringPart::VarLength(path) => {
+                    let value = self.eval_var_length(path)?;
                     result.push_str(&value_to_string(&value));
                 }
                 StringPart::Positional(n) => {
@@ -635,29 +618,47 @@ pub fn value_length(value: &Value) -> i64 {
     }
 }
 
-/// A name inside `${#name}` or `${name:-default}` that carries a `[...]`
-/// subscript. Length-of-path and default-on-path aren't wired through the path
-/// resolver yet (they land with the collections lvalue/resolver work), so these
-/// forms take a bare-name lookup that misses the subscript. Detect it and fail
-/// loudly with a "bind first" hint instead of returning the silent wrong answer
-/// (`0` for length, always-default for defaults) they produced before.
-pub fn name_is_subscripted(name: &str) -> bool {
-    name.contains('[')
+/// Decision A: `${path:-default}` yields the default on *absence or emptiness*,
+/// never on falsy values. Fires for a JSON `null` and an empty string; NOT for
+/// `false`, `0`, an empty list `[]`, or an empty record `{}` — those are present
+/// values, and Python-style truthiness leaking into a shell would be a
+/// silent-wrong factory. (Unset roots and missing keys are absence too, but
+/// they surface as `PathError` before a value exists — see [`resolve_default`].)
+pub fn value_defaults_on_emptiness(value: &Value) -> bool {
+    match value {
+        Value::Null | Value::Json(serde_json::Value::Null) => true,
+        Value::String(s) => s.is_empty(),
+        _ => false,
+    }
 }
 
-/// Loud error for `${#path}` on a subscripted name (see [`name_is_subscripted`]).
-pub fn subscripted_length_error(name: &str) -> EvalError {
-    let root = name.split('[').next().unwrap_or(name);
-    EvalError::Unsupported(format!(
-        "${{#{name}}}: length of a subscripted path isn't supported yet — bind it first: `x=${{{name}}}; ${{#x}}` (root `{root}` alone works: `${{#{root}}}`)"
-    ))
+/// `${#path}` length semantics over the shared path resolver. An unset *root* is
+/// length 0 (bash parity for `${#unset}`); a missing key, out-of-bounds index,
+/// or shape error is loud (consistent with bare `${u[nope]}` being loud). The
+/// resolver borrows the tree — no whole-root clone.
+pub fn resolve_length(scope: &Scope, path: &VarPath) -> Result<i64, String> {
+    match scope.resolve_path(path) {
+        Ok(value) => Ok(value_length(&value)),
+        Err(super::scope::PathError::UndefinedRoot(_)) => Ok(0),
+        Err(super::scope::PathError::Absence(msg)) | Err(super::scope::PathError::Shape(msg)) => {
+            Err(msg)
+        }
+    }
 }
 
-/// Loud error for `${path:-default}` on a subscripted name (see [`name_is_subscripted`]).
-pub fn subscripted_default_error(name: &str) -> EvalError {
-    EvalError::Unsupported(format!(
-        "${{{name}:-…}}: a default on a subscripted path isn't supported yet — bind it first: `x=${{{name}}}; ${{x:-…}}`"
-    ))
+/// `${path:-default}` decision over the shared path resolver (decision A):
+/// `Ok(Some(v))` use the value, `Ok(None)` use the default (absence or
+/// emptiness), `Err(msg)` a loud shape error the default does NOT suppress. An
+/// unset root, a missing key, and an out-of-bounds index all fold into the
+/// default; only a wrong-shaped access shouts.
+pub fn resolve_default(scope: &Scope, path: &VarPath) -> Result<Option<Value>, String> {
+    match scope.resolve_path(path) {
+        Ok(value) if value_defaults_on_emptiness(&value) => Ok(None),
+        Ok(value) => Ok(Some(value)),
+        Err(super::scope::PathError::UndefinedRoot(_))
+        | Err(super::scope::PathError::Absence(_)) => Ok(None),
+        Err(super::scope::PathError::Shape(msg)) => Err(msg),
+    }
 }
 
 /// Reject exporting a structured value into an OS env var. A list/record can't
@@ -1557,7 +1558,7 @@ mod tests {
         let mut scope = Scope::new();
         scope.set("NAME", Value::String("hello".into()));
 
-        let expr = Expr::VarLength("NAME".into());
+        let expr = Expr::VarLength(VarPath::simple("NAME"));
         let result = eval_expr(&expr, &mut scope).unwrap();
         assert_eq!(result, Value::Int(5));
     }
@@ -1567,7 +1568,7 @@ mod tests {
         let mut scope = Scope::new();
         scope.set("EMPTY", Value::String("".into()));
 
-        let expr = Expr::VarLength("EMPTY".into());
+        let expr = Expr::VarLength(VarPath::simple("EMPTY"));
         let result = eval_expr(&expr, &mut scope).unwrap();
         assert_eq!(result, Value::Int(0));
     }
@@ -1577,7 +1578,7 @@ mod tests {
         let mut scope = Scope::new();
 
         // Unset variable has length 0
-        let expr = Expr::VarLength("MISSING".into());
+        let expr = Expr::VarLength(VarPath::simple("MISSING"));
         let result = eval_expr(&expr, &mut scope).unwrap();
         assert_eq!(result, Value::Int(0));
     }
@@ -1588,7 +1589,7 @@ mod tests {
         scope.set("NUM", Value::Int(12345));
 
         // Length of the string representation
-        let expr = Expr::VarLength("NUM".into());
+        let expr = Expr::VarLength(VarPath::simple("NUM"));
         let result = eval_expr(&expr, &mut scope).unwrap();
         assert_eq!(result, Value::Int(5)); // "12345" has length 5
     }
@@ -1600,7 +1601,7 @@ mod tests {
 
         // Variable is set, return its value
         let expr = Expr::VarWithDefault {
-            name: "NAME".into(),
+            path: VarPath::simple("NAME"),
             default: vec![StringPart::Literal("default".into())],
         };
         let result = eval_expr(&expr, &mut scope).unwrap();
@@ -1613,7 +1614,7 @@ mod tests {
 
         // Variable is unset, return default
         let expr = Expr::VarWithDefault {
-            name: "MISSING".into(),
+            path: VarPath::simple("MISSING"),
             default: vec![StringPart::Literal("fallback".into())],
         };
         let result = eval_expr(&expr, &mut scope).unwrap();
@@ -1627,7 +1628,7 @@ mod tests {
 
         // Variable is set but empty, return default
         let expr = Expr::VarWithDefault {
-            name: "EMPTY".into(),
+            path: VarPath::simple("EMPTY"),
             default: vec![StringPart::Literal("not empty".into())],
         };
         let result = eval_expr(&expr, &mut scope).unwrap();
@@ -1641,7 +1642,7 @@ mod tests {
 
         // Variable is set to a non-string value, return the value
         let expr = Expr::VarWithDefault {
-            name: "NUM".into(),
+            path: VarPath::simple("NUM"),
             default: vec![StringPart::Literal("default".into())],
         };
         let result = eval_expr(&expr, &mut scope).unwrap();
@@ -1741,22 +1742,64 @@ mod tests {
     }
 
     #[test]
-    fn subscripted_name_guards_fire() {
-        assert!(name_is_subscripted("u[tags]"));
-        assert!(!name_is_subscripted("plain"));
-        // The sync eval path surfaces the loud "bind first" error (not silent 0).
+    fn defaults_on_emptiness_matches_decision_a() {
+        // Default fires on absence/emptiness (null, empty string) — NEVER on a
+        // falsy-but-present value (false, 0, [], {}).
+        assert!(value_defaults_on_emptiness(&Value::Null));
+        assert!(value_defaults_on_emptiness(&Value::Json(serde_json::Value::Null)));
+        assert!(value_defaults_on_emptiness(&Value::String(String::new())));
+        assert!(!value_defaults_on_emptiness(&Value::Bool(false)));
+        assert!(!value_defaults_on_emptiness(&Value::Int(0)));
+        assert!(!value_defaults_on_emptiness(&Value::Json(serde_json::json!([]))));
+        assert!(!value_defaults_on_emptiness(&Value::Json(serde_json::json!({}))));
+        assert!(!value_defaults_on_emptiness(&Value::String("x".into())));
+    }
+
+    #[test]
+    fn subscripted_length_and_default_resolve_the_path() {
+        // Path-aware length and default via the shared resolver — the old
+        // placeholder "bind first" errors are gone; the forms now work.
         let mut scope = Scope::new();
-        let err = eval_expr(&Expr::VarLength("u[tags]".into()), &mut scope).unwrap_err();
-        assert!(matches!(err, EvalError::Unsupported(_)), "got: {err}");
-        // And the default-on-path form too.
-        let err = eval_expr(
+        scope.set("u", Value::Json(serde_json::json!({"tags": ["a", "b"]})));
+        let len = eval_expr(
+            &Expr::VarLength(crate::parser::parse_varpath("${u[tags]}")),
+            &mut scope,
+        )
+        .unwrap();
+        assert_eq!(len, Value::Int(2));
+
+        scope.set("cfg", Value::Json(serde_json::json!({"port": 9000})));
+        // A present value wins over the default.
+        let val = eval_expr(
             &Expr::VarWithDefault {
-                name: "cfg[port]".into(),
+                path: crate::parser::parse_varpath("${cfg[port]}"),
                 default: vec![StringPart::Literal("8080".into())],
             },
             &mut scope,
         )
+        .unwrap();
+        assert_eq!(value_to_string(&val), "9000");
+
+        // A missing key falls to the default (absence — decision A).
+        let missing = eval_expr(
+            &Expr::VarWithDefault {
+                path: crate::parser::parse_varpath("${cfg[nope]}"),
+                default: vec![StringPart::Literal("8080".into())],
+            },
+            &mut scope,
+        )
+        .unwrap();
+        assert_eq!(value_to_string(&missing), "8080");
+
+        // A shape error stays loud even with `:-` (an integer index on a record).
+        let err = eval_expr(
+            &Expr::VarWithDefault {
+                path: crate::parser::parse_varpath("${cfg[0]}"),
+                default: vec![StringPart::Literal("x".into())],
+            },
+            &mut scope,
+        )
         .unwrap_err();
-        assert!(matches!(err, EvalError::Unsupported(_)), "got: {err}");
+        assert!(matches!(err, EvalError::InvalidPath(_)), "got: {err}");
     }
 }

--- a/crates/kaish-kernel/src/interpreter/eval.rs
+++ b/crates/kaish-kernel/src/interpreter/eval.rs
@@ -433,8 +433,10 @@ impl<'a, E: Executor> Evaluator<'a, E> {
             Err(super::scope::PathError::UndefinedRoot(_)) => {
                 Err(EvalError::InvalidPath(format_path(path)))
             }
-            // A loud path error carries its own actionable message.
-            Err(super::scope::PathError::Invalid(msg)) => Err(EvalError::InvalidPath(msg)),
+            // A loud path error (absence or shape) carries its own actionable
+            // message.
+            Err(super::scope::PathError::Absence(msg))
+            | Err(super::scope::PathError::Shape(msg)) => Err(EvalError::InvalidPath(msg)),
         }
     }
 
@@ -504,8 +506,10 @@ impl<'a, E: Executor> Evaluator<'a, E> {
                         Ok(value) => result.push_str(&value_to_string(&value)),
                         // Unset variables expand to empty string (bash-compatible).
                         Err(super::scope::PathError::UndefinedRoot(_)) => {}
-                        // A loud path error is surfaced, never swallowed to empty.
-                        Err(super::scope::PathError::Invalid(msg)) => {
+                        // A loud path error (absence or shape) is surfaced, never
+                        // swallowed to empty.
+                        Err(super::scope::PathError::Absence(msg))
+                        | Err(super::scope::PathError::Shape(msg)) => {
                             return Err(EvalError::InvalidPath(msg))
                         }
                     }

--- a/crates/kaish-kernel/src/interpreter/scope.rs
+++ b/crates/kaish-kernel/src/interpreter/scope.rs
@@ -91,12 +91,12 @@ enum Step {
 /// error (keys are strings — the design's "integers index lists" rule). The
 /// container is a collection by [`resolve_step`]'s guard, so the scalar arm is
 /// unreachable.
-fn classify_index(json: &serde_json::Value, i: i64, root: &str) -> Result<Step, PathError> {
+fn classify_index(json: &serde_json::Value, i: i64, path: &str) -> Result<Step, PathError> {
     let arr = match json {
         serde_json::Value::Array(a) => a,
         serde_json::Value::Object(_) => {
             return Err(PathError::Shape(format!(
-                "${{{root}[{i}]}}: integer index on a record — record keys are strings, use ${{{root}[\"{i}\"]}}"
+                "${{{path}[{i}]}}: integer index on a record — record keys are strings, use ${{{path}[\"{i}\"]}}"
             )))
         }
         _ => unreachable!("resolve_step guards non-collection containers"),
@@ -105,7 +105,7 @@ fn classify_index(json: &serde_json::Value, i: i64, root: &str) -> Result<Step, 
     let idx = if i < 0 { len + i } else { i };
     if idx < 0 || idx >= len {
         return Err(PathError::Absence(format!(
-            "${{{root}[{i}]}}: index out of bounds (list length {len})"
+            "${{{path}[{i}]}}: index out of bounds (list length {len})"
         )));
     }
     Ok(Step::Index(idx as usize))
@@ -114,11 +114,11 @@ fn classify_index(json: &serde_json::Value, i: i64, root: &str) -> Result<Step, 
 /// Classify a record key against an object. A bareword/string key on a list is
 /// an error; key *presence* is checked when the step is applied ([`descend`]),
 /// not here — the read/write split lives in that leaf policy.
-fn classify_key(json: &serde_json::Value, key: &str, root: &str) -> Result<Step, PathError> {
+fn classify_key(json: &serde_json::Value, key: &str, path: &str) -> Result<Step, PathError> {
     match json {
         serde_json::Value::Object(_) => Ok(Step::Key(key.to_string())),
         serde_json::Value::Array(_) => Err(PathError::Shape(format!(
-            "${{{root}[{key}]}}: string key on a list — use an integer index"
+            "${{{path}[{key}]}}: string key on a list — use an integer index"
         ))),
         _ => unreachable!("resolve_step guards non-collection containers"),
     }
@@ -131,13 +131,13 @@ fn classify_slice(
     json: &serde_json::Value,
     start: Option<i64>,
     end: Option<i64>,
-    root: &str,
+    path: &str,
 ) -> Result<Step, PathError> {
     let arr = match json {
         serde_json::Value::Array(a) => a,
         serde_json::Value::Object(_) => {
             return Err(PathError::Shape(format!(
-                "${{{root}[..]}}: cannot slice a record"
+                "${{{path}[..]}}: cannot slice a record"
             )))
         }
         _ => unreachable!("resolve_step guards non-collection containers"),
@@ -160,10 +160,27 @@ fn classify_slice(
 /// A dotted `.field` access. Brackets-only: always a loud error, with the
 /// bracket fix in the message. Shared by the root pre-check and `resolve_step`
 /// so a dotted segment reports identically at any hop.
-fn dotted_access_error(root: &str, field: &str) -> PathError {
+fn dotted_access_error(path: &str, field: &str) -> PathError {
     PathError::Shape(format!(
-        "${{{root}…}}: kaish uses bracket access, not dots — write the key as a subscript: [{field}]"
+        "${{{path}…}}: kaish uses bracket access, not dots — write the key as a subscript: [{field}]"
     ))
+}
+
+/// Render a subscript as the user wrote it, for building the path prefix that
+/// error messages carry (`a` → `a[b]` → `a[b][0]`) so a nested failure names the
+/// real path, not just the root.
+fn render_segment(seg: &VarSegment) -> String {
+    match seg {
+        VarSegment::Index(i) => format!("[{i}]"),
+        VarSegment::Key(k) => format!("[{k}]"),
+        VarSegment::Dynamic(v) => format!("[${v}]"),
+        VarSegment::Slice(a, b) => format!(
+            "[{}:{}]",
+            a.map(|n| n.to_string()).unwrap_or_default(),
+            b.map(|n| n.to_string()).unwrap_or_default()
+        ),
+        VarSegment::Field(f) => format!(".{f}"),
+    }
 }
 
 /// Classify one subscript against its container — the shared per-hop unit that
@@ -175,13 +192,13 @@ fn resolve_step(
     container: &serde_json::Value,
     seg: &VarSegment,
     scope: &Scope,
-    root: &str,
+    path: &str,
 ) -> Result<Step, PathError> {
     // A non-root `Field` is a dotted `.field` access — checked before the
     // container guard so a dotted segment always wins over a "not a collection"
     // message (the per-hop precedence the old walker had).
     if let VarSegment::Field(name) = seg {
-        return Err(dotted_access_error(root, name));
+        return Err(dotted_access_error(path, name));
     }
 
     // Every remaining subscript needs a collection container.
@@ -190,31 +207,31 @@ fn resolve_step(
         serde_json::Value::Array(_) | serde_json::Value::Object(_)
     ) {
         return Err(PathError::Shape(format!(
-            "${{{root}…}}: cannot subscript {} — it is not a collection",
+            "${{{path}…}}: cannot subscript {} — it is not a collection",
             type_name(&json_to_value_no_envelope(container.clone()))
         )));
     }
 
     match seg {
-        VarSegment::Index(i) => classify_index(container, *i, root),
-        VarSegment::Key(k) => classify_key(container, k, root),
-        VarSegment::Slice(start, end) => classify_slice(container, *start, *end, root),
+        VarSegment::Index(i) => classify_index(container, *i, path),
+        VarSegment::Key(k) => classify_key(container, k, path),
+        VarSegment::Slice(start, end) => classify_slice(container, *start, *end, path),
         VarSegment::Dynamic(var) => {
             // The variable's value is the subscript; the container type decides
             // whether it's an index or a key. An unset `$k` is UndefinedRoot,
             // not Absence — the *variable* is missing, so `${r[$k]:-d}` defaults.
             let key_val = scope.get(var).ok_or_else(|| {
-                PathError::UndefinedRoot(format!("${{{root}[${var}]}}: ${var} is not set"))
+                PathError::UndefinedRoot(format!("${{{path}[${var}]}}: ${var} is not set"))
             })?;
             match container {
                 serde_json::Value::Array(_) => {
                     let idx = value_as_index(key_val).ok_or_else(|| {
                         PathError::Shape(format!(
-                            "${{{root}[${var}]}}: a list index must be an integer, got \"{}\"",
+                            "${{{path}[${var}]}}: a list index must be an integer, got \"{}\"",
                             value_to_string(key_val)
                         ))
                     })?;
-                    classify_index(container, idx, root)
+                    classify_index(container, idx, path)
                 }
                 serde_json::Value::Object(_) => Ok(Step::Key(value_to_string(key_val))),
                 _ => unreachable!("non-collection container guarded above"),
@@ -232,7 +249,7 @@ fn resolve_step(
 fn descend<'a>(
     current: Cow<'a, serde_json::Value>,
     step: Step,
-    root: &str,
+    path: &str,
 ) -> Result<Cow<'a, serde_json::Value>, PathError> {
     match step {
         Step::Slice(s, e) => {
@@ -258,11 +275,11 @@ fn descend<'a>(
         Step::Key(k) => match current {
             Cow::Borrowed(j) => match j.as_object().and_then(|m| m.get(&k)) {
                 Some(child) => Ok(Cow::Borrowed(child)),
-                None => Err(PathError::Absence(format!("${{{root}[{k}]}}: no such key"))),
+                None => Err(PathError::Absence(format!("${{{path}[{k}]}}: no such key"))),
             },
             Cow::Owned(j) => match j.as_object().and_then(|m| m.get(&k)) {
                 Some(child) => Ok(Cow::Owned(child.clone())),
-                None => Err(PathError::Absence(format!("${{{root}[{k}]}}: no such key"))),
+                None => Err(PathError::Absence(format!("${{{path}[{k}]}}: no such key"))),
             },
         },
     }
@@ -670,11 +687,15 @@ impl Scope {
         };
 
         // Walk the subscripts, borrowing into the tree; only a slice (which
-        // builds a new list) and the terminal unwrap allocate.
+        // builds a new list) and the terminal unwrap allocate. `prefix`
+        // accumulates the path walked so far so a nested failure names the real
+        // path (`${a[b][9]}`, not `${a[9]}`).
         let mut current = Cow::Borrowed(root_json);
+        let mut prefix = root_name.clone();
         for seg in subscripts {
-            let step = resolve_step(&current, seg, self, root_name)?;
-            current = descend(current, step, root_name)?;
+            let step = resolve_step(&current, seg, self, &prefix)?;
+            current = descend(current, step, &prefix)?;
+            prefix.push_str(&render_segment(seg));
         }
         Ok(json_to_value_no_envelope(current.into_owned()))
     }

--- a/crates/kaish-kernel/src/interpreter/scope.rs
+++ b/crates/kaish-kernel/src/interpreter/scope.rs
@@ -5,6 +5,7 @@
 //! - The special `$?` variable holding the last command's exit code
 //! - Path resolution for nested access (`${VAR.field[0]}`)
 
+use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
@@ -56,10 +57,28 @@ fn value_as_index(value: &Value) -> Option<i64> {
     }
 }
 
-/// Index into a list. Negative indices count from the end; out of bounds is a
-/// loud error, and an integer subscript on a record is an error (keys are
-/// strings — the design's "integers index lists" rule).
-fn index_into(json: &serde_json::Value, i: i64, root: &str) -> Result<Value, PathError> {
+/// A concrete, container-resolved subscript. [`resolve_step`] produces one per
+/// hop *after* seeing the container — negative indices normalized, bounds
+/// checked, dynamic keys looked up — so read traversal and (next phase) lvalue
+/// writes share one classification and can never drift. Record-key *presence*
+/// is deliberately NOT decided here: that is per-hop walk policy (a read errors
+/// on a missing key; a write leaf inserts it).
+#[derive(Debug, Clone, PartialEq)]
+enum Step {
+    /// A validated, in-bounds list index.
+    Index(usize),
+    /// A record key (existence unchecked — see the type doc).
+    Key(String),
+    /// A normalized, end-exclusive slice range (`s <= e <= len`).
+    Slice(usize, usize),
+}
+
+/// Classify a list index against an array. Negative indices count from the end;
+/// out of bounds is a loud error, and an integer subscript on a record is an
+/// error (keys are strings — the design's "integers index lists" rule). The
+/// container is a collection by [`resolve_step`]'s guard, so the scalar arm is
+/// unreachable.
+fn classify_index(json: &serde_json::Value, i: i64, root: &str) -> Result<Step, PathError> {
     let arr = match json {
         serde_json::Value::Array(a) => a,
         serde_json::Value::Object(_) => {
@@ -67,11 +86,7 @@ fn index_into(json: &serde_json::Value, i: i64, root: &str) -> Result<Value, Pat
                 "${{{root}[{i}]}}: integer index on a record — record keys are strings, use ${{{root}[\"{i}\"]}}"
             )))
         }
-        _ => {
-            return Err(PathError::Invalid(format!(
-                "${{{root}[{i}]}}: not a collection"
-            )))
-        }
+        _ => unreachable!("resolve_step guards non-collection containers"),
     };
     let len = arr.len() as i64;
     let idx = if i < 0 { len + i } else { i };
@@ -80,37 +95,31 @@ fn index_into(json: &serde_json::Value, i: i64, root: &str) -> Result<Value, Pat
             "${{{root}[{i}]}}: index out of bounds (list length {len})"
         )));
     }
-    Ok(json_to_value_no_envelope(arr[idx as usize].clone()))
+    Ok(Step::Index(idx as usize))
 }
 
-/// Look up a record key. A missing key is a loud error (use `[[ k in $r ]]` to
-/// test presence); a bareword/string key on a list is an error.
-fn key_into(json: &serde_json::Value, key: &str, root: &str) -> Result<Value, PathError> {
+/// Classify a record key against an object. A bareword/string key on a list is
+/// an error; key *presence* is checked when the step is applied ([`descend`]),
+/// not here — the read/write split lives in that leaf policy.
+fn classify_key(json: &serde_json::Value, key: &str, root: &str) -> Result<Step, PathError> {
     match json {
-        serde_json::Value::Object(map) => match map.get(key) {
-            Some(v) => Ok(json_to_value_no_envelope(v.clone())),
-            None => Err(PathError::Invalid(format!(
-                "${{{root}[{key}]}}: no such key"
-            ))),
-        },
+        serde_json::Value::Object(_) => Ok(Step::Key(key.to_string())),
         serde_json::Value::Array(_) => Err(PathError::Invalid(format!(
             "${{{root}[{key}]}}: string key on a list — use an integer index"
         ))),
-        _ => Err(PathError::Invalid(format!(
-            "${{{root}[{key}]}}: not a collection"
-        ))),
+        _ => unreachable!("resolve_step guards non-collection containers"),
     }
 }
 
-/// Slice a list, end-exclusive. Bounds clamp; negatives count from the end; an
-/// inverted or empty range yields an empty list. Slicing a record is an error.
-/// The result stays a list (`Value::Json`), never unwrapped.
-fn slice_into(
+/// Classify a slice against an array, end-exclusive. Bounds clamp; negatives
+/// count from the end; an inverted or empty range yields an empty range.
+/// Slicing a record is an error.
+fn classify_slice(
     json: &serde_json::Value,
     start: Option<i64>,
     end: Option<i64>,
     root: &str,
-) -> Result<Value, PathError> {
+) -> Result<Step, PathError> {
     let arr = match json {
         serde_json::Value::Array(a) => a,
         serde_json::Value::Object(_) => {
@@ -118,11 +127,7 @@ fn slice_into(
                 "${{{root}[..]}}: cannot slice a record"
             )))
         }
-        _ => {
-            return Err(PathError::Invalid(format!(
-                "${{{root}[..]}}: not a collection"
-            )))
-        }
+        _ => unreachable!("resolve_step guards non-collection containers"),
     };
     let len = arr.len() as i64;
     let norm = |b: i64| -> i64 {
@@ -131,12 +136,122 @@ fn slice_into(
     };
     let s = start.map(norm).unwrap_or(0);
     let e = end.map(norm).unwrap_or(len);
-    let slice = if s >= e {
-        Vec::new()
+    let (s, e) = if s >= e {
+        (s as usize, s as usize)
     } else {
-        arr[s as usize..e as usize].to_vec()
+        (s as usize, e as usize)
     };
-    Ok(Value::Json(serde_json::Value::Array(slice)))
+    Ok(Step::Slice(s, e))
+}
+
+/// A dotted `.field` access. Brackets-only: always a loud error, with the
+/// bracket fix in the message. Shared by the root pre-check and `resolve_step`
+/// so a dotted segment reports identically at any hop.
+fn dotted_access_error(root: &str, field: &str) -> PathError {
+    PathError::Invalid(format!(
+        "${{{root}…}}: kaish uses bracket access, not dots — write the key as a subscript: [{field}]"
+    ))
+}
+
+/// Classify one subscript against its container — the shared per-hop unit that
+/// keeps read traversal and (next phase) lvalue writes from diverging. Only the
+/// dynamic-key arm needs the scope (to look up `$k`); everything else is a pure
+/// function of the container and segment. A non-collection container is caught
+/// here once, so the `classify_*` helpers never see a scalar.
+fn resolve_step(
+    container: &serde_json::Value,
+    seg: &VarSegment,
+    scope: &Scope,
+    root: &str,
+) -> Result<Step, PathError> {
+    // A non-root `Field` is a dotted `.field` access — checked before the
+    // container guard so a dotted segment always wins over a "not a collection"
+    // message (the per-hop precedence the old walker had).
+    if let VarSegment::Field(name) = seg {
+        return Err(dotted_access_error(root, name));
+    }
+
+    // Every remaining subscript needs a collection container.
+    if !matches!(
+        container,
+        serde_json::Value::Array(_) | serde_json::Value::Object(_)
+    ) {
+        return Err(PathError::Invalid(format!(
+            "${{{root}…}}: cannot subscript {} — it is not a collection",
+            type_name(&json_to_value_no_envelope(container.clone()))
+        )));
+    }
+
+    match seg {
+        VarSegment::Index(i) => classify_index(container, *i, root),
+        VarSegment::Key(k) => classify_key(container, k, root),
+        VarSegment::Slice(start, end) => classify_slice(container, *start, *end, root),
+        VarSegment::Dynamic(var) => {
+            // The variable's value is the subscript; the container type decides
+            // whether it's an index or a key.
+            let key_val = scope.get(var).ok_or_else(|| {
+                PathError::Invalid(format!("${{{root}[${var}]}}: ${var} is not set"))
+            })?;
+            match container {
+                serde_json::Value::Array(_) => {
+                    let idx = value_as_index(key_val).ok_or_else(|| {
+                        PathError::Invalid(format!(
+                            "${{{root}[${var}]}}: a list index must be an integer, got \"{}\"",
+                            value_to_string(key_val)
+                        ))
+                    })?;
+                    classify_index(container, idx, root)
+                }
+                serde_json::Value::Object(_) => Ok(Step::Key(value_to_string(key_val))),
+                _ => unreachable!("non-collection container guarded above"),
+            }
+        }
+        VarSegment::Field(_) => unreachable!("dotted segment handled above"),
+    }
+}
+
+/// Apply one classified step, descending the borrowed JSON tree. Borrowed input
+/// stays borrowed for index/key (no clone); a slice always allocates a new list,
+/// and once owned (post-slice) descent clones the selected child. A missing
+/// record key is a loud read error here — the write-leaf insert is the next
+/// phase, and lives in the walk, not in [`resolve_step`].
+fn descend<'a>(
+    current: Cow<'a, serde_json::Value>,
+    step: Step,
+    root: &str,
+) -> Result<Cow<'a, serde_json::Value>, PathError> {
+    match step {
+        Step::Slice(s, e) => {
+            let Some(arr) = current.as_array() else {
+                unreachable!("slice classified against an array")
+            };
+            Ok(Cow::Owned(serde_json::Value::Array(arr[s..e].to_vec())))
+        }
+        Step::Index(i) => match current {
+            Cow::Borrowed(j) => {
+                let Some(arr) = j.as_array() else {
+                    unreachable!("index classified against an array")
+                };
+                Ok(Cow::Borrowed(&arr[i]))
+            }
+            Cow::Owned(j) => {
+                let Some(arr) = j.as_array() else {
+                    unreachable!("index classified against an array")
+                };
+                Ok(Cow::Owned(arr[i].clone()))
+            }
+        },
+        Step::Key(k) => match current {
+            Cow::Borrowed(j) => match j.as_object().and_then(|m| m.get(&k)) {
+                Some(child) => Ok(Cow::Borrowed(child)),
+                None => Err(PathError::Invalid(format!("${{{root}[{k}]}}: no such key"))),
+            },
+            Cow::Owned(j) => match j.as_object().and_then(|m| m.get(&k)) {
+                Some(child) => Ok(Cow::Owned(child.clone())),
+                None => Err(PathError::Invalid(format!("${{{root}[{k}]}}: no such key"))),
+            },
+        },
+    }
 }
 
 /// Variable scope with nested frames and last-result tracking.
@@ -483,6 +598,12 @@ impl Scope {
     /// landing on a collection stays `Value::Json`. `$?` resolves to the
     /// previous command's exit code (bare only).
     ///
+    /// Traversal borrows into the root's JSON tree and clones only the selected
+    /// leaf (a slice builds a new list); the whole-root clone is never taken, so
+    /// repeated `${u[$k]}` in a loop stays O(depth), not O(root size). The
+    /// per-hop classification lives in [`resolve_step`], shared with the future
+    /// lvalue-write walk so read and write can never diverge.
+    ///
     /// Errors distinguish an undefined root (soft) from a loud path error (see
     /// [`PathError`]).
     pub fn resolve_path(&self, path: &VarPath) -> Result<Value, PathError> {
@@ -504,77 +625,44 @@ impl Scope {
 
         let root = self
             .get(root_name)
-            .cloned()
             .ok_or_else(|| PathError::UndefinedRoot(root_name.clone()))?;
 
-        // Walk the subscripts (none for a bare `${VAR}`).
-        let mut current = root;
-        for seg in &path.segments[1..] {
-            current = self.apply_segment(&current, seg, root_name)?;
-        }
-        Ok(current)
-    }
-
-    /// Apply one subscript to a value during path traversal.
-    fn apply_segment(
-        &self,
-        value: &Value,
-        seg: &VarSegment,
-        root: &str,
-    ) -> Result<Value, PathError> {
-        // A non-root `Field` is a dotted `.field` access. Brackets-only: this is
-        // always a loud error regardless of the value's type, with the fix in
-        // the message.
-        if let VarSegment::Field(name) = seg {
-            // Generic (not a full-path reconstruction, which would drop earlier
-            // subscripts and mislead on nested dotted access): brackets-only.
-            return Err(PathError::Invalid(format!(
-                "${{{root}…}}: kaish uses bracket access, not dots — write the key as a subscript: [{name}]"
-            )));
+        // Bare `${VAR}`: return the stored value unchanged — no subscript, no
+        // envelope unwrap.
+        let subscripts = &path.segments[1..];
+        if subscripts.is_empty() {
+            return Ok(root.clone());
         }
 
-        // Everything else needs a collection.
-        let json = match value {
+        // A leading dotted segment is brackets-only regardless of the root's
+        // type (matches the per-hop Field-before-container precedence in
+        // `resolve_step`, which the root-collection check below would otherwise
+        // preempt on a scalar root).
+        if let Some(VarSegment::Field(name)) = subscripts.first() {
+            return Err(dotted_access_error(root_name, name));
+        }
+
+        // Subscripted: the root must be a collection to descend into. A scalar
+        // root reports the same "not a collection" message a mid-path scalar
+        // would (via `resolve_step`).
+        let root_json = match root {
             Value::Json(j) => j,
             other => {
                 return Err(PathError::Invalid(format!(
-                    "${{{root}…}}: cannot subscript {} — it is not a collection",
+                    "${{{root_name}…}}: cannot subscript {} — it is not a collection",
                     type_name(other)
                 )))
             }
         };
 
-        match seg {
-            VarSegment::Index(i) => index_into(json, *i, root),
-            VarSegment::Key(k) => key_into(json, k, root),
-            VarSegment::Slice(start, end) => slice_into(json, *start, *end, root),
-            VarSegment::Dynamic(var) => {
-                // The variable's value is the subscript; the container type
-                // decides whether it's an index or a key.
-                let key_val = self.get(var).ok_or_else(|| {
-                    PathError::Invalid(format!("${{{root}[${var}]}}: ${var} is not set"))
-                })?;
-                match json {
-                    serde_json::Value::Array(_) => {
-                        let idx = value_as_index(key_val).ok_or_else(|| {
-                            PathError::Invalid(format!(
-                                "${{{root}[${var}]}}: a list index must be an integer, got \"{}\"",
-                                value_to_string(key_val)
-                            ))
-                        })?;
-                        index_into(json, idx, root)
-                    }
-                    serde_json::Value::Object(_) => {
-                        key_into(json, &value_to_string(key_val), root)
-                    }
-                    _ => Err(PathError::Invalid(format!(
-                        "${{{root}[${var}]}}: not a collection"
-                    ))),
-                }
-            }
-            // Field handled above.
-            VarSegment::Field(_) => unreachable!("dotted segment handled above"),
+        // Walk the subscripts, borrowing into the tree; only a slice (which
+        // builds a new list) and the terminal unwrap allocate.
+        let mut current = Cow::Borrowed(root_json);
+        for seg in subscripts {
+            let step = resolve_step(&current, seg, self, root_name)?;
+            current = descend(current, step, root_name)?;
         }
+        Ok(json_to_value_no_envelope(current.into_owned()))
     }
 
     /// Check if a variable exists in any frame.

--- a/crates/kaish-kernel/src/interpreter/scope.rs
+++ b/crates/kaish-kernel/src/interpreter/scope.rs
@@ -18,18 +18,31 @@ use super::result::ExecResult;
 
 /// Why a variable path failed to resolve.
 ///
-/// The distinction is load-bearing: an undefined *root* is soft (expression
-/// position surfaces an error, string interpolation expands to empty, matching
-/// bash), while any deeper path failure is **loud** — subscripting a scalar, an
-/// out-of-bounds index, a missing record key, a dotted (non-bracket) segment,
-/// or a bad slice. A loud error is surfaced everywhere, including inside
-/// strings; it is NEVER silently swallowed to an empty expansion.
+/// The three-way split is load-bearing for `${path:-default}` (decision A): the
+/// default fires on **absence** but never on a **shape** error — a wrong-typed
+/// access is a bug, not a missing value. All three are loud for a bare access;
+/// they diverge only when `:-` is present (see the default handling), where
+/// `UndefinedRoot`/`Absence` yield the default and `Shape` still shouts.
+///
+/// - `UndefinedRoot` — the root variable (or an unset dynamic `$k` subscript) is
+///   not in scope. Soft in string interpolation (expands to empty, matching
+///   bash), loud in expression position.
+/// - `Absence` — the path is well-shaped but the target isn't there: a missing
+///   record key or an out-of-bounds list index.
+/// - `Shape` — the access is wrong for the value: a string key on a list, an
+///   integer index on a record, subscripting a scalar, a dotted (non-bracket)
+///   segment, or slicing a record. Never suppressed by `:-`.
+///
+/// A loud error is surfaced everywhere, including inside strings; it is NEVER
+/// silently swallowed to an empty expansion.
 #[derive(Debug, Clone, PartialEq)]
 pub enum PathError {
-    /// The root variable is not in scope.
+    /// The root variable is not in scope (or an unset dynamic `$k` subscript).
     UndefinedRoot(String),
-    /// A loud path error, message ready to display.
-    Invalid(String),
+    /// A missing key or out-of-bounds index — absence, not misuse.
+    Absence(String),
+    /// A wrong-for-the-shape access. Message ready to display.
+    Shape(String),
 }
 
 /// A human-readable type name for a value, for path error messages.
@@ -82,7 +95,7 @@ fn classify_index(json: &serde_json::Value, i: i64, root: &str) -> Result<Step, 
     let arr = match json {
         serde_json::Value::Array(a) => a,
         serde_json::Value::Object(_) => {
-            return Err(PathError::Invalid(format!(
+            return Err(PathError::Shape(format!(
                 "${{{root}[{i}]}}: integer index on a record — record keys are strings, use ${{{root}[\"{i}\"]}}"
             )))
         }
@@ -91,7 +104,7 @@ fn classify_index(json: &serde_json::Value, i: i64, root: &str) -> Result<Step, 
     let len = arr.len() as i64;
     let idx = if i < 0 { len + i } else { i };
     if idx < 0 || idx >= len {
-        return Err(PathError::Invalid(format!(
+        return Err(PathError::Absence(format!(
             "${{{root}[{i}]}}: index out of bounds (list length {len})"
         )));
     }
@@ -104,7 +117,7 @@ fn classify_index(json: &serde_json::Value, i: i64, root: &str) -> Result<Step, 
 fn classify_key(json: &serde_json::Value, key: &str, root: &str) -> Result<Step, PathError> {
     match json {
         serde_json::Value::Object(_) => Ok(Step::Key(key.to_string())),
-        serde_json::Value::Array(_) => Err(PathError::Invalid(format!(
+        serde_json::Value::Array(_) => Err(PathError::Shape(format!(
             "${{{root}[{key}]}}: string key on a list — use an integer index"
         ))),
         _ => unreachable!("resolve_step guards non-collection containers"),
@@ -123,7 +136,7 @@ fn classify_slice(
     let arr = match json {
         serde_json::Value::Array(a) => a,
         serde_json::Value::Object(_) => {
-            return Err(PathError::Invalid(format!(
+            return Err(PathError::Shape(format!(
                 "${{{root}[..]}}: cannot slice a record"
             )))
         }
@@ -148,7 +161,7 @@ fn classify_slice(
 /// bracket fix in the message. Shared by the root pre-check and `resolve_step`
 /// so a dotted segment reports identically at any hop.
 fn dotted_access_error(root: &str, field: &str) -> PathError {
-    PathError::Invalid(format!(
+    PathError::Shape(format!(
         "${{{root}…}}: kaish uses bracket access, not dots — write the key as a subscript: [{field}]"
     ))
 }
@@ -176,7 +189,7 @@ fn resolve_step(
         container,
         serde_json::Value::Array(_) | serde_json::Value::Object(_)
     ) {
-        return Err(PathError::Invalid(format!(
+        return Err(PathError::Shape(format!(
             "${{{root}…}}: cannot subscript {} — it is not a collection",
             type_name(&json_to_value_no_envelope(container.clone()))
         )));
@@ -188,14 +201,15 @@ fn resolve_step(
         VarSegment::Slice(start, end) => classify_slice(container, *start, *end, root),
         VarSegment::Dynamic(var) => {
             // The variable's value is the subscript; the container type decides
-            // whether it's an index or a key.
+            // whether it's an index or a key. An unset `$k` is UndefinedRoot,
+            // not Absence — the *variable* is missing, so `${r[$k]:-d}` defaults.
             let key_val = scope.get(var).ok_or_else(|| {
-                PathError::Invalid(format!("${{{root}[${var}]}}: ${var} is not set"))
+                PathError::UndefinedRoot(format!("${{{root}[${var}]}}: ${var} is not set"))
             })?;
             match container {
                 serde_json::Value::Array(_) => {
                     let idx = value_as_index(key_val).ok_or_else(|| {
-                        PathError::Invalid(format!(
+                        PathError::Shape(format!(
                             "${{{root}[${var}]}}: a list index must be an integer, got \"{}\"",
                             value_to_string(key_val)
                         ))
@@ -244,11 +258,11 @@ fn descend<'a>(
         Step::Key(k) => match current {
             Cow::Borrowed(j) => match j.as_object().and_then(|m| m.get(&k)) {
                 Some(child) => Ok(Cow::Borrowed(child)),
-                None => Err(PathError::Invalid(format!("${{{root}[{k}]}}: no such key"))),
+                None => Err(PathError::Absence(format!("${{{root}[{k}]}}: no such key"))),
             },
             Cow::Owned(j) => match j.as_object().and_then(|m| m.get(&k)) {
                 Some(child) => Ok(Cow::Owned(child.clone())),
-                None => Err(PathError::Invalid(format!("${{{root}[{k}]}}: no such key"))),
+                None => Err(PathError::Absence(format!("${{{root}[{k}]}}: no such key"))),
             },
         },
     }
@@ -617,7 +631,7 @@ impl Scope {
             if path.segments.len() == 1 {
                 return Ok(Value::Int(self.last_result.code));
             }
-            return Err(PathError::Invalid(
+            return Err(PathError::Shape(
                 "$? is the POSIX exit code, not a collection — use `kaish-last` for structured data"
                     .to_string(),
             ));
@@ -648,7 +662,7 @@ impl Scope {
         let root_json = match root {
             Value::Json(j) => j,
             other => {
-                return Err(PathError::Invalid(format!(
+                return Err(PathError::Shape(format!(
                     "${{{root_name}…}}: cannot subscript {} — it is not a collection",
                     type_name(other)
                 )))
@@ -789,7 +803,7 @@ mod tests {
         };
         assert!(matches!(
             scope.resolve_path(&path),
-            Err(PathError::Invalid(_))
+            Err(PathError::Shape(_))
         ));
     }
 
@@ -807,7 +821,7 @@ mod tests {
         };
         assert!(matches!(
             scope.resolve_path(&path),
-            Err(PathError::Invalid(_))
+            Err(PathError::Shape(_))
         ));
     }
 
@@ -819,6 +833,72 @@ mod tests {
             scope.resolve_path(&path),
             Err(PathError::UndefinedRoot(_))
         ));
+    }
+
+    // ── PathError classification (Absence vs Shape) ─────────────────────────
+    // Pins the three-way split: `${path:-default}` (a later commit) leans on
+    // Absence-vs-Shape, so a misclassification here is a real semantic bug, not
+    // cosmetics. All three stay loud for a bare access.
+
+    /// Build `${root[seg]}` with one bracket subscript.
+    fn subscripted(scope: &mut Scope, root: &str, value: serde_json::Value, seg: VarSegment) -> Result<Value, PathError> {
+        scope.set(root, Value::Json(value));
+        let path = VarPath {
+            segments: vec![VarSegment::Field(root.into()), seg],
+        };
+        scope.resolve_path(&path)
+    }
+
+    #[test]
+    fn out_of_bounds_index_is_absence() {
+        let mut scope = Scope::new();
+        let r = subscripted(&mut scope, "xs", serde_json::json!([1, 2]), VarSegment::Index(9));
+        assert!(matches!(r, Err(PathError::Absence(_))), "got: {r:?}");
+    }
+
+    #[test]
+    fn missing_record_key_is_absence() {
+        let mut scope = Scope::new();
+        let r = subscripted(&mut scope, "u", serde_json::json!({"name": "amy"}), VarSegment::Key("nope".into()));
+        assert!(matches!(r, Err(PathError::Absence(_))), "got: {r:?}");
+    }
+
+    #[test]
+    fn string_key_on_a_list_is_shape() {
+        let mut scope = Scope::new();
+        let r = subscripted(&mut scope, "xs", serde_json::json!([1, 2]), VarSegment::Key("web".into()));
+        assert!(matches!(r, Err(PathError::Shape(_))), "got: {r:?}");
+    }
+
+    #[test]
+    fn integer_index_on_a_record_is_shape() {
+        let mut scope = Scope::new();
+        let r = subscripted(&mut scope, "u", serde_json::json!({"name": "amy"}), VarSegment::Index(0));
+        assert!(matches!(r, Err(PathError::Shape(_))), "got: {r:?}");
+    }
+
+    #[test]
+    fn subscripting_a_scalar_is_shape() {
+        let mut scope = Scope::new();
+        scope.set("s", Value::String("hello".into()));
+        let path = VarPath {
+            segments: vec![VarSegment::Field("s".into()), VarSegment::Index(0)],
+        };
+        assert!(matches!(scope.resolve_path(&path), Err(PathError::Shape(_))));
+    }
+
+    #[test]
+    fn unset_dynamic_key_is_undefined_root_not_absence() {
+        // `${r[$k]}` with `$k` unset: the *variable* is missing, so it's
+        // UndefinedRoot-class (which `:-` treats as absence), not a Shape error.
+        let mut scope = Scope::new();
+        let r = subscripted(
+            &mut scope,
+            "r",
+            serde_json::json!({"name": "amy"}),
+            VarSegment::Dynamic("k".into()),
+        );
+        assert!(matches!(r, Err(PathError::UndefinedRoot(_))), "got: {r:?}");
     }
 
     #[test]

--- a/crates/kaish-kernel/src/kernel.rs
+++ b/crates/kaish-kernel/src/kernel.rs
@@ -3660,7 +3660,9 @@ impl Kernel {
                     Err(PathError::UndefinedRoot(_)) => {
                         Err(anyhow::anyhow!("undefined variable"))
                     }
-                    Err(PathError::Invalid(msg)) => Err(anyhow::anyhow!(msg)),
+                    Err(PathError::Absence(msg)) | Err(PathError::Shape(msg)) => {
+                        Err(anyhow::anyhow!(msg))
+                    }
                 }
             }
             Expr::Interpolated(parts) => {
@@ -3964,7 +3966,9 @@ impl Kernel {
                         Ok(value) => Ok(value_to_string(&value)),
                         // Unset vars expand to empty; loud path errors surface.
                         Err(PathError::UndefinedRoot(_)) => Ok(String::new()),
-                        Err(PathError::Invalid(msg)) => Err(anyhow::anyhow!(msg)),
+                        Err(PathError::Absence(msg)) | Err(PathError::Shape(msg)) => {
+                            Err(anyhow::anyhow!(msg))
+                        }
                     }
                 }
                 StringPart::VarWithDefault { name, default } => {

--- a/crates/kaish-kernel/src/kernel.rs
+++ b/crates/kaish-kernel/src/kernel.rs
@@ -51,7 +51,7 @@ pub use kaish_types::{CommandKind, ExecuteOptions};
 use crate::backend::{BackendError, KernelBackend};
 use kaish_glob::glob_match;
 use crate::dispatch::{CommandDispatcher, PipelinePosition};
-use crate::interpreter::{apply_output_format, eval_expr, expand_tilde, json_to_value_no_envelope, value_to_bool, value_length, value_to_string, ControlFlow, ExecResult, PathError, Scope};
+use crate::interpreter::{apply_output_format, eval_expr, expand_tilde, json_to_value_no_envelope, value_to_bool, value_to_string, ControlFlow, ExecResult, PathError, Scope};
 use crate::parser::parse;
 use crate::scheduler::{is_bool_type, schema_param_lookup, select_leaf, stderr_stream, BoundedStream, JobManager, PipelineRunner, StderrReceiver};
 #[cfg(feature = "subprocess")]
@@ -3782,32 +3782,23 @@ impl Kernel {
                 let scope = self.scope.read().await;
                 Ok(Value::Int(scope.arg_count() as i64))
             }
-            Expr::VarLength(name) => {
-                if crate::interpreter::name_is_subscripted(name) {
-                    return Err(anyhow::anyhow!("{}", crate::interpreter::subscripted_length_error(name)));
-                }
+            Expr::VarLength(path) => {
                 let scope = self.scope.read().await;
-                match scope.get(name) {
-                    Some(value) => Ok(Value::Int(value_length(value))),
-                    None => Ok(Value::Int(0)),
-                }
+                crate::interpreter::resolve_length(&scope, path)
+                    .map(Value::Int)
+                    .map_err(|msg| anyhow::anyhow!(msg))
             }
-            Expr::VarWithDefault { name, default } => {
-                if crate::interpreter::name_is_subscripted(name) {
-                    return Err(anyhow::anyhow!("{}", crate::interpreter::subscripted_default_error(name)));
-                }
-                let scope = self.scope.read().await;
-                let use_default = match scope.get(name) {
-                    Some(value) => value_to_string(value).is_empty(),
-                    None => true,
-                };
-                drop(scope); // Release the lock before recursive evaluation
-                if use_default {
-                    // Evaluate the default parts (supports nested expansions)
-                    self.eval_string_parts_async(default).await.map(Value::String)
-                } else {
+            Expr::VarWithDefault { path, default } => {
+                // Resolve inside a scoped guard so the lock is released before the
+                // recursive default evaluation.
+                let resolved = {
                     let scope = self.scope.read().await;
-                    scope.get(name).cloned().ok_or_else(|| anyhow::anyhow!("variable '{}' not found", name))
+                    crate::interpreter::resolve_default(&scope, path)
+                        .map_err(|msg| anyhow::anyhow!(msg))?
+                };
+                match resolved {
+                    Some(value) => Ok(value),
+                    None => self.eval_string_parts_async(default).await.map(Value::String),
                 }
             }
             Expr::Arithmetic(expr_str) => {
@@ -3971,33 +3962,22 @@ impl Kernel {
                         }
                     }
                 }
-                StringPart::VarWithDefault { name, default } => {
-                    if crate::interpreter::name_is_subscripted(name) {
-                        return Err(anyhow::anyhow!("{}", crate::interpreter::subscripted_default_error(name)));
-                    }
-                    let scope = self.scope.read().await;
-                    let use_default = match scope.get(name) {
-                        Some(value) => value_to_string(value).is_empty(),
-                        None => true,
-                    };
-                    drop(scope); // Release lock before recursive evaluation
-                    if use_default {
-                        // Evaluate the default parts (supports nested expansions)
-                        self.eval_string_parts_async(default).await
-                    } else {
+                StringPart::VarWithDefault { path, default } => {
+                    let resolved = {
                         let scope = self.scope.read().await;
-                        Ok(value_to_string(scope.get(name).ok_or_else(|| anyhow::anyhow!("variable '{}' not found", name))?))
+                        crate::interpreter::resolve_default(&scope, path)
+                            .map_err(|msg| anyhow::anyhow!(msg))?
+                    };
+                    match resolved {
+                        Some(value) => Ok(value_to_string(&value)),
+                        None => self.eval_string_parts_async(default).await,
                     }
                 }
-            StringPart::VarLength(name) => {
-                if crate::interpreter::name_is_subscripted(name) {
-                    return Err(anyhow::anyhow!("{}", crate::interpreter::subscripted_length_error(name)));
-                }
+            StringPart::VarLength(path) => {
                 let scope = self.scope.read().await;
-                match scope.get(name) {
-                    Some(value) => Ok(value_length(value).to_string()),
-                    None => Ok("0".to_string()),
-                }
+                crate::interpreter::resolve_length(&scope, path)
+                    .map(|n| n.to_string())
+                    .map_err(|msg| anyhow::anyhow!(msg))
             }
             StringPart::Positional(n) => {
                 let scope = self.scope.read().await;

--- a/crates/kaish-kernel/src/lexer.rs
+++ b/crates/kaish-kernel/src/lexer.rs
@@ -521,8 +521,11 @@ pub enum Token {
     #[token("$$")]
     CurrentPid,
 
-    /// Variable string length: `${#VAR}`
-    #[regex(r"\$\{#[a-zA-Z_][a-zA-Z0-9_]*\}", lex_var_length)]
+    /// Variable string length: `${#VAR}` or a subscripted path `${#u[tags]}`.
+    /// The trailing `(\[[^\]]*\])*` admits chained bracket subscripts so a
+    /// length-of-path lexes in expression position, not just inside strings; the
+    /// parser turns the captured inner into a `VarPath`.
+    #[regex(r"\$\{#[a-zA-Z_][a-zA-Z0-9_]*(\[[^\]]*\])*\}", lex_var_length)]
     VarLength(String),
 
     /// Here-doc content: synthesized by preprocessing, not directly lexed.

--- a/crates/kaish-kernel/src/lexer.rs
+++ b/crates/kaish-kernel/src/lexer.rs
@@ -3009,6 +3009,16 @@ mod tests {
     }
 
     #[test]
+    fn var_length_with_subscript() {
+        // The widened regex admits `[...]` subscripts so a length-of-path lexes
+        // in expression position; the parser turns the inner into a VarPath.
+        assert_eq!(lex("${#u[tags]}"), vec![Token::VarLength("u[tags]".to_string())]);
+        assert_eq!(lex("${#a[0]}"), vec![Token::VarLength("a[0]".to_string())]);
+        assert_eq!(lex("${#a[b][c]}"), vec![Token::VarLength("a[b][c]".to_string())]);
+        assert_eq!(lex("${#r[$k]}"), vec![Token::VarLength("r[$k]".to_string())]);
+    }
+
+    #[test]
     fn var_length_in_context() {
         assert_eq!(
             lex("echo ${#NAME}"),

--- a/crates/kaish-kernel/src/parser.rs
+++ b/crates/kaish-kernel/src/parser.rs
@@ -34,8 +34,8 @@ fn parse_var_expr(raw: &str) -> Expr {
     // Check for default value syntax: ${VAR:-default}
     // Need to find :- that's not inside a nested ${...}
     if let Some(colon_idx) = find_default_separator(raw) {
-        // Extract variable name (between ${ and :-)
-        let name = raw[2..colon_idx].to_string();
+        // Extract the variable path (between ${ and :-) — may carry subscripts.
+        let path = parse_varpath(&format!("${{{}}}", &raw[2..colon_idx]));
         // Extract default value (between :- and }) and recursively parse it,
         // after stripping shell quoting from the word (quotes are syntax).
         let default_str = &raw[colon_idx + 2..raw.len() - 1];
@@ -45,7 +45,7 @@ fn parse_var_expr(raw: &str) -> Expr {
         let default_word = unquote_default_word(default_str);
         let default = parse_interpolated_string(&default_word)
             .unwrap_or_else(|_| vec![StringPart::Literal(default_word.clone())]);
-        return Expr::VarWithDefault { name, default };
+        return Expr::VarWithDefault { path, default };
     }
 
     // Regular variable path
@@ -442,7 +442,7 @@ fn parse_interpolated_string_spanned(s: &str, base_offset: usize) -> Vec<Spanned
                     }
                 }
                 let part = if let Some(name) = var_content.strip_prefix('#') {
-                    StringPart::VarLength(name.to_string())
+                    StringPart::VarLength(parse_varpath(&format!("${{{name}}}")))
                 } else if var_content.starts_with("__ARITH:") && var_content.ends_with("__") {
                     let expr = var_content
                         .strip_prefix("__ARITH:")
@@ -450,7 +450,7 @@ fn parse_interpolated_string_spanned(s: &str, base_offset: usize) -> Vec<Spanned
                         .unwrap_or("");
                     StringPart::Arithmetic(expr.to_string())
                 } else if let Some(colon_idx) = find_default_separator_in_content(&var_content) {
-                    let name = var_content[..colon_idx].to_string();
+                    let path = parse_varpath(&format!("${{{}}}", &var_content[..colon_idx]));
                     let default_str = &var_content[colon_idx + 2..];
                     // Default value spans recursively kept relative to the
                     // outer body — the inner parts get their own offsets via
@@ -459,7 +459,7 @@ fn parse_interpolated_string_spanned(s: &str, base_offset: usize) -> Vec<Spanned
                     let default_word = unquote_default_word(default_str);
                     let default = parse_interpolated_string(&default_word)
                         .unwrap_or_else(|_| vec![StringPart::Literal(default_word.clone())]);
-                    StringPart::VarWithDefault { name, default }
+                    StringPart::VarWithDefault { path, default }
                 } else {
                     StringPart::Var(parse_varpath(&format!("${{{}}}", var_content)))
                 };
@@ -675,8 +675,8 @@ fn parse_interpolated_string(s: &str) -> Result<Vec<StringPart>, String> {
 
                 // Parse the content for special syntax
                 let part = if let Some(name) = var_content.strip_prefix('#') {
-                    // Variable length: ${#VAR}
-                    StringPart::VarLength(name.to_string())
+                    // Variable length: ${#VAR} / ${#path[sub]}
+                    StringPart::VarLength(parse_varpath(&format!("${{{name}}}")))
                 } else if var_content.starts_with("__ARITH:") && var_content.ends_with("__") {
                     // Arithmetic expression: ${__ARITH:expr__}
                     let expr = var_content
@@ -686,10 +686,10 @@ fn parse_interpolated_string(s: &str) -> Result<Vec<StringPart>, String> {
                     StringPart::Arithmetic(expr.to_string())
                 } else if let Some(colon_idx) = find_default_separator_in_content(&var_content) {
                     // Variable with default: ${VAR:-default} - recursively parse the default
-                    let name = var_content[..colon_idx].to_string();
+                    let path = parse_varpath(&format!("${{{}}}", &var_content[..colon_idx]));
                     let default_str = &var_content[colon_idx + 2..];
                     let default = parse_interpolated_string(&unquote_default_word(default_str))?;
-                    StringPart::VarWithDefault { name, default }
+                    StringPart::VarWithDefault { path, default }
                 } else {
                     // Regular variable: ${VAR} or ${VAR.field}
                     StringPart::Var(parse_varpath(&format!("${{{}}}", var_content)))
@@ -2109,7 +2109,7 @@ where
         Token::Positional(n) => Expr::Positional(n),
         Token::AllArgs => Expr::AllArgs,
         Token::ArgCount => Expr::ArgCount,
-        Token::VarLength(name) => Expr::VarLength(name),
+        Token::VarLength(name) => Expr::VarLength(parse_varpath(&format!("${{{name}}}"))),
         Token::LastExitCode => Expr::LastExitCode,
         Token::CurrentPid => Expr::CurrentPid,
     };

--- a/crates/kaish-kernel/src/scheduler/pipeline.rs
+++ b/crates/kaish-kernel/src/scheduler/pipeline.rs
@@ -951,28 +951,23 @@ pub(crate) fn eval_simple_expr(expr: &Expr, ctx: &ExecContext) -> Option<Value> 
                             result.push_str(&value_to_string(&value));
                         }
                     }
-                    crate::ast::StringPart::VarWithDefault { name, default } => {
-                        match ctx.scope.get(name) {
-                            Some(value) => {
-                                let s = value_to_string(value);
-                                if s.is_empty() {
-                                    result.push_str(&eval_string_parts_sync(default, ctx));
-                                } else {
-                                    result.push_str(&s);
-                                }
-                            }
-                            None => result.push_str(&eval_string_parts_sync(default, ctx)),
+                    crate::ast::StringPart::VarWithDefault { path, default } => {
+                        // Reduced-sync path has no error channel, so a shape error
+                        // coalesces (skipped) here — the known reduced-sync gap
+                        // (issues.md P3). Absence still yields the default.
+                        match crate::interpreter::resolve_default(&ctx.scope, path) {
+                            Ok(Some(value)) => result.push_str(&value_to_string(&value)),
+                            Ok(None) => result.push_str(&eval_string_parts_sync(default, ctx)),
+                            Err(_) => {}
                         }
                     }
-                    crate::ast::StringPart::VarLength(name) => {
-                        let len = match ctx.scope.get(name) {
-                            // Element/key count for collections, byte count for
-                            // binary — the same helper the async/interp paths use
-                            // (not the string byte-length of a rendered value).
-                            Some(value) => crate::interpreter::value_length(value) as usize,
-                            None => 0,
-                        };
-                        result.push_str(&len.to_string());
+                    crate::ast::StringPart::VarLength(path) => {
+                        // Element/key count for collections, byte count for binary;
+                        // unset root → 0. A shape/absence error coalesces to nothing
+                        // (reduced-sync gap, P3).
+                        if let Ok(len) = crate::interpreter::resolve_length(&ctx.scope, path) {
+                            result.push_str(&len.to_string());
+                        }
                     }
                     crate::ast::StringPart::Positional(n) => {
                         if let Some(s) = ctx.scope.get_positional(*n) {
@@ -1055,27 +1050,20 @@ fn eval_string_parts_sync(parts: &[crate::ast::StringPart], ctx: &ExecContext) -
                     result.push_str(&value_to_string(&value));
                 }
             }
-            crate::ast::StringPart::VarWithDefault { name, default } => {
-                match ctx.scope.get(name) {
-                    Some(value) => {
-                        let s = value_to_string(value);
-                        if s.is_empty() {
-                            result.push_str(&eval_string_parts_sync(default, ctx));
-                        } else {
-                            result.push_str(&s);
-                        }
-                    }
-                    None => result.push_str(&eval_string_parts_sync(default, ctx)),
+            crate::ast::StringPart::VarWithDefault { path, default } => {
+                // Reduced-sync path: a shape error coalesces (issues.md P3);
+                // absence still yields the default.
+                match crate::interpreter::resolve_default(&ctx.scope, path) {
+                    Ok(Some(value)) => result.push_str(&value_to_string(&value)),
+                    Ok(None) => result.push_str(&eval_string_parts_sync(default, ctx)),
+                    Err(_) => {}
                 }
             }
-            crate::ast::StringPart::VarLength(name) => {
-                let len = match ctx.scope.get(name) {
-                    // Element/key count for collections, byte count for binary —
-                    // the same helper the async/interp paths use.
-                    Some(value) => crate::interpreter::value_length(value) as usize,
-                    None => 0,
-                };
-                result.push_str(&len.to_string());
+            crate::ast::StringPart::VarLength(path) => {
+                // Unset root → 0; shape/absence coalesces to nothing (P3).
+                if let Ok(len) = crate::interpreter::resolve_length(&ctx.scope, path) {
+                    result.push_str(&len.to_string());
+                }
             }
             crate::ast::StringPart::Positional(n) => {
                 if let Some(s) = ctx.scope.get_positional(*n) {

--- a/crates/kaish-kernel/src/validator/walker.rs
+++ b/crates/kaish-kernel/src/validator/walker.rs
@@ -428,10 +428,13 @@ impl<'a> Validator<'a> {
             }
             Expr::Test(test) => self.validate_test(test),
             Expr::Positional(_) | Expr::AllArgs | Expr::ArgCount => {}
-            Expr::VarLength(name) => self.check_var_defined(name),
-            Expr::VarWithDefault { name, .. } => {
-                // Don't warn - default handles undefined case
-                let _ = name;
+            Expr::VarLength(path) => {
+                if let Some(VarSegment::Field(root)) = path.segments.first() {
+                    self.check_var_defined(root);
+                }
+            }
+            Expr::VarWithDefault { .. } => {
+                // Don't warn — the default handles the undefined/absent case.
             }
             Expr::Arithmetic(_) => {
                 // Arithmetic parsing is done at runtime
@@ -488,7 +491,11 @@ impl<'a> Validator<'a> {
                     self.validate_string_part(p);
                 }
             }
-            StringPart::VarLength(name) => self.check_var_defined(name),
+            StringPart::VarLength(path) => {
+                if let Some(VarSegment::Field(root)) = path.segments.first() {
+                    self.check_var_defined(root);
+                }
+            }
             StringPart::Positional(_) | StringPart::AllArgs | StringPart::ArgCount => {}
             StringPart::Arithmetic(_) => {} // Arithmetic expressions are validated at eval time
             StringPart::CommandSubst(stmts) => {

--- a/crates/kaish-kernel/tests/collection_access_tests.rs
+++ b/crates/kaish-kernel/tests/collection_access_tests.rs
@@ -257,6 +257,20 @@ async fn integer_index_on_a_record_is_a_loud_error() {
 }
 
 #[tokio::test]
+async fn nested_error_names_the_full_path() {
+    // A failure deep in a path names the real path (`${s[web][9]}`), not just the
+    // root and failing segment — the walker accumulates the prefix.
+    let k = setup().await;
+    let (_, code, err) = run(
+        &k,
+        r#"s=$(fromjson '{"web":[80,443]}'); echo ${s[web][9]}"#,
+    )
+    .await;
+    assert_ne!(code, 0, "out-of-bounds must be an error");
+    assert!(err.contains("s[web][9]"), "should name the full path: {err}");
+}
+
+#[tokio::test]
 async fn nested_dynamic_key_through_a_path() {
     // `${services[$k][port]}` — a dynamic key mid-path, then a literal key.
     let k = setup().await;

--- a/crates/kaish-kernel/tests/collection_access_tests.rs
+++ b/crates/kaish-kernel/tests/collection_access_tests.rs
@@ -338,33 +338,92 @@ async fn negative_slice_end_is_not_mistaken_for_a_default() {
     assert_eq!(out, r#"["a","b"]"#);
 }
 
+// ── Path-aware ${#path} and ${path:-default} (decision A) ──────────────────
+// The subscripted forms are wired through the shared resolver now (they used to
+// be a loud "bind first" placeholder). `:-` defaults on ABSENCE (unset root,
+// missing key, out-of-bounds, null, empty string) but never on a falsy-but-
+// present value; a SHAPE error stays loud even with `:-`.
+
 #[tokio::test]
-async fn default_on_a_subscripted_path_is_a_loud_error_not_the_default() {
-    // `${cfg[port]:-8080}` must not silently return 8080 while a real value
-    // exists — length/default on a path isn't wired yet, so it's loud with a
-    // "bind first" hint (never silent-wrong-output).
+async fn default_on_a_subscripted_path_returns_the_present_value() {
+    // `${cfg[port]:-8080}` with a real value returns it, not the default.
     let k = setup().await;
-    let (_, code, err) = run(
+    let (out, code, err) = run(
         &k,
         r#"cfg=$(fromjson '{"port":9000}'); echo ${cfg[port]:-8080}"#,
     )
     .await;
-    assert_ne!(code, 0, "default-on-path must be loud, not silently the default");
-    assert!(err.contains("bind it first"), "should hint at binding first: {err}");
+    assert_eq!(code, 0, "err: {err}");
+    assert_eq!(out, "9000");
 }
 
 #[tokio::test]
-async fn length_of_a_subscripted_path_is_a_loud_error_not_zero() {
-    // `${#u[tags]}` must not silently print 0 (bare-name lookup miss) — loud with
-    // a "bind first" hint until nested length lands.
+async fn default_on_a_missing_key_yields_the_default() {
+    // A missing key is absence — the default fires (decision A).
     let k = setup().await;
-    let (_, code, err) = run(
+    let (out, code, err) = run(
         &k,
-        r#"u=$(fromjson '{"tags":["a","b"]}'); echo "${#u[tags]}""#,
+        r#"cfg=$(fromjson '{"port":9000}'); echo ${cfg[host]:-localhost}"#,
     )
     .await;
-    assert_ne!(code, 0, "length-of-path must be loud, not silent 0");
-    assert!(err.contains("bind it first"), "should hint at binding first: {err}");
+    assert_eq!(code, 0, "err: {err}");
+    assert_eq!(out, "localhost");
+}
+
+#[tokio::test]
+async fn default_on_an_out_of_bounds_index_yields_the_default() {
+    let k = setup().await;
+    let (out, code, err) =
+        run(&k, r#"xs=$(fromjson '["a","b"]'); echo ${xs[9]:-none}"#).await;
+    assert_eq!(code, 0, "err: {err}");
+    assert_eq!(out, "none");
+}
+
+#[tokio::test]
+async fn default_does_not_suppress_a_shape_error() {
+    // An integer index on a record is misuse, not absence — loud even with `:-`.
+    let k = setup().await;
+    let (_, code, err) =
+        run(&k, r#"cfg=$(fromjson '{"port":9000}'); echo ${cfg[0]:-x}"#).await;
+    assert_ne!(code, 0, "a shape error must stay loud despite `:-`");
+    assert!(err.contains("record keys are strings"), "got: {err}");
+}
+
+#[tokio::test]
+async fn bare_default_fires_on_null_but_not_on_false_or_zero() {
+    // Decision A at the value level: null/empty default; false/0 are present.
+    let k = setup().await;
+    let (out_null, _, _) = run(&k, r#"x=$(fromjson 'null'); echo ${x:-fallback}"#).await;
+    assert_eq!(out_null, "fallback", "null defaults");
+    let (out_false, _, _) = run(&k, r#"x=$(fromjson 'false'); echo ${x:-fallback}"#).await;
+    assert_eq!(out_false, "false", "false is present, not absent");
+    let (out_zero, _, _) = run(&k, r#"x=$(fromjson '0'); echo ${x:-fallback}"#).await;
+    assert_eq!(out_zero, "0", "zero is present, not absent");
+}
+
+#[tokio::test]
+async fn length_of_a_subscripted_path_is_the_element_count() {
+    // `${#u[tags]}` resolves the path and counts — expression position exercises
+    // the widened lexer regex; the string form the interpolation path.
+    let k = setup().await;
+    let (bare, code, err) =
+        run(&k, r#"u=$(fromjson '{"tags":["a","b","c"]}'); echo ${#u[tags]}"#).await;
+    assert_eq!(code, 0, "err: {err}");
+    assert_eq!(bare, "3");
+
+    let (in_string, code2, err2) =
+        run(&k, r#"u=$(fromjson '{"tags":["a","b"]}'); echo "count=${#u[tags]}""#).await;
+    assert_eq!(code2, 0, "err: {err2}");
+    assert_eq!(in_string, "count=2");
+}
+
+#[tokio::test]
+async fn length_of_a_missing_key_is_a_loud_error() {
+    // Length has no default operator, so absence is loud (like bare `${u[nope]}`).
+    let k = setup().await;
+    let (_, code, _) =
+        run(&k, r#"u=$(fromjson '{"tags":["a"]}'); echo ${#u[nope]}"#).await;
+    assert_ne!(code, 0, "length of a missing key must be loud");
 }
 
 #[tokio::test]

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -81,6 +81,7 @@ ${xs[-1]}           # negative index counts from the end
 ${xs[0:2]}          # slice — end-exclusive, yields a list
 ${u[tags][0]}       # nested path
 ${#xs}   ${#u}      # length: list element count / record key count
+${#u[tags]}         # length of a nested value (path-aware)
 ```
 
 A subscript that lands on a JSON **scalar** unwraps to a native value, so
@@ -90,7 +91,26 @@ comparisons and arithmetic are typed (not stringly):
 c=$(fromjson '{"port":8080,"healthy":false}')
 echo $(( ${c[port]} + 1 ))                       # 8081  (integer arithmetic)
 [[ ${c[healthy]} == false ]] && echo "down"      # typed bool
+xs=$(fromjson '[10,20,30]'); i=1; echo $(( xs[i] ))   # bare subscript reads VARIABLE i → 20
 ```
+
+Inside `$(( … ))` a bare subscript is a numeric expression, so `xs[i]` reads the
+**variable** `i` — the opposite of the interpolation form `${xs[i]}`, where a
+bareword is a literal key. Write `${xs[$i]}` for a variable key in interpolation.
+
+**Default with `:-`.** `${path:-default}` yields the default on **absence** — an
+unset root, a missing key, an out-of-bounds index — and on an **empty** value
+(JSON `null` or empty string), but never on a present-but-falsy value:
+
+```sh
+cfg=$(fromjson '{"port":9000}')
+echo ${cfg[port]:-8080}       # 9000  (present)
+echo ${cfg[host]:-localhost}  # localhost  (missing key → default)
+echo ${cfg[flag]:-on}         # if flag is false/0/[]/{} you get that value, not "on"
+```
+
+A **shape** error (integer index on a record, string key on a list, subscripting
+a scalar, dotted access) stays loud even with `:-` — misuse is not absence.
 
 Every bad access is a **loud error**, never a silent empty — dotted access
 (`${u.name}` → use `[name]`), a missing record key, an out-of-bounds index, a

--- a/docs/arrays-and-hashes.md
+++ b/docs/arrays-and-hashes.md
@@ -680,11 +680,19 @@ paths relative to `crates/kaish-kernel/src`).
   `cmd.env(...)` at both spawn sites (`kernel.rs::try_execute_external`, test-only twin
   `dispatch.rs::try_external` — the hermetic two-spawn-site rule). `export.rs` declaration-time
   display was deliberately left as-is (the process edge is the boundary that matters).
-### #6 — the shared per-hop resolver (design settled 2026-07-02)
+### #6 — the shared per-hop resolver (design settled 2026-07-02; read-side SHIPPED 2026-07-02)
 
 *The single most important thing before the literal/lvalue grammar. This is a read-side refactor
 that also unblocks the deferred `${#path}` / `${path:-default}` forms and arithmetic subscripts;
 lvalue **writes** are the phase after, but the resolver is shaped so they slot in.*
+
+**SHIPPED (read side, branch `feat/collections-resolver`):** `resolve_step` + the `Cow` borrow
+walk (kills the O(n²) root clone), the `PathError` → `UndefinedRoot`/`Absence`/`Shape` split,
+path-aware `${#path}` / `${path:-default}` with decision-A semantics (`VarLength`/`VarWithDefault`
+now carry a `VarPath`; the lexer `VarLength` regex widened for bracket subscripts), arithmetic
+decision B (`$(( xs[i] ))` reads variable `i`), and full-path-prefix error messages. The two
+`subscripted_*_error` "bind first" placeholders are deleted. **NOT shipped:** lvalue writes
+(`a[b]=x` grammar + `walk_write` + validator root-binding) — the next phase, sharing `resolve_step`.
 
 **The problem.** Today `Scope::apply_segment` (`scope.rs:519`) fuses three jobs per hop — classify
 a segment against the container (index-vs-key, negative-index normalization, every loud message),
@@ -733,6 +741,40 @@ guarantees read and write can't diverge.
 `Scope` read-guard, unwrapping to owned only at the leaf (this is what removes the O(n²) clone). The
 borrow must complete within the `RwLock` guard's lifetime — validate that borrow shape before
 building out.
+
+**Grounding pass 2026-07-02 (against HEAD; design-pass with the code open).** Three findings that
+sharpen the plan:
+- **The borrow risk mostly dissolves.** `resolve_path(&self, &VarPath) -> Result<Value, PathError>`
+  takes `&self` and returns **owned** `Value`, and every caller already holds the guard
+  (`let scope = self.scope.read().await; scope.resolve_path(&path)` — `scope: RwLock<Scope>`,
+  `kernel.rs:665`). So `walk_read`'s `&serde_json::Value` borrow lives **entirely inside the method
+  body**, well within the guard; no lifetime threads out to any caller and the public signature is
+  unchanged. The actual O(n²) is today's `self.get(root_name).cloned()` (`scope.rs:507`) cloning the
+  *whole root* on every `${u[$k]}`; deleting that `.cloned()` (walk the borrowed root, clone only the
+  leaf) is the fix.
+- **Arithmetic decision B is a correctness bug, not a refinement.** `arithmetic.rs:352-379`
+  hand-collects the bracket text, rebuilds `${root[...]}` as a string, and reparses through the
+  *shared* `parse_subscript` — so `$(( xs[i] ))` today resolves `i` as a **literal key**, not variable
+  `i`. Fix per B: arithmetic builds the `VarPath` directly, emitting `VarSegment::Dynamic("i")` for a
+  bareword subscript (interpolation keeps emitting `Key("i")`), so `resolve_step` stays context-free.
+- **The read/write seam, made minimal.** `resolve_step` owns everything **identical** across read and
+  write — index-vs-key classification, negative-index math, and `Index` bounds (out-of-bounds →
+  `Absence`; a write index-set is also in-bounds-only, so bounds are genuinely shared). The **only**
+  thing the walk decides is *missing-`Key` policy*: `walk_read` → `Absence`; the future `walk_write`
+  leaf → insert. That is the smallest split that keeps `${a[-1]}` read and `a[-1]=x` write from
+  drifting. `resolve_step` does **not** check `Key` existence (that's walk policy).
+
+**`PathError` reclassification — every current `Invalid` site.** Today `UndefinedRoot | Invalid`
+(`scope.rs:27`); the split assigns each site:
+- **UndefinedRoot** — root not in scope; **unset dynamic key** `${r[$k]}` when `$k` itself is unset
+  (`scope.rs:554` — the *variable* is missing, so `${r[$k]:-d}` defaults).
+- **Absence** — out-of-bounds index (`scope.rs:79`); missing record key `no such key` (`scope.rs:92`).
+- **Shape** — dotted `.field` (`scope.rs:531`); subscript-a-scalar (`scope.rs:540`);
+  integer-index-on-record (`scope.rs:66`); string-key-on-list (`scope.rs:96`); slice-a-record
+  (`scope.rs:117`); dynamic-index-not-integer (`scope.rs:560`); `$?` subscripted (`scope.rs:499`).
+
+`${path:-default}` catches **UndefinedRoot + Absence** → default; **Shape always stays loud**; plus
+the post-resolution `null`/empty-string → default check (decision A — *not* on `false`/`0`/`[]`/`{}`).
 - **`...` spread**: new lexer token; no existing `..`/`...` handling to collide with. Scope it
   to `[ ]` value context only.
 

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -447,6 +447,17 @@ pipeline, control, …}` with `execute_stmt_flow` reduced to dispatch-arm-per-mo
 The six-field `ExecContext` ↔ kernel-state sync appears near every fork call site
 (`kernel.rs:~4100-4140` and duplicates). One helper, one truth.
 
+### Focused session: clean up & streamline the parser
+`parser.rs` has accreted a lot of special-casing and the lexer/parser boundary is
+doing more than it should (context-free glob/colon merge passes the parser then has
+to fight against, hand-rolled bracket collection in `arithmetic.rs`, the
+value-vs-argv grammar split still pending for collection literals). Worth a dedicated
+pass to consolidate: unify the subscript/path machinery, push the value/argv
+bifurcation through cleanly, and thin the merge-pass workarounds. Surfaced while
+grounding the #6 resolver work (2026-07-02) — the resolver refactor is the read-side
+half; the parser is where the *write*-side literal/lvalue grammar will land, so
+streamlining it first de-risks that phase. (P2)
+
 ### No unquoted token-pasting — residual polish
 (Decision recorded in devlog — keep the quoting requirement.) Live residuals (P4):
 - **Redirect target** (`parser.rs`, `redirect_parser`): `> /tmp/$(echo x).txt` is a


### PR DESCRIPTION
The read-side of #6 — the shared per-hop path resolver that must land before the collections literal/lvalue grammar. Seven commits, each independently green (built to survive a merge commit rather than a squash).

## What lands

- **`resolve_step` + Cow borrow walk** (`2cbdd02`, inert refactor). Splits the fused per-hop `apply_segment` into a shared `resolve_step(container, seg, scope, path) -> Step` classifier + a `descend` walk over `Cow<serde_json::Value>`. Kills the old O(n²) whole-root clone (`self.get(root).cloned()` on every `${u[$k]}`); the walk borrows into the tree and clones only the leaf. `resolve_path` still returns owned `Value`, so no lifetime escapes. The future lvalue `walk_write` reuses `resolve_step` verbatim — read/write classification can't drift. Behavior byte-identical (all read-access tests + repl integration tests green).
- **`PathError` → `UndefinedRoot` / `Absence` / `Shape`** (`bd69074`). Absence = missing key / out-of-bounds; Shape = wrong-shaped access (string key on list, int index on record, subscript a scalar, dotted, slice a record). Load-bearing for the `:-` semantics below. Unset dynamic key `${r[$k]}` is UndefinedRoot-class.
- **Path-aware `${#path}` and `${path:-default}`** (`28ec480`). `VarLength`/`VarWithDefault` carry a `VarPath`; lexer `VarLength` regex widened for subscripts. Decision A: `:-` defaults on absence (unset root, missing key, OOB) and empty (JSON null / empty string), **never** on `false`/`0`/`[]`/`{}`; a Shape error stays loud even with `:-`. Also fixes a bare-name bug: `${x:-d}` with `x` = JSON null used to return `"null"`. Semantics centralized in `resolve_length`/`resolve_default` so sync/async/reduced-sync paths agree. The old loud "bind first" placeholders are deleted.
- **Arithmetic decision B** (`5c10462`). `$(( xs[i] ))` bare subscript reads the **variable** `i` (each bracket inner is a nested arithmetic expression → integer index); the braced `${xs[i]}` stays a literal key. Fixes a real gap (bare subscripts were dropped, failing as "variable is JSON, not a number").
- **Full-path-prefix error messages + docs** (`8e972a0`). `${s[web][9]}: index out of bounds`, not `${s[9]}`. LANGUAGE.md Collections + CHANGELOG updated; arrays-and-hashes.md marks the #6 read side shipped.
- **Lexer test for subscripted `${#path}`** (`0ddc0ba`) — closes a gap the review flagged.

## Review

kaibo (deepseek) holistic review, no diff supplied: **no silent-corruption issues, "safe to merge."** Verified the Cow borrow soundness (unreachable arms genuinely unreachable), every PathError classification site, three-eval-path agreement, deadlock-free RwLock guard scoping, and that the braced arithmetic form is untouched. Non-blocking notes documented: `$(( u[port] ))` on a record reads index 0 (decision-B foot-gun, now in LANGUAGE.md); slice start-OOB clamps to empty (Python-style, intentional).

## Not in this PR

Lvalue writes (`a[b]=x` grammar + `walk_write` + validator root-binding) — the next phase, reusing `resolve_step` unchanged. Then the literal grammar (`xs=[…]`, `push`), decision D/E boundary errors, and the pre-sign-off panel gate.

## Gate

`cargo test --all` (97 binaries) and `cargo clippy --all --all-targets` clean at every commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)