### PR TITLE
feat(collections): close the last two silent-stringify boundaries (D+E)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,6 +134,19 @@ breaking entries are marked **BREAKING**.
     default on a *subscripted* path — `${#u[tags]}`, `${cfg[port]:-8080}` — were
     briefly a loud "bind it first" error; they are now fully path-aware, see
     Added.)
+- **A bare collection reaching an external command's argv or a redirect
+  target silently JSON-serialized** (e.g. `curl -d $cfg` or `echo x > $cfg`);
+  both process-boundary sinks now refuse it with a `$(tojson $x)` hint, closing
+  the last two silent-stringify seams alongside the OS-env-export guard above.
+  A quoted `"$cfg"` is unaffected — string interpolation already renders
+  compact JSON before either sink sees it.
+- **Scalar-only `[[ ]]` test operators silently stringified a collection
+  operand** — `-z`/`-n`, `=~`/`!~`, ordering (`<`/`>`/`<=`/`>=`), and numeric
+  (`-eq`/`-ne`/`-gt`/`-lt`/`-ge`/`-le`) now refuse a list/record operand with a
+  loud Shape error naming the operator (e.g. an empty list no longer reads as
+  `-z`-true via its JSON text `"[]"`). `==`/`!=` already errored; `in`/`not in`
+  are unaffected (the one operator family that legitimately takes a
+  collection).
 - **`${x:-default}` no longer treats JSON `null` as present** — a variable
   holding `null` stringified to the non-empty `"null"`, so `${x:-fallback}`
   returned `null` instead of the default. `:-` now fires on `null` and empty

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,10 +136,13 @@ breaking entries are marked **BREAKING**.
     Added.)
 - **A bare collection reaching an external command's argv or a redirect
   target silently JSON-serialized** (e.g. `curl -d $cfg` or `echo x > $cfg`);
-  both process-boundary sinks now refuse it with a `$(tojson $x)` hint, closing
-  the last two silent-stringify seams alongside the OS-env-export guard above.
-  A quoted `"$cfg"` is unaffected — string interpolation already renders
-  compact JSON before either sink sees it.
+  every process-boundary sink now refuses it with a `$(tojson $x)` hint. This
+  covers the generic external-argv/redirect paths **and** the three subprocess
+  builtins that build argv/env themselves (`spawn`, `exec`, `env`) — including
+  `spawn`'s nested-collection argv elements and `env <cmd>`'s child-environment
+  export (which previously bypassed the OS-env-export guard). A quoted `"$cfg"`
+  is unaffected — string interpolation renders compact JSON before either sink
+  sees it.
 - **Scalar-only `[[ ]]` test operators silently stringified a collection
   operand** — `-z`/`-n`, `=~`/`!~`, ordering (`<`/`>`/`<=`/`>=`), and numeric
   (`-eq`/`-ne`/`-gt`/`-lt`/`-ge`/`-le`) now refuse a list/record operand with a

--- a/crates/kaish-kernel/src/dispatch.rs
+++ b/crates/kaish-kernel/src/dispatch.rs
@@ -190,29 +190,39 @@ impl BackendDispatcher {
             resolve_in_path(name, &path_var)?
         };
 
-        // Build flat argv from args
-        let argv: Vec<String> = args.iter().filter_map(|arg| {
+        // Build flat argv from args. A for-loop (not filter_map) so the
+        // Decision D collection-argv guard can short-circuit the whole spawn
+        // — kept in sync with the production build in kernel.rs::build_args_flat.
+        let mut argv: Vec<String> = Vec::new();
+        for arg in args {
             match arg {
                 Arg::Positional(expr) => match expr {
-                    Expr::Literal(Value::String(s)) => Some(s.clone()),
-                    Expr::Literal(Value::Int(i)) => Some(i.to_string()),
-                    Expr::Literal(Value::Float(f)) => Some(f.to_string()),
-                    Expr::VarRef(path) => ctx.scope.resolve_path(path).ok().map(|v| crate::interpreter::value_to_string(&v)),
-                    _ => None,
+                    Expr::Literal(Value::String(s)) => argv.push(s.clone()),
+                    Expr::Literal(Value::Int(i)) => argv.push(i.to_string()),
+                    Expr::Literal(Value::Float(f)) => argv.push(f.to_string()),
+                    Expr::VarRef(path) => {
+                        if let Ok(v) = ctx.scope.resolve_path(path) {
+                            if let Some(msg) = crate::interpreter::structured_boundary_error("a command argument", &v) {
+                                return Some(ExecResult::failure(1, msg));
+                            }
+                            argv.push(crate::interpreter::value_to_string(&v));
+                        }
+                    }
+                    _ => {}
                 },
-                Arg::ShortFlag(f) => Some(format!("-{f}")),
-                Arg::LongFlag(f) => Some(format!("--{f}")),
+                Arg::ShortFlag(f) => argv.push(format!("-{f}")),
+                Arg::LongFlag(f) => argv.push(format!("--{f}")),
                 Arg::Named { key, value } => match value {
-                    Expr::Literal(Value::String(s)) => Some(format!("--{key}={s}")),
-                    _ => Some(format!("--{key}=")),
+                    Expr::Literal(Value::String(s)) => argv.push(format!("--{key}={s}")),
+                    _ => argv.push(format!("--{key}=")),
                 },
                 Arg::WordAssign { key, value } => match value {
-                    Expr::Literal(Value::String(s)) => Some(format!("{key}={s}")),
-                    _ => Some(format!("{key}=")),
+                    Expr::Literal(Value::String(s)) => argv.push(format!("{key}={s}")),
+                    _ => argv.push(format!("{key}=")),
                 },
-                Arg::DoubleDash => Some("--".to_string()),
+                Arg::DoubleDash => argv.push("--".to_string()),
             }
-        }).collect();
+        }
 
         // Check for streaming pipes
         let has_pipe_stdin = ctx.pipe_stdin.is_some();

--- a/crates/kaish-kernel/src/interpreter.rs
+++ b/crates/kaish-kernel/src/interpreter.rs
@@ -37,6 +37,6 @@ mod result;
 mod scope;
 
 pub use control_flow::ControlFlow;
-pub use eval::{eval_expr, expand_tilde, resolve_default, resolve_length, strip_leading_tabs, structured_export_error, value_defaults_on_emptiness, value_to_bool, value_to_exit_code, value_length, value_to_string, value_to_string_with_tilde, EvalError, EvalResult, Evaluator, Executor, HeredocAssembler, NoOpExecutor};
+pub use eval::{eval_expr, expand_tilde, is_collection, resolve_default, resolve_length, scalar_test_operand_error, strip_leading_tabs, structured_boundary_error, structured_export_error, value_defaults_on_emptiness, value_to_bool, value_to_exit_code, value_length, value_to_string, value_to_string_with_tilde, EvalError, EvalResult, Evaluator, Executor, HeredocAssembler, NoOpExecutor};
 pub use result::{apply_output_format, hex_dump, json_to_value, json_to_value_no_envelope, value_to_json, EntryType, ExecResult, LatchRequest, OutputData, OutputFormat, OutputNode, OutputPayload};
 pub use scope::{PathError, Scope};

--- a/crates/kaish-kernel/src/interpreter/eval.rs
+++ b/crates/kaish-kernel/src/interpreter/eval.rs
@@ -313,6 +313,17 @@ impl<'a, E: Executor> Evaluator<'a, E> {
             TestExpr::StringTest { op, value } => match op {
                 StringTestOp::IsEmpty | StringTestOp::IsNonEmpty => {
                     let val = self.eval(value)?;
+                    // Decision E: a collection operand is a loud Shape error,
+                    // never silently stringified-then-measured (an empty list
+                    // `[]` must not read as "-z"-true via its JSON text).
+                    let symbol = match op {
+                        StringTestOp::IsEmpty => "-z",
+                        StringTestOp::IsNonEmpty => "-n",
+                        StringTestOp::IsList | StringTestOp::IsRecord => unreachable!(),
+                    };
+                    if let Some(msg) = scalar_test_operand_error(symbol, &val) {
+                        return Err(EvalError::Unsupported(msg));
+                    }
                     let s = value_to_string(&val);
                     match op {
                         StringTestOp::IsEmpty => s.is_empty(),
@@ -339,6 +350,8 @@ impl<'a, E: Executor> Evaluator<'a, E> {
                     TestCmpOp::Eq => values_equal(&left_val, &right_val)?,
                     TestCmpOp::NotEq => !(values_equal(&left_val, &right_val)?),
                     TestCmpOp::Match => {
+                        // Decision E: regex match is scalar-only.
+                        guard_scalar_test_operands(op, &left_val, &right_val)?;
                         // Regex match — propagate compile errors loudly (no silent false).
                         match regex_match(&left_val, &right_val, false)? {
                             Value::Bool(b) => b,
@@ -346,6 +359,7 @@ impl<'a, E: Executor> Evaluator<'a, E> {
                         }
                     }
                     TestCmpOp::NotMatch => {
+                        guard_scalar_test_operands(op, &left_val, &right_val)?;
                         // Regex not match — propagate compile errors loudly (no silent true).
                         match regex_match(&left_val, &right_val, true)? {
                             Value::Bool(b) => b,
@@ -353,6 +367,8 @@ impl<'a, E: Executor> Evaluator<'a, E> {
                         }
                     }
                     TestCmpOp::Gt | TestCmpOp::Lt | TestCmpOp::GtEq | TestCmpOp::LtEq => {
+                        // Decision E: ordering is scalar-only.
+                        guard_scalar_test_operands(op, &left_val, &right_val)?;
                         // String comparison: `>` `<` `>=` `<=` use lexicographic ordering.
                         let ord = compare_values(&left_val, &right_val)?;
                         match op {
@@ -369,6 +385,8 @@ impl<'a, E: Executor> Evaluator<'a, E> {
                     | TestCmpOp::NumLt
                     | TestCmpOp::NumGtEq
                     | TestCmpOp::NumLtEq => {
+                        // Decision E: numeric comparison is scalar-only.
+                        guard_scalar_test_operands(op, &left_val, &right_val)?;
                         // Arithmetic comparison: `-eq` `-ne` `-gt` `-lt` `-ge` `-le`
                         // always coerce operands to numbers. Non-numeric strings error.
                         let ord = numeric_compare(&left_val, &right_val)?;
@@ -680,6 +698,67 @@ pub fn structured_export_error(vars: &[(String, Value)]) -> Option<String> {
     None
 }
 
+/// True if `value` is a first-class collection (list/record) rather than a
+/// scalar. `Value::Json` also carries JSON scalars (numbers/strings/bool/null
+/// unwrapped at the value boundary — see `json_to_value_no_envelope`), so
+/// this only matches the two container variants.
+pub fn is_collection(value: &Value) -> bool {
+    matches!(
+        value,
+        Value::Json(serde_json::Value::Array(_)) | Value::Json(serde_json::Value::Object(_))
+    )
+}
+
+/// "list" or "record" for a value that `is_collection`. Callers only reach
+/// the fallback arm if they call this without checking `is_collection` first.
+fn collection_kind(value: &Value) -> &'static str {
+    match value {
+        Value::Json(serde_json::Value::Array(_)) => "list",
+        Value::Json(serde_json::Value::Object(_)) => "record",
+        _ => "collection",
+    }
+}
+
+/// Decision D: reject a bare collection value crossing a process-boundary
+/// sink — an external command's argv element, or a redirect target. String
+/// interpolation (`"$c"`) already reduces to a `Value::String` (rendering
+/// compact JSON) before reaching either sink, so only a *live*,
+/// un-interpolated `Value::Json(Array|Object)` — a bare `$c` — trips this.
+/// `sink` names the boundary in the message (e.g. "a command argument",
+/// "a redirect target"). `None` for scalars. Callers: `kernel.rs`
+/// (`build_args_flat`, `try_execute_external`), `dispatch.rs` (`try_external`,
+/// test-only twin), `scheduler/pipeline.rs` (`eval_redirect_target`).
+pub fn structured_boundary_error(sink: &str, value: &Value) -> Option<String> {
+    if is_collection(value) {
+        let kind = collection_kind(value);
+        Some(format!(
+            "cannot use a {kind} as {sink} — serialize it explicitly first, e.g. `cmd $(tojson $x)`"
+        ))
+    } else {
+        None
+    }
+}
+
+/// Decision E: scalar-only test operators (`-z`/`-n`, `=~`/`!~`, ordering
+/// `<`/`>`/`<=`/`>=`, and numeric `-eq`/`-ne`/`-gt`/`-lt`/`-ge`/`-le`) refuse a
+/// collection operand loudly rather than falling through a stringify/silent
+/// path. `==`/`!=` already error via `values_equal`; `in`/`not in` are the one
+/// operator family that legitimately takes a collection operand and must
+/// never call this. `None` for scalars. Shared by the sync `eval_test`
+/// (interpreter/eval.rs) and the async `eval_test_async` (kernel.rs) so the
+/// two `[[ ]]` evaluators can't drift apart on this guard.
+pub fn scalar_test_operand_error(op_symbol: &str, value: &Value) -> Option<String> {
+    if is_collection(value) {
+        let kind = collection_kind(value);
+        Some(format!(
+            "`{op_symbol}` needs a scalar; got a {kind} — use `${{#x}}` for length, \
+             `-list`/`-record` to test shape, or `in` for membership"
+        ))
+    } else {
+        None
+    }
+}
+
 pub fn value_to_string(value: &Value) -> String {
     match value {
         Value::Null => "null".to_string(),
@@ -937,6 +1016,41 @@ fn eval_membership(needle: &Value, haystack: &Value) -> EvalResult<bool> {
             type_name(other),
         ))),
     }
+}
+
+/// The literal operator spelling for a `TestCmpOp`, used in Decision E's Shape
+/// error message so it names the exact operator the user wrote.
+fn cmp_op_symbol(op: &TestCmpOp) -> &'static str {
+    match op {
+        TestCmpOp::Eq => "==",
+        TestCmpOp::NotEq => "!=",
+        TestCmpOp::Match => "=~",
+        TestCmpOp::NotMatch => "!~",
+        TestCmpOp::Gt => ">",
+        TestCmpOp::Lt => "<",
+        TestCmpOp::GtEq => ">=",
+        TestCmpOp::LtEq => "<=",
+        TestCmpOp::NumEq => "-eq",
+        TestCmpOp::NumNotEq => "-ne",
+        TestCmpOp::NumGt => "-gt",
+        TestCmpOp::NumLt => "-lt",
+        TestCmpOp::NumGtEq => "-ge",
+        TestCmpOp::NumLtEq => "-le",
+    }
+}
+
+/// Decision E guard for every `TestExpr::Comparison` operator except `==`/`!=`
+/// (already loud via `values_equal`): a single call point so a new comparison
+/// operator can't be added without picking up the collection guard.
+fn guard_scalar_test_operands(op: &TestCmpOp, left: &Value, right: &Value) -> EvalResult<()> {
+    let symbol = cmp_op_symbol(op);
+    if let Some(msg) = scalar_test_operand_error(symbol, left) {
+        return Err(EvalError::Unsupported(msg));
+    }
+    if let Some(msg) = scalar_test_operand_error(symbol, right) {
+        return Err(EvalError::Unsupported(msg));
+    }
+    Ok(())
 }
 
 /// Compare two values for ordering.

--- a/crates/kaish-kernel/src/kernel.rs
+++ b/crates/kaish-kernel/src/kernel.rs
@@ -3615,16 +3615,30 @@ impl Kernel {
                         }
                     }
                     let value = self.eval_expr_async(expr).await?;
+                    // Decision D: a bare collection can't cross the external
+                    // process boundary as an argv element — refuse rather than
+                    // silently JSON-serializing it. A quoted `"$x"` already
+                    // reduced to a `Value::String` above (via `Expr::Interpolated`),
+                    // so only a live, un-interpolated `$x` trips this.
+                    if let Some(msg) = crate::interpreter::structured_boundary_error("a command argument", &value) {
+                        return Err(anyhow::anyhow!(msg));
+                    }
                     let value = apply_tilde_expansion(value, home.as_deref());
                     argv.push(value_to_string(&value));
                 }
                 Arg::Named { key, value } => {
                     let val = self.eval_expr_async(value).await?;
+                    if let Some(msg) = crate::interpreter::structured_boundary_error("a command argument", &val) {
+                        return Err(anyhow::anyhow!(msg));
+                    }
                     let val = apply_tilde_expansion(val, home.as_deref());
                     argv.push(format!("--{}={}", key, value_to_string(&val)));
                 }
                 Arg::WordAssign { key, value } => {
                     let val = self.eval_expr_async(value).await?;
+                    if let Some(msg) = crate::interpreter::structured_boundary_error("a command argument", &val) {
+                        return Err(anyhow::anyhow!(msg));
+                    }
                     let val = apply_tilde_expansion(val, home.as_deref());
                     argv.push(format!("{}={}", key, value_to_string(&val)));
                 }
@@ -3868,6 +3882,18 @@ impl Kernel {
                 TestExpr::StringTest { op, value } => match op {
                     crate::ast::StringTestOp::IsEmpty | crate::ast::StringTestOp::IsNonEmpty => {
                         let val = self.eval_expr_async(value).await?;
+                        // Decision E: a collection operand is a loud Shape error
+                        // here too — must not diverge from the sync path in
+                        // interpreter/eval.rs (shared `scalar_test_operand_error`).
+                        let symbol = match op {
+                            crate::ast::StringTestOp::IsEmpty => "-z",
+                            crate::ast::StringTestOp::IsNonEmpty => "-n",
+                            crate::ast::StringTestOp::IsList
+                            | crate::ast::StringTestOp::IsRecord => unreachable!(),
+                        };
+                        if let Some(msg) = crate::interpreter::scalar_test_operand_error(symbol, &val) {
+                            anyhow::bail!(msg);
+                        }
                         let s = value_to_string(&val);
                         Ok(match op {
                             crate::ast::StringTestOp::IsEmpty => s.is_empty(),

--- a/crates/kaish-kernel/src/scheduler/pipeline.rs
+++ b/crates/kaish-kernel/src/scheduler/pipeline.rs
@@ -162,17 +162,18 @@ async fn apply_redirects(
 /// inside a heredoc body. Falls back to the sync evaluator (which skips
 /// command substitution) only when no dispatcher is attached.
 async fn eval_redirect_target(expr: &Expr, ctx: &ExecContext) -> Result<String, String> {
-    if let Some(dispatcher) = &ctx.dispatcher {
-        dispatcher
-            .eval_expr(expr, ctx)
-            .await
-            .map(|v| value_to_string(&v))
-            .map_err(|e| e.to_string())
+    let value = if let Some(dispatcher) = &ctx.dispatcher {
+        dispatcher.eval_expr(expr, ctx).await.map_err(|e| e.to_string())?
     } else {
         eval_simple_expr(expr, ctx)
-            .map(|v| value_to_string(&v))
-            .ok_or_else(|| "could not evaluate redirect target".to_string())
+            .ok_or_else(|| "could not evaluate redirect target".to_string())?
+    };
+    // Decision D: a bare collection can't be a redirect target either — same
+    // process-boundary guard as external argv (see `structured_boundary_error`).
+    if let Some(msg) = crate::interpreter::structured_boundary_error("a redirect target", &value) {
+        return Err(msg);
     }
+    Ok(value_to_string(&value))
 }
 
 /// Write data to a file via the VFS backend.

--- a/crates/kaish-kernel/src/tools/builtin/env.rs
+++ b/crates/kaish-kernel/src/tools/builtin/env.rs
@@ -134,6 +134,15 @@ impl Tool for Env {
         let Some(cmd_idx) = command_start else {
             return ExecResult::failure(1, "env: internal error: missing command index");
         };
+        // Decision D: a bare collection can't cross the process boundary as the
+        // command name or an argv element — loud, not a silent JSON stringify.
+        // env consumes typed Values directly (no `build_args_flat`), so the
+        // guard lives here at env's own edge.
+        for v in &args.positional[cmd_idx..] {
+            if let Some(msg) = crate::interpreter::structured_boundary_error("a command argument", v) {
+                return ExecResult::failure(1, format!("env: {msg}"));
+            }
+        }
         let command = match &args.positional[cmd_idx] {
             Value::String(s) => s.clone(),
             other => value_to_string(other),
@@ -261,11 +270,22 @@ async fn execute_with_env(
     if clear {
         cmd.env_clear();
     } else {
-        // Set exported variables from scope
-        for (name, value) in ctx.scope.exported_vars() {
-            if !unset.contains(&name) {
-                cmd.env(&name, value_to_string(&value));
-            }
+        // Set exported variables from scope. A structured value can't cross the
+        // process boundary; refuse rather than silently JSON-serializing it into
+        // the child's environment. This is an independent spawn path that
+        // bypasses `try_execute_external`, so it must run the same
+        // `structured_export_error` guard (Decision D).
+        let exported: Vec<(String, Value)> = ctx
+            .scope
+            .exported_vars()
+            .into_iter()
+            .filter(|(name, _)| !unset.contains(name))
+            .collect();
+        if let Some(msg) = crate::interpreter::structured_export_error(&exported) {
+            return ExecResult::failure(1, msg);
+        }
+        for (name, value) in exported {
+            cmd.env(&name, value_to_string(&value));
         }
     }
 

--- a/crates/kaish-kernel/src/tools/builtin/exec.rs
+++ b/crates/kaish-kernel/src/tools/builtin/exec.rs
@@ -103,16 +103,18 @@ impl Tool for Exec {
             }
         };
 
-        // Remaining positionals become argv
-        let argv: Vec<String> = args
-            .positional
-            .iter()
-            .skip(1)
-            .map(|v| match v {
-                Value::String(s) => s.clone(),
-                other => value_to_string(other),
-            })
-            .collect();
+        // Remaining positionals become argv. Decision D: a bare collection
+        // can't cross the process boundary as an argv element — refuse rather
+        // than the previous silent JSON stringify (via `value_to_string`).
+        // exec consumes typed Values directly (no `build_args_flat`), so the
+        // guard lives here at exec's own edge.
+        let mut argv: Vec<String> = Vec::with_capacity(args.positional.len().saturating_sub(1));
+        for v in args.positional.iter().skip(1) {
+            if let Some(msg) = crate::interpreter::structured_boundary_error("a command argument", v) {
+                return ExecResult::failure(1, format!("exec: {msg}"));
+            }
+            argv.push(value_to_string(v));
+        }
 
         // Platform-specific: Unix replaces the process, others error
         #[cfg(unix)]

--- a/crates/kaish-kernel/src/tools/builtin/spawn.rs
+++ b/crates/kaish-kernel/src/tools/builtin/spawn.rs
@@ -122,12 +122,17 @@ impl Tool for Spawn {
             }
         };
 
-        // Get argv (optional)
-        let argv = args
-            .get_named("argv")
-            .or_else(|| args.get_positional(1))
-            .map(extract_string_array)
-            .unwrap_or_default();
+        // Get argv (optional). Decision D: a collection *element* (or a record
+        // as the whole argv) can't cross the process boundary — loud, not a
+        // silent JSON stringify. spawn's argv is legitimately a list of
+        // strings, so only nested collections trip the guard.
+        let argv = match args.get_named("argv").or_else(|| args.get_positional(1)) {
+            Some(v) => match extract_string_array(v) {
+                Ok(argv) => argv,
+                Err(msg) => return ExecResult::failure(1, format!("spawn: {msg}")),
+            },
+            None => Vec::new(),
+        };
 
         // Get env (optional)
         let env_vars = args
@@ -286,27 +291,47 @@ fn value_to_string(value: &Value) -> String {
 /// - JSON array (Value::Json): use elements directly
 /// - JSON array string: parse and extract string items
 /// - Plain string: one-element array (no implicit splitting)
-fn extract_string_array(value: &Value) -> Vec<String> {
+///
+/// Decision D: a nested-collection element (a list/record *inside* the argv
+/// list), or a record used as the whole argv, is a loud error — never a silent
+/// JSON stringify or a silently-dropped element. The top-level list itself is
+/// legitimate (spawn's argv is a list of strings). Reuses the shared
+/// `structured_boundary_error` so the message matches every other boundary.
+fn extract_string_array(value: &Value) -> Result<Vec<String>, String> {
     match value {
         Value::Json(serde_json::Value::Array(arr)) => {
-            arr.iter().map(|v| match v {
-                serde_json::Value::String(s) => s.clone(),
-                other => other.to_string(),
-            }).collect()
+            let mut out = Vec::with_capacity(arr.len());
+            for v in arr {
+                if let Some(msg) = crate::interpreter::structured_boundary_error(
+                    "a command argument",
+                    &Value::Json(v.clone()),
+                ) {
+                    return Err(msg);
+                }
+                out.push(match v {
+                    serde_json::Value::String(s) => s.clone(),
+                    other => other.to_string(),
+                });
+            }
+            Ok(out)
         }
+        Value::Json(obj @ serde_json::Value::Object(_)) => Err(
+            crate::interpreter::structured_boundary_error("a command argument", &Value::Json(obj.clone()))
+                .unwrap_or_else(|| "argv must be a list of strings".to_string()),
+        ),
         Value::String(s) => {
             // Try to parse as JSON array
             if s.starts_with('[')
                 && let Ok(arr) = serde_json::from_str::<Vec<serde_json::Value>>(s) {
-                    return arr
+                    return Ok(arr
                         .iter()
                         .filter_map(|v| v.as_str().map(String::from))
-                        .collect();
+                        .collect());
                 }
             // Plain string is one argument — no implicit whitespace splitting
-            vec![s.clone()]
+            Ok(vec![s.clone()])
         }
-        _ => vec![],
+        _ => Ok(vec![]),
     }
 }
 

--- a/crates/kaish-kernel/tests/collection_access_tests.rs
+++ b/crates/kaish-kernel/tests/collection_access_tests.rs
@@ -968,3 +968,100 @@ fi
     assert_eq!(code_list, 0, "err: {err_list}");
     assert_eq!(out_list, "val:x\nval:y");
 }
+
+// ── Decision E: scalar test operators refuse a collection operand ──────────
+//
+// `==`/`!=` already error via `values_equal` (see
+// `values_equal_collection_vs_scalar_is_loud` in interpreter/eval.rs); `in`/
+// `not in` are the one operator family that legitimately takes a collection
+// and is exercised extensively above. Every other scalar-only test operator
+// must refuse a list/record operand loudly rather than silently stringifying
+// it (an empty list `[]` reading as `-z`-true was the trap).
+
+#[tokio::test]
+async fn dash_z_on_a_list_is_a_loud_shape_error() {
+    let k = setup().await;
+    let result = k
+        .execute(r#"xs=$(fromjson '[1,2]'); if [[ -z $xs ]]; then echo T; fi"#)
+        .await;
+    let msg = result.expect_err("-z on a list must be a loud Shape error, not silent JSON-string emptiness");
+    let msg = format!("{msg:#}");
+    assert!(msg.contains("-z"), "should name the operator: {msg}");
+    assert!(msg.contains("scalar"), "should say it needs a scalar: {msg}");
+}
+
+#[tokio::test]
+async fn dash_n_on_a_record_is_a_loud_shape_error() {
+    let k = setup().await;
+    let result = k
+        .execute(r#"r=$(fromjson '{"a":1}'); if [[ -n $r ]]; then echo T; fi"#)
+        .await;
+    result.expect_err("-n on a record must be a loud Shape error");
+}
+
+#[tokio::test]
+async fn regex_match_on_a_list_is_a_loud_shape_error() {
+    let k = setup().await;
+    let result = k
+        .execute(r#"xs=$(fromjson '["a","b"]'); if [[ $xs =~ a ]]; then echo T; fi"#)
+        .await;
+    let msg = result.expect_err("=~ on a list must be a loud Shape error");
+    assert!(format!("{msg:#}").contains("=~"), "should name the operator: {msg:#}");
+}
+
+#[tokio::test]
+async fn regex_not_match_on_a_list_is_a_loud_shape_error() {
+    let k = setup().await;
+    let result = k
+        .execute(r#"xs=$(fromjson '["a","b"]'); if [[ $xs !~ a ]]; then echo T; fi"#)
+        .await;
+    result.expect_err("!~ on a list must be a loud Shape error");
+}
+
+#[tokio::test]
+async fn numeric_gt_on_a_list_is_a_loud_shape_error() {
+    let k = setup().await;
+    let result = k
+        .execute(r#"xs=$(fromjson '[1,2,3]'); if [[ $xs -gt 3 ]]; then echo T; fi"#)
+        .await;
+    let msg = result.expect_err("-gt on a list must be a loud Shape error");
+    assert!(format!("{msg:#}").contains("-gt"), "should name the operator: {msg:#}");
+}
+
+#[tokio::test]
+async fn ordering_lt_on_two_lists_is_a_loud_shape_error() {
+    let k = setup().await;
+    let result = k
+        .execute(r#"a=$(fromjson '[1]'); b=$(fromjson '[2]'); if [[ $a < $b ]]; then echo T; fi"#)
+        .await;
+    let msg = result.expect_err("< on two lists must be a loud Shape error");
+    assert!(format!("{msg:#}").contains('<'), "should name the operator: {msg:#}");
+}
+
+#[tokio::test]
+async fn scalar_test_operators_still_work_on_scalars() {
+    let k = setup().await;
+    let (out, code, err) = run(&k, r#"if [[ -z "" ]]; then echo T; else echo F; fi"#).await;
+    assert_eq!(code, 0, "err: {err}");
+    assert_eq!(out, "T");
+
+    let (out2, code2, err2) = run(&k, r#"s=hi; if [[ -n $s ]]; then echo T; else echo F; fi"#).await;
+    assert_eq!(code2, 0, "err: {err2}");
+    assert_eq!(out2, "T");
+}
+
+// ── Decision D: a bare collection can't be a redirect target ───────────────
+
+#[tokio::test]
+async fn redirect_target_bare_collection_is_a_loud_error() {
+    let k = setup().await;
+    let result = k.execute(r#"x=$(fromjson '[1,2]'); echo hi > $x"#).await;
+    let msg = match result {
+        Ok(r) => {
+            assert_ne!(r.code, 0, "redirecting into a bare collection target must fail: {r:?}");
+            r.err
+        }
+        Err(e) => format!("{e:#}"),
+    };
+    assert!(msg.contains("tojson"), "should hint at serializing with tojson: {msg}");
+}

--- a/crates/kaish-kernel/tests/external_command_tests.rs
+++ b/crates/kaish-kernel/tests/external_command_tests.rs
@@ -117,6 +117,46 @@ async fn exporting_a_structured_value_to_a_subprocess_is_a_loud_error() {
 }
 
 #[tokio::test]
+async fn bare_collection_in_external_argv_is_a_loud_error() {
+    // A live (un-interpolated) collection reaching an external command's argv
+    // is a loud error, never a silent JSON-serialize — the argv-side twin of
+    // the OS-env-export guard above. `printenv` is a real external (no kaish
+    // builtin by that name), so this exercises the production spawn-site
+    // guard in `build_args_flat`.
+    let kernel = repl_kernel();
+    let result = kernel
+        .execute(r#"xs=$(fromjson '[1,2]'); printenv $xs"#)
+        .await;
+    let msg = match result {
+        Ok(r) => {
+            assert_ne!(r.code, 0, "a bare collection argv element must fail: {r:?}");
+            r.err
+        }
+        Err(e) => format!("{e:#}"),
+    };
+    assert!(msg.contains("tojson"), "should hint at serializing with tojson: {msg}");
+}
+
+// Linux-gated + absolute path so the external spawn is unconditionally taken
+// (bypasses PATH lookup entirely), mirroring
+// `external_argv_does_not_split_space_containing_var` above — the exact
+// argv content is what's under test, so we pin it via `printf`.
+#[cfg(target_os = "linux")]
+#[tokio::test]
+async fn interpolated_collection_is_a_string_arg() {
+    // `"$xs"` interpolates to compact JSON text BEFORE reaching argv (an
+    // ordinary `Value::String`), so it is not a boundary violation — only a
+    // bare, un-interpolated collection value trips the guard above.
+    let kernel = repl_kernel();
+    let result = kernel
+        .execute(r#"xs=$(fromjson '[1,2]'); /usr/bin/printf "[%s]" "$xs""#)
+        .await
+        .unwrap();
+    assert!(result.ok(), "interpolated collection arg must not error: {:?}", result);
+    assert_eq!(result.text_out(), "[[1,2]]");
+}
+
+#[tokio::test]
 async fn external_command_not_found() {
     let kernel = repl_kernel();
     let result = kernel

--- a/crates/kaish-kernel/tests/external_command_tests.rs
+++ b/crates/kaish-kernel/tests/external_command_tests.rs
@@ -156,6 +156,108 @@ async fn interpolated_collection_is_a_string_arg() {
     assert_eq!(result.text_out(), "[[1,2]]");
 }
 
+// ── Decision D completeness: the three subprocess builtins with their own
+// argv/env stringify paths (spawn/exec/env) bypass `build_args_flat`, so each
+// carries the same boundary guard at its own edge. Linux-gated + absolute
+// command paths (`/bin/echo`, `/bin/true`) so the spawn is unconditional. ──
+
+#[cfg(target_os = "linux")]
+#[tokio::test]
+async fn spawn_nested_collection_argv_element_is_a_loud_error() {
+    // spawn's argv is legitimately a list of strings, so the top-level list
+    // passes — but a *nested* collection element can't be a process argument.
+    // Previously `extract_string_array` silently JSON-stringified it.
+    let kernel = repl_kernel();
+    let result = kernel
+        .execute(r#"xs=$(fromjson '["ok",[1,2]]'); spawn --command /bin/echo --argv $xs"#)
+        .await;
+    let msg = match result {
+        Ok(r) => {
+            assert_ne!(r.code, 0, "a nested collection argv element must fail: {r:?}");
+            r.err
+        }
+        Err(e) => format!("{e:#}"),
+    };
+    assert!(msg.contains("tojson"), "should hint at serializing with tojson: {msg}");
+}
+
+#[cfg(target_os = "linux")]
+#[tokio::test]
+async fn spawn_record_as_whole_argv_is_a_loud_error() {
+    // A record used as the whole argv is not a list of strings — previously a
+    // silent empty argv (data loss), now loud.
+    let kernel = repl_kernel();
+    let result = kernel
+        .execute(r#"r=$(fromjson '{"a":1}'); spawn --command /bin/echo --argv $r"#)
+        .await;
+    let ok = match result {
+        Ok(r) => r.code != 0,
+        Err(_) => true,
+    };
+    assert!(ok, "a record as the whole argv must be a loud error, not a silent empty argv");
+}
+
+#[cfg(target_os = "linux")]
+#[tokio::test]
+async fn exec_bare_collection_argv_is_a_loud_error() {
+    // exec consumes typed Values from `args.positional`, not `build_args_flat`,
+    // so its own edge carries the guard. The guard fires BEFORE `execvp`, so
+    // the test process is never actually replaced.
+    let kernel = repl_kernel();
+    let result = kernel
+        .execute(r#"xs=$(fromjson '[1,2]'); exec /bin/echo $xs"#)
+        .await;
+    let msg = match result {
+        Ok(r) => {
+            assert_ne!(r.code, 0, "a bare collection exec argv element must fail: {r:?}");
+            r.err
+        }
+        Err(e) => format!("{e:#}"),
+    };
+    assert!(msg.contains("tojson"), "should hint at serializing with tojson: {msg}");
+}
+
+#[cfg(target_os = "linux")]
+#[tokio::test]
+async fn env_bare_collection_argv_is_a_loud_error() {
+    // env also builds argv from typed positionals with its own private
+    // `value_to_string`; a bare collection argv element is now loud.
+    let kernel = repl_kernel();
+    let result = kernel
+        .execute(r#"xs=$(fromjson '[1,2]'); env /bin/echo $xs"#)
+        .await;
+    let msg = match result {
+        Ok(r) => {
+            assert_ne!(r.code, 0, "a bare collection env argv element must fail: {r:?}");
+            r.err
+        }
+        Err(e) => format!("{e:#}"),
+    };
+    assert!(msg.contains("tojson"), "should hint at serializing with tojson: {msg}");
+}
+
+#[cfg(target_os = "linux")]
+#[tokio::test]
+async fn env_command_exporting_a_collection_var_is_a_loud_error() {
+    // `env <command>` spawns via its OWN path (`execute_with_env`), which
+    // populates the child env directly — bypassing `try_execute_external`'s
+    // export guard. It now runs the same `structured_export_error` check, so an
+    // exported collection variable is refused rather than silently serialized.
+    let kernel = repl_kernel();
+    let result = kernel
+        .execute(r#"export CFG=$(fromjson '{"port":8080}'); env /bin/true"#)
+        .await;
+    let msg = match result {
+        Ok(r) => {
+            assert_ne!(r.code, 0, "exporting a record through `env cmd` must fail: {r:?}");
+            r.err
+        }
+        Err(e) => format!("{e:#}"),
+    };
+    assert!(msg.contains("tojson"), "should hint at serializing with tojson: {msg}");
+    assert!(msg.contains("CFG"), "should name the offending variable: {msg}");
+}
+
 #[tokio::test]
 async fn external_command_not_found() {
     let kernel = repl_kernel();

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -486,6 +486,20 @@ the `WordAssign` arm degrade to a stringified positional when `past_double_dash`
 
 ## P3 — Scheduler and infra
 
+### `"$(cmd)"` interpolation drops a `.data`-only collection to empty string (silent data LOSS)
+Found alongside the collections boundary-ops work (2026-07-02, `feat/collections-boundary-ops`).
+Quoted command-substitution interpolation reads a command's `.out` via
+`try_text_out()` (kernel.rs `StringPart::CommandSubst`, ~line 4035), so a builtin
+that sets only structured `.data` (a collection) with an empty `.out` interpolates
+to `""` inside `"...$(cmd)..."`. This is a **silent data-loss** distinct from the
+Decision-D stringify boundary (which is now loud): the collection never reaches a
+process edge — it evaporates before it can. Repro shape: any builtin whose result
+carries `.data` but no materialized `.out`, spliced into a double-quoted string.
+Fix direction: when `.out` is empty but `.data` is a collection, either render the
+collection as compact JSON (consistent with bare `$c` display) or fail loud —
+decide which; do NOT leave the silent `""`. Different bug class from the
+boundary guards, so deferred here rather than fixed in that branch.
+
 ### `JobManager` output-stream reads hold the jobs lock across `await`
 Surfaced fixing the `wait`/`spawn` deadlock (2026-06-24). `read_stdout`/`read_stderr`
 (`scheduler/job.rs`, the `/v/jobs/{id}/stdout|stderr` reads) do


### PR DESCRIPTION
Implements decisions **D** and **E** from `docs/arrays-and-hashes.md` — the last two places a live collection (`Value::Json(Array|Object)`) could silently stringify past a boundary via `value_to_string`, mirroring the shipped `structured_export_error` guard for OS-env export.

## Decision D — collection at the process edge is a loud error
A bare (un-interpolated) collection reaching an external command's argv or a redirect target now errors, pointing at `$(tojson $x)`. A quoted `"$x"` already reduces to `Value::String` via interpolation before the boundary, so `curl -d "$cfg"` is unaffected — only bare `curl -d $cfg` trips it.

Guarded at **every** external/redirect edge (a kaibo completeness audit drove the second commit — the first pass missed the passthrough builtins):
- `kernel.rs::build_args_flat` (production argv: Positional/Named/WordAssign) + `dispatch.rs::try_external` (test twin)
- `scheduler/pipeline.rs::eval_redirect_target` (all `>`/`>>`/`<`/`<<<` targets)
- **`spawn` / `exec` / `env` builtins** — each has its own argv/env stringify path that bypasses `build_args_flat`. The `env` case was a genuine silent-corruption path: `env /bin/true` with an exported record previously exited **0** with the collection JSON-serialized into the child env.

## Decision E — scalar test operators reject collection operands
In `[[ ]]`, a collection operand to `-z`/`-n`/`=~`/`!~`/`-eq`/`-ne`/`-gt`/`-lt`/`-ge`/`-le`/`<`/`>`/`<=`/`>=` is a loud Shape error (with a hint: `${#x}` for length, `-list`/`-record` for shape, `in` for membership). Applied via a single `guard_scalar_test_operands` call point in both the sync (`eval.rs::eval_test`) and async (`kernel.rs::eval_test_async`) evaluators. **`==`/`!=` are excluded** (they route to `values_equal`, which keeps structural collection-vs-collection equality and its own collection-vs-scalar loud error) and `in`/`not in` still accept a collection RHS.

## Verification
- Load-bearing red-toggle: disabling the env-export and spawn-nested guards reproduces exit-0-with-corruption / silent stringify; restored.
- `cargo test --all --features subprocess` (97 binaries) + `cargo test --all` + `cargo clippy --all --all-targets` (with and without `subprocess`) — all green.
- New tests through `kernel.execute()` (Linux-gated, `subprocess`): external argv, redirect target, spawn nested element, spawn record-as-argv, exec, env argv, env exported-collection.

Also files a P3 in `docs/issues.md` (separate bug class, not fixed here): `"$(cmd)"` quoted interpolation reads `.out`, so a command setting only `.data` (a collection) silently interpolates to `""` — a data-loss, not a stringify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)