### PR TITLE
feat(collections): native list & record literals (rebased onto main)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,24 +10,6 @@ breaking entries are marked **BREAKING**.
 
 ## [Unreleased]
 
-### Added
-- **`grep`, `sed`, and `awk` accept the GNU BRE backslash-metas** (`\|`, `\+`,
-  `\?`, `\(`, `\)`, `\{`, `\}`) as a superset of their ERE regex, so
-  agent-idiomatic `grep 'foo\|bar'`, `sed 's/cat\|dog/X/'`, and
-  `awk '/a\|b/'` now alternate (and `sed 's/\(a\)\(b\)/\2\1/'` groups) instead
-  of silently matching a literal `|`/`(` and returning nothing (issue #60).
-  Pass `-E` (`grep`) or `-E`/`-r` (`sed`) for strict ERE, where those escapes
-  match the literal character — the escape hatch for a literal `|`/`+`; `awk`
-  has no such flag and always rewrites. Bare ERE (`foo|bar`) and `-F` are
-  unchanged. Narrow trade-off: in the default dialect a backslash before one of
-  these metas is the operator, never a literal — match the character itself with
-  a bracket class (`[+]`, `[|]`). A stray `\)`/`\{` that no longer parses fails
-  loudly, with a hint naming the dialect, the bracket-class spelling, and
-  (grep/sed) the strict-ERE flag. awk field splitting stays gawk-compatible:
-  `-F '\|'`, `FS="\\|"`, and `split(s, a, "\\|")` split on a literal pipe (the
-  rewrite runs before the single-char-FS-is-literal rule, matching gawk's
-  demotion of `\|` to plain `|`).
-
 ### Changed
 - **BREAKING:** **`sed` no longer rejects BRE idioms with a hint** — `\|`,
   `\(…\)`, and `\{N,M\}` used to be a loud `E006` error; they now behave as
@@ -55,6 +37,18 @@ breaking entries are marked **BREAKING**.
   builtin may return someday.
 
 ### Added
+- **Native collection literals** — `xs=[a b c]` (list), `{port: 8080}` /
+  `{port:8080}` (record, colon may be spaced or unspaced), `xs=[]` / `xs=[dog]`
+  (empty and single-element lists), multi-line records with a trailing comma,
+  nesting (`{tags: [a b], meta: {active: true}}`), and spread
+  (`new=[...$xs date]`, `[...$a ...$b]` — flattens a list operand's elements; a
+  bare `$var` inside `[ ]` nests as ONE element instead). Literals are
+  value-position only (assignment RHS, the `in`/`not in` RHS operand, and
+  nested literal interiors) — never argv (`ls [dog]` stays a glob) or a
+  `for`-head item (`for x in [a]` stays a word list). A `[`-leading glob at
+  value position (`logs=[0-9]*.log`) is now a loud parse error instead of
+  silently reinterpreting the glob; a multi-word bareword record value
+  (`{msg: hello world}`) is a loud parse error too — quote it.
 - **Native collection read access** — `${xs[0]}`, `${r[key]}`, `${r[$k]}`,
   `${r["weird-key"]}`, `${xs[-1]}` (negative index), `${xs[0:2]}` (end-exclusive
   slice → a list), and chained `${a[b][c]}`, over any `Value::Json` (e.g. from
@@ -136,6 +130,22 @@ breaking entries are marked **BREAKING**.
   / `Dynamic` / `External`, mirroring the interpreter's real resolution order so
   the embedder never forks kaish's rules. `CommandKind::escapes_kernel()` flags
   the `External`/`Dynamic` cases a gate must scrutinize.
+- **`grep`, `sed`, and `awk` accept the GNU BRE backslash-metas** (`\|`, `\+`,
+  `\?`, `\(`, `\)`, `\{`, `\}`) as a superset of their ERE regex, so
+  agent-idiomatic `grep 'foo\|bar'`, `sed 's/cat\|dog/X/'`, and
+  `awk '/a\|b/'` now alternate (and `sed 's/\(a\)\(b\)/\2\1/'` groups) instead
+  of silently matching a literal `|`/`(` and returning nothing (issue #60).
+  Pass `-E` (`grep`) or `-E`/`-r` (`sed`) for strict ERE, where those escapes
+  match the literal character — the escape hatch for a literal `|`/`+`; `awk`
+  has no such flag and always rewrites. Bare ERE (`foo|bar`) and `-F` are
+  unchanged. Narrow trade-off: in the default dialect a backslash before one of
+  these metas is the operator, never a literal — match the character itself with
+  a bracket class (`[+]`, `[|]`). A stray `\)`/`\{` that no longer parses fails
+  loudly, with a hint naming the dialect, the bracket-class spelling, and
+  (grep/sed) the strict-ERE flag. awk field splitting stays gawk-compatible:
+  `-F '\|'`, `FS="\\|"`, and `split(s, a, "\\|")` split on a literal pipe (the
+  rewrite runs before the single-char-FS-is-literal rule, matching gawk's
+  demotion of `\|` to plain `|`).
 
 ### Fixed
 - **Collection read-access silent-corruption traps** (found by the collections

--- a/crates/kaish-help/content/en/limits.md
+++ b/crates/kaish-help/content/en/limits.md
@@ -19,14 +19,15 @@ string arguments, invisible to the validator until runtime — exactly the kind 
 late-failure footgun kaish avoids. Use `[[ -f x ]]`, `[[ $a = $b ]]`, `[[ -z $s ]]`.
 
 A `test` builtin might return someday if a compelling case appears. `[` will not:
-the bracket belongs to kaish — `[[ … ]]` today, native list literals in the planned
-collections syntax — and invoking an external `[` binary isn't supported either.
+the bracket belongs to kaish — `[[ … ]]` and native list literals (`xs=[a b c]`,
+see `help syntax` → Collections) — and invoking an external `[` binary isn't
+supported either.
 
 ## Lexer/Parser Limitations
 
 | Limitation | Details | Workaround |
 |-----------|---------|------------|
-| `[[ ]]` parsed as two brackets | Two separate `[` tokens, not a compound keyword | Works for tests; the two-token design deliberately reserves `[ ]` for kaish's planned native list literals |
+| `[[ ]]` parsed as two brackets | Two separate `[` tokens, not a compound keyword | Works for tests; the two-token design deliberately reserves `[ ]` for kaish's native list literals |
 | Statement-opening keywords as bare arguments | `echo if` / `echo for` / `echo while` / `echo case` are parse errors (keyword starts a statement). Closers (`done`, `then`, `fi`) are fine. | Quote: `echo "if"` |
 | No token-pasting of adjacent unquoted words | `$VAR`/`$(cmd)`/globs are separate words. Unquoted text glued to an expansion (`echo $dir/f`, `echo /tmp/$(id -u).x`, `> $dir/f`) is a **parse error**, not a silent splat. Single-token words (`file.txt`, `v1.2.3`) are fine. | **Quote the whole word**: `"$dir/f"`, `"/tmp/$(id -u).x"`. See `help syntax` → Quoting. |
 

--- a/crates/kaish-kernel/src/ast/sexpr.rs
+++ b/crates/kaish-kernel/src/ast/sexpr.rs
@@ -307,6 +307,29 @@ pub fn format_expr(expr: &Expr) -> String {
         Expr::LastExitCode => "(last-exit-code)".to_string(),
         Expr::CurrentPid => "(current-pid)".to_string(),
         Expr::GlobPattern(s) => format!("(glob \"{}\")", s),
+        Expr::ListLiteral(elems) => {
+            let parts: Vec<String> = elems
+                .iter()
+                .map(|elem| match elem {
+                    ListElem::Item(e) => format_expr(e),
+                    ListElem::Spread(e) => format!("(spread {})", format_expr(e)),
+                })
+                .collect();
+            format!("(list {})", parts.join(" "))
+        }
+        Expr::RecordLiteral(entries) => {
+            let parts: Vec<String> = entries
+                .iter()
+                .map(|entry| {
+                    let key = match &entry.key {
+                        RecordKey::Bare(s) => s.clone(),
+                        RecordKey::Quoted(s) => format!("\"{}\"", s),
+                    };
+                    format!("({} {})", key, format_expr(&entry.value))
+                })
+                .collect();
+            format!("(record {})", parts.join(" "))
+        }
     }
 }
 

--- a/crates/kaish-kernel/src/ast/types.rs
+++ b/crates/kaish-kernel/src/ast/types.rs
@@ -300,6 +300,67 @@ pub enum Expr {
     CurrentPid,
     /// Bare glob pattern: `*.txt`, `src/**/*.rs` — expanded during arg building
     GlobPattern(String),
+    /// List literal: `[a b c]`, `[]`, `[...$xs date]`. Value-position only
+    /// (assignment RHS, `in`/`not in` RHS, nested literal interiors) — never
+    /// argv or a `for`-head item. See `docs/arrays-and-hashes.md`.
+    ListLiteral(Vec<ListElem>),
+    /// Record literal: `{name: amy, role: maintainer}`, `{port:8080}` (colon
+    /// may be spaced or unspaced). Value-position only, same as `ListLiteral`.
+    RecordLiteral(Vec<RecordEntry>),
+}
+
+/// One element of a list literal.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ListElem {
+    /// A plain element: `[a b c]` — each word nests as ONE element (no implicit
+    /// splitting of a variable's contents).
+    Item(Expr),
+    /// A spread element: `[...$xs date]` — flattens the referenced list's
+    /// elements into the new list at this position. Records have no spread
+    /// (out of scope, see `docs/arrays-and-hashes.md`).
+    Spread(Expr),
+}
+
+/// One `key: value` entry of a record literal.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RecordEntry {
+    pub key: RecordKey,
+    pub value: Expr,
+}
+
+/// A record literal key: `{name: amy}` (bare) or `{"content-type": x}` (quoted,
+/// for anything that isn't a bareword). See `docs/arrays-and-hashes.md`.
+#[derive(Debug, Clone, PartialEq)]
+pub enum RecordKey {
+    Bare(String),
+    Quoted(String),
+}
+
+/// Human-readable value-kind name for a spread (`[...expr]`) operand that
+/// turned out not to be a list. Shared between the sync (`interpreter/eval.rs`)
+/// and async (`kernel.rs::eval_expr_async`) literal evaluators so the two
+/// paths can't diverge on wording (same convention as `StringTestOp::matches_shape`).
+pub fn spread_value_kind(value: &Value) -> &'static str {
+    match value {
+        Value::Null => "null",
+        Value::Bool(_) => "a bool",
+        Value::Int(_) => "an int",
+        Value::Float(_) => "a float",
+        Value::String(_) => "a string",
+        Value::Bytes(_) => "bytes",
+        Value::Json(serde_json::Value::Object(_)) => "a record",
+        Value::Json(serde_json::Value::Array(_)) => "a list",
+        Value::Json(_) => "a json scalar",
+    }
+}
+
+/// Full teaching message for a non-list spread: "`[...$scalar]`" — the operand
+/// must be a list; spread only flattens a list's elements into the new one.
+pub fn spread_non_list_message(value: &Value) -> String {
+    format!(
+        "cannot spread `...` — value is {}, not a list; spread only flattens a list's elements, e.g. `[...$xs date]`",
+        spread_value_kind(value)
+    )
 }
 
 /// Test expression for `[[ ... ]]` conditionals.

--- a/crates/kaish-kernel/src/interpreter/eval.rs
+++ b/crates/kaish-kernel/src/interpreter/eval.rs
@@ -12,7 +12,10 @@ use std::fmt;
 use kaish_types::json_to_value_no_envelope;
 
 use crate::arithmetic;
-use crate::ast::{BinaryOp, Expr, FileTestOp, Stmt, StringPart, StringTestOp, TestCmpOp, TestExpr, Value, VarPath};
+use crate::ast::{
+    spread_non_list_message, BinaryOp, Expr, FileTestOp, ListElem, RecordEntry, RecordKey, Stmt,
+    StringPart, StringTestOp, TestCmpOp, TestExpr, Value, VarPath,
+};
 use crate::vfs::DirEntry;
 use std::path::Path;
 
@@ -252,7 +255,48 @@ impl<'a, E: Executor> Evaluator<'a, E> {
             Expr::LastExitCode => self.eval_last_exit_code(),
             Expr::CurrentPid => self.eval_current_pid(),
             Expr::GlobPattern(s) => Ok(Value::String(s.clone())),
+            Expr::ListLiteral(elems) => self.eval_list_literal(elems),
+            Expr::RecordLiteral(entries) => self.eval_record_literal(entries),
         }
+    }
+
+    /// Evaluate a list literal (`[a b c]`, `[...$xs date]`) to `Value::Json(Array)`.
+    /// A `Spread` element must itself evaluate to a list — a scalar/record spread
+    /// is a loud `EvalError::Unsupported`, never silently coerced or dropped.
+    fn eval_list_literal(&mut self, elems: &[ListElem]) -> EvalResult<Value> {
+        let mut out = Vec::with_capacity(elems.len());
+        for elem in elems {
+            match elem {
+                ListElem::Item(e) => {
+                    let value = self.eval(e)?;
+                    out.push(kaish_types::value_to_json(&value));
+                }
+                ListElem::Spread(e) => {
+                    let value = self.eval(e)?;
+                    match value {
+                        Value::Json(serde_json::Value::Array(items)) => out.extend(items),
+                        other => return Err(EvalError::Unsupported(spread_non_list_message(&other))),
+                    }
+                }
+            }
+        }
+        Ok(Value::Json(serde_json::Value::Array(out)))
+    }
+
+    /// Evaluate a record literal (`{name: amy}`, `{port:8080}`) to
+    /// `Value::Json(Object)`. Insertion order is preserved (workspace
+    /// `serde_json` has the `preserve_order` feature on); a duplicate key
+    /// keeps the last value written, matching plain map-insert semantics.
+    fn eval_record_literal(&mut self, entries: &[RecordEntry]) -> EvalResult<Value> {
+        let mut map = serde_json::Map::new();
+        for entry in entries {
+            let key = match &entry.key {
+                RecordKey::Bare(s) | RecordKey::Quoted(s) => s.clone(),
+            };
+            let value = self.eval(&entry.value)?;
+            map.insert(key, kaish_types::value_to_json(&value));
+        }
+        Ok(Value::Json(serde_json::Value::Object(map)))
     }
 
     /// Evaluate last exit code ($?).

--- a/crates/kaish-kernel/src/kernel.rs
+++ b/crates/kaish-kernel/src/kernel.rs
@@ -46,7 +46,10 @@ static KERNEL_COUNTER: AtomicU64 = AtomicU64::new(1);
 
 use async_trait::async_trait;
 
-use crate::ast::{Arg, Command, Expr, FileTestOp, Stmt, StringPart, TestExpr, ToolDef, Value, BinaryOp};
+use crate::ast::{
+    spread_non_list_message, Arg, BinaryOp, Command, Expr, FileTestOp, ListElem, RecordKey, Stmt,
+    StringPart, TestExpr, ToolDef, Value,
+};
 pub use kaish_types::{CommandKind, ExecuteOptions};
 use crate::backend::{BackendError, KernelBackend};
 use kaish_glob::glob_match;
@@ -3835,6 +3838,43 @@ impl Kernel {
                 Ok(Value::Int(scope.pid() as i64))
             }
             Expr::GlobPattern(s) => Ok(Value::String(s.clone())),
+            Expr::ListLiteral(elems) => {
+                // Spread must itself be a list — a scalar/record spread is a
+                // loud error, never silently coerced or dropped (mirrors the
+                // sync `Evaluator::eval_list_literal`; wording shared via
+                // `spread_non_list_message` so the two paths can't diverge).
+                let mut out = Vec::with_capacity(elems.len());
+                for elem in elems {
+                    match elem {
+                        ListElem::Item(e) => {
+                            let value = self.eval_expr_async(e).await?;
+                            out.push(crate::interpreter::value_to_json(&value));
+                        }
+                        ListElem::Spread(e) => {
+                            let value = self.eval_expr_async(e).await?;
+                            match value {
+                                Value::Json(serde_json::Value::Array(items)) => out.extend(items),
+                                other => return Err(anyhow::anyhow!(spread_non_list_message(&other))),
+                            }
+                        }
+                    }
+                }
+                Ok(Value::Json(serde_json::Value::Array(out)))
+            }
+            Expr::RecordLiteral(entries) => {
+                // Insertion order preserved (workspace serde_json has
+                // `preserve_order`); a duplicate key keeps the last value
+                // written, matching plain map-insert semantics.
+                let mut map = serde_json::Map::new();
+                for entry in entries {
+                    let key = match &entry.key {
+                        RecordKey::Bare(s) | RecordKey::Quoted(s) => s.clone(),
+                    };
+                    let value = self.eval_expr_async(&entry.value).await?;
+                    map.insert(key, crate::interpreter::value_to_json(&value));
+                }
+                Ok(Value::Json(serde_json::Value::Object(map)))
+            }
         }
         })
     }

--- a/crates/kaish-kernel/src/lexer.rs
+++ b/crates/kaish-kernel/src/lexer.rs
@@ -1727,12 +1727,22 @@ fn mergeable_text(token: &Token) -> Option<String> {
 /// colon-fusion note right after it).
 ///
 /// A run is "at value position" when it opens immediately after `Token::Eq`
-/// (assignment) or a genuine membership `Token::In` — NOT the `for`-loop
-/// keyword, which reuses the exact same token (`for x in *.txt` must keep
-/// fusing argv globs after `in`). The `for`-loop shape is always precisely
-/// three tokens (`For Ident In` — `ident_parser` matches exactly one
-/// `Ident`), so it's excluded by lookback without needing parser-level
-/// context in the lexer.
+/// (assignment) or a genuine membership `Token::In` — NOT a *statement-head*
+/// `in`, which reuses the exact same token. Both `for VAR in ITEMS` and
+/// `case EXPR in PATTERN)` take an `in` that introduces argv-shaped words
+/// (globs, brace expansion, char-class patterns), so their `in` must NOT open
+/// value position (`for x in *.txt` keeps fusing argv globs;
+/// `case 5 in [0-9]*)` keeps its char-class pattern as a `GlobWord`).
+///
+/// `for` has a fixed three-token head (`For Ident In`), but `case` has a
+/// variable-length head (`case EXPR in`, where EXPR can be a VarRef, string,
+/// etc.), so a fixed lookback can't cover it. Instead we carry a *pending
+/// statement-head* flag: seeing `Token::For`/`Token::Case` arms it, and the
+/// FIRST `Token::In` while armed is that head's `in` (the `in` always comes
+/// right after the loop var / scrutinee) — treated as non-membership and the
+/// flag is consumed. A membership `in` inside `[[ ]]` is never preceded by an
+/// unconsumed `for`/`case` head, so it still correctly opens value position
+/// for its RHS.
 ///
 /// Depth is a simple counter, not a real stack — deeply-nested *glued*
 /// literals (e.g. `x=[[a] [b]]`) are a documented deferral (see
@@ -1754,14 +1764,18 @@ fn compute_value_context(tokens: &[Spanned<Token>]) -> Vec<ValueContext> {
     let mut bracket_depth: usize = 0;
     let mut brace_depth: usize = 0;
     let mut expect_value = false;
+    // Armed by a `for`/`case` keyword; consumed by that head's `in` so it
+    // doesn't open value position. (`case` heads can nest — a `case` inside a
+    // branch — but each head's `in` consumes exactly one arming, so a counter
+    // is more robust than a bool if branches interleave.)
+    let mut pending_stmt_head_ins: usize = 0;
 
     for i in 0..tokens.len() {
         let tok = &tokens[i].token;
 
-        let is_for_loop_in = matches!(tok, Token::In)
-            && i >= 2
-            && matches!(tokens[i - 1].token, Token::Ident(_))
-            && matches!(tokens[i - 2].token, Token::For);
+        // A statement-head `in` (the first `in` after a `for`/`case` keyword)
+        // is NOT a membership `in` — it introduces argv words, not a literal.
+        let is_stmt_head_in = matches!(tok, Token::In) && pending_stmt_head_ins > 0;
 
         let currently_value = expect_value || bracket_depth > 0 || brace_depth > 0;
         ctx[i] = ValueContext {
@@ -1770,6 +1784,8 @@ fn compute_value_context(tokens: &[Spanned<Token>]) -> Vec<ValueContext> {
         };
 
         match tok {
+            Token::For | Token::Case => pending_stmt_head_ins += 1,
+            Token::In if pending_stmt_head_ins > 0 => pending_stmt_head_ins -= 1,
             Token::LBracket if currently_value => bracket_depth += 1,
             Token::RBracket if bracket_depth > 0 => bracket_depth -= 1,
             Token::LBrace if currently_value => brace_depth += 1,
@@ -1777,7 +1793,7 @@ fn compute_value_context(tokens: &[Spanned<Token>]) -> Vec<ValueContext> {
             _ => {}
         }
 
-        expect_value = matches!(tok, Token::Eq) || (matches!(tok, Token::In) && !is_for_loop_in);
+        expect_value = matches!(tok, Token::Eq) || (matches!(tok, Token::In) && !is_stmt_head_in);
     }
 
     ctx

--- a/crates/kaish-kernel/src/lexer.rs
+++ b/crates/kaish-kernel/src/lexer.rs
@@ -355,6 +355,13 @@ pub enum Token {
     #[token(",")]
     Comma,
 
+    /// Spread operator: `[...$xs date]`. Only meaningful inside a list literal
+    /// (value context); inert everywhere else. logos resolves the `"..."` vs
+    /// `".."` (`DotDot`) ambiguity by longest match, so no explicit priority
+    /// is needed here.
+    #[token("...")]
+    DotDotDot,
+
     #[token("..")]
     DotDot,
 
@@ -750,7 +757,8 @@ impl Token {
             | Token::Star
             | Token::Newline
             | Token::LineContinuation
-            | Token::CmdSubstStart => TokenCategory::Punctuation,
+            | Token::CmdSubstStart
+            | Token::DotDotDot => TokenCategory::Punctuation,
 
             // Glob words (merged tokens containing wildcards)
             Token::GlobWord(_) => TokenCategory::Path,
@@ -998,6 +1006,7 @@ impl fmt::Display for Token {
             Token::Comma => write!(f, ","),
             Token::Dot => write!(f, "."),
             Token::DotDot => write!(f, ".."),
+            Token::DotDotDot => write!(f, "..."),
             Token::Tilde => write!(f, "~"),
             Token::TildePath(s) => write!(f, "{}", s),
             Token::RelativePath(s) => write!(f, "{}", s),
@@ -1709,6 +1718,71 @@ fn mergeable_text(token: &Token) -> Option<String> {
     }
 }
 
+/// Per-token context computed ahead of the colon-merge and glob-merge passes:
+/// is this token part of a *value*-position collection literal (assignment
+/// RHS, `in`/`not in` RHS)? Both merge passes suppress their fusion there so
+/// `x=[dog]` / `{port:8080}` reach the parser as primitive tokens instead of
+/// a fused `GlobWord`/`Ident` — see docs/arrays-and-hashes.md
+/// ("Implementation notes: Glob-merge is the big lexer collision" and the
+/// colon-fusion note right after it).
+///
+/// A run is "at value position" when it opens immediately after `Token::Eq`
+/// (assignment) or a genuine membership `Token::In` — NOT the `for`-loop
+/// keyword, which reuses the exact same token (`for x in *.txt` must keep
+/// fusing argv globs after `in`). The `for`-loop shape is always precisely
+/// three tokens (`For Ident In` — `ident_parser` matches exactly one
+/// `Ident`), so it's excluded by lookback without needing parser-level
+/// context in the lexer.
+///
+/// Depth is a simple counter, not a real stack — deeply-nested *glued*
+/// literals (e.g. `x=[[a] [b]]`) are a documented deferral (see
+/// docs/issues.md); spaced nesting (`[ [a] [b] ]`) was never glued in the
+/// first place and is unaffected.
+#[derive(Clone, Copy, Default)]
+struct ValueContext {
+    /// Inside (or opening) a value-position `[`/`{` literal — suppresses
+    /// glob-merge bracket-pair fusion.
+    in_literal: bool,
+    /// Inside a value-position `{` literal specifically — suppresses
+    /// colon-merge fusion. Narrower than `in_literal` on purpose: a plain
+    /// scalar assignment like `x=foo:bar` must keep fusing into one `Ident`.
+    in_brace: bool,
+}
+
+fn compute_value_context(tokens: &[Spanned<Token>]) -> Vec<ValueContext> {
+    let mut ctx = vec![ValueContext::default(); tokens.len()];
+    let mut bracket_depth: usize = 0;
+    let mut brace_depth: usize = 0;
+    let mut expect_value = false;
+
+    for i in 0..tokens.len() {
+        let tok = &tokens[i].token;
+
+        let is_for_loop_in = matches!(tok, Token::In)
+            && i >= 2
+            && matches!(tokens[i - 1].token, Token::Ident(_))
+            && matches!(tokens[i - 2].token, Token::For);
+
+        let currently_value = expect_value || bracket_depth > 0 || brace_depth > 0;
+        ctx[i] = ValueContext {
+            in_literal: currently_value,
+            in_brace: brace_depth > 0,
+        };
+
+        match tok {
+            Token::LBracket if currently_value => bracket_depth += 1,
+            Token::RBracket if bracket_depth > 0 => bracket_depth -= 1,
+            Token::LBrace if currently_value => brace_depth += 1,
+            Token::RBrace if brace_depth > 0 => brace_depth -= 1,
+            _ => {}
+        }
+
+        expect_value = matches!(tok, Token::Eq) || (matches!(tok, Token::In) && !is_for_loop_in);
+    }
+
+    ctx
+}
+
 /// Merge span-adjacent token runs containing `Token::Colon` into single `Ident` tokens.
 ///
 /// In bash, `:` is a regular character in unquoted words. kaish tokenizes it
@@ -1716,19 +1790,25 @@ fn mergeable_text(token: &Token) -> Option<String> {
 ///
 /// This pass fuses span-adjacent mergeable tokens (Ident, Colon, Int, Path, Float)
 /// into a single `Ident` when the run contains at least one `Colon`. Runs without
-/// colons or standalone tokens pass through unchanged.
+/// colons or standalone tokens pass through unchanged. A run that opens inside a
+/// value-position record literal (`{port:8080}`) is exempted — see
+/// `ValueContext`/`compute_value_context` above — so the record parser sees the
+/// `Colon` as its own token.
 fn merge_colon_adjacent(tokens: Vec<Spanned<Token>>) -> Vec<Spanned<Token>> {
     if tokens.is_empty() {
         return tokens;
     }
 
+    let value_ctx = compute_value_context(&tokens);
     let mut result = Vec::with_capacity(tokens.len());
     let mut run: Vec<&Spanned<Token>> = Vec::new();
+    let mut run_start = 0usize;
 
-    for token in &tokens {
+    for (idx, token) in tokens.iter().enumerate() {
         if run.is_empty() {
             if mergeable_text(&token.token).is_some() {
                 run.push(token);
+                run_start = idx;
             } else {
                 result.push(token.clone());
             }
@@ -1743,29 +1823,33 @@ fn merge_colon_adjacent(tokens: Vec<Spanned<Token>>) -> Vec<Spanned<Token>> {
         if adjacent && mergeable_text(&token.token).is_some() {
             run.push(token);
         } else {
-            flush_colon_run(&mut run, &mut result);
+            flush_colon_run(&mut run, &mut result, value_ctx[run_start].in_brace);
             if mergeable_text(&token.token).is_some() {
                 run.push(token);
+                run_start = idx;
             } else {
                 result.push(token.clone());
             }
         }
     }
 
-    flush_colon_run(&mut run, &mut result);
+    flush_colon_run(&mut run, &mut result, value_ctx[run_start].in_brace);
 
     result
 }
 
-/// Flush a run of mergeable tokens: merge if it contains a colon, otherwise emit individually.
-fn flush_colon_run(run: &mut Vec<&Spanned<Token>>, result: &mut Vec<Spanned<Token>>) {
+/// Flush a run of mergeable tokens: merge if it contains a colon, otherwise emit
+/// individually. `suppress` (true when the run opened inside a value-position
+/// record literal) forces individual emission even when `has_colon` would
+/// otherwise fuse — see `ValueContext`.
+fn flush_colon_run(run: &mut Vec<&Spanned<Token>>, result: &mut Vec<Spanned<Token>>, suppress: bool) {
     if run.is_empty() {
         return;
     }
 
     let has_colon = run.iter().any(|t| matches!(t.token, Token::Colon));
 
-    if run.len() >= 2 && has_colon {
+    if !suppress && run.len() >= 2 && has_colon {
         let text: String = run
             .iter()
             .filter_map(|t| mergeable_text(&t.token))
@@ -1895,18 +1979,27 @@ fn merge_flag_metachar_adjacent(tokens: Vec<Spanned<Token>>) -> Vec<Spanned<Toke
 ///
 /// Runs after colon merge: `foo::bar` stays as `Ident("foo::bar")` because colon merge
 /// already fused it before this pass sees it.
+///
+/// A run that opens at *value position* (`x=[dog]`, `[[ $a in [dog] ]]`) is exempted
+/// from the `[`/`]` bracket-pair fusion — see `ValueContext`/`compute_value_context`
+/// above — so the list-literal parser sees primitive `LBracket`/`RBracket` tokens
+/// instead of a fused `GlobWord`. Argv-position brackets (`ls [dog]`, `for x in [a]`)
+/// are untouched.
 fn merge_glob_adjacent(tokens: Vec<Spanned<Token>>) -> Vec<Spanned<Token>> {
     if tokens.is_empty() {
         return tokens;
     }
 
+    let value_ctx = compute_value_context(&tokens);
     let mut result = Vec::with_capacity(tokens.len());
     let mut run: Vec<&Spanned<Token>> = Vec::new();
+    let mut run_start = 0usize;
 
-    for token in &tokens {
+    for (idx, token) in tokens.iter().enumerate() {
         if run.is_empty() {
             if glob_mergeable_text(&token.token).is_some() {
                 run.push(token);
+                run_start = idx;
             } else {
                 result.push(token.clone());
             }
@@ -1920,32 +2013,45 @@ fn merge_glob_adjacent(tokens: Vec<Spanned<Token>>) -> Vec<Spanned<Token>> {
         if adjacent && glob_mergeable_text(&token.token).is_some() {
             run.push(token);
         } else {
-            flush_glob_run(&mut run, &mut result);
+            flush_glob_run(&mut run, &mut result, value_ctx[run_start].in_literal);
             if glob_mergeable_text(&token.token).is_some() {
                 run.push(token);
+                run_start = idx;
             } else {
                 result.push(token.clone());
             }
         }
     }
 
-    flush_glob_run(&mut run, &mut result);
+    flush_glob_run(&mut run, &mut result, value_ctx[run_start].in_literal);
 
     result
 }
 
 /// Flush a run of glob-mergeable tokens: merge if it contains glob metacharacters.
-fn flush_glob_run(run: &mut Vec<&Spanned<Token>>, result: &mut Vec<Spanned<Token>>) {
+/// `suppress` (true when the run opened at value position — see `ValueContext`)
+/// forces individual emission for a run that contains an `LBracket`, so a
+/// `[`-leading run at value position always reaches the parser as primitive
+/// tokens for the list-literal grammar, never a `GlobWord`. A pure `Star`/
+/// `Question` glob with no brackets (`X=*.txt`) is untouched by `suppress` —
+/// it keeps fusing to a `GlobWord`, which evaluates to a literal string at
+/// value position exactly as it did before collection literals existed
+/// (see `test_glob_in_assignment_is_literal`); only bracket-shaped runs are
+/// reinterpreted as list-literal syntax.
+fn flush_glob_run(run: &mut Vec<&Spanned<Token>>, result: &mut Vec<Spanned<Token>>, suppress: bool) {
     if run.is_empty() {
         return;
     }
 
-    let has_glob = run.iter().any(|t| {
-        matches!(t.token, Token::Star | Token::Question)
-    }) || (run.iter().any(|t| matches!(t.token, Token::LBracket))
-        && run.iter().any(|t| matches!(t.token, Token::RBracket)));
+    let has_bracket_pair = run.iter().any(|t| matches!(t.token, Token::LBracket))
+        && run.iter().any(|t| matches!(t.token, Token::RBracket));
+    let has_glob = run
+        .iter()
+        .any(|t| matches!(t.token, Token::Star | Token::Question))
+        || has_bracket_pair;
+    let suppress = suppress && has_bracket_pair;
 
-    if run.len() >= 2 && has_glob {
+    if !suppress && run.len() >= 2 && has_glob {
         let text: String = run
             .iter()
             .filter_map(|t| glob_mergeable_text(&t.token))

--- a/crates/kaish-kernel/src/lexer.rs
+++ b/crates/kaish-kernel/src/lexer.rs
@@ -1726,28 +1726,35 @@ fn mergeable_text(token: &Token) -> Option<String> {
 /// ("Implementation notes: Glob-merge is the big lexer collision" and the
 /// colon-fusion note right after it).
 ///
-/// A run is "at value position" when it opens immediately after `Token::Eq`
-/// (assignment) or a genuine membership `Token::In` — NOT a *statement-head*
-/// `in`, which reuses the exact same token. Both `for VAR in ITEMS` and
-/// `case EXPR in PATTERN)` take an `in` that introduces argv-shaped words
-/// (globs, brace expansion, char-class patterns), so their `in` must NOT open
-/// value position (`for x in *.txt` keeps fusing argv globs;
-/// `case 5 in [0-9]*)` keeps its char-class pattern as a `GlobWord`).
+/// A run is "at value position" when it opens immediately after a token that
+/// *grammatically* introduces a value — an **assignment** `=` or a
+/// **membership** `in`. The trap is that both of those tokens are reused for a
+/// non-value role: `Token::Eq` is also the `[[ ]]` comparison `=`
+/// (`[[ $x = [0-9]* ]]`), and `Token::In` is also the `for`/`case` statement
+/// head (`for f in *.txt`, `case 5 in [0-9]*)`). In every one of those
+/// non-value uses the following word is argv-shaped (a glob / char-class
+/// pattern) and must keep fusing, so getting this discrimination wrong breaks
+/// real syntax.
 ///
-/// `for` has a fixed three-token head (`For Ident In`), but `case` has a
-/// variable-length head (`case EXPR in`, where EXPR can be a VarRef, string,
-/// etc.), so a fixed lookback can't cover it. Instead we carry a *pending
-/// statement-head* flag: seeing `Token::For`/`Token::Case` arms it, and the
-/// FIRST `Token::In` while armed is that head's `in` (the `in` always comes
-/// right after the loop var / scrutinee) — treated as non-membership and the
-/// flag is consumed. A membership `in` inside `[[ ]]` is never preceded by an
-/// unconsumed `for`/`case` head, so it still correctly opens value position
-/// for its RHS.
+/// The discrimination is **grammar-exact by `[[ ]]` test depth**, which needs
+/// no per-keyword special-casing:
+/// - membership `in` occurs ONLY inside `[[ ]]`; a `for`/`case` head `in`
+///   occurs ONLY outside. So `Token::In` opens value position **iff
+///   `test_depth > 0`**.
+/// - an assignment `=` occurs outside `[[ ]]`; a comparison `=` occurs inside.
+///   So `Token::Eq` opens value position **iff `test_depth == 0`**.
 ///
-/// Depth is a simple counter, not a real stack — deeply-nested *glued*
-/// literals (e.g. `x=[[a] [b]]`) are a documented deferral (see
-/// docs/issues.md); spaced nesting (`[ [a] [b] ]`) was never glued in the
-/// first place and is unaffected.
+/// Tracking `test_depth` in the same forward pass also dissolves two `$()`
+/// leaks a hand-rolled keyword counter suffered: a bareword `in`/`for`/`case`
+/// inside `$(…)` sits at `test_depth == 0` and never opens value position (nor
+/// leaks any state past `RParen`), while a real sub-shell assignment
+/// `$(x=[a b])` is still `test_depth == 0` and correctly does. This replaces
+/// the earlier pending-`for`/`case` counter entirely.
+///
+/// `bracket_depth`/`brace_depth` are simple counters, not a real stack —
+/// deeply-nested *glued* literals (e.g. `x=[[a] [b]]`) are a documented
+/// deferral (see docs/issues.md); spaced nesting (`[ [a] [b] ]`) was never
+/// glued in the first place and is unaffected.
 #[derive(Clone, Copy, Default)]
 struct ValueContext {
     /// Inside (or opening) a value-position `[`/`{` literal — suppresses
@@ -1763,19 +1770,18 @@ fn compute_value_context(tokens: &[Spanned<Token>]) -> Vec<ValueContext> {
     let mut ctx = vec![ValueContext::default(); tokens.len()];
     let mut bracket_depth: usize = 0;
     let mut brace_depth: usize = 0;
+    // `[[ ]]` nesting depth. `[[` is two `Token::LBracket`, `]]` two
+    // `Token::RBracket` (kaish has no compound bracket token). This is what
+    // tells an assignment `=` from a comparison `=`, and a membership `in`
+    // from a `for`/`case` head `in`.
+    let mut test_depth: usize = 0;
     let mut expect_value = false;
-    // Armed by a `for`/`case` keyword; consumed by that head's `in` so it
-    // doesn't open value position. (`case` heads can nest — a `case` inside a
-    // branch — but each head's `in` consumes exactly one arming, so a counter
-    // is more robust than a bool if branches interleave.)
-    let mut pending_stmt_head_ins: usize = 0;
+    // Set after consuming the first `[`/`]` of a `[[`/`]]` pair so the paired
+    // bracket is skipped for depth accounting (it's a pure test delimiter).
+    let mut skip_paired_bracket = false;
 
     for i in 0..tokens.len() {
         let tok = &tokens[i].token;
-
-        // A statement-head `in` (the first `in` after a `for`/`case` keyword)
-        // is NOT a membership `in` — it introduces argv words, not a literal.
-        let is_stmt_head_in = matches!(tok, Token::In) && pending_stmt_head_ins > 0;
 
         let currently_value = expect_value || bracket_depth > 0 || brace_depth > 0;
         ctx[i] = ValueContext {
@@ -1783,17 +1789,56 @@ fn compute_value_context(tokens: &[Spanned<Token>]) -> Vec<ValueContext> {
             in_brace: brace_depth > 0,
         };
 
-        match tok {
-            Token::For | Token::Case => pending_stmt_head_ins += 1,
-            Token::In if pending_stmt_head_ins > 0 => pending_stmt_head_ins -= 1,
-            Token::LBracket if currently_value => bracket_depth += 1,
-            Token::RBracket if bracket_depth > 0 => bracket_depth -= 1,
-            Token::LBrace if currently_value => brace_depth += 1,
-            Token::RBrace if brace_depth > 0 => brace_depth -= 1,
-            _ => {}
+        if skip_paired_bracket {
+            // Second `[` of `[[` or second `]` of `]]`: already accounted for
+            // by its partner, no depth effect.
+            skip_paired_bracket = false;
+        } else {
+            match tok {
+                Token::LBracket => {
+                    let next_is_lbracket =
+                        matches!(tokens.get(i + 1).map(|t| &t.token), Some(Token::LBracket));
+                    if next_is_lbracket && !currently_value {
+                        // `[[` opens a test — NOT a value literal. The
+                        // `!currently_value` guard keeps a glued nested value
+                        // list (`x=[[a] [b]]`) as literal brackets, not a bogus
+                        // test.
+                        test_depth += 1;
+                        skip_paired_bracket = true;
+                    } else if currently_value {
+                        bracket_depth += 1;
+                    }
+                    // A lone `[` outside any value literal (argv `ls [dog]`,
+                    // a `[0-9]` char-class) neither opens a test nor a literal.
+                }
+                Token::RBracket => {
+                    let next_is_rbracket =
+                        matches!(tokens.get(i + 1).map(|t| &t.token), Some(Token::RBracket));
+                    if bracket_depth > 0 {
+                        // Close an open value-literal bracket first — in
+                        // `[[ x in [a b] ]]` the `[a b]`'s own `]` closes here
+                        // (bracket_depth 1→0) before the trailing `]]`.
+                        bracket_depth -= 1;
+                    } else if test_depth > 0 && next_is_rbracket {
+                        test_depth -= 1;
+                        skip_paired_bracket = true;
+                    }
+                }
+                Token::LBrace if currently_value => brace_depth += 1,
+                Token::RBrace if brace_depth > 0 => brace_depth -= 1,
+                _ => {}
+            }
         }
 
-        expect_value = matches!(tok, Token::Eq) || (matches!(tok, Token::In) && !is_stmt_head_in);
+        // Grammar-exact: assignment `=` (outside `[[ ]]`) and membership `in`
+        // (inside `[[ ]]`) open value position; comparison `=` and for/case
+        // head `in` do not. `Token::EqEq` (`==`) is a distinct token and never
+        // opens value position at all.
+        expect_value = match tok {
+            Token::Eq => test_depth == 0,
+            Token::In => test_depth > 0,
+            _ => false,
+        };
     }
 
     ctx

--- a/crates/kaish-kernel/src/parser.rs
+++ b/crates/kaish-kernel/src/parser.rs
@@ -5,8 +5,8 @@
 
 use crate::ast::{
     Arg, Assignment, BinaryOp, CaseBranch, CaseStmt, Command, Expr, FileTestOp, ForLoop, IfStmt,
-    Pipeline, Program, Redirect, RedirectKind, SpannedPart, Stmt, StringPart, StringTestOp,
-    TestCmpOp, TestExpr, ToolDef, Value, VarPath, VarSegment, WhileLoop,
+    ListElem, Pipeline, Program, RecordEntry, RecordKey, Redirect, RedirectKind, SpannedPart, Stmt,
+    StringPart, StringTestOp, TestCmpOp, TestExpr, ToolDef, Value, VarPath, VarSegment, WhileLoop,
 };
 use crate::lexer::{self, HereDocData, Token};
 use chumsky::{input::ValueInput, prelude::*};
@@ -2102,27 +2102,121 @@ where
 }
 
 /// Value-position expression parser (assignment RHS: bash-style, `local`,
-/// and env-prefix). Currently identical to `expr_parser`; the seam where
-/// collection literals (lists/records) will be added so they appear on
-/// assignment RHS but never in argv or `for`-head items.
+/// and env-prefix). Adds collection literals on top of everything
+/// `primary_expr_parser` covers, so they appear on assignment RHS but never
+/// in argv or `for`-head items (`expr_parser`, above, stays untouched).
 fn value_expr_parser<'tokens, I>(
 ) -> impl Parser<'tokens, I, Expr, extra::Err<Rich<'tokens, Token, Span>>> + Clone
 where
     I: ValueInput<'tokens, Token = Token, Span = Span>,
 {
-    primary_expr_parser()
+    value_literal_parser()
 }
 
 /// Value-position primary parser (`in`/`not in` RHS operand only — the
 /// collection being tested for membership; the left needle stays on
-/// `primary_expr_parser`). Currently identical to `primary_expr_parser`;
-/// the seam where list/record literal arms get added later.
+/// `primary_expr_parser`). Same grammar as `value_expr_parser`; kept as a
+/// separate name because the two seams are conceptually distinct call sites
+/// (see PR-A) even though they currently share an implementation.
 fn value_primary_parser<'tokens, I>(
 ) -> impl Parser<'tokens, I, Expr, extra::Err<Rich<'tokens, Token, Span>>> + Clone
 where
     I: ValueInput<'tokens, Token = Token, Span = Span>,
 {
-    primary_expr_parser()
+    value_literal_parser()
+}
+
+/// The value-position grammar: list/record literals (tried first, so a
+/// `[`/`{` at value position is always a literal — never a bareword/glob),
+/// falling back to everything `primary_expr_parser` covers ($(), `$VAR`,
+/// scalars, …). `recursive` lets literal interiors reference this same
+/// grammar, so nesting (`{tags: [a b], meta: {active: true}}`) and spread
+/// (`[...$xs date]`) both parse.
+///
+/// The lexer guarantees a `[`/`{` reaching here at value position was never
+/// fused into a `GlobWord`/colon-joined `Ident` (see
+/// `lexer::compute_value_context`), so this choice never needs to "unfuse"
+/// anything — it just sees primitive bracket/brace tokens.
+fn value_literal_parser<'tokens, I>(
+) -> impl Parser<'tokens, I, Expr, extra::Err<Rich<'tokens, Token, Span>>> + Clone
+where
+    I: ValueInput<'tokens, Token = Token, Span = Span>,
+{
+    recursive(|value| {
+        choice((
+            list_literal_parser(value.clone()),
+            record_literal_parser(value.clone()),
+            primary_expr_parser(),
+        ))
+    })
+    .boxed()
+}
+
+/// List literal: `[a b c]`, `[]`, `[...$xs date]`. Elements may be separated
+/// by whitespace alone, commas, newlines, or any mix — all optional and
+/// interchangeable (see docs/arrays-and-hashes.md, "Commas optional in BOTH
+/// lists and records") — and newlines are consumed rather than treated as
+/// statement terminators, so a multi-line literal doesn't end the assignment
+/// early. A bare element nests as ONE item; `...` flattens a list operand's
+/// elements into this one (spread).
+fn list_literal_parser<'tokens, I, V>(
+    value: V,
+) -> impl Parser<'tokens, I, Expr, extra::Err<Rich<'tokens, Token, Span>>> + Clone
+where
+    I: ValueInput<'tokens, Token = Token, Span = Span>,
+    V: Parser<'tokens, I, Expr, extra::Err<Rich<'tokens, Token, Span>>> + Clone + 'tokens,
+{
+    let spread_elem = just(Token::DotDotDot)
+        .ignore_then(value.clone())
+        .map(ListElem::Spread);
+    let item_elem = value.map(ListElem::Item);
+    let elem = choice((spread_elem, item_elem));
+
+    let sep = choice((just(Token::Comma).to(()), just(Token::Newline).to(()))).repeated();
+
+    just(Token::LBracket)
+        .ignore_then(just(Token::Newline).repeated())
+        .ignore_then(elem.then_ignore(sep).repeated().collect::<Vec<_>>())
+        .then_ignore(just(Token::RBracket))
+        .map(Expr::ListLiteral)
+        .labelled("list literal")
+}
+
+/// Record literal: `{name: amy, role: maintainer}`, `{port:8080}` (the
+/// colon-fusion exemption in the lexer means both spellings reach here as
+/// the same three tokens). Keys are a bareword (`Ident`) or a quoted string
+/// (for anything that isn't a bareword, e.g. `{"content-type": x}`); values
+/// are the full recursive value grammar, so nested literals work. Entries
+/// separate the same way list elements do (comma/newline/whitespace, all
+/// optional) — including multi-line literals with a trailing comma.
+fn record_literal_parser<'tokens, I, V>(
+    value: V,
+) -> impl Parser<'tokens, I, Expr, extra::Err<Rich<'tokens, Token, Span>>> + Clone
+where
+    I: ValueInput<'tokens, Token = Token, Span = Span>,
+    V: Parser<'tokens, I, Expr, extra::Err<Rich<'tokens, Token, Span>>> + Clone + 'tokens,
+{
+    let bare_key = select! { Token::Ident(s) => RecordKey::Bare(s) };
+    let quoted_key = choice((
+        select! { Token::String(s) => s },
+        select! { Token::SingleString(s) => s },
+    ))
+    .map(RecordKey::Quoted);
+    let key = choice((quoted_key, bare_key)).labelled("record key");
+
+    let entry = key
+        .then_ignore(just(Token::Colon))
+        .then(value)
+        .map(|(key, value)| RecordEntry { key, value });
+
+    let sep = choice((just(Token::Comma).to(()), just(Token::Newline).to(()))).repeated();
+
+    just(Token::LBrace)
+        .ignore_then(just(Token::Newline).repeated())
+        .ignore_then(entry.then_ignore(sep).repeated().collect::<Vec<_>>())
+        .then_ignore(just(Token::RBrace))
+        .map(Expr::RecordLiteral)
+        .labelled("record literal")
 }
 
 /// Primary expression: literal, variable reference, command substitution, or bare identifier.
@@ -4312,5 +4406,198 @@ cmd < "input.txt"
         assert_eq!(parts.len(), 1);
         assert!(matches!(&parts[0].part, StringPart::Literal(s) if s == "\\"));
         assert_eq!(parts[0].len, 2);
+    }
+
+    // ── Collection literals ─────────────────────────────────────────────
+
+    /// Extract the RHS `Expr` from a one-statement `NAME=value` assignment.
+    fn assignment_value(source: &str) -> Expr {
+        let program = parse(source).unwrap_or_else(|e| panic!("parse {source:?}: {e:?}"));
+        match program.statements.as_slice() {
+            [Stmt::Assignment(a)] => a.value.clone(),
+            other => panic!("expected a single assignment, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn list_literal_three_elements() {
+        let expr = assignment_value("xs=[a b c]");
+        match expr {
+            Expr::ListLiteral(elems) => {
+                assert_eq!(elems.len(), 3);
+                assert!(elems.iter().all(|e| matches!(e, ListElem::Item(_))));
+            }
+            other => panic!("expected ListLiteral, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn list_literal_empty() {
+        let expr = assignment_value("xs=[]");
+        assert!(matches!(expr, Expr::ListLiteral(elems) if elems.is_empty()));
+    }
+
+    #[test]
+    fn list_literal_single_glued_dog() {
+        // `[dog]` is glued (no spaces) — the value-position glob-merge
+        // suppression must still hand it to the parser as a one-element list,
+        // not a fused GlobWord.
+        let expr = assignment_value("xs=[dog]");
+        match expr {
+            Expr::ListLiteral(elems) => assert_eq!(elems.len(), 1),
+            other => panic!("expected ListLiteral, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn list_literal_single_int() {
+        let expr = assignment_value("xs=[1]");
+        match expr {
+            Expr::ListLiteral(elems) => match elems.as_slice() {
+                [ListElem::Item(Expr::Literal(Value::Int(1)))] => {}
+                other => panic!("expected one Int(1) item, got {other:?}"),
+            },
+            other => panic!("expected ListLiteral, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn record_literal_unspaced_colon_equals_spaced() {
+        let spaced = assignment_value("x={port: 8080}");
+        let unspaced = assignment_value("x={port:8080}");
+        assert_eq!(spaced, unspaced, "{{port:8080}} must parse identically to {{port: 8080}}");
+        match spaced {
+            Expr::RecordLiteral(entries) => match entries.as_slice() {
+                [RecordEntry { key: RecordKey::Bare(k), value: Expr::Literal(Value::Int(8080)) }] => {
+                    assert_eq!(k, "port");
+                }
+                other => panic!("expected one port:8080 entry, got {other:?}"),
+            },
+            other => panic!("expected RecordLiteral, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn record_literal_name_role() {
+        let expr = assignment_value("u={name: amy, role: maintainer}");
+        match expr {
+            Expr::RecordLiteral(entries) => assert_eq!(entries.len(), 2),
+            other => panic!("expected RecordLiteral, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn record_literal_multiline_trailing_comma() {
+        let source = "services={\n  web:    {port: 8080, replicas: 3, healthy: true},\n  api:    {port: 9000, replicas: 2, healthy: false},\n}";
+        let expr = assignment_value(source);
+        match expr {
+            Expr::RecordLiteral(entries) => assert_eq!(entries.len(), 2, "web + api entries"),
+            other => panic!("expected RecordLiteral, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn record_literal_quoted_key() {
+        let expr = assignment_value(r#"r={"content-type": x}"#);
+        match expr {
+            Expr::RecordLiteral(entries) => match entries.as_slice() {
+                [RecordEntry { key: RecordKey::Quoted(k), .. }] => assert_eq!(k, "content-type"),
+                other => panic!("expected one quoted-key entry, got {other:?}"),
+            },
+            other => panic!("expected RecordLiteral, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn nested_list_and_record_in_record() {
+        let expr = assignment_value("x={tags: [a b], meta: {active: true}}");
+        match expr {
+            Expr::RecordLiteral(entries) => {
+                assert_eq!(entries.len(), 2);
+                assert!(matches!(entries[0].value, Expr::ListLiteral(_)));
+                assert!(matches!(entries[1].value, Expr::RecordLiteral(_)));
+            }
+            other => panic!("expected RecordLiteral, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn spread_and_item_elements() {
+        let expr = assignment_value("new=[...$xs date]");
+        match expr {
+            Expr::ListLiteral(elems) => match elems.as_slice() {
+                [ListElem::Spread(Expr::VarRef(_)), ListElem::Item(Expr::Literal(Value::String(s)))] => {
+                    assert_eq!(s, "date");
+                }
+                other => panic!("expected [Spread($xs), Item(date)], got {other:?}"),
+            },
+            other => panic!("expected ListLiteral, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn spread_of_two_variables() {
+        let expr = assignment_value("c=[...$a ...$b]");
+        match expr {
+            Expr::ListLiteral(elems) => {
+                assert_eq!(elems.len(), 2);
+                assert!(elems.iter().all(|e| matches!(e, ListElem::Spread(_))));
+            }
+            other => panic!("expected ListLiteral, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn in_rhs_accepts_a_list_literal() {
+        let program = parse("if [[ $a not in [dog] ]]; then echo hit; fi")
+            .unwrap_or_else(|e| panic!("parse: {e:?}"));
+        assert_eq!(program.statements.len(), 1);
+    }
+
+    #[test]
+    fn multiword_bareword_record_value_is_a_parse_error() {
+        // Strict quoting inside literals: a record value must be exactly one
+        // word or one quoted string — never silently split or joined.
+        assert!(parse("x={msg: hello world}").is_err());
+    }
+
+    // ── Invariant guards: argv/for-head globs must be unaffected ────────
+
+    #[test]
+    fn argv_bracket_glob_stays_a_glob_pattern() {
+        // `ls [dog]` is argv position — the glued `[dog]` run must still fuse
+        // to a GlobWord (the value-position suppression only applies right
+        // after `Eq`/a genuine membership `In`, not after a command name).
+        let program = parse("ls [dog]").unwrap_or_else(|e| panic!("parse: {e:?}"));
+        assert_eq!(program.statements.len(), 1);
+    }
+
+    #[test]
+    fn brace_expansion_at_argv_position_is_unaffected() {
+        // `*.{rs,go}` is glob/brace-expansion argv syntax (the glob-merge run
+        // needs a wildcard char present to fuse at all — a bare `{a,b}` with
+        // no `*`/`?`/`[...]` never fuses into a GlobWord, independent of this
+        // PR). Value-position literal parsing must not leak into argv.
+        let program = parse("cmd *.{rs,go}").unwrap_or_else(|e| panic!("parse: {e:?}"));
+        assert_eq!(program.statements.len(), 1);
+    }
+
+    #[test]
+    fn for_head_item_is_not_a_literal() {
+        // `for x in [a]` stays argv (a GlobPattern word list), never a
+        // ListLiteral — collection literals are value-position only.
+        let program = parse("for x in [a]; do echo $x; done")
+            .unwrap_or_else(|e| panic!("parse: {e:?}"));
+        match program.statements.as_slice() {
+            [Stmt::For(for_loop)] => {
+                assert_eq!(for_loop.items.len(), 1);
+                assert!(
+                    !matches!(for_loop.items[0], Expr::ListLiteral(_)),
+                    "for-head item must not be a ListLiteral: {:?}",
+                    for_loop.items[0]
+                );
+            }
+            other => panic!("expected a single For statement, got {other:?}"),
+        }
     }
 }

--- a/crates/kaish-kernel/src/validator/walker.rs
+++ b/crates/kaish-kernel/src/validator/walker.rs
@@ -3,8 +3,9 @@
 use std::collections::{HashMap, HashSet};
 
 use crate::ast::{
-    Arg, Assignment, CaseBranch, CaseStmt, Command, Expr, ForLoop, IfStmt, Pipeline, Program,
-    SpannedPart, Stmt, StringPart, TestExpr, ToolDef, VarPath, VarSegment, WhileLoop, Value,
+    Arg, Assignment, CaseBranch, CaseStmt, Command, Expr, ForLoop, IfStmt, ListElem, Pipeline,
+    Program, SpannedPart, Stmt, StringPart, TestExpr, ToolDef, VarPath, VarSegment, WhileLoop,
+    Value,
 };
 use crate::kernel::{bind_glued_short_value, push_repeatable_value};
 use crate::scheduler::{is_bool_type, schema_param_lookup};
@@ -442,6 +443,18 @@ impl<'a> Validator<'a> {
             Expr::Command(cmd) => self.validate_command(cmd),
             Expr::LastExitCode | Expr::CurrentPid => {}
             Expr::GlobPattern(_) => {}
+            Expr::ListLiteral(elems) => {
+                for elem in elems {
+                    match elem {
+                        ListElem::Item(e) | ListElem::Spread(e) => self.validate_expr(e),
+                    }
+                }
+            }
+            Expr::RecordLiteral(entries) => {
+                for entry in entries {
+                    self.validate_expr(&entry.value);
+                }
+            }
         }
     }
 

--- a/crates/kaish-kernel/tests/collection_literals_tests.rs
+++ b/crates/kaish-kernel/tests/collection_literals_tests.rs
@@ -403,3 +403,46 @@ async fn inner_in_word_inside_cmd_subst_does_not_pollute_for_head() {
     assert_eq!(code, 0, "err: {err}");
     assert_eq!(out.lines().collect::<Vec<_>>(), vec!["in", "z"]);
 }
+
+#[tokio::test]
+async fn bracket_char_class_containing_rbracket_in_test_parses() {
+    let k = setup().await;
+    // COMMON case pin: a `]`-containing glob char-class (`[]]` matches a literal
+    // `]`) inside a `[[ ]]` test. The lexer sees `[ ] ]` before glob fusion, so
+    // the inner `]` at bracket_depth==0 internally desyncs `test_depth` — but
+    // nothing gets suppressed and the parser matches its own brackets, so this
+    // common form parses+runs identically to bash (`==` is string equality here,
+    // so "y" != "]" → nm). This must never break. The EXOTIC combination that
+    // this desync DOES break loudly is pinned below.
+    let (out, code, err) =
+        run(&k, "x=y; if [[ $x == []] ]]; then echo m; else echo nm; fi").await;
+    assert_eq!(code, 0, "err: {err}");
+    assert_eq!(out, "nm");
+}
+
+// KNOWN LIMITATION (low severity, LOUD — never silent corruption; see
+// docs/issues.md "compute_value_context: `[[`/`]]` detection vs `]`-containing
+// glob char-classes"). A `]`-char-class glob (`[]]`) followed by a *later*
+// single-`=` bracket-glob comparison inside the SAME `[[ ]]` test desyncs the
+// forward pass's `test_depth`, so the second comparison's RHS is mis-suppressed
+// and hits `primary_expr_parser` (no list-literal arm) → a loud PARSE ERROR,
+// never a wrong result. Exotic construct; the common `]`-char-class case above
+// is unaffected. Pinned `#[ignore]` so the current behavior is documented and a
+// future fix that makes it pass is visible (remove the ignore + flip to a
+// success assertion). Robust fix if it ever matters: a context-aware test-region
+// pass or matching char-classes as units before glob-fusion (see issues.md).
+#[tokio::test]
+#[ignore = "known limitation: `]`-char-class + later single-`=` bracket-glob in one [[ ]] errors loud; see docs/issues.md"]
+async fn rbracket_char_class_plus_later_eq_comparison_currently_errors() {
+    let k = setup().await;
+    let result = k
+        .execute("a=y; b=5; if [[ $a == []] && $b = [0-9] ]]; then echo m; else echo nm; fi")
+        .await;
+    // CURRENT behavior: a loud parse error (documented, not desired). When the
+    // durable fix lands, this becomes `Ok` with output "nm" — flip the assert
+    // and drop the `#[ignore]`.
+    assert!(
+        result.is_err(),
+        "if this now parses, the test_depth/char-class desync was fixed — update the pin"
+    );
+}

--- a/crates/kaish-kernel/tests/collection_literals_tests.rs
+++ b/crates/kaish-kernel/tests/collection_literals_tests.rs
@@ -308,3 +308,61 @@ async fn foo_bracket_glob_argv_unaffected() {
     assert_ne!(code, 0, "glob with zero matches must be a loud non-zero exit");
     assert!(err.contains("no matches: foo[0-9]"), "got: {err}");
 }
+
+// ── case-head `in` is a statement head, NOT membership (regression) ──────────
+//
+// `case EXPR in PATTERN)` reuses `Token::In`, but the FIRST case pattern is an
+// argv-shaped glob (char-class) pattern, not a value-position literal. If the
+// value-context suppression treats the case-head `in` like membership `in`, it
+// suppresses the first pattern's glob fusion, forcing it down `case_parser`'s
+// primitive `[ … ]` char-class branch (which doesn't accept a DASHNUM like
+// `0-9`) → a parse error. Guard the first-pattern char-class here.
+
+#[tokio::test]
+async fn case_first_pattern_digit_char_class() {
+    let k = setup().await;
+    let (out, code, err) =
+        run(&k, "case 5 in [0-9]*) echo digit ;; *) echo other ;; esac").await;
+    assert_eq!(code, 0, "err: {err}");
+    assert_eq!(out, "digit");
+}
+
+#[tokio::test]
+async fn case_first_pattern_negated_char_class() {
+    let k = setup().await;
+    let (out, code, err) =
+        run(&k, "case dog in [!0-9]*) echo nd ;; *) echo x ;; esac").await;
+    assert_eq!(code, 0, "err: {err}");
+    assert_eq!(out, "nd");
+}
+
+#[tokio::test]
+async fn case_first_pattern_alpha_range() {
+    let k = setup().await;
+    // Already worked (no DASHNUM), but pin it against future suppression drift.
+    let (out, code, err) =
+        run(&k, "case dog in [a-z]*) echo lc ;; *) echo x ;; esac").await;
+    assert_eq!(code, 0, "err: {err}");
+    assert_eq!(out, "lc");
+}
+
+#[tokio::test]
+async fn membership_rhs_literal_still_parses_after_case_fix() {
+    let k = setup().await;
+    // The statement-head-`in` exclusion must NOT swallow a real membership
+    // `in`: `[[ x in [a b] ]]` still gets the RHS list literal.
+    let (out, code, err) = run(&k, r#"if [[ a in [a b] ]]; then echo hit; fi"#).await;
+    assert_eq!(code, 0, "err: {err}");
+    assert_eq!(out, "hit");
+}
+
+#[tokio::test]
+async fn for_head_glob_still_a_glob_after_case_fix() {
+    let k = setup().await;
+    // The general statement-head exclusion still covers `for … in` — a glued
+    // char-class glob in a for-head stays a glob (strict-no-match error in the
+    // fs-less isolated kernel), never a list literal.
+    let result = k.execute("for f in [0-9]*.nomatch; do echo $f; done").await;
+    let err = result.expect_err("for-head glob with zero matches must error").to_string();
+    assert!(err.contains("no matches: [0-9]*.nomatch"), "got: {err}");
+}

--- a/crates/kaish-kernel/tests/collection_literals_tests.rs
+++ b/crates/kaish-kernel/tests/collection_literals_tests.rs
@@ -309,14 +309,15 @@ async fn foo_bracket_glob_argv_unaffected() {
     assert!(err.contains("no matches: foo[0-9]"), "got: {err}");
 }
 
-// ── case-head `in` is a statement head, NOT membership (regression) ──────────
+// ── Reused tokens: `=` and `in` open value position by `[[ ]]` test depth ────
 //
-// `case EXPR in PATTERN)` reuses `Token::In`, but the FIRST case pattern is an
-// argv-shaped glob (char-class) pattern, not a value-position literal. If the
-// value-context suppression treats the case-head `in` like membership `in`, it
-// suppresses the first pattern's glob fusion, forcing it down `case_parser`'s
-// primitive `[ … ]` char-class branch (which doesn't accept a DASHNUM like
-// `0-9`) → a parse error. Guard the first-pattern char-class here.
+// The value-context suppression discriminates by `[[ ]]` test depth (not by
+// per-keyword heuristics): `Token::In` opens value position iff inside `[[ ]]`
+// (membership, not a for/case head); `Token::Eq` opens it iff OUTSIDE (an
+// assignment, not a `[[ ]]` comparison). These regressions all came from
+// getting one of those two token-role splits wrong — a suppressed glob run
+// gets forced down a primitive-bracket grammar branch (case char-class or a
+// comparison RHS) that doesn't accept it, → a parse error.
 
 #[tokio::test]
 async fn case_first_pattern_digit_char_class() {
@@ -365,4 +366,40 @@ async fn for_head_glob_still_a_glob_after_case_fix() {
     let result = k.execute("for f in [0-9]*.nomatch; do echo $f; done").await;
     let err = result.expect_err("for-head glob with zero matches must error").to_string();
     assert!(err.contains("no matches: [0-9]*.nomatch"), "got: {err}");
+}
+
+#[tokio::test]
+async fn single_eq_comparison_with_bracket_glob_rhs_parses() {
+    let k = setup().await;
+    // `[[ $x = [0-9]* ]]` — a single-`=` comparison inside `[[ ]]`. `Token::Eq`
+    // at test_depth > 0 is a comparison, NOT an assignment, so the `[0-9]*`
+    // RHS must stay a fused glob (comparison RHS parses on primary_expr, which
+    // has no list-literal arm). Regression: it parse-errored ("found '['").
+    // kaish `=`/`==` are string equality (not glob match), so 5 != "[0-9]*".
+    let (out, code, err) =
+        run(&k, "x=5; if [[ $x = [0-9]* ]]; then echo m; else echo n; fi").await;
+    assert_eq!(code, 0, "err: {err}");
+    assert_eq!(out, "n");
+}
+
+#[tokio::test]
+async fn double_eq_comparison_with_bracket_glob_rhs_parses() {
+    let k = setup().await;
+    // `==` (`Token::EqEq`) never opens value position — this always parsed, but
+    // pin it alongside the single-`=` case so the pair is guarded together.
+    let (out, code, err) =
+        run(&k, "x=5; if [[ $x == [0-9]* ]]; then echo m; else echo n; fi").await;
+    assert_eq!(code, 0, "err: {err}");
+    assert_eq!(out, "n");
+}
+
+#[tokio::test]
+async fn inner_in_word_inside_cmd_subst_does_not_pollute_for_head() {
+    let k = setup().await;
+    // Risk-B guard: a bareword `in` inside `$(echo in)` sits at test_depth 0
+    // (not membership), so it must not leak value position onto the following
+    // `z`. The for-head iterates the two words `in` and `z`.
+    let (out, code, err) = run(&k, "for x in $(echo in) z; do echo $x; done").await;
+    assert_eq!(code, 0, "err: {err}");
+    assert_eq!(out.lines().collect::<Vec<_>>(), vec!["in", "z"]);
 }

--- a/crates/kaish-kernel/tests/collection_literals_tests.rs
+++ b/crates/kaish-kernel/tests/collection_literals_tests.rs
@@ -1,0 +1,310 @@
+//! Native collection LITERALS: `xs=[a b c]` (list), `{port: 8080}` / `{port:8080}`
+//! (record), multi-line literals with trailing commas, `[...$xs date]` (spread),
+//! nesting. See docs/arrays-and-hashes.md.
+//!
+//! Kernel-routed via `KernelConfig::isolated()` (pure data, no localfs) — pairs
+//! with `collection_access_tests.rs` (read side, already shipped) and
+//! `sed_awk_bre_dialect_tests.rs`-style conventions in this crate.
+
+// Test-fixture code: unwrap/expect on known-good setup is the idiom here.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::sync::Arc;
+
+use kaish_kernel::{Kernel, KernelConfig};
+
+async fn setup() -> Arc<Kernel> {
+    Kernel::new(KernelConfig::isolated().with_skip_validation(true))
+        .expect("failed to create kernel")
+        .into_arc()
+}
+
+/// Run a script; return (trimmed stdout, exit code, stderr).
+async fn run(k: &Kernel, script: &str) -> (String, i64, String) {
+    let r = k.execute(script).await.expect("kernel execute");
+    (r.text_out().trim().to_string(), r.code, r.err.clone())
+}
+
+// ── List literals ───────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn list_literal_three_elements() {
+    let k = setup().await;
+    let (out, code, err) = run(&k, "xs=[a b c]; echo $xs").await;
+    assert_eq!(code, 0, "err: {err}");
+    assert_eq!(out, r#"["a","b","c"]"#);
+}
+
+#[tokio::test]
+async fn list_literal_empty() {
+    let k = setup().await;
+    let (out, code, err) = run(&k, "xs=[]; echo $xs").await;
+    assert_eq!(code, 0, "err: {err}");
+    assert_eq!(out, "[]");
+}
+
+#[tokio::test]
+async fn list_literal_single_glued_element() {
+    let k = setup().await;
+    let (out, code, err) = run(&k, "xs=[dog]; echo $xs").await;
+    assert_eq!(code, 0, "err: {err}");
+    assert_eq!(out, r#"["dog"]"#);
+}
+
+#[tokio::test]
+async fn list_literal_single_int() {
+    let k = setup().await;
+    let (out, code, err) = run(&k, "xs=[1]; echo $xs").await;
+    assert_eq!(code, 0, "err: {err}");
+    assert_eq!(out, "[1]");
+}
+
+#[tokio::test]
+async fn list_literal_commas_optional() {
+    let k = setup().await;
+    let (out1, code1, _) = run(&k, "xs=[1 2 3]; echo $xs").await;
+    let (out2, code2, _) = run(&k, "xs=[1, 2, 3]; echo $xs").await;
+    assert_eq!(code1, 0);
+    assert_eq!(code2, 0);
+    assert_eq!(out1, out2);
+    assert_eq!(out1, "[1,2,3]");
+}
+
+#[tokio::test]
+async fn list_literal_heterogeneous() {
+    let k = setup().await;
+    let (out, code, err) = run(&k, "xs=[1 two true]; echo $xs").await;
+    assert_eq!(code, 0, "err: {err}");
+    assert_eq!(out, r#"[1,"two",true]"#);
+}
+
+#[tokio::test]
+async fn list_literal_quoted_element_with_space() {
+    let k = setup().await;
+    let (out, code, err) = run(&k, r#"xs=["green apple" banana]; echo $xs"#).await;
+    assert_eq!(code, 0, "err: {err}");
+    assert_eq!(out, r#"["green apple","banana"]"#);
+}
+
+#[tokio::test]
+async fn list_literal_element_count() {
+    let k = setup().await;
+    let (out, code, err) = run(&k, "xs=[1 2 3]; echo ${#xs}").await;
+    assert_eq!(code, 0, "err: {err}");
+    assert_eq!(out, "3");
+}
+
+#[tokio::test]
+async fn list_literal_access_rides_shipped_resolver() {
+    let k = setup().await;
+    let (out0, code0, _) = run(&k, "xs=[1 2 3]; echo ${xs[0]}").await;
+    let (out_neg, code_neg, _) = run(&k, "xs=[1 2 3]; echo ${xs[-1]}").await;
+    let (out_slice, code_slice, _) = run(&k, "xs=[1 2 3]; echo ${xs[0:2]}").await;
+    assert_eq!(code0, 0);
+    assert_eq!(out0, "1");
+    assert_eq!(code_neg, 0);
+    assert_eq!(out_neg, "3");
+    assert_eq!(code_slice, 0);
+    assert_eq!(out_slice, "[1,2]");
+}
+
+// ── Record literals ──────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn record_literal_spaced_colon() {
+    let k = setup().await;
+    let (out, code, err) = run(&k, "x={port: 8080}; echo $x").await;
+    assert_eq!(code, 0, "err: {err}");
+    assert_eq!(out, r#"{"port":8080}"#);
+}
+
+#[tokio::test]
+async fn record_literal_unspaced_colon_matches_spaced() {
+    let k = setup().await;
+    let (spaced, code1, _) = run(&k, "x={port: 8080}; echo $x").await;
+    let (unspaced, code2, _) = run(&k, "x={port:8080}; echo $x").await;
+    assert_eq!(code1, 0);
+    assert_eq!(code2, 0);
+    assert_eq!(spaced, unspaced, "{{port:8080}} must equal {{port: 8080}}");
+}
+
+#[tokio::test]
+async fn record_literal_multiple_entries() {
+    let k = setup().await;
+    let (out, code, err) = run(&k, "u={name: amy, role: maintainer}; echo $u").await;
+    assert_eq!(code, 0, "err: {err}");
+    assert_eq!(out, r#"{"name":"amy","role":"maintainer"}"#);
+}
+
+#[tokio::test]
+async fn record_literal_multiline_with_trailing_comma() {
+    let k = setup().await;
+    let script = "services={\n  web:    {port: 8080, replicas: 3, healthy: true},\n  api:    {port: 9000, replicas: 2, healthy: false},\n}\necho ${services[web][port]}\necho ${services[api][replicas]}";
+    let (out, code, err) = run(&k, script).await;
+    assert_eq!(code, 0, "err: {err}");
+    let mut lines = out.lines();
+    assert_eq!(lines.next(), Some("8080"));
+    assert_eq!(lines.next(), Some("2"));
+}
+
+#[tokio::test]
+async fn record_literal_quoted_key() {
+    let k = setup().await;
+    let (out, code, err) = run(&k, r#"r={"content-type": x}; echo ${r["content-type"]}"#).await;
+    assert_eq!(code, 0, "err: {err}");
+    assert_eq!(out, "x");
+}
+
+#[tokio::test]
+async fn record_literal_access_by_bareword_key() {
+    let k = setup().await;
+    let (out, code, err) = run(&k, "u={port: 8080}; echo ${u[port]}").await;
+    assert_eq!(code, 0, "err: {err}");
+    assert_eq!(out, "8080");
+}
+
+#[tokio::test]
+async fn record_literal_key_count() {
+    let k = setup().await;
+    let (out, code, err) = run(&k, "u={a: 1, b: 2, c: 3}; echo ${#u}").await;
+    assert_eq!(code, 0, "err: {err}");
+    assert_eq!(out, "3");
+}
+
+// ── Nesting / spread ─────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn nested_list_in_record() {
+    let k = setup().await;
+    let (out, code, err) =
+        run(&k, "x={tags: [a b], meta: {active: true}}; echo ${x[tags][1]}").await;
+    assert_eq!(code, 0, "err: {err}");
+    assert_eq!(out, "b");
+}
+
+#[tokio::test]
+async fn nested_record_in_record() {
+    let k = setup().await;
+    let (out, code, err) =
+        run(&k, "x={tags: [a b], meta: {active: true}}; echo ${x[meta][active]}").await;
+    assert_eq!(code, 0, "err: {err}");
+    assert_eq!(out, "true");
+}
+
+#[tokio::test]
+async fn spread_flattens_a_list() {
+    let k = setup().await;
+    let (out, code, err) = run(&k, "xs=[a b c]; new=[...$xs date]; echo $new").await;
+    assert_eq!(code, 0, "err: {err}");
+    assert_eq!(out, r#"["a","b","c","date"]"#);
+}
+
+#[tokio::test]
+async fn spread_of_two_lists() {
+    let k = setup().await;
+    let (out, code, err) = run(&k, "a=[1 2]; b=[3 4]; c=[...$a ...$b]; echo $c").await;
+    assert_eq!(code, 0, "err: {err}");
+    assert_eq!(out, "[1,2,3,4]");
+}
+
+#[tokio::test]
+async fn bare_variable_in_list_nests_instead_of_splatting() {
+    let k = setup().await;
+    // A bare $var inside `[ ]` is ONE element (nests) — contrast with spread.
+    let (out, code, err) = run(&k, "xs=[1 2]; ys=[0 $xs 4]; echo $ys").await;
+    assert_eq!(code, 0, "err: {err}");
+    assert_eq!(out, "[0,[1,2],4]");
+}
+
+// ── `in`/`not in` RHS literal (value-primary seam) ─────────────────────────
+
+#[tokio::test]
+async fn in_rhs_accepts_a_list_literal() {
+    let k = setup().await;
+    let (out, code, err) =
+        run(&k, r#"a=cat; if [[ $a in [cat dog] ]]; then echo hit; fi"#).await;
+    assert_eq!(code, 0, "err: {err}");
+    assert_eq!(out, "hit");
+}
+
+#[tokio::test]
+async fn not_in_rhs_accepts_a_list_literal() {
+    let k = setup().await;
+    let (out, code, err) =
+        run(&k, r#"a=fish; if [[ $a not in [cat dog] ]]; then echo hit; fi"#).await;
+    assert_eq!(code, 0, "err: {err}");
+    assert_eq!(out, "hit");
+}
+
+// ── Loud errors ──────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn bracket_leading_glob_at_value_position_is_a_loud_error() {
+    let k = setup().await;
+    // `[0-9]*.log` at value position must never silently become a glob
+    // expansion or a partial list literal — it's a parse error.
+    let result = k.execute("logs=[0-9]*.log").await;
+    assert!(result.is_err(), "bracket-leading glob assignment must be a loud parse error");
+}
+
+#[tokio::test]
+async fn multiword_bareword_record_value_is_a_loud_error() {
+    let k = setup().await;
+    let result = k.execute("x={msg: hello world}").await;
+    assert!(result.is_err(), "unquoted multi-word record value must be a loud parse error");
+}
+
+#[tokio::test]
+async fn nonlist_spread_is_a_loud_runtime_error() {
+    let k = setup().await;
+    let result = k.execute("s=hello; xs=[...$s]").await;
+    assert!(result.is_err(), "spreading a scalar must be a loud error");
+}
+
+#[tokio::test]
+async fn dotted_access_on_a_record_is_still_a_loud_error() {
+    let k = setup().await;
+    // Regression guard: dot access was never introduced by literals — brackets
+    // stay the only access form. Surfaces as a non-zero exit + message (same
+    // shape as the other PathError::Shape cases in collection_access_tests.rs),
+    // not a hard `Result::Err` from `kernel.execute()`.
+    let (_, code, err) = run(&k, "u={name: amy}; echo ${u.name}").await;
+    assert_ne!(code, 0, "${{u.name}} dotted access must stay a loud error");
+    assert!(err.contains("[name]"), "error should suggest the bracket form, got: {err}");
+}
+
+// ── Invariant guards: argv/for-head globs must be unaffected ────────────────
+
+#[tokio::test]
+async fn glob_in_assignment_stays_literal_string() {
+    let k = setup().await;
+    // Pre-existing invariant (kernel::tests::test_glob_in_assignment_is_literal):
+    // a pure Star/Question glob (no brackets) at value position is untouched —
+    // only bracket-shaped runs are reinterpreted as list literals.
+    let (out, code, err) = run(&k, "x=*.txt; echo $x").await;
+    assert_eq!(code, 0, "err: {err}");
+    assert_eq!(out, "*.txt");
+}
+
+#[tokio::test]
+async fn for_head_glued_bracket_glob_is_unaffected() {
+    let k = setup().await;
+    // `for x in [a]` is argv position, not a literal — the for-loop `in`
+    // keyword must not trip the value-position suppression (it shares the
+    // same lexer token as membership `in`). `KernelConfig::isolated()` has no
+    // real filesystem, so kaish's strict-glob contract (zero matches is an
+    // error, see glob_no_match_tests.rs) fires — proof the pattern still
+    // reached the glob machinery as `GlobWord("[a]")`, not a list literal
+    // (which would instead be a completely different parse/eval error).
+    let result = k.execute("for x in [a]; do echo $x; done").await;
+    let err = result.expect_err("glob with zero matches must error").to_string();
+    assert!(err.contains("no matches: [a]"), "got: {err}");
+}
+
+#[tokio::test]
+async fn foo_bracket_glob_argv_unaffected() {
+    let k = setup().await;
+    let (_, code, err) = run(&k, "echo foo[0-9]").await;
+    assert_ne!(code, 0, "glob with zero matches must be a loud non-zero exit");
+    assert!(err.contains("no matches: foo[0-9]"), "got: {err}");
+}

--- a/crates/kaish-kernel/tests/lexer_tests.rs
+++ b/crates/kaish-kernel/tests/lexer_tests.rs
@@ -76,6 +76,7 @@ fn format_token(token: &Token) -> String {
         Token::Comma => "COMMA".to_string(),
         Token::Dot => "DOT".to_string(),
         Token::DotDot => "DOTDOT".to_string(),
+        Token::DotDotDot => "DOTDOTDOT".to_string(),
         Token::Tilde => "TILDE".to_string(),
         Token::TildePath(s) => format!("TILDEPATH({})", s),
         Token::RelativePath(s) => format!("RELPATH({})", s),

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -70,6 +70,57 @@ u=$(fromjson '{"name":"amy","tags":["rust","shell"]}')
 xs=$(fromjson '[10,20,30]')
 ```
 
+### Construction — list/record literals
+
+Lists and records also have native syntax, no `fromjson` needed. Commas are
+optional in both — whitespace, commas, or a mix all work as separators:
+
+```sh
+xs=[apple banana cherry]     # list — space-separated, like shell words
+nums=[1 2 3] ≡ [1, 2, 3]     # commas optional
+empty=[]
+dog=[dog]                    # single-element list (glued `[dog]` still a list, never a glob)
+
+user={name: amy, role: maintainer}     # record — string-keyed map
+compact={port:8080}                    # colon may be spaced or unspaced — same value
+r={"content-type": x}                  # quoted key for anything that isn't a bareword
+
+nested={tags: [a b], meta: {active: true}}   # nesting works both ways
+```
+
+Multi-line literals consume interior newlines instead of ending the statement,
+so a trailing comma before the closing brace is fine:
+
+```sh
+services={
+  web: {port: 8080, replicas: 3},
+  api: {port: 9000, replicas: 2},
+}
+```
+
+A list element or record value is exactly **one** word or **one** quoted
+string — `["green apple" banana]`, `{msg: "hello world"}`. An unquoted
+multi-word value (`{msg: hello world}`) is a parse error with the quoted fix
+in the message, never silently split or joined.
+
+**Spread (`...`) flattens; a bare variable nests.** Inside `[ ]`, a bare
+`$var` is ONE element (it nests); `...$var` flattens that list's elements into
+the new one:
+
+```sh
+xs=[1 2]
+ys=[0 $xs 4]        # [0,[1,2],4]     — nests (one element)
+new=[...$xs date]   # [1,2,"date"]    — flattens
+both=[...$a ...$b]  # concatenates two lists
+```
+
+Collection literals are **value-position only** — an assignment RHS, the
+`in`/`not in` right-hand operand, or nested inside another literal. They never
+appear in a command argument (`ls [dog]` is still a glob) or a `for`-head item
+(`for x in [a]` is still a word list) — see "Iteration is `$()`-only" below.
+Assigning a `[`-leading glob (`logs=[0-9]*.log`) is a parse error at value
+position; use `$(glob '[0-9]*.log')` if you actually want glob expansion there.
+
 ### Read access — brackets only, never dots
 
 ```sh
@@ -192,9 +243,10 @@ cannot silently cross into an OS environment variable: `export CFG=$cfg` where
 `$cfg` is a list/record is a loud error — serialize it first with
 `export CFG=$(tojson $cfg)`.
 
-> Construction — list/record **literals** (`xs=[a b c]`, `{k: v}`), `push`, and
-> bracket-path **assignment** (`a[b]=x`) — is designed but not yet implemented;
-> today collections enter the shell via `fromjson` / `$(...)`.
+> List/record **literals** (`xs=[a b c]`, `{k: v}`, spread) are documented
+> above and shipped. `push` and bracket-path **assignment** (`a[b]=x`,
+> `fruits[0]=kiwi`) are designed but not yet implemented — today, beyond
+> literals, collections enter the shell via `fromjson` / `$(...)`.
 
 ## Quoting
 

--- a/docs/arrays-and-hashes.md
+++ b/docs/arrays-and-hashes.md
@@ -1,6 +1,9 @@
 # Arrays & Hashes — Design Doc
 
-Status: **proposal / design exploration** (not yet implemented)
+Status: read access, `keys`/`values`, membership, shape guards, the shared
+per-hop path resolver, and **list/record literals + spread** are SHIPPED (see
+`docs/LANGUAGE.md` Collections section). `push` and bracket-path **assignment**
+(`a[b]=x`) remain design-only — the rest of this document.
 Author: design notes from a 2026-06-05 session.
 **Revised 2026-07-01** — brackets-only access, record iteration, comparison/unwrap semantics,
 full lvalue rules; implementation notes re-grounded against HEAD `f92070e`. Superseded
@@ -559,6 +562,27 @@ tojson --pretty $cfg | tee config.json
 
 Re-grounded 2026-07-01 against HEAD `f92070e` (all file:line refs current as of that pass;
 paths relative to `crates/kaish-kernel/src`).
+
+**SHIPPED 2026-07-02** (branch `feat/collections-literals`, on top of the value/argv
+grammar seam PR): list/record literals + spread. The mechanism landed is **context-aware
+lexer suppression**, not "stop fusing `[`-runs entirely" as the first sketch below
+proposed — `lexer::compute_value_context` walks the raw token stream once, marking a
+per-token `ValueContext` (inside/opening a value-position `[`/`{`, and specifically
+inside a value-position `{` for the colon exemption), and `merge_glob_adjacent` /
+`merge_colon_adjacent` skip fusion only when that flag is set. This keeps argv-position
+globs (`ls [dog]`, `foo[0-9]`) and scalar assignments (`x=foo:bar`) byte-for-byte
+unchanged — lower blast radius than a global lexer rule. Two points the sketch didn't
+anticipate: (1) `for x in ...` reuses the exact same `Token::In` as membership `in`, so
+the "value position starts after `Eq`/`In`" rule needed a lookback exclusion for the
+fixed three-token `for`-loop shape (`For Ident In`) to keep `for x in [a]` fusing as a
+glob; (2) the bracket-pair suppression only fires for runs that actually contain an
+`LBracket`/`RBracket` pair, so a pure `Star`/`Question` glob at value position
+(`X=*.txt`) is untouched and still evaluates to a literal string, exactly as before
+literals existed. Deferred, as flagged below: deeply-nested *glued* literals
+(`x=[[a] [b]]`) — spaced nesting (`[ [a] [b] ]`) was never glued and is unaffected; see
+`docs/issues.md` P3. The multi-word bareword record-value error
+(`{msg: hello world}`) is a loud parse error but with chumsky's generic message, not
+the hand-crafted "quote it" wording sketched in Teaching note #10 — also P3.
 
 - **Glob-merge is the big lexer collision — including one the first draft missed.**
   Space-separated literals are safe: the glob-run merger only fuses **span-adjacent** tokens

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -64,18 +64,26 @@ glob-merge/colon-merge passes skip fusion *only* where that flag is set. Value
 position starts right after `Token::Eq` (assignment) or a genuine membership
 `Token::In`; everything else is untouched.
 
-Two collisions the design doc's sketch didn't fully anticipate, found by
-actually running the lexer against the invariant-guard cases rather than
-reasoning from the token grammar alone:
+Three collisions the design doc's sketch didn't fully anticipate — two found
+by running the lexer against the invariant-guard cases, the third by an
+empirical smoke test on the built binary during review:
 
-- **`for x in ...` reuses the exact same `Token::In`** as `[[ e in $coll ]]`
-  membership — there's no separate token. Naively suppressing after any `In`
-  would have silently turned `for x in [a]` into a suppressed (unfused)
-  bracket run instead of the `GlobWord` the for-loop body expects. Fixed with
-  a lookback: the `for`-loop shape is always exactly three tokens (`For Ident
-  In` — `ident_parser` matches one bare `Ident`), so that specific shape is
-  excluded from triggering value position, and every *other* `In` is
-  membership.
+- **Statement-head `in` (`for … in`, `case … in`) reuses the exact same
+  `Token::In`** as `[[ e in $coll ]]` membership — there's no separate token.
+  Naively suppressing after any `In` turns `for x in [a]` (and `case 5 in
+  [0-9]*)`) into a suppressed/unfused bracket run instead of the `GlobWord`
+  the loop body / `case_parser`'s char-class branch expects. The first cut
+  used a fixed three-token lookback (`For Ident In`), which correctly covered
+  `for` but MISSED `case` — its head is variable-length (`case EXPR in`, EXPR
+  can be a VarRef/string/`$()`), so `case 5 in [0-9]*)` regressed to a parse
+  error ("found DASHNUM(0-9)" — the char-class branch doesn't accept `0-9`).
+  Replaced the `for`-only lookback with a general **pending-statement-head**
+  counter: `For`/`Case` arm it, the first `In` while armed consumes it and is
+  treated as non-membership. Every `for`/`case` head has a mandatory `in`
+  right after the loop var / scrutinee (and `echo for`/`echo case` are already
+  parse errors, so a `For`/`Case` token is always a real head), which keeps
+  the counter balanced; a membership `in` inside `[[ ]]` is never preceded by
+  an unconsumed head, so it still opens value position for its RHS.
 - **A pure `Star`/`Question` glob at value position must NOT suppress.**
   The first pass suppressed *any* run that opened right after `Eq`, which
   broke the existing `X=*.txt` → literal-string-`"*.txt"` invariant (caught by

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -43,6 +43,67 @@ now fails compile with an error describing a pattern the author never wrote
 spelling + the strict-ERE flag where one exists) whenever the rewrite actually
 changed the pattern.
 
+## Collection literals + spread land (2026-07-02)
+
+`xs=[a b c]`, `{port: 8080}`/`{port:8080}`, multi-line records with a trailing
+comma, nesting, and `[...$xs date]` spread — the construction half of the
+collections effort, on top of the read-side resolver and the value/argv
+grammar seam (both already landed). Value model unchanged: a literal just
+evaluates to `Value::Json(Array|Object)`, so every existing access/`keys`/
+`values`/membership/shape-guard/`${#…}` mechanism works on a literal for free.
+
+The load-bearing decision was **context-aware lexer suppression over a global
+rule**. The obvious fix — stop the glob-merge pass from ever fusing a
+`[`-leading run — was rejected up front: kaish's argv glob path (`ls [dog]`,
+`foo[0-9]`) and scalar assignment (`x=foo:bar`) both lean on the *existing*
+fusion behavior, so a global change would either break those or need a second,
+parallel "argv assembles from primitives" grammar that doesn't exist. Instead
+`lexer::compute_value_context` walks the token stream once and marks a
+per-token flag — inside/opening a value-position `[`/`{` literal — and the
+glob-merge/colon-merge passes skip fusion *only* where that flag is set. Value
+position starts right after `Token::Eq` (assignment) or a genuine membership
+`Token::In`; everything else is untouched.
+
+Two collisions the design doc's sketch didn't fully anticipate, found by
+actually running the lexer against the invariant-guard cases rather than
+reasoning from the token grammar alone:
+
+- **`for x in ...` reuses the exact same `Token::In`** as `[[ e in $coll ]]`
+  membership — there's no separate token. Naively suppressing after any `In`
+  would have silently turned `for x in [a]` into a suppressed (unfused)
+  bracket run instead of the `GlobWord` the for-loop body expects. Fixed with
+  a lookback: the `for`-loop shape is always exactly three tokens (`For Ident
+  In` — `ident_parser` matches one bare `Ident`), so that specific shape is
+  excluded from triggering value position, and every *other* `In` is
+  membership.
+- **A pure `Star`/`Question` glob at value position must NOT suppress.**
+  The first pass suppressed *any* run that opened right after `Eq`, which
+  broke the existing `X=*.txt` → literal-string-`"*.txt"` invariant (caught by
+  the pre-existing `kernel::tests::test_glob_in_assignment_is_literal`, not a
+  new test — the full suite is the safety net here). Narrowed to: suppress
+  only when the run actually contains an `LBracket`/`RBracket` pair — a glob
+  with no brackets at value position is unaffected and keeps evaluating to a
+  literal string exactly as before literals existed.
+
+The colon-fusion exemption for `{port:8080}` needed the same care in the other
+direction: it must NOT fire for a plain scalar assignment like `x=foo:bar`
+(which must keep fusing into one `Ident`), so the suppression flag there is
+narrower than the bracket one — specifically "inside an open value-position
+`{`", not just "at value position".
+
+AST: `Expr::ListLiteral(Vec<ListElem>)` / `Expr::RecordLiteral(Vec<RecordEntry>)`,
+`ListElem::{Item,Spread}`, `RecordKey::{Bare,Quoted}`. Eval landed twice (async
+`kernel.rs::eval_expr_async` for real execution, sync `interpreter/eval.rs`
+`Evaluator::eval` for the reduced sync path) with a shared `spread_non_list_message`
+helper so the two paths can't diverge on wording for a non-list spread — the
+same dual-eval-site pattern as `${#…}` length and `${…:-default}` before it.
+
+Deferred (`docs/issues.md` P3): deeply-nested *glued* list literals
+(`x=[[a] [b]]` — spaced nesting works fine, only the glued form isn't
+unfused), and the multi-word-bareword-record-value error
+(`{msg: hello world}`) is loud but carries chumsky's generic message instead
+of the hand-crafted "quote it" wording the design doc sketched.
+
 ## Importance-ranked onboarding tiers (2026-07-01)
 
 Step 3 of the collections effort splits in two: the tier *mechanism* (pure infra,

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -64,26 +64,37 @@ glob-merge/colon-merge passes skip fusion *only* where that flag is set. Value
 position starts right after `Token::Eq` (assignment) or a genuine membership
 `Token::In`; everything else is untouched.
 
-Three collisions the design doc's sketch didn't fully anticipate — two found
-by running the lexer against the invariant-guard cases, the third by an
-empirical smoke test on the built binary during review:
+The load-bearing subtlety is that the two tokens the suppression keys on are
+each **reused** for a non-value grammatical role, and getting the split wrong
+breaks real syntax. This took three iterations to get right (two intermediate
+heuristics landed and regressed before the grammar-exact rule) — the story is
+worth keeping because it's a clean case of "reason from the grammar, not the
+token":
 
-- **Statement-head `in` (`for … in`, `case … in`) reuses the exact same
-  `Token::In`** as `[[ e in $coll ]]` membership — there's no separate token.
-  Naively suppressing after any `In` turns `for x in [a]` (and `case 5 in
-  [0-9]*)`) into a suppressed/unfused bracket run instead of the `GlobWord`
-  the loop body / `case_parser`'s char-class branch expects. The first cut
-  used a fixed three-token lookback (`For Ident In`), which correctly covered
-  `for` but MISSED `case` — its head is variable-length (`case EXPR in`, EXPR
-  can be a VarRef/string/`$()`), so `case 5 in [0-9]*)` regressed to a parse
-  error ("found DASHNUM(0-9)" — the char-class branch doesn't accept `0-9`).
-  Replaced the `for`-only lookback with a general **pending-statement-head**
-  counter: `For`/`Case` arm it, the first `In` while armed consumes it and is
-  treated as non-membership. Every `for`/`case` head has a mandatory `in`
-  right after the loop var / scrutinee (and `echo for`/`echo case` are already
-  parse errors, so a `For`/`Case` token is always a real head), which keeps
-  the counter balanced; a membership `in` inside `[[ ]]` is never preceded by
-  an unconsumed head, so it still opens value position for its RHS.
+- **`Token::In` is both membership and a statement head; `Token::Eq` is both
+  assignment and `[[ ]]` comparison.** Membership `in` (`[[ e in $c ]]`) must
+  open value position for its RHS literal; a `for`/`case` head `in`
+  (`for f in *.txt`, `case 5 in [0-9]*)`) must NOT (the following word is an
+  argv glob / char-class pattern). Symmetrically, an assignment `=`
+  (`x=[a b]`) must open value position; a comparison `=` (`[[ $x = [0-9]* ]]`)
+  must NOT. The **grammar-exact discriminator is `[[ ]]` test depth**:
+  membership `in` occurs only *inside* `[[ ]]`, a head `in` only *outside*;
+  assignment `=` occurs *outside*, comparison `=` only *inside*. So
+  `compute_value_context` tracks `test_depth` in its forward pass and opens
+  value position on `Token::In` iff `test_depth > 0` and on `Token::Eq` iff
+  `test_depth == 0`. (`==` is a distinct `Token::EqEq` and never opens value.)
+  Two rejected intermediate heuristics that each shipped and regressed:
+  (1) a fixed three-token lookback `For Ident In` — covered `for` but missed
+  `case`'s variable-length head (`case EXPR in`), so `case 5 in [0-9]*)`
+  parse-errored; (2) a general pending-`for`/`case` counter — fixed the `in`
+  half but the `=` half was still wrong (`[[ $x = [0-9]* ]]` regressed), and a
+  bareword `for`/`case`/`in` inside `$(…)` could leak the counter/flag past
+  `RParen`. The `test_depth` rule subsumes all of it: no per-keyword casing, no
+  state to leak across `$()` (a bareword `in` inside `$(echo in)` is at
+  `test_depth 0` → never membership; a real sub-shell assignment `$(x=…)` is
+  also `test_depth 0` → still an assignment), and the `[[` detection is guarded
+  by `!currently_value` so a glued nested value list `x=[[a] [b]]` reads as
+  literal brackets, not a bogus test.
 - **A pure `Star`/`Question` glob at value position must NOT suppress.**
   The first pass suppressed *any* run that opened right after `Eq`, which
   broke the existing `X=*.txt` → literal-string-`"*.txt"` invariant (caught by

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -805,6 +805,38 @@ Revisit when the first external tool bundle wants unit tests.
 
 ## P4 — Eventually
 
+### `compute_value_context`: `[[`/`]]` detection vs `]`-containing glob char-classes
+Surfaced in the collection-literals cross-model review (gemini-pro, 2026-07-02).
+The value-position suppression (`lexer.rs::compute_value_context`) discriminates
+assignment `=` from `[[ ]]` comparison `=` (and membership `in` from a for/case
+head `in`) by tracking `[[ ]]` **test depth** in a forward pass over raw tokens.
+`[[`/`]]` are deduced from *adjacent single brackets* (`LBracket LBracket` /
+`RBracket RBracket`) **before glob-fusion**, which is inherently fragile: a glob
+char-class that itself contains `]` (`[]]` matches a literal `]`, lexed as
+`[ ] ]`) has an inner `]` at `bracket_depth==0` that can prematurely decrement
+`test_depth`.
+- **Trigger:** a `]`-char-class glob AND a *later* single-`=` bracket-glob
+  comparison inside the SAME `[[ ]]` — e.g. `[[ $a == []] && $b = [0-9] ]]`.
+  The desynced `test_depth` reads the later `=` as an assignment, suppresses the
+  `[0-9]` glob, and the comparison RHS (parsed on `primary_expr_parser`, no
+  list-literal arm) hits primitive brackets.
+- **Failure mode: LOUD.** A parse error ("found '['"), never a wrong result —
+  per the "crash beats corrupt" directive this is acceptable to ship. Confirmed:
+  the *common* case `[[ $x == []] ]]` (a `]`-char-class alone in a test) parses
+  and runs identically to bash — the internal desync suppresses nothing and the
+  parser matches its own brackets.
+- **Why low priority:** exotic construct (a `]`-char-class next to a single-`=`
+  bracket-glob comparison in one test); every common form is unaffected. Pinned
+  by `collection_literals_tests.rs::bracket_char_class_containing_rbracket_in_test_parses`
+  (common case works) plus an `#[ignore]`'d
+  `rbracket_char_class_plus_later_eq_comparison_currently_errors` documenting the
+  exotic failure so a future fix is visible.
+- **Robust fix if it ever matters:** deducing `[[`/`]]` from adjacent single
+  brackets before glob-fusion can't be made reliable. The durable options are a
+  context-aware test-region pass, or reworking the pipeline so glob char-classes
+  are matched as single units before `compute_value_context` runs (so a `]`
+  inside a class is never mistaken for a test delimiter).
+
 ### Pre-release sweep — minor / edge (2026-06-23, verified)
 - **Backticks inside double-quotes and heredoc bodies are silently literal** — bare
   backticks are a loud lexer error, but quoted/heredoc ones slip through

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -486,6 +486,26 @@ the `WordAssign` arm degrade to a stringified positional when `past_double_dash`
 
 ## P3 — Scheduler and infra
 
+### Collection literals: deeply-nested *glued* brackets, and generic multi-word-value error text
+Two scoped deferrals from the collection-literals grammar landing (2026-07-02,
+`feat/collections-literals`, see `docs/arrays-and-hashes.md` "Implementation
+notes" for the shipped mechanism):
+- **Deeply-nested glued list literals** like `x=[[a] [b]]` aren't unfused by the
+  lexer's value-position suppression today — only a flat/glued-single/empty
+  bracket run (`[dog]`, `[]`, `[1]`) is exempted from `GlobWord` fusion.
+  Spaced nesting (`[ [a] [b] ]`) was never glued in the first place and works
+  fine. Fix would extend `lexer::compute_value_context`'s depth tracking to
+  also unfuse an inner glued bracket run once already inside an open value
+  literal (the counter is there; the glob-merge run-detection loop would need
+  to stop treating the WHOLE glued span as one run when depth re-enters 0 mid-run).
+- **Unquoted multi-word record value** (`{msg: hello world}`) is already a loud
+  parse error (never silently split/joined — the invariant that matters), but
+  the message is chumsky's generic "expected `:`/`}`, found identifier" rather
+  than the hand-crafted "quote it: `{msg: \"hello world\"}`" wording sketched
+  in the design doc's Teaching note #10. Fix: a `try_map` guard in
+  `record_literal_parser` (`parser.rs`) that peeks for a stray bareword not
+  followed by `:` and raises a custom `Rich::custom` message.
+
 ### `"$(cmd)"` interpolation drops a `.data`-only collection to empty string (silent data LOSS)
 Found alongside the collections boundary-ops work (2026-07-02, `feat/collections-boundary-ops`).
 Quoted command-substitution interpolation reads a command's `.out` via
@@ -784,18 +804,6 @@ Revisit when the first external tool bundle wants unit tests.
 ---
 
 ## P4 — Eventually
-
-### `docs/LANGUAGE.md` has no Collections section
-Native collection read access (`${xs[0]}`, `${r[key]}`, slices, `${#…}`),
-`fromjson`/`tojson`, and now `keys`/`values` all landed without a corresponding
-`docs/LANGUAGE.md` section — the file has zero mentions of any of them (checked
-2026-07-02 while adding `keys`/`values`). `help syntax`/`syntax.md` and
-`docs/arrays-and-hashes.md` cover the design and composable-help fragments, but
-LANGUAGE.md (the hand-written "deep" layer per the composable-help doc's Help &
-teaching delivery section) hasn't been swept since collections started landing.
-Worth a dedicated pass once the collections literal grammar (`xs=[a b c]`,
-`{k: v}`) lands too, so it's one coherent "Collections" section rather than
-three incremental patches.
 
 ### Pre-release sweep — minor / edge (2026-06-23, verified)
 - **Backticks inside double-quotes and heredoc bodies are silently literal** — bare


### PR DESCRIPTION
## Summary
- Re-lands PR #64 (native list/record literals + spread) on top of actual `main`. #64 merged onto a stale copy of `feat/collections-value-argv` on GitHub instead of main — after #62 merged into main via a real merge commit, GitHub's ref for that branch never advanced, so #64's merge commit (`234c0e6`) is a sibling of main, not a descendant. The content never reached main despite showing `MERGED`.
- Same 4 commits as #64 (`7cad972`, `a6f0677`, `9bf703e`, `8a64f37`), rebased cleanly onto `fbe8fdf` (post #62/#63/#65). Two doc conflicts (`docs/devlog.md`, `docs/issues.md`) were append-only and resolved by keeping both entries. Folded a CHANGELOG cleanup (duplicate `### Added` heading left by the merge) into the literals commit via fixup.
- No code changes beyond the rebase — this is the same reviewed literals PR, just correctly based.

## Test plan
- [x] `cargo build --all`
- [x] `cargo test --all` (all green, 0 failed)
- [x] `cargo clippy --all --all-targets` (zero warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)