### PR TITLE
feat(collections): bracket-path lvalue writes + bareword push

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,21 @@ breaking entries are marked **BREAKING**.
   key). `xs[0]`, `xs[i]`, `xs[i + 1]`, `xs[-1]`, and chained `grid[i][j]` all
   work; an out-of-bounds index is loud. Previously a bare subscript was dropped
   and failed as "variable is JSON, not a number".
+- **Collection lvalue writes + `push`** — bracket paths are now assignment
+  targets too: `xs[0]=9` (in-bounds list index update, negative indices work),
+  `user[email]=x` (record key insert-or-update), and deep paths
+  (`services[web][port]=9000`). No autovivification — every intermediate
+  segment must already exist with the right shape; the ONLY thing a path-set
+  may create is the final record key. An out-of-bounds index set, a missing
+  intermediate, a scalar/undefined root, and a slice lvalue (`xs[0:2]=x`) are
+  all loud errors, never silent. `push NAME VALUE...` appends to a top-level
+  list variable in place (bareword target, like `read`/`unset`); the target
+  must already exist and be a list. The validator now rejects a dotted
+  assignment target (`user.email=x`, since the `Ident` token admits `.` for
+  other uses) with a bracket-form suggestion, and a subscripted assignment
+  whose root isn't already bound. Env-prefix assignment (`X=v cmd`) stays
+  bare-ident-only — a subscripted target there is never captured as an
+  exported command-scoped variable.
 - **`json_to_value_no_envelope` (kaish-types)** — envelope-free JSON→`Value`
   conversion for external JSON, so byte-envelope-shaped objects are never
   silently decoded to `Value::Bytes`.

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ everywhere, a `jq` that always uses the same filter syntax, an `awk` that never 
 | **Text** | awk, base64, cut, diff, grep, head, sed, sort, split, tac, tail, tr, uniq, wc, xxd |
 | **Files** | basename, cat, cd, checksum, cmp, cp, dd, dirname, file, find, glob, ln, ls, mkdir, mktemp, mv, patch, pwd, readlink, realpath, rm, stat, tee, touch, tree, write |
 | **JSON** | fromjson, jq, keys, tojson, typeof, values |
-| **System** | alias, bg, date, echo, env, exec, export, fg, help, hostname, jobs, kill, printf, ps, read, seq, set, sleep, spawn, timeout, tokens, uname, unalias, unset, wait, which |
+| **System** | alias, bg, date, echo, env, exec, export, fg, help, hostname, jobs, kill, printf, ps, push, read, seq, set, sleep, spawn, timeout, tokens, uname, unalias, unset, wait, which |
 | **Parallel** | scatter, gather |
 | **Meta** | assert, false, true |
 | **kaish-*** | kaish-ast, kaish-clear, kaish-ignore, kaish-last, kaish-mounts, kaish-output-limit, kaish-status, kaish-tools, kaish-trash, kaish-validate, kaish-vars, kaish-version, kaish-vfs |

--- a/crates/kaish-help/content/en/syntax.md
+++ b/crates/kaish-help/content/en/syntax.md
@@ -77,6 +77,20 @@ elif [[ -list $data ]]; then
 fi
 
 tojson $u                 # serialize back to JSON text (--pretty to indent)
+
+# ASSIGNMENT — the same bracket paths write, in place, no spaces around `=`.
+# No autovivification — every intermediate must already exist with the right
+# shape; the ONLY thing a path-set may create is the final record key.
+xs[0]=9                   # in-bounds index update (negative index works too)
+u[host]=localhost         # record key: insert or update
+s[web][port]=9000         # deep path
+xs[9]=x                   # error — index out of bounds (push grows lists)
+s[api][port]=1            # error — no `api` key (no autoviv; init it first)
+user.email=x              # error — brackets only, use `user[email]=x`
+
+# push appends to a top-level LIST in place — takes the NAME (like read/unset)
+push xs date               # xs is now [...,"date"]
+push xs $rec               # values push as typed Values, not stringified text
 ```
 
 ## Paths

--- a/crates/kaish-help/src/fragments.rs
+++ b/crates/kaish-help/src/fragments.rs
@@ -309,6 +309,20 @@ elif [[ -list $data ]]; then
 fi
 
 tojson $u                 # serialize back to JSON text (--pretty to indent)
+
+# ASSIGNMENT — the same bracket paths write, in place, no spaces around `=`.
+# No autovivification — every intermediate must already exist with the right
+# shape; the ONLY thing a path-set may create is the final record key.
+xs[0]=9                   # in-bounds index update (negative index works too)
+u[host]=localhost         # record key: insert or update
+s[web][port]=9000         # deep path
+xs[9]=x                   # error — index out of bounds (push grows lists)
+s[api][port]=1            # error — no `api` key (no autoviv; init it first)
+user.email=x              # error — brackets only, use `user[email]=x`
+
+# push appends to a top-level LIST in place — takes the NAME (like read/unset)
+push xs date               # xs is now [...,"date"]
+push xs $rec               # values push as typed Values, not stringified text
 ```"#,
     ),
     syntax_section(

--- a/crates/kaish-kernel/src/ast/sexpr.rs
+++ b/crates/kaish-kernel/src/ast/sexpr.rs
@@ -71,7 +71,7 @@ pub fn format_stmt(stmt: &Stmt) -> String {
 /// Format an assignment as an S-expression.
 fn format_assignment(a: &Assignment) -> String {
     let value = format_expr(&a.value);
-    format!("(assign {} {} local={})", a.name, value, a.local)
+    format!("(assign {} {} local={})", format_varpath(&a.path), value, a.local)
 }
 
 /// Format a command as an S-expression.

--- a/crates/kaish-kernel/src/ast/types.rs
+++ b/crates/kaish-kernel/src/ast/types.rs
@@ -75,13 +75,30 @@ impl Stmt {
     }
 }
 
-/// Variable assignment: `NAME=value` (bash-style) or `local NAME = value` (scoped)
+/// Variable assignment: `NAME=value` (bash-style), `local NAME = value` (scoped),
+/// or a bracket-path lvalue (`xs[0]=value`, `user[email]=value`,
+/// `services[web][port]=value`). The path's first segment is always the root
+/// `Field` name; a bare assignment is a one-segment path.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Assignment {
-    pub name: String,
+    pub path: VarPath,
     pub value: Expr,
-    /// True if declared with `local` keyword (explicit local scope)
+    /// True if declared with `local` keyword (explicit local scope). Ignored
+    /// for a subscripted path — a bracket-path write always mutates the
+    /// existing root (see `docs/arrays-and-hashes.md`, "Assignment lvalues").
     pub local: bool,
+}
+
+impl Assignment {
+    /// The root variable name — the target of a bare assignment, or the root
+    /// of a subscripted lvalue path. The parser only ever builds an
+    /// `Assignment.path` starting with a `Field` segment, so this never fails.
+    pub fn name(&self) -> &str {
+        match self.path.segments.first() {
+            Some(VarSegment::Field(name)) => name,
+            _ => unreachable!("Assignment.path always starts with a root Field segment"),
+        }
+    }
 }
 
 /// A command invocation with arguments and redirections.

--- a/crates/kaish-kernel/src/interpreter/scope.rs
+++ b/crates/kaish-kernel/src/interpreter/scope.rs
@@ -9,7 +9,7 @@ use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
-use kaish_types::json_to_value_no_envelope;
+use kaish_types::{json_to_value_no_envelope, value_to_json};
 
 use crate::ast::{Value, VarPath, VarSegment};
 
@@ -282,6 +282,77 @@ fn descend<'a>(
                 None => Err(PathError::Absence(format!("${{{path}[{k}]}}: no such key"))),
             },
         },
+    }
+}
+
+/// Apply one classified step during a **write** walk's intermediate hops:
+/// descend mutably, requiring the child to already exist — no
+/// autovivification. Bounds/shape were already checked by `resolve_step`;
+/// this only adds the "must already exist" policy that only a write walk
+/// needs (a read's `descend` also requires existence for `Key`, but a write's
+/// *final* hop diverges — see `apply_leaf_write`). A `Slice` step can never
+/// be part of a valid lvalue path (mutating through a detached slice copy
+/// wouldn't write back), so it is always a loud `Shape` error here,
+/// intermediate or not.
+fn descend_mut<'a>(
+    current: &'a mut serde_json::Value,
+    step: Step,
+    path: &str,
+) -> Result<&'a mut serde_json::Value, PathError> {
+    match step {
+        Step::Slice(..) => Err(PathError::Shape(format!(
+            "${{{path}[..]}}: slice lvalues are not supported — index or key paths only"
+        ))),
+        Step::Index(i) => {
+            let Some(arr) = current.as_array_mut() else {
+                unreachable!("index classified against an array")
+            };
+            Ok(&mut arr[i])
+        }
+        Step::Key(k) => {
+            let Some(map) = current.as_object_mut() else {
+                unreachable!("key classified against an object")
+            };
+            match map.get_mut(&k) {
+                Some(child) => Ok(child),
+                None => Err(PathError::Absence(format!(
+                    "${{{path}[{k}]}}: no such key — no autovivification, create it first (e.g. `{path}[{k}]={{}}`)"
+                ))),
+            }
+        }
+    }
+}
+
+/// Apply the classified **final** step of a write walk: a record key inserts
+/// or updates (the one thing a path-set may create), a list index updates
+/// in-bounds (already validated by `resolve_step`'s `classify_index` — an
+/// out-of-bounds index is an `Absence` error before this is ever reached),
+/// and a slice is a loud `Shape` error (no slice lvalues — `push` grows
+/// lists).
+fn apply_leaf_write(
+    current: &mut serde_json::Value,
+    step: Step,
+    value: serde_json::Value,
+    path: &str,
+) -> Result<(), PathError> {
+    match step {
+        Step::Slice(..) => Err(PathError::Shape(format!(
+            "${{{path}[..]}}: slice lvalues are not supported — index or key paths only"
+        ))),
+        Step::Index(i) => {
+            let Some(arr) = current.as_array_mut() else {
+                unreachable!("index classified against an array")
+            };
+            arr[i] = value;
+            Ok(())
+        }
+        Step::Key(k) => {
+            let Some(map) = current.as_object_mut() else {
+                unreachable!("key classified against an object")
+            };
+            map.insert(k, value);
+            Ok(())
+        }
     }
 }
 
@@ -700,6 +771,90 @@ impl Scope {
         Ok(json_to_value_no_envelope(current.into_owned()))
     }
 
+    /// Write a value into a collection lvalue path: `xs[0]=9`,
+    /// `user[email]=amy@example.com`, `services[web][port]=9090`.
+    ///
+    /// Shares `resolve_step` with [`resolve_path`](Self::resolve_path) so
+    /// classification (bounds, shape) never drifts between read and write.
+    /// The walk itself diverges at the leaf: every intermediate hop requires
+    /// the child to already exist (`descend_mut` — **no autovivification**),
+    /// while the final hop may insert a new record key (`apply_leaf_write`) —
+    /// the ONLY thing a path-set may create. A list index write is in-bounds
+    /// update only (`resolve_step`'s `classify_index` already turns an
+    /// out-of-bounds index into a loud `Absence`); `push` is how lists grow.
+    /// A slice lvalue (`xs[0:2]=…`) is always a `Shape` error.
+    ///
+    /// The root must already be defined (`UndefinedRoot`) and be a collection
+    /// (`Shape` for a scalar root) — same rule as a read. On success the
+    /// mutated root replaces the old value via `set_global` (bracket-path
+    /// writes always update wherever the variable lives, regardless of
+    /// `local` — see `docs/arrays-and-hashes.md`, "Assignment lvalues").
+    pub fn walk_write(&mut self, path: &VarPath, value: Value) -> Result<(), PathError> {
+        let Some(VarSegment::Field(root_name)) = path.segments.first() else {
+            return Err(PathError::UndefinedRoot(String::new()));
+        };
+
+        let root = self
+            .get(root_name)
+            .ok_or_else(|| PathError::UndefinedRoot(root_name.clone()))?;
+
+        let mut root_json = match root {
+            Value::Json(j) => j.clone(),
+            other => {
+                return Err(PathError::Shape(format!(
+                    "${{{root_name}…}}: cannot subscript {} — it is not a collection",
+                    type_name(other)
+                )))
+            }
+        };
+
+        let subscripts = &path.segments[1..];
+        let Some((last, intermediates)) = subscripts.split_last() else {
+            // A bare name never reaches walk_write — the kernel routes a
+            // one-segment path through set/set_global. Guard defensively
+            // rather than silently no-op.
+            return Err(PathError::Shape(format!(
+                "{root_name}: assignment target has no subscript"
+            )));
+        };
+
+        let mut current = &mut root_json;
+        let mut prefix = root_name.clone();
+        for seg in intermediates {
+            let step = resolve_step(current, seg, self, &prefix)?;
+            current = descend_mut(current, step, &prefix)?;
+            prefix.push_str(&render_segment(seg));
+        }
+
+        let step = resolve_step(current, last, self, &prefix)?;
+        apply_leaf_write(current, step, value_to_json(&value), &prefix)?;
+
+        self.set_global(root_name.clone(), Value::Json(root_json));
+        Ok(())
+    }
+
+    /// Append value(s) to a top-level list variable, in place (`push xs val`).
+    ///
+    /// The target must already exist and be a list — an undefined or
+    /// non-list target is a loud error, never a silent create (see
+    /// `docs/arrays-and-hashes.md`, "Append — push"). Bracket-path push
+    /// (`push services[web][tags] item`) is deferred (see `docs/issues.md`);
+    /// this only handles a top-level bareword name.
+    pub fn walk_append(&mut self, name: &str, values: Vec<Value>) -> Result<(), String> {
+        let current = self
+            .get(name)
+            .ok_or_else(|| format!("push: {name} is not defined"))?;
+        if !matches!(current, Value::Json(serde_json::Value::Array(_))) {
+            return Err(format!("push: {name} is not a list ({})", type_name(current)));
+        }
+        let Value::Json(serde_json::Value::Array(mut arr)) = current.clone() else {
+            unreachable!("checked above")
+        };
+        arr.extend(values.iter().map(value_to_json));
+        self.set_global(name, Value::Json(serde_json::Value::Array(arr)));
+        Ok(())
+    }
+
     /// Check if a variable exists in any frame.
     pub fn contains(&self, name: &str) -> bool {
         self.get(name).is_some()
@@ -1047,5 +1202,149 @@ mod tests {
 
         let names = scope.exported_names();
         assert_eq!(names, vec!["A", "M", "Z"]);
+    }
+
+    // ── walk_write (lvalue assignment) ──────────────────────────────────────
+
+    /// Build `xs[seg]=value` and apply it.
+    fn write_at(
+        scope: &mut Scope,
+        root: &str,
+        segs: Vec<VarSegment>,
+    ) -> Result<(), PathError> {
+        let mut segments = vec![VarSegment::Field(root.into())];
+        segments.extend(segs);
+        scope.walk_write(&VarPath { segments }, Value::Int(0))
+    }
+
+    #[test]
+    fn walk_write_list_index_update() {
+        let mut scope = Scope::new();
+        scope.set("xs", Value::Json(serde_json::json!([1, 2, 3])));
+        let path = VarPath {
+            segments: vec![VarSegment::Field("xs".into()), VarSegment::Index(0)],
+        };
+        scope.walk_write(&path, Value::Int(9)).expect("write should succeed");
+        assert_eq!(scope.get("xs"), Some(&Value::Json(serde_json::json!([9, 2, 3]))));
+    }
+
+    #[test]
+    fn walk_write_negative_index() {
+        let mut scope = Scope::new();
+        scope.set("xs", Value::Json(serde_json::json!([1, 2, 3])));
+        let path = VarPath {
+            segments: vec![VarSegment::Field("xs".into()), VarSegment::Index(-1)],
+        };
+        scope.walk_write(&path, Value::Int(7)).expect("write should succeed");
+        assert_eq!(scope.get("xs"), Some(&Value::Json(serde_json::json!([1, 2, 7]))));
+    }
+
+    #[test]
+    fn walk_write_inserts_a_new_record_key() {
+        let mut scope = Scope::new();
+        scope.set("u", Value::Json(serde_json::json!({"port": 8080})));
+        let path = VarPath {
+            segments: vec![VarSegment::Field("u".into()), VarSegment::Key("host".into())],
+        };
+        scope
+            .walk_write(&path, Value::String("localhost".into()))
+            .expect("write should succeed");
+        assert_eq!(
+            scope.get("u"),
+            Some(&Value::Json(serde_json::json!({"port": 8080, "host": "localhost"})))
+        );
+    }
+
+    #[test]
+    fn walk_write_deep_path_updates_nested_key() {
+        let mut scope = Scope::new();
+        scope.set("s", Value::Json(serde_json::json!({"web": {"port": 8080}})));
+        let path = VarPath {
+            segments: vec![
+                VarSegment::Field("s".into()),
+                VarSegment::Key("web".into()),
+                VarSegment::Key("port".into()),
+            ],
+        };
+        scope.walk_write(&path, Value::Int(9000)).expect("write should succeed");
+        assert_eq!(
+            scope.get("s"),
+            Some(&Value::Json(serde_json::json!({"web": {"port": 9000}})))
+        );
+    }
+
+    #[test]
+    fn walk_write_out_of_bounds_index_is_absence() {
+        let mut scope = Scope::new();
+        scope.set("xs", Value::Json(serde_json::json!([1, 2, 3])));
+        let r = write_at(&mut scope, "xs", vec![VarSegment::Index(9)]);
+        assert!(matches!(r, Err(PathError::Absence(_))), "got: {r:?}");
+    }
+
+    #[test]
+    fn walk_write_missing_intermediate_is_absence_no_autoviv() {
+        let mut scope = Scope::new();
+        scope.set("s", Value::Json(serde_json::json!({"web": {"port": 8080}})));
+        let r = write_at(
+            &mut scope,
+            "s",
+            vec![VarSegment::Key("api".into()), VarSegment::Key("port".into())],
+        );
+        assert!(matches!(r, Err(PathError::Absence(_))), "got: {r:?}");
+        // The root is untouched — no partial autovivification.
+        assert_eq!(
+            scope.get("s"),
+            Some(&Value::Json(serde_json::json!({"web": {"port": 8080}})))
+        );
+    }
+
+    #[test]
+    fn walk_write_scalar_root_is_shape() {
+        let mut scope = Scope::new();
+        scope.set("y", Value::String("hi".into()));
+        let r = write_at(&mut scope, "y", vec![VarSegment::Index(0)]);
+        assert!(matches!(r, Err(PathError::Shape(_))), "got: {r:?}");
+    }
+
+    #[test]
+    fn walk_write_undefined_root_is_undefined_root() {
+        let mut scope = Scope::new();
+        let r = write_at(&mut scope, "z", vec![VarSegment::Index(0)]);
+        assert!(matches!(r, Err(PathError::UndefinedRoot(_))), "got: {r:?}");
+    }
+
+    #[test]
+    fn walk_write_slice_lvalue_is_shape() {
+        let mut scope = Scope::new();
+        scope.set("xs", Value::Json(serde_json::json!([1, 2, 3])));
+        let r = write_at(&mut scope, "xs", vec![VarSegment::Slice(Some(0), Some(2))]);
+        assert!(matches!(r, Err(PathError::Shape(_))), "got: {r:?}");
+    }
+
+    // ── walk_append (push) ──────────────────────────────────────────────────
+
+    #[test]
+    fn walk_append_extends_a_list_in_place() {
+        let mut scope = Scope::new();
+        scope.set("xs", Value::Json(serde_json::json!(["a", "b"])));
+        scope
+            .walk_append("xs", vec![Value::String("c".into())])
+            .expect("push should succeed");
+        assert_eq!(scope.get("xs"), Some(&Value::Json(serde_json::json!(["a", "b", "c"]))));
+    }
+
+    #[test]
+    fn walk_append_undefined_target_is_a_loud_error() {
+        let mut scope = Scope::new();
+        let r = scope.walk_append("nope", vec![Value::Int(1)]);
+        assert!(r.is_err(), "expected a loud error for an undefined target");
+    }
+
+    #[test]
+    fn walk_append_non_list_target_is_a_loud_error() {
+        let mut scope = Scope::new();
+        scope.set("y", Value::String("hi".into()));
+        let r = scope.walk_append("y", vec![Value::Int(1)]);
+        assert!(r.is_err(), "expected a loud error for a non-list target");
     }
 }

--- a/crates/kaish-kernel/src/kernel.rs
+++ b/crates/kaish-kernel/src/kernel.rs
@@ -2058,12 +2058,26 @@ impl Kernel {
                 let value = self.eval_expr_async(&assign.value).await
                     .context("failed to evaluate assignment")?;
                 let mut scope = self.scope.write().await;
-                if assign.local {
-                    // local: set in innermost (current function) frame
-                    scope.set(&assign.name, value.clone());
+                if assign.path.segments.len() == 1 {
+                    // Plain `NAME=value` — no subscript, so `local` applies.
+                    if assign.local {
+                        // local: set in innermost (current function) frame
+                        scope.set(assign.name(), value.clone());
+                    } else {
+                        // non-local: update existing or create in root frame
+                        scope.set_global(assign.name(), value.clone());
+                    }
                 } else {
-                    // non-local: update existing or create in root frame
-                    scope.set_global(&assign.name, value.clone());
+                    // Subscripted lvalue (`xs[0]=v`, `user[email]=v`, …): always
+                    // mutates the existing root wherever it lives — `local` is
+                    // meaningless here (see docs/arrays-and-hashes.md, "Assignment
+                    // lvalues").
+                    scope.walk_write(&assign.path, value.clone()).map_err(|e| match e {
+                        PathError::UndefinedRoot(name) => anyhow::anyhow!(
+                            "{name}: undefined — create it first, e.g. `{name}={{}}` or `{name}=[]`"
+                        ),
+                        PathError::Absence(msg) | PathError::Shape(msg) => anyhow::anyhow!(msg),
+                    })?;
                 }
                 drop(scope);
 
@@ -2531,8 +2545,8 @@ impl Kernel {
                         Ok(value) => {
                             let mut scope = self.scope.write().await;
                             prior_export
-                                .push((assign.name.clone(), scope.is_exported(&assign.name)));
-                            scope.set_exported(&assign.name, value);
+                                .push((assign.name().to_string(), scope.is_exported(assign.name())));
+                            scope.set_exported(assign.name(), value);
                         }
                         Err(e) => {
                             setup_err = Some(e);

--- a/crates/kaish-kernel/src/lexer.rs
+++ b/crates/kaish-kernel/src/lexer.rs
@@ -2148,7 +2148,20 @@ fn flush_glob_run(
         .any(|t| matches!(t.token, Token::Star | Token::Question));
     let has_glob = has_star_or_question || has_bracket_pair;
 
-    let lvalue_suppress = followed_by_eq && has_bracket_pair && !has_star_or_question;
+    // An lvalue subscript run is a ROOT IDENTIFIER followed by brackets, so the
+    // run STARTS with an `Ident` (`arr[0]=` → run is `arr [ 0 ]`, glued, so
+    // `arr` is the first token OF the run — a lvalue root parses via
+    // `ident_parser()`, i.e. `Token::Ident`). A bare char-class comparison
+    // operand starts with `[` instead (`[[ [a] = b ]]` → the suppressible run
+    // is `[ a ]`, since the leading `[[` was flushed separately), so requiring
+    // an `Ident`-led run keeps `[[ [a] = b ]]` fusing-and-comparing as before
+    // while still catching every real lvalue.
+    let run_starts_with_ident = matches!(
+        run.first().map(|t| &t.token),
+        Some(Token::Ident(_))
+    );
+    let lvalue_suppress =
+        followed_by_eq && has_bracket_pair && !has_star_or_question && run_starts_with_ident;
     let suppress = (value_position_suppress && has_bracket_pair) || lvalue_suppress;
 
     if !suppress && run.len() >= 2 && has_glob {

--- a/crates/kaish-kernel/src/lexer.rs
+++ b/crates/kaish-kernel/src/lexer.rs
@@ -2046,6 +2046,16 @@ fn merge_flag_metachar_adjacent(tokens: Vec<Spanned<Token>>) -> Vec<Spanned<Toke
 /// above — so the list-literal parser sees primitive `LBracket`/`RBracket` tokens
 /// instead of a fused `GlobWord`. Argv-position brackets (`ls [dog]`, `for x in [a]`)
 /// are untouched.
+///
+/// A SEPARATE trigger suppresses fusion for an **assignment lvalue**:
+/// `fruits[0]=kiwi`, `user[email]=x`, `services[web][port]=9090`. This run sits
+/// at *argv/LHS position* (before `=`), not value position, so
+/// `ValueContext::in_literal` is false for it — the lvalue grammar needs its
+/// own peek-ahead: a bracket-pair run (no `*`/`?`) immediately followed by
+/// `Token::Eq` is a subscripted assignment target, not a glob, so it is
+/// suppressed the same way regardless of whitespace before the `=` (see
+/// `flush_glob_run`'s `followed_by_eq` parameter). See
+/// `docs/arrays-and-hashes.md` ("Assignment lvalues").
 fn merge_glob_adjacent(tokens: Vec<Spanned<Token>>) -> Vec<Spanned<Token>> {
     if tokens.is_empty() {
         return tokens;
@@ -2074,7 +2084,17 @@ fn merge_glob_adjacent(tokens: Vec<Spanned<Token>>) -> Vec<Spanned<Token>> {
         if adjacent && glob_mergeable_text(&token.token).is_some() {
             run.push(token);
         } else {
-            flush_glob_run(&mut run, &mut result, value_ctx[run_start].in_literal);
+            // `token` is whatever broke the run — an lvalue's `=` is never
+            // glob-mergeable, so it always lands here (not in the `if` arm
+            // above) regardless of whether whitespace separates it from the
+            // run (`fruits[0]=kiwi` and `fruits[0] = kiwi` both see it).
+            let followed_by_eq = matches!(token.token, Token::Eq);
+            flush_glob_run(
+                &mut run,
+                &mut result,
+                value_ctx[run_start].in_literal,
+                followed_by_eq,
+            );
             if glob_mergeable_text(&token.token).is_some() {
                 run.push(token);
                 run_start = idx;
@@ -2084,33 +2104,52 @@ fn merge_glob_adjacent(tokens: Vec<Spanned<Token>>) -> Vec<Spanned<Token>> {
         }
     }
 
-    flush_glob_run(&mut run, &mut result, value_ctx[run_start].in_literal);
+    // End of input: no token follows the final run, so it can't be an lvalue
+    // (an assignment always has a value after `=`).
+    flush_glob_run(&mut run, &mut result, value_ctx[run_start].in_literal, false);
 
     result
 }
 
 /// Flush a run of glob-mergeable tokens: merge if it contains glob metacharacters.
-/// `suppress` (true when the run opened at value position — see `ValueContext`)
-/// forces individual emission for a run that contains an `LBracket`, so a
-/// `[`-leading run at value position always reaches the parser as primitive
-/// tokens for the list-literal grammar, never a `GlobWord`. A pure `Star`/
-/// `Question` glob with no brackets (`X=*.txt`) is untouched by `suppress` —
-/// it keeps fusing to a `GlobWord`, which evaluates to a literal string at
-/// value position exactly as it did before collection literals existed
-/// (see `test_glob_in_assignment_is_literal`); only bracket-shaped runs are
-/// reinterpreted as list-literal syntax.
-fn flush_glob_run(run: &mut Vec<&Spanned<Token>>, result: &mut Vec<Spanned<Token>>, suppress: bool) {
+///
+/// `value_position_suppress` (true when the run opened at value position — see
+/// `ValueContext`) forces individual emission for a run that contains an
+/// `LBracket`, so a `[`-leading run at value position always reaches the
+/// parser as primitive tokens for the list-literal grammar, never a
+/// `GlobWord`. A pure `Star`/`Question` glob with no brackets (`X=*.txt`) is
+/// untouched by `value_position_suppress` — it keeps fusing to a `GlobWord`,
+/// which evaluates to a literal string at value position exactly as it did
+/// before collection literals existed (see `test_glob_in_assignment_is_literal`);
+/// only bracket-shaped runs are reinterpreted as list-literal syntax.
+///
+/// `followed_by_eq` (true when the token right after this run — in stream
+/// order, whitespace or not — is `Token::Eq`) is the SEPARATE lvalue trigger:
+/// a bracket-pair run with no `*`/`?` immediately before `=` is a subscripted
+/// assignment target (`fruits[0]=kiwi`), not a glob, so it is suppressed too
+/// — even though it sits at argv/LHS position, not value position. The
+/// `has_star_or_question` guard keeps a real glob pattern that happens to
+/// precede an `=` (vanishingly rare, but not this run's job to reinterpret)
+/// out of the suppression.
+fn flush_glob_run(
+    run: &mut Vec<&Spanned<Token>>,
+    result: &mut Vec<Spanned<Token>>,
+    value_position_suppress: bool,
+    followed_by_eq: bool,
+) {
     if run.is_empty() {
         return;
     }
 
     let has_bracket_pair = run.iter().any(|t| matches!(t.token, Token::LBracket))
         && run.iter().any(|t| matches!(t.token, Token::RBracket));
-    let has_glob = run
+    let has_star_or_question = run
         .iter()
-        .any(|t| matches!(t.token, Token::Star | Token::Question))
-        || has_bracket_pair;
-    let suppress = suppress && has_bracket_pair;
+        .any(|t| matches!(t.token, Token::Star | Token::Question));
+    let has_glob = has_star_or_question || has_bracket_pair;
+
+    let lvalue_suppress = followed_by_eq && has_bracket_pair && !has_star_or_question;
+    let suppress = (value_position_suppress && has_bracket_pair) || lvalue_suppress;
 
     if !suppress && run.len() >= 2 && has_glob {
         let text: String = run

--- a/crates/kaish-kernel/src/parser.rs
+++ b/crates/kaish-kernel/src/parser.rs
@@ -1037,10 +1037,20 @@ where
         // following, this alternative fails and we fall through to a plain,
         // persistent assignment. Must precede `assignment_parser` so the
         // prefixed-command form wins when a command follows.
+        // Env-prefix assignment stays BARE-IDENT ONLY — a subscripted target
+        // (`user[email]=x cmd`) is illegal here, not just unsupported:
+        // structured values can't cross the process boundary anyway (see
+        // docs/arrays-and-hashes.md, "Assignment lvalues"). Using
+        // `ident_parser()` directly (not `lvalue_path_parser()`) means a
+        // bracket run before `=` in this position never gets a chance to
+        // parse as a path — it either isn't there (plain ident) or the
+        // lexer's lvalue suppression fires and the stray `LBracket` fails
+        // this parser, falling through to a real parse error instead of
+        // silently being accepted.
         let env_prefix_assign = ident_parser()
             .then_ignore(just(Token::Eq))
             .then(value_expr_parser())
-            .map(|(name, value)| Assignment { name, value, local: false });
+            .map(|(name, value)| Assignment { path: VarPath::simple(name), value, local: false });
         let env_scoped = env_prefix_assign
             .repeated()
             .at_least(1)
@@ -1106,7 +1116,59 @@ where
     })
 }
 
-/// Assignment: `NAME=value` (bash-style) or `local NAME = value` (scoped)
+/// One bracket subscript in an assignment LHS: `[0]`, `[email]`, `["a b"]`,
+/// `[$k]`, `[0:2]`. Reached only via the lexer's lvalue suppression (see
+/// `lexer::flush_glob_run`), which keeps a bracket run immediately followed by
+/// `=` from fusing into a `GlobWord` — so this always sees primitive
+/// `LBracket`/`RBracket` tokens around one of a handful of interior shapes.
+/// Interior classification reuses [`parse_subscript`] (string-based) for the
+/// `Ident` case (bareword key or colon-fused slice like `0:2`/`0:-1` — colon
+/// merge already ran ahead of this parser) so read and write share one
+/// subscript grammar; the other interior kinds map straight to their segment.
+fn lvalue_subscript_parser<'tokens, I>(
+) -> impl Parser<'tokens, I, VarSegment, extra::Err<Rich<'tokens, Token, Span>>> + Clone
+where
+    I: ValueInput<'tokens, Token = Token, Span = Span>,
+{
+    let interior = choice((
+        select! { Token::SimpleVarRef(name) => VarSegment::Dynamic(name) },
+        select! { Token::String(s) => VarSegment::Key(s) },
+        select! { Token::SingleString(s) => VarSegment::Key(s) },
+        select! { Token::Int(n) => VarSegment::Index(n) },
+        select! { Token::Ident(s) => parse_subscript(&s) },
+    ));
+
+    just(Token::LBracket)
+        .ignore_then(interior)
+        .then_ignore(just(Token::RBracket))
+        .labelled("subscript")
+}
+
+/// An lvalue path: `NAME`, `NAME[sub]`, `NAME[sub][sub]…`. The root is a
+/// plain identifier; zero or more bracket subscripts follow with no
+/// whitespace expected between them (the lexer only suppresses fusion for a
+/// bracket run immediately followed by `=`, so this is the only shape that
+/// reaches here already split into primitive tokens).
+fn lvalue_path_parser<'tokens, I>(
+) -> impl Parser<'tokens, I, VarPath, extra::Err<Rich<'tokens, Token, Span>>> + Clone
+where
+    I: ValueInput<'tokens, Token = Token, Span = Span>,
+{
+    ident_parser()
+        .then(lvalue_subscript_parser().repeated().collect::<Vec<_>>())
+        .map(|(name, subscripts)| {
+            let mut segments = vec![VarSegment::Field(name)];
+            segments.extend(subscripts);
+            VarPath { segments }
+        })
+        .labelled("lvalue path")
+}
+
+/// Assignment: `NAME=value` / `NAME[sub]=value` (bash-style), or
+/// `local NAME = value` (scoped). Bracket paths are lvalues here — see
+/// `docs/arrays-and-hashes.md` ("Assignment lvalues") — and are resolved at
+/// runtime by `Scope::walk_write`, sharing the read resolver's per-hop
+/// classification.
 fn assignment_parser<'tokens, I>(
 ) -> impl Parser<'tokens, I, Assignment, extra::Err<Rich<'tokens, Token, Span>>> + Clone
 where
@@ -1114,22 +1176,22 @@ where
 {
     // local NAME = value (with spaces around =)
     let local_assignment = just(Token::Local)
-        .ignore_then(ident_parser())
+        .ignore_then(lvalue_path_parser())
         .then_ignore(just(Token::Eq))
         .then(value_expr_parser())
-        .map(|(name, value)| Assignment {
-            name,
+        .map(|(path, value)| Assignment {
+            path,
             value,
             local: true,
         });
 
-    // Bash-style: NAME=value (no spaces around =)
-    // The lexer produces IDENT EQ EXPR, so we parse it here
-    let bash_assignment = ident_parser()
+    // Bash-style: NAME=value / NAME[sub]=value (no spaces around =)
+    // The lexer produces IDENT (LBRACKET ... RBRACKET)* EQ EXPR, so we parse it here
+    let bash_assignment = lvalue_path_parser()
         .then_ignore(just(Token::Eq))
         .then(value_expr_parser())
-        .map(|(name, value)| Assignment {
-            name,
+        .map(|(path, value)| Assignment {
+            path,
             value,
             local: false,
         });
@@ -2950,12 +3012,124 @@ mod tests {
     }
 
     #[test]
+    fn parse_lvalue_single_index() {
+        let result = parse("xs[0]=9").unwrap();
+        match &result.statements[0] {
+            Stmt::Assignment(a) => {
+                assert_eq!(a.name(), "xs");
+                assert_eq!(
+                    a.path.segments,
+                    vec![VarSegment::Field("xs".into()), VarSegment::Index(0)]
+                );
+                assert!(!a.local);
+            }
+            other => panic!("expected assignment, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_lvalue_negative_index() {
+        let result = parse("xs[-1]=7").unwrap();
+        match &result.statements[0] {
+            Stmt::Assignment(a) => assert_eq!(
+                a.path.segments,
+                vec![VarSegment::Field("xs".into()), VarSegment::Index(-1)]
+            ),
+            other => panic!("expected assignment, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_lvalue_bareword_key() {
+        let result = parse("user[email]=x").unwrap();
+        match &result.statements[0] {
+            Stmt::Assignment(a) => assert_eq!(
+                a.path.segments,
+                vec![
+                    VarSegment::Field("user".into()),
+                    VarSegment::Key("email".into())
+                ]
+            ),
+            other => panic!("expected assignment, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_lvalue_chained_keys() {
+        let result = parse("s[web][port]=9000").unwrap();
+        match &result.statements[0] {
+            Stmt::Assignment(a) => assert_eq!(
+                a.path.segments,
+                vec![
+                    VarSegment::Field("s".into()),
+                    VarSegment::Key("web".into()),
+                    VarSegment::Key("port".into())
+                ]
+            ),
+            other => panic!("expected assignment, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_lvalue_dynamic_key() {
+        let result = parse("r[$k]=v").unwrap();
+        match &result.statements[0] {
+            Stmt::Assignment(a) => assert_eq!(
+                a.path.segments,
+                vec![
+                    VarSegment::Field("r".into()),
+                    VarSegment::Dynamic("k".into())
+                ]
+            ),
+            other => panic!("expected assignment, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_local_lvalue_spaced() {
+        let result = parse("local xs[0] = 9").unwrap();
+        match &result.statements[0] {
+            Stmt::Assignment(a) => {
+                assert!(a.local);
+                assert_eq!(
+                    a.path.segments,
+                    vec![VarSegment::Field("xs".into()), VarSegment::Index(0)]
+                );
+            }
+            other => panic!("expected assignment, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn env_prefix_subscripted_target_is_not_captured_as_env_scoped() {
+        // A subscripted target before a following command (`user[email]=x
+        // echo hi`) must NOT become `Stmt::EnvScoped` — structured values
+        // can't cross the process boundary, so env-prefix stays bare-ident
+        // only. The lexer suppression + `env_prefix_assign` using
+        // `ident_parser()` (not `lvalue_path_parser()`) means this falls
+        // through to an ordinary subscripted assignment followed by an
+        // independent statement — the SAME back-to-back-without-a-terminator
+        // shape `X=1 Y=2` already has (kaish's `terminator` is
+        // `.repeated()`, not `.at_least(1)`), not a new hazard.
+        let result = parse("user={}\nuser[email]=x echo hi").unwrap();
+        for stmt in &result.statements {
+            assert!(
+                !matches!(stmt, Stmt::EnvScoped { .. }),
+                "a subscripted assignment must never be captured into EnvScoped: {stmt:?}"
+            );
+        }
+        // Sanity: it really did parse as two independent statements.
+        assert!(matches!(&result.statements[1], Stmt::Assignment(a) if a.name() == "user"));
+        assert!(matches!(&result.statements[2], Stmt::Command(c) if c.name == "echo"));
+    }
+
+    #[test]
     fn parse_nested_cmd_subst() {
         // Nested command substitution is supported
         let result = parse("X=$(echo $(date))").unwrap();
         match &result.statements[0] {
             Stmt::Assignment(a) => {
-                assert_eq!(a.name, "X");
+                assert_eq!(a.name(), "X");
                 let outer = subst_cmd(&a.value);
                 assert_eq!(outer.name, "echo");
                 // The argument should be another command substitution
@@ -3005,7 +3179,7 @@ mod tests {
         let result = parse("X=42").unwrap();
         match &result.statements[0] {
             Stmt::Assignment(a) => {
-                assert_eq!(a.name, "X");
+                assert_eq!(a.name(), "X");
                 match &a.value {
                     Expr::Literal(Value::Int(n)) => assert_eq!(*n, 42),
                     other => panic!("expected int literal, got {:?}", other),
@@ -3083,7 +3257,7 @@ mod tests {
     fn value_assignment_name_preserved() {
         let result = parse("MY_VAR=1").unwrap();
         match &result.statements[0] {
-            Stmt::Assignment(a) => assert_eq!(a.name, "MY_VAR"),
+            Stmt::Assignment(a) => assert_eq!(a.name(), "MY_VAR"),
             other => panic!("expected assignment, got {:?}", other),
         }
     }
@@ -3436,7 +3610,7 @@ mod tests {
         let result = parse("X=$(echo)").unwrap();
         match &result.statements[0] {
             Stmt::Assignment(a) => {
-                assert_eq!(a.name, "X");
+                assert_eq!(a.name(), "X");
                 assert_eq!(subst_cmd(&a.value).name, "echo");
             }
             other => panic!("expected assignment, got {:?}", other),
@@ -3499,7 +3673,7 @@ mod tests {
         match &result.statements[0] {
             Stmt::EnvScoped { assignments, body } => {
                 assert_eq!(assignments.len(), 1);
-                assert_eq!(assignments[0].name, "FOO");
+                assert_eq!(assignments[0].name(), "FOO");
                 assert!(!assignments[0].local);
                 match body.as_ref() {
                     Stmt::Command(cmd) => assert_eq!(cmd.name, "echo"),
@@ -3516,8 +3690,8 @@ mod tests {
         match &result.statements[0] {
             Stmt::EnvScoped { assignments, body } => {
                 assert_eq!(assignments.len(), 2);
-                assert_eq!(assignments[0].name, "A");
-                assert_eq!(assignments[1].name, "B");
+                assert_eq!(assignments[0].name(), "A");
+                assert_eq!(assignments[1].name(), "B");
                 assert!(matches!(body.as_ref(), Stmt::Command(c) if c.name == "run"));
             }
             other => panic!("expected env-scoped, got {other:?}"),
@@ -3529,7 +3703,7 @@ mod tests {
         // No command follows — stays a plain (persistent) assignment.
         let result = parse("FOO=bar").unwrap();
         assert!(
-            matches!(&result.statements[0], Stmt::Assignment(a) if a.name == "FOO"),
+            matches!(&result.statements[0], Stmt::Assignment(a) if a.name() == "FOO"),
             "got {:?}",
             result.statements[0]
         );
@@ -3542,7 +3716,7 @@ mod tests {
         let result = parse("FOO=bar && echo hi").unwrap();
         match &result.statements[0] {
             Stmt::AndChain { left, right } => {
-                assert!(matches!(left.as_ref(), Stmt::Assignment(a) if a.name == "FOO"));
+                assert!(matches!(left.as_ref(), Stmt::Assignment(a) if a.name() == "FOO"));
                 assert!(matches!(right.as_ref(), Stmt::Command(c) if c.name == "echo"));
             }
             other => panic!("expected and-chain, got {other:?}"),
@@ -3554,7 +3728,7 @@ mod tests {
         let result = parse("FOO=bar cat | grep x").unwrap();
         match &result.statements[0] {
             Stmt::EnvScoped { assignments, body } => {
-                assert_eq!(assignments[0].name, "FOO");
+                assert_eq!(assignments[0].name(), "FOO");
                 match body.as_ref() {
                     Stmt::Pipeline(p) => assert_eq!(p.commands.len(), 2),
                     other => panic!("expected pipeline body, got {other:?}"),
@@ -3816,7 +3990,7 @@ fi
         // First: assignment with command substitution
         match stmts[0] {
             Stmt::Assignment(a) => {
-                assert_eq!(a.name, "RESULT");
+                assert_eq!(a.name(), "RESULT");
                 assert!(matches!(&a.value, Expr::CommandSubst(_)));
             }
             other => panic!("expected assignment, got {:?}", other),
@@ -3959,7 +4133,7 @@ fi
         // Command substitution with pipeline
         match stmts[0] {
             Stmt::Assignment(a) => {
-                assert_eq!(a.name, "RESULT");
+                assert_eq!(a.name(), "RESULT");
                 assert_eq!(subst_pipeline(&a.value).commands.len(), 3);
             }
             other => panic!("expected assignment, got {:?}", other),

--- a/crates/kaish-kernel/src/tools/builtin/mod.rs
+++ b/crates/kaish-kernel/src/tools/builtin/mod.rs
@@ -66,6 +66,7 @@ mod mktemp;
 mod mv;
 mod output_limit;
 mod printf;
+mod push;
 mod pwd;
 mod read;
 mod readlink;
@@ -191,6 +192,7 @@ pub fn register_builtins(registry: &mut ToolRegistry) {
     registry.register(output_limit::KaishOutputLimit);
     registry.register(patch::Patch);
     registry.register(printf::Printf);
+    registry.register(push::Push);
     #[cfg(all(target_os = "linux", feature = "host"))]
     registry.register(kaish_tools_host::Ps);
     registry.register(pwd::Pwd);

--- a/crates/kaish-kernel/src/tools/builtin/push.rs
+++ b/crates/kaish-kernel/src/tools/builtin/push.rs
@@ -1,0 +1,193 @@
+//! push — append value(s) to a list variable, in place.
+//!
+//! Part of the native-collections OPS surface (see `docs/arrays-and-hashes.md`,
+//! "Append — `push` (in-place); spelling frozen, pure `append` dropped"). `push`
+//! mutates the named list in place, so it takes the variable **name**
+//! (bareword, like `read`/`unset`), not `$name` — `push xs date`, not
+//! `push $xs date`. The pure functional `append` builtin was deliberately
+//! never added: its only niche (build a new list with an extra element) is
+//! already covered by `...` spread (`new=[...$xs date]`), and a return-value
+//! `append` re-imports the silent-discard trap the design doc's evidence #6
+//! called out (a model wrote `append $colors purple` and threw the result
+//! away, then reported the OLD length).
+//!
+//! `push` to an undefined target, or a target that isn't a list, is a loud
+//! runtime error — never a silent create (see `Scope::walk_append`).
+//!
+//! **Scope note — bareword target only.** `push services[web][tags] item`
+//! (a bracket-path target) is deferred: the target isn't followed by `=`, so
+//! the lvalue lexer suppression never fires and `services[web][tags]` fuses
+//! into a `GlobWord` that glob-expands (and fails as "no matches") before
+//! `push` ever runs. Solving that needs its own lexer/parser design pass —
+//! see `docs/issues.md`.
+//!
+//! # Examples
+//!
+//! ```kaish
+//! xs=[a b]
+//! push xs c              # xs is now [a b c]
+//! push xs $rec           # values are read as typed Values, not stringified
+//! ```
+
+use async_trait::async_trait;
+use clap::{CommandFactory, Parser};
+
+use crate::ast::Value;
+use crate::interpreter::ExecResult;
+use crate::tools::{schema_from_clap, ExecContext, GlobalFlags, Tool, ToolArgs, ToolCtx, ToolSchema};
+
+/// push tool: append value(s) to a list variable, in place.
+pub struct Push;
+
+/// clap-derived argv layer for push.
+#[derive(Parser, Debug)]
+#[command(name = "push", about = "Append value(s) to a list variable, in place")]
+struct PushArgs {
+    #[command(flatten)]
+    global: GlobalFlags,
+
+    /// Target name and values. Hidden sink — the real values are read off
+    /// `args.positional` (typed `Value`s, not stringified) per the
+    /// Value-typed positional rule.
+    #[arg(hide = true)]
+    rest: Vec<String>,
+}
+
+#[async_trait]
+impl Tool for Push {
+    fn name(&self) -> &str {
+        "push"
+    }
+
+    fn schema(&self) -> ToolSchema {
+        schema_from_clap(
+            &PushArgs::command(),
+            "push",
+            "Append value(s) to a list variable, in place",
+            [
+                ("Append one element", "push xs date"),
+                ("Append a record value", "push xs $rec"),
+            ],
+        )
+    }
+
+    async fn execute(&self, args: ToolArgs, ctx: &mut dyn ToolCtx) -> ExecResult {
+        let Some(ctx) = ctx.as_any_mut().downcast_mut::<ExecContext>() else {
+            return ExecResult::failure(1, "internal error: kernel builtin requires ExecContext");
+        };
+        let parsed = match PushArgs::try_parse_from(
+            std::iter::once("push".to_string()).chain(args.to_argv()),
+        ) {
+            Ok(p) => p,
+            Err(e) => return ExecResult::failure(2, format!("push: {e}")),
+        };
+        parsed.global.apply(ctx);
+
+        // Values MUST come from `args.positional` (typed), not the clap
+        // struct — `to_argv()` stringifies, so `push xs $rec` would push the
+        // stringified record instead of the record itself.
+        let Some(target) = args.positional.first() else {
+            return ExecResult::failure(2, "push: usage: push NAME VALUE...");
+        };
+        let name = match target {
+            Value::String(s) => s.clone(),
+            other => {
+                return ExecResult::failure(
+                    2,
+                    format!(
+                        "push: target must be a bareword variable name (e.g. `push xs val`), \
+                         not {other:?}"
+                    ),
+                )
+            }
+        };
+
+        let values: Vec<Value> = args.positional[1..].to_vec();
+        if values.is_empty() {
+            return ExecResult::failure(2, "push: usage: push NAME VALUE...");
+        }
+
+        match ctx.scope.walk_append(&name, values) {
+            Ok(()) => ExecResult::success(""),
+            Err(msg) => ExecResult::failure(1, msg),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::vfs::{MemoryFs, VfsRouter};
+    use std::sync::Arc;
+
+    fn make_ctx() -> ExecContext {
+        let mut vfs = VfsRouter::new();
+        vfs.mount("/", MemoryFs::new());
+        ExecContext::new(Arc::new(vfs))
+    }
+
+    #[tokio::test]
+    async fn push_appends_to_list_in_place() {
+        let mut ctx = make_ctx();
+        ctx.scope.set(
+            "xs",
+            Value::Json(serde_json::json!(["a", "b"])),
+        );
+
+        let mut args = ToolArgs::new();
+        args.positional.push(Value::String("xs".into()));
+        args.positional.push(Value::String("c".into()));
+
+        let result = Push.execute(args, &mut ctx).await;
+        assert!(result.ok(), "push failed: {}", result.err);
+        assert_eq!(
+            ctx.scope.get("xs"),
+            Some(&Value::Json(serde_json::json!(["a", "b", "c"])))
+        );
+    }
+
+    #[tokio::test]
+    async fn push_pushes_a_record_value_untouched() {
+        let mut ctx = make_ctx();
+        ctx.scope.set("xs", Value::Json(serde_json::json!([])));
+
+        let mut args = ToolArgs::new();
+        args.positional.push(Value::String("xs".into()));
+        args.positional
+            .push(Value::Json(serde_json::json!({"k": "v"})));
+
+        let result = Push.execute(args, &mut ctx).await;
+        assert!(result.ok(), "push failed: {}", result.err);
+        assert_eq!(
+            ctx.scope.get("xs"),
+            Some(&Value::Json(serde_json::json!([{"k": "v"}])))
+        );
+    }
+
+    #[tokio::test]
+    async fn push_undefined_target_is_a_loud_error() {
+        let mut ctx = make_ctx();
+
+        let mut args = ToolArgs::new();
+        args.positional.push(Value::String("nope".into()));
+        args.positional.push(Value::String("x".into()));
+
+        let result = Push.execute(args, &mut ctx).await;
+        assert!(!result.ok());
+        assert!(result.err.contains("not defined"), "got: {}", result.err);
+    }
+
+    #[tokio::test]
+    async fn push_non_list_target_is_a_loud_error() {
+        let mut ctx = make_ctx();
+        ctx.scope.set("y", Value::String("hi".into()));
+
+        let mut args = ToolArgs::new();
+        args.positional.push(Value::String("y".into()));
+        args.positional.push(Value::String("z".into()));
+
+        let result = Push.execute(args, &mut ctx).await;
+        assert!(!result.ok());
+        assert!(result.err.contains("not a list"), "got: {}", result.err);
+    }
+}

--- a/crates/kaish-kernel/src/validator/walker.rs
+++ b/crates/kaish-kernel/src/validator/walker.rs
@@ -90,11 +90,50 @@ impl<'a> Validator<'a> {
     }
 
     /// Validate an assignment statement.
+    ///
+    /// A plain `NAME=value` is checked for a dotted target (`user.email=x`) —
+    /// kaish is brackets-only for collection access, and the `Ident` token
+    /// admits `.` for other uses (filenames), so a dotted assignment target
+    /// is caught here rather than by tightening the lexer regex. A
+    /// subscripted lvalue (`x[k]=v`) additionally requires the root to
+    /// already be bound — a path-set never autovivifies the root (see
+    /// `docs/arrays-and-hashes.md`, "Assignment lvalues").
     fn validate_assignment(&mut self, assign: &Assignment) {
         // Validate the value expression
         self.validate_expr(&assign.value);
-        // Bind the variable name in scope
-        self.scope.bind(&assign.name);
+
+        let name = assign.name();
+        if assign.path.segments.len() == 1 {
+            if let Some(dot) = name.find('.') {
+                let (root, rest) = (&name[..dot], &name[dot + 1..]);
+                self.issues.push(
+                    ValidationIssue::error(
+                        IssueCode::DottedAssignmentTarget,
+                        format!(
+                            "'{name}' is not a valid assignment target — kaish uses bracket \
+                             access, not dots"
+                        ),
+                    )
+                    .with_suggestion(format!("use `{root}[{rest}]=value`")),
+                );
+            }
+            // Bind the variable name in scope
+            self.scope.bind(name);
+        } else if !self.scope.is_bound(name) {
+            self.issues.push(
+                ValidationIssue::error(
+                    IssueCode::LvalueUndefinedRoot,
+                    format!(
+                        "'{name}' is not defined — a subscripted assignment never creates the \
+                         root variable"
+                    ),
+                )
+                .with_suggestion(format!("create it first, e.g. `{name}={{}}` or `{name}=[]`")),
+            );
+            // Bind it anyway so a later reference to the same (still-invalid)
+            // root doesn't ALSO trigger a separate undefined-variable warning.
+            self.scope.bind(name);
+        }
     }
 
     /// Validate a command invocation.
@@ -1089,7 +1128,7 @@ mod tests {
             statements: vec![
                 // First assign the variable
                 Stmt::Assignment(Assignment {
-                    name: "MY_VAR".to_string(),
+                    path: VarPath::simple("MY_VAR"),
                     value: Expr::Literal(Value::String("value".to_string())),
                     local: false,
                 }),

--- a/crates/kaish-kernel/tests/collections_lvalue_tests.rs
+++ b/crates/kaish-kernel/tests/collections_lvalue_tests.rs
@@ -70,6 +70,20 @@ async fn record_key_update_existing() {
 }
 
 #[tokio::test]
+async fn glued_nested_index_lvalue_writes() {
+    // `a[0][1]=9` — a chained-index lvalue (list of lists). The value comes
+    // from fromjson so this pins the lvalue write path, not glued nested
+    // literal construction.
+    let k = setup().await;
+    let out = ok(
+        &k,
+        r#"a=$(fromjson '[[1,2],[3,4]]'); a[0][1]=9; echo ${a[0][1]}"#,
+    )
+    .await;
+    assert_eq!(out, "9");
+}
+
+#[tokio::test]
 async fn deep_path_write() {
     let k = setup().await;
     let out = ok(
@@ -189,6 +203,29 @@ async fn push_undefined_target_is_loud() {
     let k = setup().await;
     let err = loud_err(&k, "push nope z").await;
     assert!(err.contains("not defined"), "got: {err}");
+}
+
+// ── Regression: the `=`-triggered lvalue lexer suppression must not fire on
+//    a BARE char-class comparison operand. `[[ [a] = b ]]` starts the
+//    suppressible run with `[`, not an Ident, so it stays a glob-vs-string
+//    comparison (parses and runs) — it is NOT a subscripted assignment. ──────
+
+#[tokio::test]
+async fn bare_char_class_comparison_operand_before_eq_is_not_an_lvalue() {
+    let k = setup().await;
+    // `[[ [a] = b ]]`: "[a]" (a fused GlobWord as a string literal) != "b",
+    // so the test is false → exit 1, but it must PARSE and RUN, not
+    // parse-error as a malformed lvalue.
+    let r = k.execute("[[ [a] = b ]]").await;
+    match r {
+        Ok(res) => assert_eq!(res.code, 1, "expected a clean false, got: {res:?}"),
+        Err(e) => panic!("must not parse-error as an lvalue: {e}"),
+    }
+
+    // And a matching form is true → exit 0, confirming it really ran as a
+    // string comparison of the literal "[a]".
+    let r2 = k.execute("[[ [a] = [a] ]]").await.expect("must run");
+    assert_eq!(r2.code, 0, "‘[a]’ == ‘[a]’ should be true: {r2:?}");
 }
 
 // ── Deferred: bracket-path push (documented, not silent) ──────────────────

--- a/crates/kaish-kernel/tests/collections_lvalue_tests.rs
+++ b/crates/kaish-kernel/tests/collections_lvalue_tests.rs
@@ -1,0 +1,210 @@
+//! Collection lvalue WRITES: `xs[0]=9`, `user[email]=x`,
+//! `services[web][port]=9000`, and the bareword `push` builtin. See
+//! `docs/arrays-and-hashes.md`, "Assignment lvalues" and "Append — push".
+//!
+//! Kernel-routed via `KernelConfig::isolated()` WITH validation ON (unlike
+//! the sibling `collection_literals_tests.rs`/`collection_access_tests.rs`,
+//! which skip validation) — the validator's E016 (undefined lvalue root) and
+//! E017 (dotted assignment target) checks are part of what this file pins.
+
+// Test-fixture code: unwrap/expect on known-good setup is the idiom here.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::sync::Arc;
+
+use kaish_kernel::{Kernel, KernelConfig};
+
+async fn setup() -> Arc<Kernel> {
+    Kernel::new(KernelConfig::isolated())
+        .expect("failed to create kernel")
+        .into_arc()
+}
+
+/// Run a script expected to succeed; return trimmed stdout.
+async fn ok(k: &Kernel, script: &str) -> String {
+    let r = k.execute(script).await.unwrap_or_else(|e| panic!("kernel execute failed: {e}\nscript: {script}"));
+    assert!(r.ok(), "expected success, got exit {}: {}\nscript: {script}", r.code, r.err);
+    r.text_out().trim().to_string()
+}
+
+/// Run a script expected to fail loudly (parse/validation error OR a runtime
+/// error propagated as `Err` from `kernel.execute()`); return the error text.
+async fn loud_err(k: &Kernel, script: &str) -> String {
+    match k.execute(script).await {
+        Err(e) => e.to_string(),
+        Ok(r) => {
+            assert!(!r.ok(), "expected a loud failure, got success: {}\nscript: {script}", r.text_out());
+            r.err.clone()
+        }
+    }
+}
+
+// ── Basic writes ─────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn list_index_update() {
+    let k = setup().await;
+    let out = ok(&k, "xs=[1 2 3]; xs[0]=9; echo ${xs[0]}").await;
+    assert_eq!(out, "9");
+}
+
+#[tokio::test]
+async fn list_negative_index_update() {
+    let k = setup().await;
+    let out = ok(&k, "xs=[1 2 3]; xs[-1]=7; echo ${xs[-1]}").await;
+    assert_eq!(out, "7");
+}
+
+#[tokio::test]
+async fn record_key_insert() {
+    let k = setup().await;
+    let out = ok(&k, "u={port: 8080}; u[host]=localhost; echo ${u[host]}").await;
+    assert_eq!(out, "localhost");
+}
+
+#[tokio::test]
+async fn record_key_update_existing() {
+    let k = setup().await;
+    let out = ok(&k, "u={port: 8080}; u[port]=9090; echo ${u[port]}").await;
+    assert_eq!(out, "9090");
+}
+
+#[tokio::test]
+async fn deep_path_write() {
+    let k = setup().await;
+    let out = ok(
+        &k,
+        "s={web: {port: 8080}}; s[web][port]=9000; echo ${s[web][port]}",
+    )
+    .await;
+    assert_eq!(out, "9000");
+}
+
+#[tokio::test]
+async fn write_does_not_disturb_sibling_keys() {
+    let k = setup().await;
+    let out = ok(
+        &k,
+        "s={web: {port: 8080, replicas: 3}}; s[web][port]=9000; echo ${s[web][replicas]}",
+    )
+    .await;
+    assert_eq!(out, "3", "sibling key must survive an unrelated write");
+}
+
+// ── Loud errors ──────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn out_of_bounds_index_set_is_loud() {
+    let k = setup().await;
+    let err = loud_err(&k, "xs=[1 2 3]; xs[9]=x").await;
+    assert!(
+        err.contains("out of bounds") || err.contains("bounds"),
+        "got: {err}"
+    );
+}
+
+#[tokio::test]
+async fn missing_intermediate_is_loud_no_autoviv() {
+    let k = setup().await;
+    let err = loud_err(&k, "s={web: {port: 8080}}; s[api][port]=1").await;
+    assert!(
+        err.contains("no such key") || err.contains("autovivification"),
+        "got: {err}"
+    );
+}
+
+#[tokio::test]
+async fn scalar_root_is_loud() {
+    let k = setup().await;
+    let err = loud_err(&k, "y=hi; y[0]=x").await;
+    assert!(err.contains("collection"), "got: {err}");
+}
+
+#[tokio::test]
+async fn undefined_root_is_loud() {
+    let k = setup().await;
+    let err = loud_err(&k, "z[0]=x").await;
+    assert!(
+        err.contains("not defined") || err.contains("E016"),
+        "got: {err}"
+    );
+}
+
+#[tokio::test]
+async fn slice_lvalue_is_loud() {
+    let k = setup().await;
+    let err = loud_err(&k, "xs=[1 2 3]; xs[0:2]=x").await;
+    assert!(err.contains("slice"), "got: {err}");
+}
+
+// ── Validator: dotted assignment target (E017) ────────────────────────────
+
+#[tokio::test]
+async fn dotted_assignment_target_is_rejected_with_bracket_suggestion() {
+    let k = setup().await;
+    let err = loud_err(&k, "user.email=x").await;
+    assert!(err.contains("E017"), "got: {err}");
+    assert!(
+        err.contains("user[email]"),
+        "expected the bracket-form suggestion: {err}"
+    );
+}
+
+// ── push ───────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn push_appends_in_place() {
+    let k = setup().await;
+    let out = ok(&k, "xs=[a b]; push xs c; echo ${#xs} ${xs[-1]}").await;
+    assert_eq!(out, "3 c");
+}
+
+#[tokio::test]
+async fn push_a_record_value_stays_structured() {
+    let k = setup().await;
+    let out = ok(
+        &k,
+        "xs=[]; rec={k: v}; push xs $rec; echo ${xs[-1][k]}",
+    )
+    .await;
+    assert_eq!(out, "v", "push must not stringify a typed Value positional");
+}
+
+#[tokio::test]
+async fn push_multiple_values_in_one_call() {
+    let k = setup().await;
+    let out = ok(&k, "xs=[a]; push xs b c; echo ${#xs}").await;
+    assert_eq!(out, "3");
+}
+
+#[tokio::test]
+async fn push_non_list_target_is_loud() {
+    let k = setup().await;
+    let err = loud_err(&k, "y=hi; push y z").await;
+    assert!(err.contains("not a list"), "got: {err}");
+}
+
+#[tokio::test]
+async fn push_undefined_target_is_loud() {
+    let k = setup().await;
+    let err = loud_err(&k, "push nope z").await;
+    assert!(err.contains("not defined"), "got: {err}");
+}
+
+// ── Deferred: bracket-path push (documented, not silent) ──────────────────
+
+#[tokio::test]
+async fn bracket_path_push_target_is_deferred_but_loud_not_a_crash() {
+    // `push services[web][tags] item` is out of scope for this PR (see
+    // docs/issues.md): the target isn't followed by `=`, so the lvalue
+    // lexer suppression never fires and `services[web][tags]` fuses into a
+    // GlobWord that glob-expands before `push` runs. Pin that it's a loud
+    // error, not silent corruption or a panic, until that's designed.
+    let k = setup().await;
+    let err = loud_err(
+        &k,
+        "services={web: {tags: []}}; push services[web][tags] item",
+    )
+    .await;
+    assert!(!err.is_empty(), "expected a non-empty loud error");
+}

--- a/crates/kaish-kernel/tests/json_sweep_tests.rs
+++ b/crates/kaish-kernel/tests/json_sweep_tests.rs
@@ -152,6 +152,8 @@ const CASES: &[Case] = &[
     },
     Case { name: "printf", setup: &[], cmd: "printf 'x' --json", expect: Expect::String },
     Case { name: "ps", setup: &[], cmd: "ps --json", expect: Expect::Array },
+    // push mutates in place and is silent on success, like unset.
+    Case { name: "push", setup: &["xs=[a b]"], cmd: "push xs c --json", expect: Expect::Empty },
     Case { name: "pwd", setup: &[], cmd: "pwd --json", expect: Expect::String },
     Case { name: "read", setup: &[], cmd: "echo hi | read X --json", expect: Expect::Empty },
     Case { name: "readlink", setup: &["ln -s tmp/data.json link.json"], cmd: "readlink link.json --json", expect: Expect::String },

--- a/crates/kaish-kernel/tests/lexer_tests.rs
+++ b/crates/kaish-kernel/tests/lexer_tests.rs
@@ -748,3 +748,45 @@ fn lexer_arithmetic_in_command_substitution(#[case] input: &str, #[case] expecte
 fn lexer_navigation_tokens(#[case] input: &str, #[case] expected: &[&str]) {
     run_lexer_test(input, expected);
 }
+
+// =============================================================================
+// Assignment lvalue subscripts: `fruits[0]=kiwi` must NOT fuse into a
+// `GlobWord` — the glob-merge pass suppresses fusion for a bracket run (no
+// `*`/`?`) immediately followed by `=`, distinct from the value-position
+// (RHS) suppression used by list/record literals. See
+// docs/arrays-and-hashes.md, "Assignment lvalues", and
+// `lexer::flush_glob_run`'s `followed_by_eq` parameter.
+// =============================================================================
+
+#[rstest]
+#[case::single_index("fruits[0]=kiwi", &["IDENT(fruits)", "LBRACK", "INT(0)", "RBRACK", "EQ", "IDENT(kiwi)"])]
+#[case::negative_index("xs[-1]=7", &["IDENT(xs)", "LBRACK", "INT(-1)", "RBRACK", "EQ", "INT(7)"])]
+#[case::bareword_key("user[email]=x", &["IDENT(user)", "LBRACK", "IDENT(email)", "RBRACK", "EQ", "IDENT(x)"])]
+#[case::chained_keys(
+    "s[web][port]=9000",
+    &["IDENT(s)", "LBRACK", "IDENT(web)", "RBRACK", "LBRACK", "IDENT(port)", "RBRACK", "EQ", "INT(9000)"]
+)]
+#[case::local_spaced(
+    "local xs[0] = 9",
+    &["LOCAL", "IDENT(xs)", "LBRACK", "INT(0)", "RBRACK", "EQ", "INT(9)"]
+)]
+fn lexer_assignment_lvalue_subscript_not_fused(#[case] input: &str, #[case] expected: &[&str]) {
+    run_lexer_test(input, expected);
+}
+
+/// A real glob pattern (has `*`) followed by `=` is NOT an lvalue and keeps
+/// fusing into a `GlobWord` — the `has_star_or_question` guard in
+/// `flush_glob_run` protects this.
+#[test]
+fn lexer_glob_pattern_before_eq_still_fuses() {
+    run_lexer_test("[[ $x = [0-9]*.txt ]]", &[
+        "LBRACK", "LBRACK", "SIMPLEVARREF(x)", "EQ", "GLOB([0-9]*.txt)", "RBRACK", "RBRACK",
+    ]);
+}
+
+/// A bracket run NOT followed by `=` (ordinary glob usage) is unaffected by
+/// the lvalue suppression and still fuses normally.
+#[test]
+fn lexer_bracket_char_class_without_eq_still_fuses() {
+    run_lexer_test("ls [dog]", &["IDENT(ls)", "GLOB([dog])"]);
+}

--- a/crates/kaish-kernel/tests/lexer_tests.rs
+++ b/crates/kaish-kernel/tests/lexer_tests.rs
@@ -790,3 +790,15 @@ fn lexer_glob_pattern_before_eq_still_fuses() {
 fn lexer_bracket_char_class_without_eq_still_fuses() {
     run_lexer_test("ls [dog]", &["IDENT(ls)", "GLOB([dog])"]);
 }
+
+/// A BARE char-class operand of a `[[ ]]` string comparison (`[[ [a] = b ]]`)
+/// starts with `[`, not an `Ident`, so the lvalue suppression must NOT fire —
+/// `[a]` keeps fusing to a `GlobWord` and `=` stays string equality against
+/// the literal "[a]". The lvalue trigger only fires on an `Ident`-led run
+/// (`arr[0]=`), where the root identifier is the first token of the run.
+#[test]
+fn lexer_bare_char_class_operand_before_eq_still_fuses() {
+    run_lexer_test("[[ [a] = b ]]", &[
+        "LBRACK", "LBRACK", "GLOB([a])", "EQ", "IDENT(b)", "RBRACK", "RBRACK",
+    ]);
+}

--- a/crates/kaish-tool-api/src/issue.rs
+++ b/crates/kaish-tool-api/src/issue.rs
@@ -58,6 +58,15 @@ pub enum IssueCode {
     /// (it would resolve to an external binary that bypasses the VFS); use
     /// `[[ … ]]`, which the validator checks before runtime.
     PosixTestCommand,
+    /// A subscripted assignment lvalue (`x[k]=v`) targets an undefined root
+    /// variable. Unlike a plain read, a path-set never autovivifies the
+    /// root — it must already exist as a collection.
+    LvalueUndefinedRoot,
+    /// An assignment target contains a dot (`user.email=x`). kaish is
+    /// brackets-only for collection access — the `Ident` token admits `.`
+    /// for other uses (filenames, `source foo.kai`), so this is caught here
+    /// rather than by tightening the lexer regex.
+    DottedAssignmentTarget,
 }
 
 impl IssueCode {
@@ -86,6 +95,8 @@ impl IssueCode {
             IssueCode::ScatterWithoutGather => "E014",
             IssueCode::LastResultFieldAccess => "E015",
             IssueCode::PosixTestCommand => "W006",
+            IssueCode::LvalueUndefinedRoot => "E016",
+            IssueCode::DottedAssignmentTarget => "E017",
         }
     }
 
@@ -113,7 +124,9 @@ impl IssueCode {
             | IssueCode::ReturnOutsideFunction
             | IssueCode::ForLoopScalarVar
             | IssueCode::ScatterWithoutGather
-            | IssueCode::LastResultFieldAccess => Severity::Error,
+            | IssueCode::LastResultFieldAccess
+            | IssueCode::LvalueUndefinedRoot
+            | IssueCode::DottedAssignmentTarget => Severity::Error,
 
             // These are warnings because context matters:
             // - MissingRequiredArg: might be provided by pipeline stdin or environment

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -236,17 +236,69 @@ value is false; a bare unset `$var` is an undefined-variable error (like
 (`[[ -list $data ]]`) — a quoted `"$data"` would test the collection's JSON
 *string*, not its value.
 
+### Assignment — bracket-path lvalues + `push`
+
+The same bracket paths that read also write, in place, with **no
+spaces around `=`**:
+
+```sh
+xs=[1 2 3]
+xs[0]=9                     # in-bounds index update
+xs[-1]=7                    # negative index works too
+
+u={port: 8080}
+u[host]=localhost           # inserts a new key
+u[port]=9090                # updates an existing key
+
+s={web: {port: 8080}}
+s[web][port]=9000           # deep path
+```
+
+**No autovivification** — every intermediate segment must already exist with
+the right shape; the *only* thing a path-set may create is the **final**
+record key. An out-of-bounds list index, a missing intermediate key, a
+scalar or undefined root, and a slice lvalue (`xs[0:2]=x`) are all loud
+errors — `push` is how lists grow, and `x={}` / `x=[]` initializes an
+intermediate before you subscript into it:
+
+```sh
+xs=[1 2 3]; xs[9]=x                        # error: index out of bounds
+s={web: {port: 8080}}; s[api][port]=1      # error: no such key (no autoviv)
+y=hi; y[0]=x                                # error: not a collection
+z[0]=x                                      # error: z is not defined
+```
+
+A dotted assignment target is also rejected — kaish is brackets-only, and the
+`Ident` token otherwise admits `.` for other uses (filenames):
+
+```sh
+user.email=x     # error — use `user[email]=x`
+```
+
+`push` appends to a top-level **list** variable in place. Like `read`/`unset`,
+it takes the variable **name** (bareword), not `$name` — this is what lets it
+write back to the caller:
+
+```sh
+xs=[a b]
+push xs c                 # xs is now [a b c] — mutated in place
+push xs $rec              # values push as typed Values, not stringified text
+echo ${#xs} ${xs[-1]}     # 3 c
+```
+
+`push` to an undefined or non-list target is a loud error, never a silent
+create. Bracket-path `push` (`push services[web][tags] item` — a subscripted
+target) isn't supported yet; only a top-level bareword target.
+
 ### Crossing the boundary
 
 A collection **displays** as compact JSON (`echo $xs` → `[10,20,30]`), but it
 cannot silently cross into an OS environment variable: `export CFG=$cfg` where
 `$cfg` is a list/record is a loud error — serialize it first with
-`export CFG=$(tojson $cfg)`.
-
-> List/record **literals** (`xs=[a b c]`, `{k: v}`, spread) are documented
-> above and shipped. `push` and bracket-path **assignment** (`a[b]=x`,
-> `fruits[0]=kiwi`) are designed but not yet implemented — today, beyond
-> literals, collections enter the shell via `fromjson` / `$(...)`.
+`export CFG=$(tojson $cfg)`. Env-prefix assignment (`FOO=bar cmd`) stays
+bare-ident-only for the same reason — a subscripted target there
+(`user[email]=x cmd`) is never captured as an exported, command-scoped
+variable.
 
 ## Quoting
 

--- a/docs/arrays-and-hashes.md
+++ b/docs/arrays-and-hashes.md
@@ -1,9 +1,12 @@
 # Arrays & Hashes — Design Doc
 
 Status: read access, `keys`/`values`, membership, shape guards, the shared
-per-hop path resolver, and **list/record literals + spread** are SHIPPED (see
-`docs/LANGUAGE.md` Collections section). `push` and bracket-path **assignment**
-(`a[b]=x`) remain design-only — the rest of this document.
+per-hop path resolver, **list/record literals + spread**, and **bracket-path
+assignment + `push`** are SHIPPED (see `docs/LANGUAGE.md` Collections
+section). Bracket-path `push` (a subscripted target, e.g. `push
+services[web][tags] item`) remains deferred — only a top-level bareword
+target ships (see `docs/issues.md`). The rest of this document is design
+history/rationale.
 Author: design notes from a 2026-06-05 session.
 **Revised 2026-07-01** — brackets-only access, record iteration, comparison/unwrap semantics,
 full lvalue rules; implementation notes re-grounded against HEAD `f92070e`. Superseded

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -43,6 +43,80 @@ now fails compile with an error describing a pattern the author never wrote
 spelling + the strict-ERE flag where one exists) whenever the rewrite actually
 changed the pattern.
 
+## Collection lvalue writes + `push` land (2026-07-02)
+
+`xs[0]=9`, `user[email]=x`, deep paths (`services[web][port]=9000`), and a
+bareword `push` — the write half of the collections effort, on top of the
+shared per-hop path resolver (`resolve_step`, from the read-side #6 work) and
+the collection-literals grammar.
+
+**`walk_write` mirrors the read descent, sharing `resolve_step` unchanged, but
+diverges at the leaf.** The read side (`resolve_path`) walks the tree with
+`Cow`-borrowed lookups; the write side clones the root once, then walks
+`&mut serde_json::Value` chains so mutating the deepest hop mutates the whole
+tree in place (no per-hop clone). Every hop still calls the SAME `resolve_step`
+for classification (bounds, shape) — read and write can never classify a
+subscript differently. The two walks diverge only in *leaf policy*: an
+intermediate hop requires the child to already exist (`descend_mut` — no
+autovivification, mirroring the read's `descend`), while the FINAL hop may
+insert a new record key (`apply_leaf_write`) — the one thing a path-set may
+create. A list index write is in-bounds only for free: `resolve_step`'s
+`classify_index` already turns an out-of-bounds index into a loud `Absence`
+before the write ever sees it. A slice step (`xs[0:2]=x`) is always a `Shape`
+error, at any hop — mutating through a detached slice copy would silently not
+write back to the real list, so it's rejected outright rather than special-cased
+only at the final position.
+
+**The lexer needed a SECOND, distinct suppression trigger.** The
+collection-literals grammar already taught the lexer to stop fusing a
+`[`-leading run into a `GlobWord` at *value position* (RHS of `=`/`in`). An
+assignment LHS (`fruits[0]=kiwi`) sits at argv position, not value position —
+a different shape entirely. `flush_glob_run` gained `followed_by_eq`: computed
+by peeking at whatever token triggers the run's flush (in token-stream order,
+regardless of whitespace, since `local xs[0] = 9` and `fruits[0]=kiwi` must
+both suppress), true only when that token is `Token::Eq`. A bracket-pair run
+with no `*`/`?` immediately before `=` is a subscripted assignment target, not
+a glob, and gets suppressed the same way the value-position case does — the
+two triggers are ORed together in `flush_glob_run`, each protecting a
+different shape of run.
+
+**`Assignment.name: String` widened to `Assignment.path: VarPath`** — no dual
+representation, every construction/read site updated in the same change
+(parser, kernel, sexpr formatter, validator, tests). `Assignment::name()`
+extracts the root `Field` for the still-common bare case; a subscripted write
+never honors `local` (it always mutates the existing root wherever it lives —
+`local` is meaningless once you're inside an existing collection).
+
+**Env-prefix assignment stays bare-ident-only, by construction, not by a
+runtime check.** `env_prefix_assign` still calls `ident_parser()` directly
+(never `lvalue_path_parser()`), so a subscripted target can't even reach the
+`EnvScoped` grammar arm — structured values can't cross the process boundary
+anyway. Grounding this surfaced a pre-existing, unrelated quirk: kaish's
+statement `terminator` is `.repeated()`, not `.at_least(1)`, so `X=1 Y=2` (no
+separator at all) already parsed as two independent assignment statements
+before this change. `user[email]=x echo hi` falls through the same way —
+NOT into `EnvScoped` (verified with a parser test), but into two ordinary
+statements. That's the existing grammar's behavior extended consistently, not
+a new hazard this work introduced.
+
+**Validator additions (E016, E017).** A subscripted assignment whose root
+isn't bound (`z[0]=x`) is now a static error with a "create it first" hint,
+the same treatment `push`'s undefined-target rule gets at runtime. A dotted
+assignment target (`user.email=x`) is now also a static error — the lexer's
+shared `Ident` token admits `.` for other legitimate uses (filenames,
+`source foo.kai`), so the restriction lives in the validator, not a regex
+change, with the fix (`user[email]=x`) in the message.
+
+**`push` ships bareword-target only; bracket-path `push` is a real, tracked
+gap, not a rejection.** `push services[web][tags] item` doesn't work: the
+target isn't followed by `=`, so the lvalue lexer's `followed_by_eq` trigger
+never fires, and the whole subscripted target fuses into a `GlobWord` that
+glob-expands (failing loudly as "no matches") before `push` ever runs. Loud,
+not silently wrong — but the feature the design doc originally scoped for
+`push` isn't there yet. Filed in `docs/issues.md` P3 rather than attempted
+here; it needs its own lexer/parser pass since the lexer has no notion of
+"this bareword run is `push`'s target."
+
 ## Collection literals + spread land (2026-07-02)
 
 `xs=[a b c]`, `{port: 8080}`/`{port:8080}`, multi-line records with a trailing

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -520,6 +520,24 @@ collection as compact JSON (consistent with bare `$c` display) or fail loud —
 decide which; do NOT leave the silent `""`. Different bug class from the
 boundary guards, so deferred here rather than fixed in that branch.
 
+### Bracket-path `push` target (`push services[web][tags] item`) — deferred
+`feat/collections-lvalues` (2026-07-02) shipped bracket-path lvalue
+**assignment** (`xs[0]=9`, `user[email]=x`, deep paths) and `push`, but `push`
+only accepts a **top-level bareword** target (`push xs val`) — a subscripted
+target is out of scope for that PR. Reason: `push`'s target is NOT followed by
+`=`, so the lvalue lexer's `=`-triggered suppression (`flush_glob_run`'s
+`followed_by_eq`) never fires for it — `services[web][tags]` fuses into a
+`GlobWord` and **glob-expands** (failing loudly as "no matches") before `push`
+ever runs. This is loud, not silently wrong, but the feature doesn't work.
+Fixing it needs its own lexer/parser design pass: either a `push`-aware lexer
+trigger (peek for a leading bareword-like run inside the `push` command
+specifically — awkward, since the lexer doesn't know command names), or
+routing `push`'s target through the same argv-position bracket-path grammar
+`Arg`s already need for other collection-consuming builtins. Not attempted
+here — `docs/arrays-and-hashes.md`'s original design intended `push` to accept
+bracket paths (revised 2026-07-01), so this is a real gap, not a design
+rejection.
+
 ### `JobManager` output-stream reads hold the jobs lock across `await`
 Surfaced fixing the `wait`/`spawn` deadlock (2026-06-24). `read_stdout`/`read_stderr`
 (`scheduler/job.rs`, the `/v/jobs/{id}/stdout|stderr` reads) do


### PR DESCRIPTION
## Summary
- **STACKED ON #66** — retarget to `main` once #66 merges (or this will be rebased then). Do not merge before #66.
- Re-lands the held `feat/collections-lvalues` branch (previously PR-D, never opened) on top of #66's corrected base, since it was itself stacked on the same stale `feat/collections-value-argv` lineage that #66 fixes.
- `xs[0]=9`, `user[email]=x`, deep paths (`services[web][port]=9000`) via `walk_write` (reuses the shipped `resolve_step` read-side resolver, diverges only at leaf policy — no autovivification except the final record-key insert). Bareword `push` (`walk_append`). Validator E016/E017 (undefined root / dotted target).
- Bracket-path `push` (`push services[web][tags] item`) intentionally out of scope — filed as a P3 gap in `docs/issues.md` (glob-expansion-of-target problem, needs its own lexer/parser pass).
- No code changes beyond the rebase — same content as the kaibo-reviewed held branch (frame-coherent `set_global`, borrow-safe, atomic), just correctly based.

## Test plan
- [x] `cargo build --all`
- [x] `cargo test --all` (all green, 0 failed)
- [x] `cargo clippy --all --all-targets` (zero warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)