### PR TITLE
fix: standalone [[ ]] writes $? + awk separator errors name the raw form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -163,6 +163,14 @@ breaking entries are marked **BREAKING**.
   demotion of `\|` to plain `|`).
 
 ### Fixed
+- **A standalone `[[ ]]` test now writes `$?`** — `[[ 1 = 2 ]]; echo $?` printed
+  `0` (the previous command's status; the test never stored its result), so
+  `[[ -f x ]]; ok=$?` patterns silently read a stale status. A bare test
+  statement now sets `$?` and honors `set -e` like any command, matching bash;
+  `&&`/`||` operands and `if`/`while` conditions are unaffected.
+- **awk invalid FS/`split()` separator errors name the separator as written**
+  (not the internal ERE-rewritten form) and carry the GNU-BRE dialect hint when
+  the rewrite is the likely culprit.
 - **Collection read-access silent-corruption traps** (found by the collections
   milestone review) — five cases that returned a plausible wrong answer instead of
   erroring, all now loud:

--- a/crates/kaish-kernel/src/kernel.rs
+++ b/crates/kaish-kernel/src/kernel.rs
@@ -2520,11 +2520,24 @@ impl Kernel {
             }
             Stmt::Test(test_expr) => {
                 let is_true = self.eval_test_async(test_expr).await?;
-                if is_true {
-                    Ok(ControlFlow::ok(ExecResult::success("")))
+                let result = if is_true {
+                    ExecResult::success("")
                 } else {
-                    Ok(ControlFlow::ok(ExecResult::failure(1, "")))
+                    ExecResult::failure(1, "")
+                };
+                // A bare test writes `$?` and honors `set -e` like any command
+                // (bash: `[[ 1 = 2 ]]; echo $?` → 1). `&&`/`||` operands stay
+                // safe: the chain arms suppress errexit around their left side,
+                // and `if`/`while` conditions evaluate as expressions, never
+                // through this statement arm.
+                self.update_last_result(&result).await;
+                if !result.ok() {
+                    let scope = self.scope.read().await;
+                    if scope.error_exit_enabled() {
+                        return Ok(ControlFlow::exit_code(result.code));
+                    }
                 }
+                Ok(ControlFlow::ok(result))
             }
             Stmt::EnvScoped { assignments, body } => {
                 // Inline env prefix (`NAME=value ... command`): apply the

--- a/crates/kaish-kernel/src/tools/builtin/awk.rs
+++ b/crates/kaish-kernel/src/tools/builtin/awk.rs
@@ -1891,14 +1891,14 @@ impl AwkRuntime {
     }
 
     fn split_record(&mut self, record: &str) -> Result<(), String> {
-        let fs = self.get_var("FS").to_string();
+        let fs_raw = self.get_var("FS").to_string();
         self.fields = vec![AwkValue::StrNum(record.to_string())];
 
         // Rewrite BRE metas BEFORE the single-char check: gawk demotes `\|` to
         // plain `|` and a single-char FS is literal (POSIX), so `-F '\|'` /
         // FS="\\|" split on a literal pipe — never the empty-alternation regex
         // `|`, which would silently split between every character.
-        let fs = bre_metas_to_ere(&fs);
+        let fs = bre_metas_to_ere(&fs_raw);
         let parts: Vec<&str> = if fs == " " {
             // Default: split on whitespace, trim leading/trailing
             record.split_whitespace().collect()
@@ -1909,9 +1909,15 @@ impl AwkRuntime {
         } else {
             // Multi-character FS is an ERE. An invalid regex is a loud error,
             // not a silent literal-split fallback (which silently miscounts
-            // fields). Matches gawk's fatal behavior.
-            let re = Regex::new(&fs)
-                .map_err(|e| format!("invalid FS regex {:?}: {}", fs, e))?;
+            // fields). Matches gawk's fatal behavior. Report the FS as the user
+            // wrote it, with the dialect hint when the rewrite changed it.
+            let re = Regex::new(&fs).map_err(|e| {
+                append_dialect_hint(
+                    format!("invalid FS regex {:?}: {}", fs_raw, e),
+                    fs != fs_raw,
+                    None,
+                )
+            })?;
             re.split(record).collect()
         };
 
@@ -2568,7 +2574,8 @@ impl AwkRuntime {
                 //   " " (default FS) → whitespace mode (split on runs, trim ends)
                 //   single char → literal split
                 //   multi-char → ERE regex
-                let sep = bre_metas_to_ere(&sep);
+                let sep_raw = sep;
+                let sep = bre_metas_to_ere(&sep_raw);
                 let parts: Vec<String> = if sep == " " {
                     s.split_whitespace().map(str::to_string).collect()
                 } else if sep.chars().count() == 1 {
@@ -2576,8 +2583,15 @@ impl AwkRuntime {
                 } else {
                     // Multi-char separator is an ERE; an invalid regex is a loud
                     // error, not a silent literal-split fallback (gawk: fatal).
-                    let re = Regex::new(&sep)
-                        .map_err(|e| format!("invalid split() separator regex {:?}: {}", sep, e))?;
+                    // Report the separator as the user wrote it, with the
+                    // dialect hint when the rewrite changed it.
+                    let re = Regex::new(&sep).map_err(|e| {
+                        append_dialect_hint(
+                            format!("invalid split() separator regex {:?}: {}", sep_raw, e),
+                            sep != sep_raw,
+                            None,
+                        )
+                    })?;
                     re.split(&s).map(str::to_string).collect()
                 };
 

--- a/crates/kaish-kernel/tests/sed_awk_bre_dialect_tests.rs
+++ b/crates/kaish-kernel/tests/sed_awk_bre_dialect_tests.rs
@@ -153,3 +153,32 @@ async fn awk_multichar_fs_still_gets_bre_rewrite() {
     assert_eq!(code, 0, "out={out:?}");
     assert_eq!(out.trim(), "3 c", "multi-char FS alternates on \\|: {out:?}");
 }
+
+/// An FS/split() separator that's invalid AFTER the rewrite errors naming the
+/// separator as the user wrote it (not the rewritten form the engine saw), and
+/// carries the dialect hint (without `-E` — awk has none). PR #65 follow-ups.
+#[tokio::test]
+async fn awk_invalid_separator_error_names_raw_form_with_hint() {
+    let kernel = kernel_at(tempdir().unwrap().path());
+
+    // FS path: `xx\(` → rewrite → `xx(` (unclosed group). The error must show
+    // `xx\(` — the separator as written — plus the dialect note.
+    let result = kernel
+        .execute(r#"echo x | awk -F 'xx\(' '{print NF}'"#)
+        .await
+        .expect("invalid FS is a runtime error, not a validation error");
+    assert_ne!(result.code, 0, "invalid FS should fail: {result:?}");
+    // The separator appears {:?}-quoted, so the raw `xx\(` renders as `"xx\\("`.
+    assert!(result.err.contains(r"xx\\("), "names raw separator: {}", result.err);
+    assert!(result.err.contains("GNU BRE"), "carries the dialect hint: {}", result.err);
+    assert!(!result.err.contains("-E"), "awk must not suggest -E: {}", result.err);
+
+    // split() path: same contract.
+    let result = kernel
+        .execute(r#"echo x | awk '{n = split("abc", a, "yy\\("); print n}'"#)
+        .await
+        .expect("invalid split() separator is a runtime error");
+    assert_ne!(result.code, 0, "invalid separator should fail: {result:?}");
+    assert!(result.err.contains(r"yy\\("), "names raw separator: {}", result.err);
+    assert!(result.err.contains("GNU BRE"), "carries the dialect hint: {}", result.err);
+}

--- a/crates/kaish-kernel/tests/shell_compat_tests.rs
+++ b/crates/kaish-kernel/tests/shell_compat_tests.rs
@@ -715,3 +715,38 @@ shell_compat! {
     script: "X=1; unset X; echo done",
     eq: "done",
 }
+
+// ---- standalone [[ ]] writes $? (docs/issues.md P1, found during PR-D) ----
+// A bare test statement must store its result in $? like any command. It
+// evaluated the test but never wrote $?, so a following read was stale.
+
+shell_compat! {
+    name: standalone_test_failure_writes_status,
+    script: "[[ 1 = 2 ]]; echo $?",
+    eq: "1",
+}
+
+shell_compat! {
+    name: standalone_test_success_writes_status,
+    script: "false; [[ 1 = 1 ]]; echo $?",
+    eq: "0",
+}
+
+shell_compat! {
+    name: standalone_test_status_captured_in_var,
+    script: "[[ a = b ]]; ok=$?; echo $ok",
+    eq: "1",
+}
+
+shell_compat! {
+    name: failing_test_gates_and_chain,
+    script: "[[ 1 = 2 ]] && echo skipped; echo done",
+    eq: "done",
+}
+
+shell_compat! {
+    name: failing_test_statement_trips_errexit,
+    script: "set -e; [[ 1 = 2 ]]; echo unreachable",
+    absent: "unreachable",
+    exit: 1,
+}

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -14,6 +14,21 @@ before it ships.
 
 ---
 
+## BRE follow-ups + the stale-`$?` bug (2026-07-03)
+
+Working the PR #65 follow-up comments: awk's invalid-FS/`split()` errors now name
+the separator as the user wrote it (not the rewritten form the engine saw) and
+carry the dialect hint when the rewrite changed it.
+
+The bigger catch was the loose end from PR-D testing: a standalone `[[ ]]` never
+wrote `$?` — `[[ 1 = 2 ]]; echo $?` printed 0, so `[[ -f x ]]; ok=$?` silently
+read the *previous* command's status. Amy called it P1 on sight and it was
+cheaper to fix than file: `Stmt::Test` now mirrors `Stmt::Command` (write the
+result, honor suppressible errexit). The chain arms already suppress errexit
+around their left side and `if`/`while` conditions evaluate as expressions, so
+`[[ … ]] && cmd` and loop conditions are unaffected — pinned with five
+`shell_compat!` tests verified against real bash, including the `set -e` trip.
+
 ## GNU BRE superset for grep/sed/awk (2026-07-03)
 
 Issue #60 measured `grep 'a\|b'` as the single largest source of wasted agent


### PR DESCRIPTION
Two follow-ups worked while the collections test-coverage batches ran.

## Standalone `[[ ]]` never wrote `$?` (P1)

`[[ 1 = 2 ]]; echo $?` printed `0` — the previous command's status. `Stmt::Test` evaluated the test and returned the right `ExecResult`, but never called `update_last_result`, so any following `$?` read was stale. Agents write `[[ -f x ]]; ok=$?` constantly; that pattern silently captured the wrong status. Found during PR-D testing (recorded in the 2026-07-02 signoff), reproduced on current main before fixing.

The fix mirrors `Stmt::Command`: write the result to `$?` and honor suppressible errexit. The composition is safe by construction — `&&`/`||` chain arms already suppress errexit around their left operand, and `if`/`while` conditions evaluate as *expressions*, never through the statement arm — so `[[ … ]] && cmd`, `set -e` scripts, and loop conditions all behave like bash. Pinned with five `shell_compat!` tests, all verified against real bash (`KAISH_BASH_COMPAT=1`): failure writes 1, success writes 0, capture into a var, `&&` gating, and the `set -e` trip on a bare failing test.

## awk separator errors name the raw form (PR #65 follow-ups 1+2)

Invalid FS/`split()` separator errors reported the internally ERE-rewritten separator (e.g. `xx(` for input `xx\(`) with no explanation. They now name the separator as the user wrote it and append the GNU-BRE dialect hint when the rewrite changed the pattern (awk's variant offers only the bracket-class spelling — no `-E` to suggest). Pinned for both the FS and `split()` paths.

## Testing

`cargo test -p kaish-kernel` (4k+ tests) and `cargo clippy -p kaish-kernel --all-targets` clean. Workspace-wide gates couldn't run at commit time — the working tree carries a parallel session's in-progress kaish-help edits (uncommitted `SyntaxSection` topic work), which fail to compile independently of this change; nothing in this PR touches kaish-help.

🤖 Generated with [Claude Code](https://claude.com/claude-code)