### PR TITLE
docs(collections): panel gate sign-off + close help-fragment drift (task 5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,8 +35,17 @@ breaking entries are marked **BREAKING**.
   brackets are reserved by kaish (`[[ ]]` today, native list literals per the
   arrays-and-hashes design). The `[` command stays banned permanently; a `test`
   builtin may return someday.
+- **The `collections` help fragment now teaches native literal construction and
+  `...` spread** — it previously only showed `fromjson`-based construction,
+  stale since list/record literals landed. Membership (`in`/`not in`) is now
+  always shown inside a full `if [[ … ]]; then … fi`, never a bare standalone
+  test line (a prior regression against the shell's own teaching-note rule).
 
 ### Added
+- **`help collections`** — a new help topic, composed straight from the
+  `collections` syntax reference fragment (single-sourced with `help syntax`,
+  not a second hand-written doc). The underlying mechanism is generic: any
+  `syntax_section` becomes queryable as `help <key>` for free.
 - **Native collection literals** — `xs=[a b c]` (list), `{port: 8080}` /
   `{port:8080}` (record, colon may be spaced or unspaced), `xs=[]` / `xs=[dog]`
   (empty and single-element lists), multi-line records with a trailing comma,

--- a/crates/kaish-help/content/en/overview.md
+++ b/crates/kaish-help/content/en/overview.md
@@ -7,6 +7,7 @@ Validates before execution. Builtins run in-process; external commands via PATH.
 
 ```
 help syntax     Variables, quoting, pipes, control flow
+help collections  Lists & records: literals, access, iteration, lvalues
 help builtins   List of all builtins
 help vfs        Virtual filesystem mounts
 help scatter    Parallel processing (散/集)

--- a/crates/kaish-help/content/en/syntax.md
+++ b/crates/kaish-help/content/en/syntax.md
@@ -31,7 +31,20 @@ processes, where the host PID is meaningless to the script.
 ## Collections (lists & records)
 
 ```sh
-# Values are structured JSON (list or record); fromjson/tojson bridge text.
+# CONSTRUCTION — native literal syntax, no fromjson needed. Commas optional.
+xs=[apple banana cherry]  # list — space-separated, like shell words
+nums=[1 2 3]               # ≡ [1, 2, 3]
+u={name: amy, role: maintainer}   # record — bareword keys
+compact={port:8080}        # colon may be spaced or unspaced
+r={"content-type": x}      # quoted key for anything that isn't a bareword
+nested={tags: [a b], meta: {active: true}}   # nesting works both ways
+
+# SPREAD (...) flattens; a bare $var nests as ONE element instead:
+xs=[1 2]
+ys=[0 $xs 4]                # [0,[1,2],4]  — nests
+new=[...$xs date]           # [1,2,"date"] — flattens
+
+# Values are also structured JSON — fromjson/tojson bridge real JSON text:
 u=$(fromjson '{"name":"amy","tags":["rust","shell"]}')
 xs=$(fromjson '[10,20,30]')
 
@@ -42,6 +55,7 @@ ${xs[0]}   ${xs[-1]}      # list index; negative counts from the end
 ${xs[0:2]}                # slice (end-exclusive) → a list
 ${u[tags][0]}             # nested path
 ${#xs}   ${#u}            # length: list elements / record keys
+${u.name}                 # error — brackets only, use ${u[name]}
 
 # ENUMERATE — always wrap the collection in $(keys ...) or $(values ...).
 # A bare `for x in $xs` is an ERROR (E012): there is no word splitting.
@@ -64,9 +78,9 @@ for x in $(values $xs); do
 done
 
 # MEMBERSHIP — RHS must be a collection (see Test Expressions):
-[[ rust in $(values ${u[tags]}) ]]                 # element present?
-[[ name in $u ]]                                   # record has key?
-[[ 1 in $(keys $xs) ]]                             # index in bounds?
+if [[ rust in $(values ${u[tags]}) ]]; then echo "has it"; fi   # element present?
+if [[ name in $u ]]; then echo "has it"; fi                     # record has key?
+if [[ 1 in $(keys $xs) ]]; then echo "in bounds"; fi            # index in bounds?
 
 # SHAPE GUARD — an API sometimes returns a list, sometimes a record; check
 # before committing to keys/values/for. typeof + [[ -list ]] / [[ -record ]]:
@@ -177,8 +191,8 @@ cmd1 || cmd2              # cmd2 if cmd1 fails
 [[ -f config.json && -n $NAME ]]
 [[ $N -gt 5 ]]
 [[ $s =~ "\.rs$" ]]
-[[ banana in $fruits ]]
-[[ tmp not in $services ]]
+if [[ banana in $fruits ]]; then echo "have one"; fi
+if [[ tmp not in $services ]]; then echo "not running"; fi
 [[ -list $x ]]
 [[ -record $x ]]
 ```

--- a/crates/kaish-help/src/compose.rs
+++ b/crates/kaish-help/src/compose.rs
@@ -305,6 +305,23 @@ pub fn render_syntax_reference() -> String {
     out
 }
 
+/// Render a single `Syntax` section by its fragment key (e.g. `"collections"`),
+/// or `None` if no such section exists.
+///
+/// This is what backs `help <subsystem>` for a syntax feature big enough to want
+/// its own topic (`help collections`) without hand-writing a second, driftable
+/// copy of the reference text — single-sourced with [`render_syntax_reference`]
+/// and `content/en/syntax.md`. The pattern generalizes to any future
+/// subsystem-sized syntax feature: give its `syntax_section` a memorable key and
+/// it's queryable via `help <key>` for free.
+pub fn render_syntax_section(key: &str) -> Option<String> {
+    let fragment = FRAGMENTS.iter().find(|f| {
+        f.concept == Concept::Syntax && f.locale == DEFAULT_LOCALE && f.key == key
+    })?;
+    let title = fragment.title.unwrap_or(fragment.key);
+    Some(format!("## {title}\n\n{}\n", fragment.body.trim()))
+}
+
 /// A fragment present in English but missing in another locale.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MissingFragment {

--- a/crates/kaish-help/src/fragments.rs
+++ b/crates/kaish-help/src/fragments.rs
@@ -72,10 +72,11 @@ pub const FRAGMENTS: &[Fragment] = &[
         Variant::Rule,
         Depth::Summary,
         None,
-        "Values can be structured JSON — a list or a record — not only strings. \
-         Access is brackets-only (`${r[key]}`, `${xs[0]}`, never dots); iterate with \
-         `$(values $c)` (elements/values) or `$(keys $c)` (indices/keys); `fromjson` / \
-         `tojson` bridge JSON text in and out. See `help syntax` → Collections.",
+        "Values can be structured — a list (`xs=[a b c]`) or a record (`u={k: v}`), not \
+         only strings. Access is brackets-only (`${r[key]}`, `${xs[0]}`, never dots); \
+         iterate with `$(values $c)` (elements/values) or `$(keys $c)` (indices/keys); \
+         `fromjson` / `tojson` bridge real JSON text in and out. See `help syntax` → \
+         Collections.",
     ),
     en(
         Concept::Model,
@@ -228,6 +229,28 @@ pub const FRAGMENTS: &[Fragment] = &[
          discarded.",
     )
     .ranked(9),
+    en(
+        Concept::Foundations,
+        "collection-literals",
+        Variant::Rule,
+        Depth::Summary,
+        None,
+        "**Collection literals.** Lists/records have native syntax — `xs=[a b c]`, \
+         `u={k: v}` — no `fromjson` needed. `push xs v` appends in place (like \
+         `read`/`unset`, it takes the bareword NAME, not `$xs`); `...$xs` spread \
+         flattens into a new list — a bare `$xs` nests as one element instead.",
+    )
+    .ranked(10),
+    en(
+        Concept::Foundations,
+        "collection-literals",
+        Variant::Contrast,
+        Depth::Reference,
+        None,
+        "Collections are brackets-only, never dots: `${u.name}` is a loud parse \
+         error naming the fix (`${u[name]}`) — the `Ident` token allows `.` for \
+         other uses (filenames), so this can't be caught silently.",
+    ),
     // ---- Syntax reference (single source for content/en/syntax.md) -----------
     syntax_section(
         "variables",
@@ -263,7 +286,20 @@ processes, where the host PID is meaningless to the script."#,
         "collections",
         "Collections (lists & records)",
         r#"```sh
-# Values are structured JSON (list or record); fromjson/tojson bridge text.
+# CONSTRUCTION — native literal syntax, no fromjson needed. Commas optional.
+xs=[apple banana cherry]  # list — space-separated, like shell words
+nums=[1 2 3]               # ≡ [1, 2, 3]
+u={name: amy, role: maintainer}   # record — bareword keys
+compact={port:8080}        # colon may be spaced or unspaced
+r={"content-type": x}      # quoted key for anything that isn't a bareword
+nested={tags: [a b], meta: {active: true}}   # nesting works both ways
+
+# SPREAD (...) flattens; a bare $var nests as ONE element instead:
+xs=[1 2]
+ys=[0 $xs 4]                # [0,[1,2],4]  — nests
+new=[...$xs date]           # [1,2,"date"] — flattens
+
+# Values are also structured JSON — fromjson/tojson bridge real JSON text:
 u=$(fromjson '{"name":"amy","tags":["rust","shell"]}')
 xs=$(fromjson '[10,20,30]')
 
@@ -274,6 +310,7 @@ ${xs[0]}   ${xs[-1]}      # list index; negative counts from the end
 ${xs[0:2]}                # slice (end-exclusive) → a list
 ${u[tags][0]}             # nested path
 ${#xs}   ${#u}            # length: list elements / record keys
+${u.name}                 # error — brackets only, use ${u[name]}
 
 # ENUMERATE — always wrap the collection in $(keys ...) or $(values ...).
 # A bare `for x in $xs` is an ERROR (E012): there is no word splitting.
@@ -296,9 +333,9 @@ for x in $(values $xs); do
 done
 
 # MEMBERSHIP — RHS must be a collection (see Test Expressions):
-[[ rust in $(values ${u[tags]}) ]]                 # element present?
-[[ name in $u ]]                                   # record has key?
-[[ 1 in $(keys $xs) ]]                             # index in bounds?
+if [[ rust in $(values ${u[tags]}) ]]; then echo "has it"; fi   # element present?
+if [[ name in $u ]]; then echo "has it"; fi                     # record has key?
+if [[ 1 in $(keys $xs) ]]; then echo "in bounds"; fi            # index in bounds?
 
 # SHAPE GUARD — an API sometimes returns a list, sometimes a record; check
 # before committing to keys/values/for. typeof + [[ -list ]] / [[ -record ]]:
@@ -414,8 +451,8 @@ cmd1 || cmd2              # cmd2 if cmd1 fails
 [[ -f config.json && -n $NAME ]]
 [[ $N -gt 5 ]]
 [[ $s =~ "\.rs$" ]]
-[[ banana in $fruits ]]
-[[ tmp not in $services ]]
+if [[ banana in $fruits ]]; then echo "have one"; fi
+if [[ tmp not in $services ]]; then echo "not running"; fi
 [[ -list $x ]]
 [[ -record $x ]]
 ```"#,

--- a/crates/kaish-help/src/topic.rs
+++ b/crates/kaish-help/src/topic.rs
@@ -7,6 +7,7 @@
 
 use kaish_types::ToolSchema;
 
+use crate::compose::render_syntax_section;
 use crate::content::{IGNORE, LIMITS, OUTPUT_LIMIT, OVERLAY, OVERVIEW, SCATTER, SYNTAX, VFS};
 
 /// Help topics available in kaish.
@@ -30,6 +31,9 @@ pub enum HelpTopic {
     Limits,
     /// Overlay VFS mode and kaish-vfs builtin.
     Overlay,
+    /// A single subsystem-sized syntax section (e.g. `collections`), composed
+    /// straight from its `Syntax` fragment — single-sourced with `help syntax`.
+    SyntaxSection(String),
     /// Help for a specific tool.
     Tool(String),
 }
@@ -50,6 +54,7 @@ impl HelpTopic {
             "output-limit" | "spill" | "truncate" | "kaish-output-limit" => Self::OutputLimit,
             "limits" | "limitations" | "missing" => Self::Limits,
             "overlay" | "kaish-vfs" | "vfs-overlay" => Self::Overlay,
+            other if render_syntax_section(other).is_some() => Self::SyntaxSection(other.to_string()),
             other => Self::Tool(other.to_string()),
         }
     }
@@ -66,6 +71,7 @@ impl HelpTopic {
             Self::OutputLimit => "Output size limit configuration",
             Self::Limits => "Known limitations",
             Self::Overlay => "Copy-on-write overlay mode and kaish-vfs",
+            Self::SyntaxSection(_) => "A single syntax reference section",
             Self::Tool(_) => "Help for a specific tool",
         }
     }
@@ -87,6 +93,11 @@ pub fn get_help(topic: &HelpTopic, tool_schemas: &[ToolSchema]) -> String {
         HelpTopic::OutputLimit => OUTPUT_LIMIT.to_string(),
         HelpTopic::Limits => LIMITS.to_string(),
         HelpTopic::Overlay => OVERLAY.to_string(),
+        HelpTopic::SyntaxSection(key) => render_syntax_section(key).unwrap_or_else(|| {
+            format!(
+                "Unknown topic or tool: {key}\n\nUse 'help' to see available topics, or 'help builtins' for tool list."
+            )
+        }),
         HelpTopic::Tool(name) => format_tool_help(name, tool_schemas),
     }
 }
@@ -172,6 +183,7 @@ pub fn list_topics() -> Vec<(&'static str, &'static str)> {
         ("output-limit", "Output size limit configuration"),
         ("limits", "Known limitations"),
         ("overlay", "Copy-on-write overlay mode and kaish-vfs"),
+        ("collections", "Lists & records: literals, access, iteration, lvalues"),
     ]
 }
 
@@ -197,6 +209,27 @@ mod tests {
             HelpTopic::parse_topic("grep"),
             HelpTopic::Tool("grep".to_string())
         );
+        assert_eq!(
+            HelpTopic::parse_topic("collections"),
+            HelpTopic::SyntaxSection("collections".to_string())
+        );
+    }
+
+    #[test]
+    fn test_get_help_collections_section() {
+        let content = get_help(&HelpTopic::SyntaxSection("collections".to_string()), &[]);
+        assert!(content.contains("Collections (lists & records)"));
+        assert!(content.contains("xs=[apple banana cherry]"));
+        // Single-sourced with `help syntax` — not a second, hand-written copy.
+        assert!(SYNTAX.contains("xs=[apple banana cherry]"));
+    }
+
+    #[test]
+    fn test_get_help_unknown_syntax_section_falls_back() {
+        // Guards against constructing the variant directly with a bad key
+        // (bypassing parse_topic's existence check) and panicking.
+        let content = get_help(&HelpTopic::SyntaxSection("not-a-real-section".to_string()), &[]);
+        assert!(content.contains("Unknown topic or tool"));
     }
 
     #[test]

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -198,10 +198,10 @@ The right-hand side must be a collection (a string RHS is a loud error — use
 `=~` / globs / `case` for substrings):
 
 ```sh
-[[ rust in $(values ${u[tags]}) ]]   # element present in a list?
-[[ name in $u ]]                     # record has key?
-[[ 1 in $(keys $xs) ]]               # index in bounds?
-[[ tmp not in $u ]]                  # absent?
+if [[ rust in $(values ${u[tags]}) ]]; then echo "has it"; fi   # element present in a list?
+if [[ name in $u ]]; then echo "has it"; fi                     # record has key?
+if [[ 1 in $(keys $xs) ]]; then echo "in bounds"; fi            # index in bounds?
+if [[ tmp not in $u ]]; then echo "absent"; fi                  # absent?
 ```
 
 Element equality uses the same rule as `==` (a numeric bareword matches a JSON
@@ -464,10 +464,10 @@ mkdir /tmp/work && cd /tmp/work && echo "ready"
 
 # Collection membership (list → element, record → key; typed equality, so
 # 443 in a list matches the JSON number, not just the string "443")
-[[ banana in $fruits ]]         # element in a list
-[[ name in $user ]]             # key in a record
-[[ tmp not in $services ]]      # negated membership
-[[ 443 in ${servers[web]} ]]    # nested path as the RHS
+if [[ banana in $fruits ]]; then echo "have one"; fi          # element in a list
+if [[ name in $user ]]; then echo "known"; fi                 # key in a record
+if [[ tmp not in $services ]]; then echo "not running"; fi    # negated membership
+if [[ 443 in ${servers[web]} ]]; then echo "listening"; fi    # nested path as the RHS
 # A scalar/string RHS is a loud error — use =~, glob ([[ $s == *sub* ]]), or
 # case for substring tests; `in` is collection-only.
 

--- a/docs/arrays-and-hashes.md
+++ b/docs/arrays-and-hashes.md
@@ -5,8 +5,13 @@ per-hop path resolver, **list/record literals + spread**, and **bracket-path
 assignment + `push`** are SHIPPED (see `docs/LANGUAGE.md` Collections
 section). Bracket-path `push` (a subscripted target, e.g. `push
 services[web][tags] item`) remains deferred — only a top-level bareword
-target ships (see `docs/issues.md`). The rest of this document is design
-history/rationale.
+target ships (see `docs/issues.md`). **The Teaching note #8 pre-sign-off panel
+re-test against the FINAL surface is DONE (2026-07-03)** — 18/18 clean across
+DeepSeek, Gemini, and Claude Haiku, including immediate, unprompted
+convergence on `$(keys $servers)`/`$(values ...)` in the for-head (the
+2026-06-05 panel's most common error). No correction round needed; the v2
+bare-collection-iterates relaxation is NOT adopted. The rest of this document
+is design history/rationale.
 Author: design notes from a 2026-06-05 session.
 **Revised 2026-07-01** — brackets-only access, record iteration, comparison/unwrap semantics,
 full lvalue rules; implementation notes re-grounded against HEAD `f92070e`. Superseded
@@ -246,7 +251,11 @@ for the record.
   side by side: arithmetic `$((x + 1))` evaluates bare names as variables (separate mini-parser,
   `arithmetic.rs:285`, inherited from bash) while bracket subscripts treat barewords as literal
   keys. Assignment *lvalues* use the same bracket paths, bare (no `${…}`) — `${…}` is for
-  reading. **Untested surface — panel re-test required before sign-off** (Teaching note #8).
+  reading. **Panel re-test DONE (Teaching note #8, 2026-07-03)** — dot-leakage did not
+  reproduce even without a fresh-context "don't use dots" warning: all three models,
+  taught only via the shipped `help collections` cheat sheet (which shows `${u.name}` as
+  the WRONG form alongside its error), used bracket access unprompted for both the
+  dynamic-vs-literal-subscript task and a bare field-access task.
 
 - **Collection iteration is `$()`-only; a bare `$var` in a for-head stays E012.** *(REVISED
   2026-07-02 — supersedes the "`for k in $record` iterates keys" decision of 2026-07-01.)* The
@@ -856,7 +865,7 @@ taught a specific way** — get the examples wrong and even capable models fail.
    kaish does not have. All future model tests must use sh-style `do/done` / `then/fi`, no-space
    assignment, and `push` for append — otherwise we're validating a language we don't ship.
 
-8. **Pre-sign-off re-test — REQUIRED AGAIN (the 2026-06-05 pass is superseded).** The earlier
+8. **Pre-sign-off re-test — DONE 2026-07-03 (the 2026-06-05 pass is superseded).** The earlier
    Haiku re-test validated the *dotted* braced syntax (`${r.key}`, `${r.$k}`, `${users.alice.city}`)
    and the bare-builtin for-head — both since replaced. Re-run the panel (include the weak tail,
    not just Haiku) against the FINAL surface: bracket access incl. `${r[$k]}` dynamic keys and
@@ -865,11 +874,45 @@ taught a specific way** — get the examples wrong and even capable models fail.
    `for k in $record` — superseded), bracket lvalues (`user[email]=x`, `fruits[0]=kiwi`), plus a
    **dot-leakage negative task** (does the model reach for `${user.name}`? does the error copy
    converge it in one round?) and a literal-vs-variable subscript task (`${user[name]}` vs
-   `${user[$name]}`). **Watch one number above all: convergence on `$(values $xs)` in the
+   `${user[$name]}`).
+
+   **Result: 18/18 clean, zero corrections needed.** Ran DeepSeek V4, Gemini 3.5-flash, and
+   Claude Haiku 4.5 as stateless `oneshot` one-round calls (no repo access — each model's ENTIRE
+   reference was the actual shipped `Recipe::agent_onboarding()` output plus the actual shipped
+   `help collections` fragment, per "Validate the shipped artifact" below), on a 6-task script
+   covering every item above. Every model, on the first try: wrote a nested record literal and
+   iterated it with `for k in $(keys $servers); do echo "$k: ${servers[$k][port]}"; done` —
+   **immediate, unprompted convergence on the exact form the 2026-06-05 panel most commonly got
+   wrong** (that panel required `$(keys $r)`-in-head prompting; this one needed none); performed
+   the dynamic-subscript task correctly (`${user[$field]}`, distinct from the literal-key form);
+   wrapped membership in a full `if [[ … ]]; then … else … fi` (never a bare `[[ ]]` line — the
+   Teaching note #1 rule, which two pre-existing fragments were found to violate and were fixed
+   as part of this pass, see below); used bracket access with **zero dot-leakage** on the bare
+   field-access probe, despite no "don't use dots" warning in the prompt; and wrote the correct
+   slice `${xs[0:3]}`. All 18 generated scripts (6 tasks × 3 models) were then run against the
+   real `./target/debug/kaish` binary and produced correct output with no errors. **The v2
+   bare-collection-iterates relaxation is NOT adopted** — the taught `$()`-only form converged
+   in one round across the whole tested capability range, so there is no evidence the mandated
+   form is a tax being paid forever. Local/self-hosted models (`qwen`, `zorak`, `glm` casts)
+   were not reachable in this environment; re-run against them if that capacity comes up, as
+   a bonus tail check, not a blocking gap — three cross-vendor commercial families already
+   exceeds the original recipe's panel composition.
+
+   **A real doc bug surfaced during test-prep, independent of the panel itself:** both the
+   `collections` and `test-expressions` Syntax fragments (`crates/kaish-help/src/fragments.rs`)
+   showed membership (`in`/`not in`) as a **bare standalone `[[ ]]` line** — exactly the pattern
+   Teaching note #1 already identified as broken (a novel operator shown standalone reads as a
+   complete statement) — introduced when membership shipped (#58) and never caught because no
+   panel re-test had exercised the actual composed artifact until now. Fixed in both fragments
+   and in `docs/LANGUAGE.md`'s matching examples before running the panel, so the tested
+   artifact reflects the corrected teaching copy, not the regression.
+
+   **Watch one number above all: convergence on `$(values $xs)` in the
    for-head** — the 2026-06-05 panel's single most common error was *requiring `$(keys $r)` in the
    head*, which the `$()`-only decision now mandates; if models need more than one verify round to
    accept it routinely, execute the v2 relaxation (bare collection iterates; bare string is a loud
-   runtime error) early. Results not yet gathered — do not sign off without them.
+   runtime error) early. **Results above: 3/3 models converged in round one — no relaxation
+   triggered.**
 
 9. **Update the "sh subset / shellcheck" framing in the same PR** (see issues.md P4). The docs
    that introduce collections are the natural place to restate "inspired by sh/bash, informed by

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -14,6 +14,62 @@ before it ships.
 
 ---
 
+## Collections panel gate + docs delivery — sign-off (2026-07-03)
+
+The last item on the collections milestone: Teaching note #8's pre-sign-off cross-model
+panel re-test against the *final* bracket surface (literals, lvalues, `push`, `$()`-only
+iteration — all merged to main this session via #66/#67), plus closing the docs/help gaps
+that closing out that milestone exposed.
+
+**The composable-help surface had drifted from `LANGUAGE.md`.** Each collections PR kept
+`docs/LANGUAGE.md` in sync (per the CLAUDE.md convention), but the `collections`
+`syntax_section` in `crates/kaish-help/src/fragments.rs` — the single source for `help
+syntax`, `syntax.md`, and (new) `help collections` — was never updated when native literal
+construction and spread landed (#66/#64). It still taught `fromjson`-only construction.
+Fixed: the syntax_section now leads with the native literal forms (list/record/nesting) and
+the `...` spread nest-vs-flatten contrast, matching LANGUAGE.md; a new ranked Foundations
+Rule (`collection-literals`, rank 10) and Contrast fragment mention the literal forms and
+the dot-leakage error in the always-on onboarding block too.
+
+**`help collections` is now a fragment query, not a file** (the design's explicit decision,
+finally implemented) — `compose::render_syntax_section(key)` renders a single `Syntax`
+fragment by its key, single-sourced with `syntax.md`, and `HelpTopic::parse_topic` falls
+back to it for any key that matches a registered syntax_section before falling through to
+`Tool(name)`. The mechanism is generic (any future subsystem-sized syntax feature gets
+`help <key>` for free by naming its section), not collections-specific plumbing.
+
+**A real regression surfaced while assembling the panel's cheat sheet, independent of the
+panel run itself.** Teaching note #1 — "teach an operator inside its full control
+structure, never bare" — is the hard-won rule from the *original* 2026-06-05 experiments
+(a standalone `[[ k in $r ]]` line reads as a complete statement to a model). Both the
+`collections` and `test-expressions` syntax_sections had shipped membership as a bare
+standalone `[[ ]]` line anyway — introduced when membership landed (#58) and never caught,
+because no panel re-test had exercised the *actual composed artifact* since then. Fixed in
+both fragments and in LANGUAGE.md's matching examples before running the panel, so the
+tested artifact reflects the corrected teaching copy rather than the regression it would
+otherwise have quietly re-validated.
+
+**The panel gate: 18/18 clean, zero correction rounds.** Ran the actual shipped
+`Recipe::agent_onboarding()` output plus the `collections` syntax_section — the real
+delivery artifact, not an ad-hoc cheat sheet — as a stateless one-shot prompt (no repo
+access) against DeepSeek V4, Gemini 3.5-flash, and Claude Haiku 4.5, on a 6-task script
+covering every item Teaching note #8 called out: nested record construction, bracket-path
+lvalues + `push`, the literal-vs-variable subscript distinction (`${user[name]}` vs
+`${user[$field]}`), membership inside a full `if/then/else`, a bare dot-leakage probe, and a
+slice. All three models converged immediately on `for k in $(keys $servers); do echo "$k:
+${servers[$k][port]}"; done` — the exact form the 2026-06-05 panel most commonly got wrong
+(it required explicit correction to stop reaching for the bare-builtin for-head). Zero
+dot-leakage on the bare field-access task, despite no "don't use dots" warning in the
+prompt — the taught contrast (`${u.name}` shown as the wrong form, with its error) held
+unprompted. All 18 generated scripts were then run against the real
+`./target/debug/kaish` binary and produced correct output. **The v2
+bare-collection-iterates relaxation is not adopted** — there's no evidence the `$()`-only
+form is a tax being paid forever; it converged in one round across the whole tested range.
+`docs/arrays-and-hashes.md` carries the full result inline at Teaching note #8 and the
+Resolved-decisions "Access form" entry, rather than a separate write-up, since the doc is
+already the design's evidence record.
+
+
 ## BRE follow-ups + the stale-`$?` bug (2026-07-03)
 
 Working the PR #65 follow-up comments: awk's invalid-FS/`split()` errors now name

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -311,19 +311,6 @@ ranked Rules instead of beside its Rule sibling. The sort key can't include
 registry order for equal ranks), so the fix is to give each Contrast/Reference
 fragment the same rank as its Rule counterpart when such a consumer is built.
 
-**Importance-ranked onboarding tiers (2026-07-01, from the arrays-and-hashes
-review):** restructure `agent_onboarding()` composition into ~200–300-char ranks in
-descending importance — the first rank carries the most critical rules so the client
-model gets them immediately even under skimming/truncation; successive ranks follow;
-everything else moves to an easy-to-find, loadable resource (help topics / MCP
-prompts) pointed at from the block's tail. Mechanically: fragments gain an importance
-rank, recipes compose by rank, and a size assertion in kaish-help's tests caps the
-ranked tier stack (today nothing caps composed size — no test, no ceiling; `Depth` is
-the only lever, and the block is already ~9–10.5K chars with the builtin index
-dominating at ~5.4K). Do this before the collections fragments land — they're the
-feature that will test it. See [arrays-and-hashes.md](arrays-and-hashes.md)
-"Help & teaching delivery".
-
 **Collection read-access follow-ups (2026-07-01, from the read-access deepseek
 review; verified locally):**
 - **P3 — reduced sync arg path coalesces a loud path error to skip.** The four


### PR DESCRIPTION
## Summary

Closes the last open item on the collections milestone — Teaching note #8's pre-sign-off cross-model panel re-test against the final bracket surface (literals #66 + lvalues/push #67, both now on main).

Getting the real delivery artifact ready for the panel surfaced two genuine gaps, fixed here:

- **`collections` syntax_section had drifted from `LANGUAGE.md`.** Each collections PR kept `LANGUAGE.md` in sync, but the composable-help fragment (the actual source for `help syntax`/`syntax.md`/agent onboarding) never got the native literal construction + `...` spread examples added when #66 landed. Fixed, plus a new ranked Foundations rule + contrast fragment in the always-on onboarding block.
- **`help collections` didn't exist** — fell through to "unknown tool" despite `docs/arrays-and-hashes.md` explicitly deciding it should be a fragment query, not a hand-written file. Implemented generically: `compose::render_syntax_section(key)` + a `HelpTopic` fallback, so any future subsystem-sized syntax feature gets `help <key>` for free.
- **A real regression**: both `collections` and `test-expressions` fragments taught membership (`in`/`not in`) as a bare standalone `[[ ]]` line — exactly the failure mode Teaching note #1 exists to prevent. Introduced when membership shipped (#58), never caught because no panel re-test had exercised the actual composed artifact since. Fixed in both fragments and `LANGUAGE.md` before running the panel.

## Panel gate result: 18/18 clean, zero correction rounds

Ran the real shipped `Recipe::agent_onboarding()` output + the `collections` syntax_section as a stateless one-shot cheat sheet (no repo access) against DeepSeek V4, Gemini 3.5-flash, and Claude Haiku 4.5 — a 6-task script covering every item Teaching note #8 called out. All three models converged immediately on:

```sh
for k in $(keys $servers); do echo "$k: ${servers[$k][port]}"; done
```

— the exact form the original 2026-06-05 panel most commonly got wrong (that panel needed explicit correction to stop reaching for a bare-builtin for-head). Also clean: bracket-path lvalues + `push`, the literal-vs-variable subscript distinction (`${user[name]}` vs `${user[$field]}`), membership inside a full `if/then/else`, a slice, and — with no "don't use dots" warning anywhere in the prompt — zero dot-leakage on a bare field-access probe. All 18 generated scripts were then run against the real `./target/debug/kaish` binary and produced correct output.

**The v2 bare-collection-iterates relaxation is not adopted** — there's no evidence the `$()`-only form is a tax being paid forever; it converged in one round across the whole tested range.

Full write-up: `docs/arrays-and-hashes.md` (Teaching note #8 + the "Access form" resolved-decision entry) and `docs/devlog.md`.

## Test plan
- [x] `cargo build --all`
- [x] `cargo test --all` (135 sections, 0 failed, incl. `kaish-help`'s drift/budget/coverage tests)
- [x] `cargo clippy --all --all-targets` (zero warnings)
- [x] `./target/debug/kaish -c "help collections"` — manually verified output
- [x] All 18 panel-generated scripts executed against the real binary with correct output

🤖 Generated with [Claude Code](https://claude.com/claude-code)