### PR TITLE
fix(collections): loud subscripted-length on unset roots; record keys interpolate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -172,6 +172,14 @@ breaking entries are marked **BREAKING**.
   demotion of `\|` to plain `|`).
 
 ### Fixed
+- **`${#path}` on an undefined subscripted root is now loud** — `${#nope[items]}`
+  silently returned `0` (the bash-parity `${#unset}` → 0 rule leaked into
+  subscripted paths), so a typo'd name in a length-guarded loop spun zero times
+  with no diagnostic. Bare `${#unset}` stays `0`.
+- **Double-quoted record-literal keys now interpolate** — `{"$k": v}` resolves
+  `$k` like any double-quoted string instead of silently creating a literal
+  `"$k"` key. Single quotes keep a literal `$` (`{'$k': v}`), same quoting
+  contract as everywhere else.
 - **A standalone `[[ ]]` test now writes `$?`** — `[[ 1 = 2 ]]; echo $?` printed
   `0` (the previous command's status; the test never stored its result), so
   `[[ -f x ]]; ok=$?` patterns silently read a stale status. A bare test

--- a/crates/kaish-help/content/en/syntax.md
+++ b/crates/kaish-help/content/en/syntax.md
@@ -37,6 +37,7 @@ nums=[1 2 3]               # ≡ [1, 2, 3]
 u={name: amy, role: maintainer}   # record — bareword keys
 compact={port:8080}        # colon may be spaced or unspaced
 r={"content-type": x}      # quoted key for anything that isn't a bareword
+d={"$k": x}                # double-quoted keys interpolate; '$k' stays literal
 nested={tags: [a b], meta: {active: true}}   # nesting works both ways
 
 # SPREAD (...) flattens; a bare $var nests as ONE element instead:

--- a/crates/kaish-help/src/fragments.rs
+++ b/crates/kaish-help/src/fragments.rs
@@ -292,6 +292,7 @@ nums=[1 2 3]               # ≡ [1, 2, 3]
 u={name: amy, role: maintainer}   # record — bareword keys
 compact={port:8080}        # colon may be spaced or unspaced
 r={"content-type": x}      # quoted key for anything that isn't a bareword
+d={"$k": x}                # double-quoted keys interpolate; '$k' stays literal
 nested={tags: [a b], meta: {active: true}}   # nesting works both ways
 
 # SPREAD (...) flattens; a bare $var nests as ONE element instead:

--- a/crates/kaish-kernel/src/ast/sexpr.rs
+++ b/crates/kaish-kernel/src/ast/sexpr.rs
@@ -324,6 +324,11 @@ pub fn format_expr(expr: &Expr) -> String {
                     let key = match &entry.key {
                         RecordKey::Bare(s) => s.clone(),
                         RecordKey::Quoted(s) => format!("\"{}\"", s),
+                        RecordKey::Interpolated(parts) => {
+                            let parts_str: Vec<String> =
+                                parts.iter().map(format_string_part).collect();
+                            format!("(interpolated {})", parts_str.join(" "))
+                        }
                     };
                     format!("({} {})", key, format_expr(&entry.value))
                 })

--- a/crates/kaish-kernel/src/ast/types.rs
+++ b/crates/kaish-kernel/src/ast/types.rs
@@ -345,12 +345,15 @@ pub struct RecordEntry {
     pub value: Expr,
 }
 
-/// A record literal key: `{name: amy}` (bare) or `{"content-type": x}` (quoted,
-/// for anything that isn't a bareword). See `docs/arrays-and-hashes.md`.
+/// A record literal key: `{name: amy}` (bare), `{"content-type": x}` (quoted,
+/// for anything that isn't a bareword), or `{"$k": x}` (double-quoted with
+/// interpolation — resolved at eval time like any double-quoted string; single
+/// quotes are the literal-`$` escape hatch). See `docs/arrays-and-hashes.md`.
 #[derive(Debug, Clone, PartialEq)]
 pub enum RecordKey {
     Bare(String),
     Quoted(String),
+    Interpolated(Vec<StringPart>),
 }
 
 /// Human-readable value-kind name for a spread (`[...expr]`) operand that

--- a/crates/kaish-kernel/src/interpreter/eval.rs
+++ b/crates/kaish-kernel/src/interpreter/eval.rs
@@ -292,6 +292,12 @@ impl<'a, E: Executor> Evaluator<'a, E> {
         for entry in entries {
             let key = match &entry.key {
                 RecordKey::Bare(s) | RecordKey::Quoted(s) => s.clone(),
+                // `{"$k": v}` — a double-quoted key resolves like any
+                // double-quoted string (issue found by the 2026-07-03 review:
+                // it used to silently create a literal "$k" key).
+                RecordKey::Interpolated(parts) => {
+                    value_to_string(&self.eval_interpolated(parts)?)
+                }
             };
             let value = self.eval(&entry.value)?;
             map.insert(key, kaish_types::value_to_json(&value));
@@ -694,14 +700,19 @@ pub fn value_defaults_on_emptiness(value: &Value) -> bool {
     }
 }
 
-/// `${#path}` length semantics over the shared path resolver. An unset *root* is
-/// length 0 (bash parity for `${#unset}`); a missing key, out-of-bounds index,
-/// or shape error is loud (consistent with bare `${u[nope]}` being loud). The
-/// resolver borrows the tree — no whole-root clone.
+/// `${#path}` length semantics over the shared path resolver. An unset BARE
+/// root is length 0 (bash parity for `${#unset}`); an unset root under a
+/// SUBSCRIPTED path is loud, consistent with bare `${nope[k]}` — a typo'd name
+/// in `while [[ ${#queue[items]} -gt 0 ]]` must not silently count 0 forever
+/// (2026-07-03 review finding). Missing key, out-of-bounds index, and shape
+/// errors stay loud. The resolver borrows the tree — no whole-root clone.
 pub fn resolve_length(scope: &Scope, path: &VarPath) -> Result<i64, String> {
     match scope.resolve_path(path) {
         Ok(value) => Ok(value_length(&value)),
-        Err(super::scope::PathError::UndefinedRoot(_)) => Ok(0),
+        Err(super::scope::PathError::UndefinedRoot(_)) if path.segments.len() <= 1 => Ok(0),
+        Err(super::scope::PathError::UndefinedRoot(_)) => {
+            Err(format!("{}: undefined variable", format_path(path)))
+        }
         Err(super::scope::PathError::Absence(msg)) | Err(super::scope::PathError::Shape(msg)) => {
             Err(msg)
         }

--- a/crates/kaish-kernel/src/kernel.rs
+++ b/crates/kaish-kernel/src/kernel.rs
@@ -3896,6 +3896,11 @@ impl Kernel {
                 for entry in entries {
                     let key = match &entry.key {
                         RecordKey::Bare(s) | RecordKey::Quoted(s) => s.clone(),
+                        // `{"$k": v}` resolves like any double-quoted string
+                        // (used to silently create a literal "$k" key).
+                        RecordKey::Interpolated(parts) => {
+                            self.eval_string_parts_async(parts).await?
+                        }
                     };
                     let value = self.eval_expr_async(&entry.value).await?;
                     map.insert(key, crate::interpreter::value_to_json(&value));

--- a/crates/kaish-kernel/src/parser.rs
+++ b/crates/kaish-kernel/src/parser.rs
@@ -2259,12 +2259,22 @@ where
     V: Parser<'tokens, I, Expr, extra::Err<Rich<'tokens, Token, Span>>> + Clone + 'tokens,
 {
     let bare_key = select! { Token::Ident(s) => RecordKey::Bare(s) };
-    let quoted_key = choice((
-        select! { Token::String(s) => s },
-        select! { Token::SingleString(s) => s },
-    ))
-    .map(RecordKey::Quoted);
-    let key = choice((quoted_key, bare_key)).labelled("record key");
+    // A double-quoted key interpolates like any double-quoted string ({"$k": v}
+    // resolves $k at eval time — it used to silently create a literal "$k"
+    // key); a pure-literal result folds back to Quoted so the common case
+    // carries no eval overhead. Single quotes stay verbatim — the escape hatch
+    // for a literal `$` in a key.
+    let double_key = select! { Token::String(s) => s }.try_map(|s, span| {
+        let parts = parse_interpolated_string(&s)
+            .map_err(|e| Rich::custom(span, format!("record key: {e}")))?;
+        Ok(match parts.as_slice() {
+            [] => RecordKey::Quoted(String::new()),
+            [StringPart::Literal(lit)] => RecordKey::Quoted(lit.clone()),
+            _ => RecordKey::Interpolated(parts),
+        })
+    });
+    let single_key = select! { Token::SingleString(s) => RecordKey::Quoted(s) };
+    let key = choice((double_key, single_key, bare_key)).labelled("record key");
 
     let entry = key
         .then_ignore(just(Token::Colon))

--- a/crates/kaish-kernel/tests/collection_access_tests.rs
+++ b/crates/kaish-kernel/tests/collection_access_tests.rs
@@ -441,6 +441,32 @@ async fn length_of_a_missing_key_is_a_loud_error() {
 }
 
 #[tokio::test]
+async fn length_of_an_undefined_subscripted_root_is_loud() {
+    // `${#nope[items]}` used to silently return 0 (the bare-`${#unset}` bash
+    // parity leaked into subscripted paths), so a typo'd name in
+    // `while [[ ${#queue[items]} -gt 0 ]]` looped zero times with no
+    // diagnostic. Loud now, consistent with bare `${nope[items]}`.
+    // (2026-07-03 cross-model review, fable finding #1.)
+    let k = setup().await;
+    let (_, code, err) = run(&k, "echo ${#nope[0]}").await;
+    assert_ne!(code, 0, "undefined subscripted root must be loud");
+    assert!(err.contains("undefined"), "should say undefined: {err}");
+
+    let (_, code, _) = run(&k, "echo ${#nope[key]}").await;
+    assert_ne!(code, 0, "record-shaped path too");
+}
+
+#[tokio::test]
+async fn length_of_an_undefined_bare_root_stays_zero() {
+    // The bash-parity half stays: `${#unset}` (no subscript) is 0, not an
+    // error. Pinned separately so the two forms can't drift together.
+    let k = setup().await;
+    let (out, code, err) = run(&k, "echo ${#unset_thing}").await;
+    assert_eq!(code, 0, "err: {err}");
+    assert_eq!(out, "0");
+}
+
+#[tokio::test]
 async fn for_loop_over_envelope_shaped_elements_stays_a_record() {
     // A `fromjson` array element that happens to be envelope-shaped is external
     // data — it must NOT be silently re-decoded to binary during iteration.

--- a/crates/kaish-kernel/tests/collection_literals_tests.rs
+++ b/crates/kaish-kernel/tests/collection_literals_tests.rs
@@ -156,6 +156,47 @@ async fn record_literal_quoted_key() {
 }
 
 #[tokio::test]
+async fn record_literal_double_quoted_key_interpolates() {
+    // `{"$k": v}` resolves $k like any double-quoted string — it used to
+    // silently create a literal "$k" key (2026-07-03 review, gemini #10).
+    let k = setup().await;
+    let (out, code, err) =
+        run(&k, r#"k=port; r={"$k": 8080}; echo ${r[port]} ${#r}"#).await;
+    assert_eq!(code, 0, "err: {err}");
+    assert_eq!(out, "8080 1", "key must be the resolved name, no phantom $k");
+}
+
+#[tokio::test]
+async fn record_literal_braced_key_interpolates_composite() {
+    let k = setup().await;
+    let (out, code, err) =
+        run(&k, r#"k=port; r={"${k}_num": 1}; keys $r"#).await;
+    assert_eq!(code, 0, "err: {err}");
+    assert_eq!(out, r#"["port_num"]"#);
+}
+
+#[tokio::test]
+async fn record_literal_single_quoted_key_stays_literal() {
+    // Single quotes are the escape hatch for a literal `$` in a key — same
+    // quoting contract as everywhere else in the shell.
+    let k = setup().await;
+    let (out, code, err) = run(&k, r#"r={'$k': 1}; keys $r"#).await;
+    assert_eq!(code, 0, "err: {err}");
+    assert_eq!(out, r#"["$k"]"#);
+}
+
+#[tokio::test]
+async fn record_literal_undefined_var_key_is_empty_string() {
+    // An unset var in a double-quoted key expands to "" — the ratified
+    // string-interpolation rule (undefined root in a string is empty), applied
+    // consistently. An empty-string key is a legal record key.
+    let k = setup().await;
+    let (out, code, err) = run(&k, r#"r={"$nope_undefined": 1}; keys $r"#).await;
+    assert_eq!(code, 0, "err: {err}");
+    assert_eq!(out, r#"[""]"#);
+}
+
+#[tokio::test]
 async fn record_literal_access_by_bareword_key() {
     let k = setup().await;
     let (out, code, err) = run(&k, "u={port: 8080}; echo ${u[port]}").await;

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -84,6 +84,8 @@ dog=[dog]                    # single-element list (glued `[dog]` still a list, 
 user={name: amy, role: maintainer}     # record — string-keyed map
 compact={port:8080}                    # colon may be spaced or unspaced — same value
 r={"content-type": x}                  # quoted key for anything that isn't a bareword
+d={"$k": x}                            # double-quoted keys interpolate ($k resolves);
+                                       # single quotes keep a literal $ ({'$k': x})
 
 nested={tags: [a b], meta: {active: true}}   # nesting works both ways
 ```

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -14,6 +14,25 @@ before it ships.
 
 ---
 
+## The two review bugs: silent-zero length + literal-`$k` record keys (2026-07-03)
+
+The 2026-07-03 coverage review verified two live silent-wrongs; both fixed here.
+`${#nope[items]}` returned 0 — `resolve_length`'s bash-parity arm (`${#unset}` →
+0) didn't distinguish bare roots from subscripted paths, so a typo'd name in a
+length-guarded loop spun zero times with no diagnostic. Subscripted paths now
+error like bare `${nope[items]}` does; bare `${#unset}` stays 0, pinned
+separately so the forms can't drift together.
+
+`{"$k": 8080}` created a literal `"$k"` key — the record-literal parser took
+`Token::String` raw. Double-quoted keys now interpolate like every other
+double-quoted string (new `RecordKey::Interpolated(Vec<StringPart>)` riding the
+existing StringPart machinery in both eval sites; a pure-literal parse folds
+back to `Quoted` so the common case is free). Single quotes remain the
+literal-`$` escape hatch, and an unset var in a key expands to `""` — the
+ratified string-interpolation rule applied consistently, pinned with a test.
+
+---
+
 ## Collections panel gate + docs delivery — sign-off (2026-07-03)
 
 The last item on the collections milestone: Teaching note #8's pre-sign-off cross-model


### PR DESCRIPTION
The two verified bugs from the 2026-07-03 cross-model coverage review (both reproduced against the live binary before fixing, both silent-wrong):

## `${#nope[items]}` silently returned 0

`resolve_length`'s bash-parity arm (`${#unset}` → 0) didn't distinguish bare roots from subscripted paths, so a typo'd variable name in `while [[ ${#queue[items]} -gt 0 ]]` looped zero times forever with no diagnostic — while the analogous bare access `${nope[items]}` errored loudly. An unset root under a **subscripted** path is now a loud `undefined variable` naming the path; bare `${#unset}` stays 0, pinned by a separate test so the two forms can't drift together. (fable finding #1; the review flagged it as "current bug or unratified — decide, then pin"; decided loud.)

## `{"$k": 8080}` silently created a literal `"$k"` key

The record-literal parser took `Token::String` raw, so double-quoted keys were the one place in the shell where `"$k"` didn't interpolate. They now resolve like every other double-quoted string: a new `RecordKey::Interpolated(Vec<StringPart>)` rides the existing StringPart machinery in both eval sites (sync `eval.rs` + async `kernel.rs`), and a pure-literal parse folds back to `Quoted` so plain `{"content-type": x}` keys carry no eval cost. `${k}_num` composites work; **single quotes remain the literal-`$` escape hatch** (`{'$k': v}` keys `$k`, unchanged); an unset var in a key expands to `""` per the ratified string-interpolation rule — pinned with a test so the choice is documented. (gemini finding #10, which flagged the unratified behavior; decided interpolate-for-consistency.)

## Docs

`LANGUAGE.md` and the collections help fragment gained the key-quoting line (`syntax.md` regenerated via `regen_syntax`); CHANGELOG `Fixed` bullets for both.

## Testing

Two new length tests in `collection_access_tests.rs`, four new key tests in `collection_literals_tests.rs` (interpolated, braced composite, single-quote literal, unset-var-empty). Full `cargo test --all` + `cargo clippy --all --all-targets` clean in the worktree; the one background-run flake (`external_command_tests`, load blip during concurrent worktree builds) re-ran green 5/5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)