### PR TITLE
feat(help): `help regex` — one-screen dialect reference (PR #65 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,10 @@ breaking entries are marked **BREAKING**.
   test line (a prior regression against the shell's own teaching-note rule).
 
 ### Added
+- **`help regex`** — a compact syntax section (also in `help syntax`/`syntax.md`)
+  covering the regex dialect in one screen: ERE everywhere (grep/sed/awk), the
+  accepted GNU BRE spellings, the bracket-class/`-E` escape hatches for literal
+  metas, and the no-backreferences-in-patterns rule.
 - **`help collections`** — a new help topic, composed straight from the
   `collections` syntax reference fragment (single-sourced with `help syntax`,
   not a second hand-written doc). The underlying mechanism is generic: any

--- a/crates/kaish-help/content/en/syntax.md
+++ b/crates/kaish-help/content/en/syntax.md
@@ -281,6 +281,27 @@ set -o glob               # re-enable (on by default)
 
 Zero matches is an error (exit code 1). The `glob` builtin still works for `--exclude` and `**`.
 
+## Regex (grep, sed, awk)
+
+```sh
+# ERE (egrep-style) everywhere: a|b  (…)  x+ y? z{2,5}  [a-z]  ^…$
+grep 'error|warn' log.txt           # alternation — one call, many terms
+sed -E 's/v([0-9]+)\.[0-9]+/\1/'    # (…) capture; \1 \2 in the REPLACEMENT
+awk '/^(GET|POST) /' access.log     # same engine in all three
+
+# GNU BRE spellings are accepted too — \| \(…\) \{n,m\} \+ \? rewrite to ERE:
+grep 'error\|warn' log.txt          # ≡ error|warn
+sed 's/\(a\)\(b\)/\2\1/'            # ≡ s/(a)(b)/\2\1/
+
+# A literal | + ? ( ) { }: bracket class, or strict-ERE mode
+grep '[|]' f                        # literal pipe (works in all three)
+grep -E 'a\|b' f                    # -E / -r (grep, sed): backslashed meta = literal
+grep -F 'a|b' f                     # -F: fixed string, nothing is a metachar
+
+grep '\d+\.\w\b' f                  # \d \w \s \b \. work; \< \> too
+sed 's/(a)\1/x/'                    # ERROR — no backreference IN a pattern
+```
+
 ## Shell Options
 
 ```sh

--- a/crates/kaish-help/src/fragments.rs
+++ b/crates/kaish-help/src/fragments.rs
@@ -547,6 +547,28 @@ set -o glob               # re-enable (on by default)
 Zero matches is an error (exit code 1). The `glob` builtin still works for `--exclude` and `**`."#,
     ),
     syntax_section(
+        "regex",
+        "Regex (grep, sed, awk)",
+        r#"```sh
+# ERE (egrep-style) everywhere: a|b  (…)  x+ y? z{2,5}  [a-z]  ^…$
+grep 'error|warn' log.txt           # alternation — one call, many terms
+sed -E 's/v([0-9]+)\.[0-9]+/\1/'    # (…) capture; \1 \2 in the REPLACEMENT
+awk '/^(GET|POST) /' access.log     # same engine in all three
+
+# GNU BRE spellings are accepted too — \| \(…\) \{n,m\} \+ \? rewrite to ERE:
+grep 'error\|warn' log.txt          # ≡ error|warn
+sed 's/\(a\)\(b\)/\2\1/'            # ≡ s/(a)(b)/\2\1/
+
+# A literal | + ? ( ) { }: bracket class, or strict-ERE mode
+grep '[|]' f                        # literal pipe (works in all three)
+grep -E 'a\|b' f                    # -E / -r (grep, sed): backslashed meta = literal
+grep -F 'a|b' f                     # -F: fixed string, nothing is a metachar
+
+grep '\d+\.\w\b' f                  # \d \w \s \b \. work; \< \> too
+sed 's/(a)\1/x/'                    # ERROR — no backreference IN a pattern
+```"#,
+    ),
+    syntax_section(
         "shell-options",
         "Shell Options",
         r#"```sh

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -14,6 +14,17 @@ before it ships.
 
 ---
 
+## `help regex` — waking the ERE weights (2026-07-03)
+
+PR #65's last follow-up: the BRE-superset story lived in four places (grep
+schema, sed schema, awk help, LANGUAGE.md) with no single teachable surface.
+Amy's framing set the design: token-efficient, and written to *wake up the
+model's ERE weights* — so the fragment leads with working ERE idioms
+(alternation, capture groups, quantifiers) before mentioning BRE compat at all,
+then covers the two escape hatches and the one hard limit. One screen, every
+line verified against the binary. Rides the #69 `syntax_section` mechanism, so
+`help regex` worked the moment the fragment was named.
+
 ## The two review bugs: silent-zero length + literal-`$k` record keys (2026-07-03)
 
 The 2026-07-03 coverage review verified two live silent-wrongs; both fixed here.
@@ -32,6 +43,7 @@ literal-`$` escape hatch, and an unset var in a key expands to `""` — the
 ratified string-interpolation rule applied consistently, pinned with a test.
 
 ---
+
 
 ## Collections panel gate + docs delivery — sign-off (2026-07-03)
 


### PR DESCRIPTION
The last open follow-up from PR #65: the regex-dialect story (ERE everywhere, GNU BRE superset, escape hatches) lived in four places — grep schema, sed schema, awk help, LANGUAGE.md — with no single surface an agent could be pointed at.

New `regex` syntax_section in `kaish-help`, riding #69's `render_syntax_section` mechanism, so `help regex` works simply by naming the section (it also appears in `help syntax` and the generated `syntax.md`).

Per the design direction: **token-efficient, and written to wake the model's ERE weights** — the fragment leads with *working ERE idioms* (alternation, capture groups, quantifiers, anchored alternation in awk) before mentioning BRE at all, so a model reading it gets primed toward the native dialect rather than the compat layer. Then one line each for: the accepted GNU BRE spellings, bracket-class literals, `-E`/`-r` strict mode, `-F`, extra escapes (`\d \w \b \< \>`), and the no-backreferences-in-patterns rule. One screen total.

Every example line in the fragment was executed against the real binary and produces the documented behavior.

`syntax.md` regenerated (drift test green); CHANGELOG `Added` bullet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)