### PR TITLE
feat(#73): scatter/gather goes typed-JSONL — the kaish-native parallel map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,23 @@ breaking entries are marked **BREAKING**.
 ## [Unreleased]
 
 ### Changed
+- **BREAKING: scatter/gather is now the typed parallel map** (GH #73,
+  panel-validated). `gather` emits one JSONL result record per worker, in item
+  order, failures included — `{"i":N,"item":<typed>,"ok":…,"code":…,"out":…,
+  "err":…}` plus `data`/`timed_out` when present (timeout → `code` 124). The
+  same records are the structured data (`for r in $(… | gather)` iterates typed
+  records; kaish `jq` receives them as one array — stream rows with `.[]`), and
+  `gather --json` renders one JSON array. Worker bindings are TYPED: a JSON
+  array fans out element-by-element with real types (`${ITEM[id]}` subscripts a
+  record; `1` and `"1"` no longer conflate). Exit codes: `0` all ok · `123` any
+  worker failed · `2` usage. `gather --format` and `--first` are REMOVED;
+  new `gather --lines` emits raw successful outputs and hard-errors if any
+  worker failed. Scatter ingress errors loudly on a single non-array object
+  (with a select-the-array hint), `null` items, and binary input; blank text
+  lines are skipped. A future `xargs` builtin (GH #78) will carry the POSIX
+  bare-lines flavor.
+
+### Changed
 - **BREAKING:** **`sed` no longer rejects BRE idioms with a hint** — `\|`,
   `\(…\)`, and `\{N,M\}` used to be a loud `E006` error; they now behave as
   alternation/groups/intervals (see Added). Scripts that relied on the error, or

--- a/crates/kaish-help/content/en/scatter.md
+++ b/crates/kaish-help/content/en/scatter.md
@@ -1,34 +1,101 @@
-# 散/集 (Scatter/Gather) — Parallel Processing
+# 散/集 (Scatter/Gather) — Parallel Map over Structured Data
 
 ## Syntax
 
 ```
-input | scatter [--as VAR] [--limit N] [--timeout DUR] | command | gather [--first N] [--format lines|json]
+input | scatter [--as VAR] [--limit N] [--timeout DUR] | worker… | gather [--lines|--json]
 ```
+
+## The model
+
+scatter fans structured input out to parallel workers; gather collects one
+**JSONL result record per worker**, in item order, **every worker — failures
+included**:
+
+```jsonl
+{"i":0,"item":"web-1","ok":true,"code":0,"out":"restarted","err":""}
+{"i":1,"item":"web-2","ok":false,"code":7,"out":"","err":"connection refused"}
+```
+
+Fields: `i` (item index), `item` (the input, **typed** — a record stays a
+record), `ok`, `code`, `out` (worker stdout, trailing newline stripped), `err`
+(worker stderr — always present) on every row; `data` (the worker's structured
+output, typed) and `timed_out:true` only when present. A timed-out worker
+reports `code` 124.
+
+`ITEM` is **typed**: from a JSON array (jq/`values`/seq/split/glob/find), each
+worker binds the real element — `${ITEM[id]}` subscripts a record, numbers stay
+numbers, `1` ≠ `"1"`. From plain text, one string item per line (blank lines
+skipped). Quote it at command boundaries: `work "$ITEM"` (a record renders as
+compact JSON). A single non-array object, a `null` element, or binary input is
+a loud error.
+
+## Consuming results
+
+```sh
+# kaish jq gets the records as ONE ARRAY — stream rows with .[] :
+… | gather | jq -r '.[] | select(.ok) | .out'        # successes' outputs
+… | gather | jq -r '.[] | select(.ok | not) | .item' # failed items
+… | gather | jq '[.[] | select(.ok)] | length'       # count successes
+
+# Typed iteration — each r is a record:
+for r in $(… | gather); do
+  if [[ ${r[ok]} == false ]]; then retry "${r[item]}"; fi
+done
+
+… | gather --json    # same records as one pretty JSON array
+… | gather --lines   # raw successful outputs only, item order — HARD ERROR
+                     # (exit 123, no partial text) if ANY worker failed
+```
+
+## Exit codes
+
+`0` every worker succeeded · `123` any worker failed (partial or total —
+distinguish via the rows) · `2` usage error. A pipeline's status is its last
+command's, so check gather's code directly or gate with `if`/`&&`.
 
 ## Parameters
 
-**scatter:** `--as VAR` (default: `ITEM`) — variable name per item. `--limit N` (default: 8, clamped to 1..=10000) — max concurrent workers. Requests above 10000 are clamped and emit a `tracing::warn` on the `kaish::scatter` target. `--timeout DUR` (default: none) — per-worker timeout (`30`, `5s`, `500ms`, `2m`, `1h`); cancels the worker and kills its external children with the kernel's `kill_grace`. Workers that hit the timeout are tagged `"timed_out": true` in `gather --format json` output.
+**scatter:** `--as VAR` (default `ITEM`) — binding name per item. `--limit N`
+(default 8, clamped 1..=10000) — max concurrent workers. `--timeout DUR`
+(`30`, `5s`, `500ms`, `2m`, `1h`) — per-worker timeout; cancels the worker,
+kills its external children, row gets `code` 124 + `timed_out:true`.
 
-**gather:** `--first N` (default: 0/all) — take first N results. `--format lines|json` (default: `lines`) — output format. JSON output includes per-worker `timed_out` flag.
+**gather:** `--lines` — raw text escape hatch (above). `--json` — one JSON
+array instead of JSONL rows.
 
-## Example
+## Examples
 
 ```sh
-# Fan out to 4 workers, compute squares, collect first 5 as JSON
-seq 1 20 | scatter --as N --limit 4 | echo "{\"id\": $N, \"square\": $((N * N))}" | gather --first 5 --format json
+# Typed records from a file: deploy each job, then list timeouts
+jq '.jobs' jobs.json | scatter --limit 4 --timeout 30s \
+  | deploy --id "${ITEM[id]}" --host "${ITEM[host]}" \
+  | gather | jq -r '.[] | select(.timed_out) | .item.id'
 
-# Process files in parallel
-glob "*.json" | scatter --as FILE --limit 4 | jq ".name" $FILE | gather
+# Fan out an existing collection variable
+values $hosts | scatter | ping -c1 "$ITEM" | gather
+
+# Sum parallel outputs (out is a string — tonumber)
+seq 1 20 | scatter | slowsquare "$ITEM" | gather --json \
+  | jq '[.[] | .out | tonumber] | add'
+
+# Retry failures sequentially
+for r in $(cat hosts.txt | scatter --as H | probe "$H" | gather); do
+  if [[ ${r[ok]} == false ]]; then probe --slow "${r[item]}"; fi
+done
 ```
 
 ## Behavior
 
-- Results arrive in **completion order**, not input order
-- Each worker runs the full pipeline with `$VAR` set to its item
-- Outer scope variables are visible to workers
-- Workers share the same VFS
-- Failed workers: error collected, other workers continue
-- `set -e` before scatter stops on first error
-- **Workers run in a forked kernel.** Each parallel worker gets its own kernel instance with snapshotted session state (scope, cwd, aliases, user tools). This means workers can run the **full dispatch chain**: user-defined functions (`tool name { ... }`), `.kai` scripts, and command substitution in arguments all work correctly inside scatter workers. Mutations within a worker (e.g. changing a variable) stay within that worker and do not leak back to the parent or other workers.
-- **Cancellation cascades.** Workers fork with `fork_attached`, so their cancellation tokens are children of the parent kernel's. A parent timeout, `Kernel::cancel`, or REPL Ctrl-C propagates into every running worker and kills its external children via SIGTERM → `kill_grace` → SIGKILL.
+- **Rows are in item order** (deterministic), regardless of completion order.
+- Each worker runs the pipeline segment in its own **forked kernel**
+  (snapshotted scope/cwd/aliases/user tools) — full dispatch chain works;
+  worker mutations don't leak back. A worker's `code` is its segment's last
+  command's exit code.
+- Workers all run to completion — gather never short-circuits remaining
+  workers on a failure (contrast with POSIX `xargs`, which may stop early).
+- Nested scatter: pass `--as` explicitly — an inner default `ITEM` shadows the
+  outer binding.
+- **Cancellation cascades**: parent timeout / `Kernel::cancel` / Ctrl-C
+  propagates into every worker (SIGTERM → `kill_grace` → SIGKILL).
+- Empty input: exit 0, no rows.

--- a/crates/kaish-kernel/src/scheduler/scatter.rs
+++ b/crates/kaish-kernel/src/scheduler/scatter.rs
@@ -41,14 +41,19 @@ pub struct ScatterOptions {
 }
 
 /// Options for gather operation.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct GatherOptions {
     /// Show progress indicator.
     pub progress: bool,
-    /// Take first N results and cancel rest (0 = all).
-    pub first: usize,
-    /// Output format: "json" or "lines".
-    pub format: String,
+    /// `--lines`: emit each successful worker's raw `out` in item order instead
+    /// of JSONL rows — and HARD-ERROR (exit 123, no partial text) if any worker
+    /// failed, since bare lines cannot represent a failure. The text escape
+    /// hatch that keeps the old line mode's safety property.
+    pub lines: bool,
+    /// `--json` (the kernel-wide flag; scatter/gather own their output, so it
+    /// reaches the tool): render the result records as ONE JSON array instead
+    /// of JSONL rows. Same records, same `.data`.
+    pub json: bool,
 }
 
 impl Default for ScatterOptions {
@@ -61,13 +66,39 @@ impl Default for ScatterOptions {
     }
 }
 
-impl Default for GatherOptions {
-    fn default() -> Self {
-        Self {
-            progress: false,
-            first: 0,
-            format: "lines".to_string(),
-        }
+/// One typed scatter item: the JSON element that fans out to a worker.
+///
+/// `json` is the source of truth — the worker binding derives from it via
+/// [`json_to_value_no_envelope`](crate::interpreter::json_to_value_no_envelope)
+/// (the exact conversion `for v in $(cmd)` uses), and the gather row's `item`
+/// field carries it typed. `label` is a char-safe truncated display form for
+/// spans and error messages.
+#[derive(Debug, Clone)]
+pub struct ScatterItem {
+    /// The element as JSON (string items are JSON strings).
+    pub json: serde_json::Value,
+    /// Compact display label for tracing and error text.
+    pub label: String,
+}
+
+impl ScatterItem {
+    fn new(json: serde_json::Value) -> Self {
+        let full = match &json {
+            serde_json::Value::String(s) => s.clone(),
+            other => other.to_string(),
+        };
+        // Char-safe truncation (a byte slice at 64 can split a UTF-8 char).
+        let label = if full.chars().count() > 64 {
+            let head: String = full.chars().take(64).collect();
+            format!("{head}...")
+        } else {
+            full
+        };
+        Self { json, label }
+    }
+
+    fn from_text_line(line: &str) -> Self {
+        Self::new(serde_json::Value::String(line.to_string()))
     }
 }
 
@@ -75,7 +106,7 @@ impl Default for GatherOptions {
 #[derive(Debug, Clone)]
 pub struct ScatterResult {
     /// The input item that was processed.
-    pub item: String,
+    pub item: ScatterItem,
     /// The execution result.
     pub result: ExecResult,
     /// Whether the worker was cancelled by the per-worker `--timeout`.
@@ -163,31 +194,20 @@ impl ScatterGatherRunner {
             .run_parallel(&items, &scatter_opts, parallel, ctx)
             .await;
 
-        // Gather results
-        let GatherOutput {
-            text: gathered,
-            dropped_failures,
-        } = gather_results(&results, &gather_opts);
+        // Gather per the GH #73 contract: JSONL result records by default (one
+        // row per worker, failures included), or `--lines` raw text. Exit codes
+        // are A′: 0 all ok · 123 any worker failed · 2 usage (clap layer).
+        let gathered = gather_results(&results, &gather_opts);
 
-        // The line format can't carry a failed worker as a row. Rather than
-        // silently omit it (data corruption — the caller sees fewer rows than
-        // items scattered), fail loud: a non-zero exit plus an err naming the
-        // failed items. Feeding the truncated set into post-gather would
-        // propagate the corruption, so we short-circuit before running it.
-        if !dropped_failures.is_empty() {
-            let err = format!(
-                "gather: {} task(s) failed and were omitted from line output: {} (use --json to capture per-task status)",
-                dropped_failures.len(),
-                dropped_failures.join(", ")
-            );
-            return ExecResult::from_output(1, gathered, err);
-        }
-
-        // Run post-gather commands if any
-        if post_gather.is_empty() {
-            ExecResult::success(gathered)
+        // Run post-gather commands if any. A failed gather short-circuits —
+        // feeding partial/failed output onward would propagate corruption.
+        if post_gather.is_empty() || gathered.code != 0 {
+            gathered
         } else {
-            ctx.set_stdin(gathered);
+            ctx.set_stdin_with_data(
+                gathered.text_out().into_owned(),
+                gathered.data.clone(),
+            );
             runner.run_sequential(post_gather, ctx, &*self.sequential_dispatcher).await
         }
     }
@@ -203,7 +223,7 @@ impl ScatterGatherRunner {
     #[tracing::instrument(level = "debug", skip(self, items, opts, commands, base_ctx), fields(worker_count = items.len()))]
     async fn run_parallel(
         &self,
-        items: &[String],
+        items: &[ScatterItem],
         opts: &ScatterOptions,
         commands: &[Command],
         base_ctx: &ExecContext,
@@ -248,21 +268,21 @@ impl ScatterGatherRunner {
             });
             let timed_out_check = timed_out_flag.clone();
 
-            let item_label = if item.len() > 64 {
-                format!("{}...", &item[..64])
-            } else {
-                item.clone()
-            };
-            let worker_span = tracing::debug_span!("scatter_worker", item = %item_label);
+            let worker_span = tracing::debug_span!("scatter_worker", item = %item.label);
             // Propagate the embedder's trace context across the spawn boundary so
             // each worker's spans stay in the same trace. `.instrument` below
             // provides the tracing parent; this provides the OTel parent.
             let handle = tokio::spawn(crate::telemetry::bind_current_context(async move {
                 let _permit = permit; // Hold permit until done
 
-                // Create context for this worker
+                // Create context for this worker. The binding is TYPED — the
+                // same json→Value conversion the for-loop uses for `$(cmd)`
+                // items (GH #73), so a record element subscripts as ${ITEM[k]}.
                 let mut scope = base_scope;
-                scope.set(&var_name, Value::String(item.clone()));
+                scope.set(
+                    &var_name,
+                    crate::interpreter::json_to_value_no_envelope(item.json.clone()),
+                );
 
                 let mut ctx = ExecContext::with_backend_and_scope(backend, scope);
                 ctx.set_cwd(cwd);
@@ -293,7 +313,9 @@ impl ScatterGatherRunner {
                 Ok(result) => results.push(result),
                 Err(e) => {
                     results.push(ScatterResult {
-                        item: String::new(),
+                        item: ScatterItem::new(serde_json::Value::String(
+                            "<worker panicked>".to_string(),
+                        )),
                         result: ExecResult::failure(1, format!("Task panicked: {}", e)),
                         timed_out: false,
                     });
@@ -305,119 +327,188 @@ impl ScatterGatherRunner {
     }
 }
 
-/// Extract items from structured data or text.
+/// Extract typed items from structured data or text (GH #73 contract).
 ///
-/// Structured `.data` (a JSON array from split/seq/glob/find) wins and fans out
-/// element-by-element. Plain-text stdin is split on newlines only — one item per
-/// line — matching the for-loop `$(cmd)` contract (docs/LANGUAGE.md):
-/// trailing newlines are trimmed once (no phantom tail item), each line's trailing
-/// `\r` is stripped, interior blank lines are preserved, and whitespace within a
-/// line is never split. Empty / newline-only input yields zero items.
-pub fn extract_items(data: Option<&Value>, text: &str) -> Result<Vec<String>, String> {
+/// Structured `.data` wins and fans out TYPED: a JSON array yields one item per
+/// element with the element's real type (a record element subscripts as
+/// `${ITEM[k]}` in the worker; number `1` and string `"1"` stay distinct). A
+/// `null` element is a loud error — a worker silently running with a null
+/// binding is corruption. A single non-array OBJECT is a loud error with a
+/// select-the-array hint (one worker running on the `{"jobs":[…]}` envelope is
+/// never what was meant); a single scalar is one item. Binary data is a loud
+/// error.
+///
+/// Plain-text stdin is split on newlines only — one item per line, each a
+/// string — matching the for-loop `$(cmd)` contract: trailing newlines trimmed
+/// once, each line's trailing `\r` stripped, whitespace within a line never
+/// split. Blank lines are SKIPPED (panel-ratified: a worker spawned on `""` is
+/// silent corruption of the most common input shape). Empty input yields zero
+/// items (the caller exits 0 with no rows).
+pub fn extract_items(data: Option<&Value>, text: &str) -> Result<Vec<ScatterItem>, String> {
     // 1. Structured data wins over text (arch_data_iteration contract).
     match data {
-        // JSON array — fan out per element (seq/split/glob/find).
+        // JSON array — fan out per element, typed (seq/split/glob/find/jq).
         Some(Value::Json(serde_json::Value::Array(arr))) => {
-            return Ok(arr.iter().map(|v| match v {
-                serde_json::Value::String(s) => s.clone(),
-                other => other.to_string(),
-            }).collect());
+            let mut items = Vec::with_capacity(arr.len());
+            for (i, elem) in arr.iter().enumerate() {
+                if elem.is_null() {
+                    return Err(format!(
+                        "scatter: item {i} is null — refusing to bind a worker to null \
+                         (filter it out first, e.g. jq 'map(select(. != null))')"
+                    ));
+                }
+                items.push(ScatterItem::new(elem.clone()));
+            }
+            return Ok(items);
         }
-        // Kaish String — one item.
-        Some(Value::String(s)) => return Ok(vec![s.clone()]),
-        // Kaish Int/Float/Bool/Null — one item serialized as its display form.
-        Some(Value::Int(i)) => return Ok(vec![i.to_string()]),
-        Some(Value::Float(f)) => return Ok(vec![f.to_string()]),
-        Some(Value::Bool(b)) => return Ok(vec![b.to_string()]),
-        Some(Value::Null) => return Ok(vec!["null".to_string()]),
-        // Single JSON non-array value (object, number, string, bool, null) —
-        // one item.  Use compact serialization; the caller gets the item as a
-        // string and the pretty-printed text is NOT used here (that is the bug:
-        // a multi-line pretty-print would be newline-split into N bogus items).
-        Some(Value::Json(json)) => return Ok(vec![json.to_string()]),
-        // Binary data in a scatter context — treat as one opaque item.
-        Some(Value::Bytes(b)) => return Ok(vec![format!("[binary: {} bytes]", b.len())]),
+        // Kaish scalars — one typed item each.
+        Some(Value::String(s)) => {
+            return Ok(vec![ScatterItem::new(serde_json::Value::String(s.clone()))])
+        }
+        Some(Value::Int(i)) => return Ok(vec![ScatterItem::new(serde_json::json!(i))]),
+        Some(Value::Float(f)) => return Ok(vec![ScatterItem::new(serde_json::json!(f))]),
+        Some(Value::Bool(b)) => return Ok(vec![ScatterItem::new(serde_json::json!(b))]),
+        Some(Value::Null) => {
+            return Err("scatter: input is null — nothing to fan out".to_string())
+        }
+        // A single JSON object is almost always the unselected envelope around
+        // the array the caller meant — loud, with the fix in the message.
+        Some(Value::Json(serde_json::Value::Object(map))) => {
+            let hint = map
+                .iter()
+                .find(|(_, v)| v.is_array())
+                .map(|(k, _)| format!(" (did you mean jq '.{k}'?)"))
+                .unwrap_or_default();
+            return Err(format!(
+                "scatter: input is a single object, not an array — select the array to \
+                 fan out over{hint}"
+            ));
+        }
+        Some(Value::Json(serde_json::Value::Null)) => {
+            return Err("scatter: input is null — nothing to fan out".to_string())
+        }
+        // Single JSON scalar — one typed item.
+        Some(Value::Json(json)) => return Ok(vec![ScatterItem::new(json.clone())]),
+        // Binary can't bind a worker variable meaningfully — loud, never a
+        // placeholder string item.
+        Some(Value::Bytes(b)) => {
+            return Err(format!(
+                "scatter: input is binary ({} bytes) — decode it to text or JSON first",
+                b.len()
+            ))
+        }
         // No structured data — fall through to plain-text newline-split.
         None => {}
     }
 
-    // 2. Plain text — newline-split, mirroring kernel.rs for-loop $(cmd) semantics.
+    // 2. Plain text — newline-split, mirroring kernel.rs for-loop $(cmd)
+    // semantics; every text item is a string.
     let trimmed = text.trim_end_matches(['\n', '\r']);
     if trimmed.is_empty() {
         return Ok(vec![]);
     }
     Ok(trimmed
         .split('\n')
-        .map(|line| line.trim_end_matches('\r').to_string())
+        .map(|line| line.trim_end_matches('\r'))
+        .filter(|line| !line.is_empty())
+        .map(ScatterItem::from_text_line)
         .collect())
 }
 
-/// Rendered gather output plus the names of any failed tasks that the
-/// line format could not represent as a row.
-struct GatherOutput {
-    text: String,
-    /// Items whose worker failed and were omitted from `text`. Only the
-    /// line format populates this — the JSON format carries every task as a
-    /// row with an explicit `"ok"` field, so nothing is dropped there.
-    dropped_failures: Vec<String>,
+/// Strip exactly one trailing newline (`\n` or `\r\n`), leaving everything
+/// else raw — the GH #73 contract for the row's `out` and `err` fields.
+fn strip_one_trailing_newline(s: &str) -> &str {
+    let s = s.strip_suffix('\n').unwrap_or(s);
+    s.strip_suffix('\r').unwrap_or(s)
 }
 
-/// Gather results into output string.
+/// Build one JSONL result record for a worker (GH #73 row schema).
 ///
-/// The JSON format emits every task as a row (`"ok"` discriminates success
-/// from failure). The line format can only carry stdout, so it returns the
-/// successful rows in `text` and reports the failed items in
-/// `dropped_failures` — the caller (`run`) turns that into a loud non-zero
-/// exit rather than letting the failures vanish (see `docs/issues.md`).
-fn gather_results(results: &[ScatterResult], opts: &GatherOptions) -> GatherOutput {
-    let results_to_use = if opts.first > 0 && opts.first < results.len() {
-        &results[..opts.first]
+/// `{"i":N, "item":<typed>, "ok":bool, "code":N, "out":"…", "err":"…"}` plus
+/// `data` (the worker's structured output, typed) when present and
+/// `timed_out:true` when it was. `i`/`item`/`ok`/`code`/`out`/`err` are always
+/// present (`err` deliberately so — omit-empty on the most-read field would
+/// make `${r[err]}` a loud missing-key error on every successful row). A
+/// timed-out worker reports `code` 124 (the `timeout(1)` prior) and `ok` false.
+fn result_row(i: usize, r: &ScatterResult) -> serde_json::Value {
+    let ok = r.result.ok() && !r.timed_out;
+    let code = if r.timed_out { 124 } else { r.result.code };
+    let mut row = serde_json::Map::new();
+    row.insert("i".into(), serde_json::json!(i));
+    row.insert("item".into(), r.item.json.clone());
+    row.insert("ok".into(), serde_json::json!(ok));
+    row.insert("code".into(), serde_json::json!(code));
+    row.insert(
+        "out".into(),
+        serde_json::json!(strip_one_trailing_newline(&r.result.text_out())),
+    );
+    row.insert(
+        "err".into(),
+        serde_json::json!(strip_one_trailing_newline(&r.result.err)),
+    );
+    if let Some(data) = &r.result.data {
+        row.insert("data".into(), kaish_types::value_to_json(data));
+    }
+    if r.timed_out {
+        row.insert("timed_out".into(), serde_json::json!(true));
+    }
+    serde_json::Value::Object(row)
+}
+
+/// Render gathered worker results as an [`ExecResult`] (GH #73 contract).
+///
+/// Default: JSONL — one compact result record per worker, in item order, EVERY
+/// worker including failures. One source, three views: the pipe text is the
+/// JSONL, `.data` is the typed record array (so `for r in $(… | gather)`
+/// iterates records and post-gather stages see typed stdin), and the kernel
+/// `--json` flag renders the same array as one JSON document via `rich_json`.
+///
+/// `--lines`: each successful worker's raw `out` in item order — and a HARD
+/// error (no partial text) if any worker failed, because bare lines cannot
+/// represent a failure (the old line mode's safety property, kept as a flag).
+///
+/// Exit codes (A′): `0` all workers ok · `123` any worker failed, partial or
+/// total (timeouts count) — partial-vs-total is distinguished in the rows.
+fn gather_results(results: &[ScatterResult], opts: &GatherOptions) -> ExecResult {
+    let failed: Vec<&ScatterResult> =
+        results.iter().filter(|r| !r.result.ok() || r.timed_out).collect();
+    let code = if failed.is_empty() { 0 } else { 123 };
+    let err = if failed.is_empty() {
+        String::new()
     } else {
-        results
+        format!(
+            "gather: {} of {} worker(s) failed: {}",
+            failed.len(),
+            results.len(),
+            failed.iter().map(|r| r.item.label.as_str()).collect::<Vec<_>>().join(", ")
+        )
     };
 
-    if opts.format == "json" {
-        // Output as JSON array of objects
-        let json_results: Vec<serde_json::Value> = results_to_use
-            .iter()
-            .map(|r| {
-                serde_json::json!({
-                    "item": r.item,
-                    "ok": r.result.ok(),
-                    "code": r.result.code,
-                    "out": r.result.text_out().trim(),
-                    "err": r.result.err.trim(),
-                    "timed_out": r.timed_out,
-                })
-            })
-            .collect();
-
-        GatherOutput {
-            text: serde_json::to_string_pretty(&json_results).unwrap_or_default(),
-            dropped_failures: Vec::new(),
+    if opts.lines {
+        // Bare lines can't carry a failure — refuse with no partial text
+        // rather than silently dropping rows.
+        if !failed.is_empty() {
+            return ExecResult::failure(code, format!("{err} (drop --lines to get per-worker rows)"));
         }
-    } else {
-        // Output as lines (stdout from each successful worker, separated by
-        // newlines). Failed workers can't be represented as a stdout row, so
-        // we collect their items and let `run` fail loud instead of dropping
-        // them silently.
-        let text = results_to_use
+        let text = results
             .iter()
-            .filter(|r| r.result.ok())
-            .map(|r| r.result.text_out())
-            .map(|t| t.trim().to_string())
+            .map(|r| strip_one_trailing_newline(&r.result.text_out()).to_string())
             .collect::<Vec<_>>()
             .join("\n");
-        let dropped_failures = results_to_use
-            .iter()
-            .filter(|r| !r.result.ok())
-            .map(|r| r.item.clone())
-            .collect();
-        GatherOutput {
-            text,
-            dropped_failures,
-        }
+        return ExecResult::success(text);
     }
+
+    let rows: Vec<serde_json::Value> =
+        results.iter().enumerate().map(|(i, r)| result_row(i, r)).collect();
+    let text = if opts.json {
+        // `--json`: the same records as one JSON document.
+        serde_json::to_string_pretty(&rows).unwrap_or_default()
+    } else {
+        // Default: JSONL — one compact record per line.
+        rows.iter().map(|row| row.to_string()).collect::<Vec<_>>().join("\n")
+    };
+    let array = serde_json::Value::Array(rows);
+    ExecResult::from_parts(code, text, err, Some(Value::Json(array)))
 }
 
 /// Parse scatter options from tool args.
@@ -476,12 +567,12 @@ pub fn parse_gather_options(args: &crate::tools::ToolArgs) -> GatherOptions {
         opts.progress = true;
     }
 
-    if let Some(Value::Int(n)) = args.named.get("first") {
-        opts.first = (*n).max(0) as usize;
+    if args.has_flag("lines") {
+        opts.lines = true;
     }
 
-    if let Some(Value::String(fmt)) = args.named.get("format") {
-        opts.format = fmt.clone();
+    if args.has_flag("json") {
+        opts.json = true;
     }
 
     opts
@@ -491,31 +582,68 @@ pub fn parse_gather_options(args: &crate::tools::ToolArgs) -> GatherOptions {
 mod tests {
     use super::*;
 
+    fn labels(items: &[ScatterItem]) -> Vec<String> {
+        items.iter().map(|i| i.label.clone()).collect()
+    }
+
+    fn item(s: &str) -> ScatterItem {
+        ScatterItem::new(serde_json::Value::String(s.to_string()))
+    }
+
     #[test]
     fn test_extract_items_structured_json_array() {
         let data = Value::Json(serde_json::json!(["a", "b", "c"]));
         let items = extract_items(Some(&data), "").unwrap();
-        assert_eq!(items, vec!["a", "b", "c"]);
+        assert_eq!(labels(&items), vec!["a", "b", "c"]);
     }
 
     #[test]
-    fn test_extract_items_structured_mixed_types() {
-        let data = Value::Json(serde_json::json!([1, "two", true]));
+    fn test_extract_items_structured_mixed_types_stay_typed() {
+        // GH #73: number 1 and string "1" must remain distinct through the
+        // fan-out — the old Vec<String> path conflated them silently.
+        let data = Value::Json(serde_json::json!([1, "1", true, {"id": 7}]));
         let items = extract_items(Some(&data), "").unwrap();
-        assert_eq!(items, vec!["1", "two", "true"]);
+        assert_eq!(items[0].json, serde_json::json!(1));
+        assert_eq!(items[1].json, serde_json::json!("1"));
+        assert_ne!(items[0].json, items[1].json, "1 and \"1\" must not conflate");
+        assert_eq!(items[2].json, serde_json::json!(true));
+        assert_eq!(items[3].json, serde_json::json!({"id": 7}));
+    }
+
+    #[test]
+    fn test_extract_items_null_element_is_loud() {
+        let data = Value::Json(serde_json::json!(["a", null, "c"]));
+        let err = extract_items(Some(&data), "").unwrap_err();
+        assert!(err.contains("null"), "should name the problem: {err}");
+        assert!(err.contains("item 1"), "should name the position: {err}");
+    }
+
+    #[test]
+    fn test_extract_items_single_object_is_loud_with_hint() {
+        let data = Value::Json(serde_json::json!({"jobs": [1, 2]}));
+        let err = extract_items(Some(&data), "").unwrap_err();
+        assert!(err.contains("single object"), "{err}");
+        assert!(err.contains("jq '.jobs'"), "should hint the array key: {err}");
+    }
+
+    #[test]
+    fn test_extract_items_binary_is_loud() {
+        let data = Value::Bytes(vec![0, 1, 2]);
+        let err = extract_items(Some(&data), "").unwrap_err();
+        assert!(err.contains("binary"), "{err}");
     }
 
     #[test]
     fn test_extract_items_structured_string() {
         let data = Value::String("single".into());
         let items = extract_items(Some(&data), "").unwrap();
-        assert_eq!(items, vec!["single"]);
+        assert_eq!(labels(&items), vec!["single"]);
     }
 
     #[test]
     fn test_extract_items_single_line_text() {
         let items = extract_items(None, "hello").unwrap();
-        assert_eq!(items, vec!["hello"]);
+        assert_eq!(labels(&items), vec!["hello"]);
     }
 
     #[test]
@@ -526,38 +654,34 @@ mod tests {
 
     #[test]
     fn test_extract_items_multiline_fans_out_per_line() {
-        // Plain-text stdin splits on newlines, matching for-loop $(cmd)
-        // semantics (docs/LANGUAGE.md) — one worker per line.
         let items = extract_items(None, "one\ntwo\nthree").unwrap();
-        assert_eq!(items, vec!["one", "two", "three"]);
+        assert_eq!(labels(&items), vec!["one", "two", "three"]);
     }
 
     #[test]
     fn test_extract_items_trailing_newline_no_phantom_item() {
-        // Trailing newline is trimmed once before splitting — no empty tail item.
         let items = extract_items(None, "one\ntwo\n").unwrap();
-        assert_eq!(items, vec!["one", "two"]);
+        assert_eq!(labels(&items), vec!["one", "two"]);
     }
 
     #[test]
     fn test_extract_items_crlf_per_line() {
-        // Each line's trailing \r is stripped (CRLF input).
         let items = extract_items(None, "one\r\ntwo\r\n").unwrap();
-        assert_eq!(items, vec!["one", "two"]);
+        assert_eq!(labels(&items), vec!["one", "two"]);
     }
 
     #[test]
-    fn test_extract_items_interior_blank_line_preserved() {
-        // Interior empty lines are preserved (matches for-loop split('\n')).
+    fn test_extract_items_blank_lines_skipped() {
+        // GH #73 panel finding: a worker spawned on "" is silent corruption of
+        // the most common input shape — blank lines are skipped, not items.
         let items = extract_items(None, "a\n\nb").unwrap();
-        assert_eq!(items, vec!["a", "", "b"]);
+        assert_eq!(labels(&items), vec!["a", "b"]);
     }
 
     #[test]
     fn test_extract_items_whitespace_within_line_not_split() {
-        // Only newlines split; spaces within a line stay in the item.
         let items = extract_items(None, "a b\nc d").unwrap();
-        assert_eq!(items, vec!["a b", "c d"]);
+        assert_eq!(labels(&items), vec!["a b", "c d"]);
     }
 
     #[test]
@@ -568,118 +692,129 @@ mod tests {
 
     #[test]
     fn test_extract_items_structured_overrides_text() {
-        // Structured data takes priority over text
         let data = Value::Json(serde_json::json!(["x", "y"]));
         let items = extract_items(Some(&data), "ignored\ntext").unwrap();
-        assert_eq!(items, vec!["x", "y"]);
+        assert_eq!(labels(&items), vec!["x", "y"]);
     }
 
     #[test]
-    fn test_gather_results_lines() {
+    fn test_item_label_truncates_on_char_boundary() {
+        // 100 multibyte chars — a byte-slice truncation would panic.
+        let long: String = "é".repeat(100);
+        let it = ScatterItem::new(serde_json::Value::String(long));
+        assert!(it.label.ends_with("..."));
+        assert_eq!(it.label.chars().count(), 67);
+    }
+
+    #[test]
+    fn test_gather_results_jsonl_rows_carry_everything() {
         let results = vec![
             ScatterResult {
-                item: "a".to_string(),
-                result: ExecResult::success("result_a"),
+                item: item("a"),
+                result: ExecResult::success("result_a\n"),
                 timed_out: false,
             },
             ScatterResult {
-                item: "b".to_string(),
-                result: ExecResult::success("result_b"),
+                item: item("b"),
+                result: ExecResult::failure(7, "boom\n"),
                 timed_out: false,
             },
         ];
-
-        let opts = GatherOptions::default();
-        let output = gather_results(&results, &opts);
-        assert_eq!(output.text, "result_a\nresult_b");
-        assert!(output.dropped_failures.is_empty());
+        let out = gather_results(&results, &GatherOptions::default());
+        assert_eq!(out.code, 123, "any failure → 123 (A′)");
+        let rows: Vec<serde_json::Value> = out
+            .text_out()
+            .lines()
+            .map(|l| serde_json::from_str(l).unwrap())
+            .collect();
+        assert_eq!(rows.len(), 2, "every worker gets a row, failures included");
+        assert_eq!(rows[0]["i"], 0);
+        assert_eq!(rows[0]["item"], "a");
+        assert_eq!(rows[0]["ok"], true);
+        assert_eq!(rows[0]["out"], "result_a", "trailing newline stripped");
+        assert_eq!(rows[0]["err"], "", "err always present");
+        assert!(rows[0].get("timed_out").is_none(), "omit-false");
+        assert!(rows[0].get("data").is_none(), "omit-empty");
+        assert_eq!(rows[1]["i"], 1);
+        assert_eq!(rows[1]["ok"], false);
+        assert_eq!(rows[1]["code"], 7);
+        assert_eq!(rows[1]["err"], "boom");
+        // .data carries the typed array for iteration / post-gather.
+        assert!(matches!(out.data, Some(Value::Json(serde_json::Value::Array(_)))));
     }
 
     #[test]
-    fn test_gather_results_lines_reports_dropped_failures() {
-        // A failed worker must not vanish from line output: it is reported in
-        // `dropped_failures` so the caller can fail loud (docs/issues.md).
-        let results = vec![
-            ScatterResult {
-                item: "a".to_string(),
-                result: ExecResult::success("result_a"),
-                timed_out: false,
-            },
-            ScatterResult {
-                item: "b".to_string(),
-                result: ExecResult::failure(1, "boom"),
-                timed_out: false,
-            },
-        ];
-
-        let opts = GatherOptions::default();
-        let output = gather_results(&results, &opts);
-        // Successful rows still render; the failure is reported, not dropped.
-        assert_eq!(output.text, "result_a");
-        assert_eq!(output.dropped_failures, vec!["b".to_string()]);
-    }
-
-    #[test]
-    fn test_gather_results_json_keeps_failures_as_rows() {
-        // JSON carries failures as rows (ok: false), so it drops nothing.
+    fn test_gather_results_all_ok_is_zero() {
         let results = vec![ScatterResult {
-            item: "b".to_string(),
-            result: ExecResult::failure(2, "boom"),
+            item: item("a"),
+            result: ExecResult::success("x"),
             timed_out: false,
         }];
-        let opts = GatherOptions {
-            format: "json".to_string(),
-            ..Default::default()
-        };
-        let output = gather_results(&results, &opts);
-        assert!(output.dropped_failures.is_empty());
-        assert!(output.text.contains("\"ok\": false"));
-        assert!(output.text.contains("\"code\": 2"));
+        let out = gather_results(&results, &GatherOptions::default());
+        assert_eq!(out.code, 0);
+        assert!(out.err.is_empty());
     }
 
     #[test]
-    fn test_gather_results_json() {
+    fn test_gather_results_timeout_row_is_124() {
         let results = vec![ScatterResult {
-            item: "test".to_string(),
-            result: ExecResult::success("output"),
+            item: item("slow"),
+            result: ExecResult::failure(1, "cancelled"),
+            timed_out: true,
+        }];
+        let out = gather_results(&results, &GatherOptions::default());
+        assert_eq!(out.code, 123);
+        let row: serde_json::Value = serde_json::from_str(out.text_out().lines().next().unwrap()).unwrap();
+        assert_eq!(row["code"], 124, "timeout reports the timeout(1) code");
+        assert_eq!(row["ok"], false);
+        assert_eq!(row["timed_out"], true);
+    }
+
+    #[test]
+    fn test_gather_results_typed_record_item_in_row() {
+        let results = vec![ScatterResult {
+            item: ScatterItem::new(serde_json::json!({"id": 3, "host": "web1"})),
+            result: ExecResult::success("ok"),
             timed_out: false,
         }];
-
-        let opts = GatherOptions {
-            format: "json".to_string(),
-            ..Default::default()
-        };
-        let output = gather_results(&results, &opts);
-        assert!(output.text.contains("\"item\": \"test\""));
-        assert!(output.text.contains("\"ok\": true"));
+        let out = gather_results(&results, &GatherOptions::default());
+        let row: serde_json::Value = serde_json::from_str(out.text_out().lines().next().unwrap()).unwrap();
+        assert_eq!(row["item"]["id"], 3, "row item is the TYPED value, not a string");
     }
 
     #[test]
-    fn test_gather_results_first_n() {
-        let results = vec![
-            ScatterResult {
-                item: "a".to_string(),
-                result: ExecResult::success("1"),
-                timed_out: false,
-            },
-            ScatterResult {
-                item: "b".to_string(),
-                result: ExecResult::success("2"),
-                timed_out: false,
-            },
-            ScatterResult {
-                item: "c".to_string(),
-                result: ExecResult::success("3"),
-                timed_out: false,
-            },
-        ];
+    fn test_gather_results_worker_data_rides_the_row() {
+        let mut r = ExecResult::success("text");
+        r.data = Some(Value::Json(serde_json::json!({"k": 1})));
+        let results = vec![ScatterResult { item: item("a"), result: r, timed_out: false }];
+        let out = gather_results(&results, &GatherOptions::default());
+        let row: serde_json::Value = serde_json::from_str(out.text_out().lines().next().unwrap()).unwrap();
+        assert_eq!(row["data"]["k"], 1, "worker .data lands typed in the row");
+        assert_eq!(row["out"], "text", "out stays alongside data");
+    }
 
-        let opts = GatherOptions {
-            first: 2,
-            ..Default::default()
-        };
-        let output = gather_results(&results, &opts);
-        assert_eq!(output.text, "1\n2");
+    #[test]
+    fn test_gather_results_lines_happy_path() {
+        let results = vec![
+            ScatterResult { item: item("a"), result: ExecResult::success("result_a\n"), timed_out: false },
+            ScatterResult { item: item("b"), result: ExecResult::success("result_b"), timed_out: false },
+        ];
+        let out = gather_results(&results, &GatherOptions { lines: true, ..Default::default() });
+        assert_eq!(out.code, 0);
+        assert_eq!(&*out.text_out(), "result_a\nresult_b");
+    }
+
+    #[test]
+    fn test_gather_results_lines_hard_errors_on_any_failure() {
+        // Bare lines can't represent a failure — no partial text, loud 123.
+        let results = vec![
+            ScatterResult { item: item("a"), result: ExecResult::success("good"), timed_out: false },
+            ScatterResult { item: item("b"), result: ExecResult::failure(1, "boom"), timed_out: false },
+        ];
+        let out = gather_results(&results, &GatherOptions { lines: true, ..Default::default() });
+        assert_eq!(out.code, 123);
+        assert!(out.text_out().is_empty(), "no partial text on --lines failure");
+        assert!(out.err.contains("b"), "names the failed item: {}", out.err);
     }
 
     #[test]
@@ -700,12 +835,11 @@ mod tests {
         use crate::tools::ToolArgs;
 
         let mut args = ToolArgs::new();
-        args.named.insert("first".to_string(), Value::Int(5));
-        args.named.insert("format".to_string(), Value::String("json".to_string()));
+        args.flags.insert("lines".to_string());
 
         let opts = parse_gather_options(&args);
-        assert_eq!(opts.first, 5);
-        assert_eq!(opts.format, "json");
+        assert!(opts.lines);
+        assert!(!parse_gather_options(&ToolArgs::new()).lines, "default is JSONL");
     }
 
     #[test]

--- a/crates/kaish-kernel/src/tools/builtin/gather.rs
+++ b/crates/kaish-kernel/src/tools/builtin/gather.rs
@@ -1,22 +1,24 @@
 //! gather — Collect results from parallel scatter processing.
 //!
-//! Gather collects results from parallel scatter workers and outputs
-//! them as lines or JSON.
+//! Gather emits one JSONL result record per worker, in item order, every
+//! worker including failures (GH #73). `--lines` is the raw-text escape hatch
+//! (successful workers' stdout; hard error if any worker failed). The kernel
+//! `--json` flag renders the same records as one JSON array.
 //!
 //! # Usage
 //!
 //! ```text
-//! echo "a\nb\nc" | scatter | process ${ITEM} | gather
-//! gather --json                               # output as JSON array
-//! gather --first 5                            # take first 5 results
-//! gather --progress                           # show progress
+//! seq 1 5 | scatter | process "$ITEM" | gather
+//! ... | gather | jq -r 'select(.ok) | .out'    # successes' outputs
+//! ... | gather --lines                         # raw outputs; loud on failure
+//! ... | gather --json                          # one JSON array (kernel flag)
 //! ```
 
 use async_trait::async_trait;
 use clap::{CommandFactory, Parser};
 
 use crate::interpreter::{ExecResult, OutputData};
-use crate::scheduler::{parse_gather_options, GatherOptions};
+use crate::scheduler::parse_gather_options;
 use crate::tools::{schema_from_clap, ExecContext, ToolCtx, GlobalFlags, Tool, ToolArgs, ToolSchema};
 
 /// Gather tool: collect results from parallel processing.
@@ -30,13 +32,11 @@ pub struct Gather;
 #[derive(Parser, Debug)]
 #[command(name = "gather", about = "Collect results from parallel scatter processing")]
 struct GatherArgs {
-    /// Take first N results only (0 = all).
-    #[arg(id = "first", long = "first")]
-    _first: Option<String>,
-
-    /// Output format: 'lines' or 'json'.
-    #[arg(id = "format", long = "format")]
-    _format: Option<String>,
+    /// Raw text mode: each successful worker's stdout in item order.
+    /// Hard error (exit 123) if ANY worker failed — bare lines can't
+    /// represent a failure. Default is JSONL result records.
+    #[arg(id = "lines", long = "lines")]
+    _lines: bool,
 
     #[command(flatten)]
     global: GlobalFlags,
@@ -58,10 +58,16 @@ impl Tool for Gather {
             "gather",
             "Collect results from parallel scatter processing",
             [
-                ("Collect scatter results", "seq 1 10 | scatter | echo ${ITEM} | gather"),
-                ("Collect first 5 results", "gather --first 5"),
+                ("Collect scatter results (JSONL rows)", "seq 1 10 | scatter | work \"$ITEM\" | gather"),
+                ("Successes' outputs only", "... | gather | jq -r 'select(.ok) | .out'"),
+                ("Raw outputs, loud on any failure", "... | gather --lines"),
+                ("One JSON array of records", "... | gather --json"),
             ],
         )
+        // scatter/gather own their output: the runner renders JSONL/array/lines
+        // itself, and the kernel-wide --json flag must REACH the tool (it
+        // selects the array view) instead of being consumed upstream.
+        .with_owned_output()
     }
 
     async fn execute(&self, args: ToolArgs, ctx: &mut dyn ToolCtx) -> ExecResult {
@@ -76,10 +82,12 @@ impl Tool for Gather {
         };
         parsed.global.apply(ctx);
 
-        // Parse options (still reads from args.named to preserve Value::Int etc.)
-        let opts = parse_gather_options(&args);
+        // Validate flags even standalone (parse_gather_options is the runner's
+        // reader; here it only needs to not reject).
+        let _opts = parse_gather_options(&args);
 
-        // Get input (in standalone mode, just pass through)
+        // Standalone (not in a scatter/gather pipeline): pass stdin through.
+        // The real result-record rendering lives in the ScatterGatherRunner.
         let input = match ctx.read_stdin_to_text().await {
             Ok(s) => s.unwrap_or_default(),
             Err(e) => return ExecResult::failure(2, format!("gather: {e}")),
@@ -89,88 +97,16 @@ impl Tool for Gather {
             return ExecResult::success("");
         }
 
-        // In standalone mode (not in a scatter/gather pipeline),
-        // format the input according to options
-        let output = format_output(&input, &opts);
-
-        ExecResult::with_output(OutputData::text(output))
-    }
-}
-
-/// Format output according to gather options.
-fn format_output(input: &str, opts: &GatherOptions) -> String {
-    let lines: Vec<&str> = input.lines().collect();
-
-    let lines_to_use = if opts.first > 0 && opts.first < lines.len() {
-        &lines[..opts.first]
-    } else {
-        &lines[..]
-    };
-
-    if opts.format == "json" {
-        // Output as JSON array of strings
-        let json_arr: Vec<serde_json::Value> = lines_to_use
-            .iter()
-            .map(|s| serde_json::Value::String(s.to_string()))
-            .collect();
-
-        serde_json::to_string_pretty(&json_arr).unwrap_or_default()
-    } else {
-        // Output as lines
-        lines_to_use.join("\n")
+        ExecResult::with_output(OutputData::text(input))
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ast::Value;
-
-    #[test]
-    fn test_format_output_lines() {
-        let opts = GatherOptions::default();
-        let output = format_output("a\nb\nc", &opts);
-        assert_eq!(output, "a\nb\nc");
-    }
-
-    #[test]
-    fn test_format_output_json() {
-        let opts = GatherOptions {
-            format: "json".to_string(),
-            ..Default::default()
-        };
-        let output = format_output("a\nb", &opts);
-        assert!(output.contains("\"a\""));
-        assert!(output.contains("\"b\""));
-    }
-
-    #[test]
-    fn test_format_output_first_n() {
-        let opts = GatherOptions {
-            first: 2,
-            ..Default::default()
-        };
-        let output = format_output("a\nb\nc\nd", &opts);
-        assert_eq!(output, "a\nb");
-    }
-
-    #[test]
-    fn test_format_output_first_n_json() {
-        let opts = GatherOptions {
-            first: 2,
-            format: "json".to_string(),
-            ..Default::default()
-        };
-        let output = format_output("a\nb\nc", &opts);
-        // Should only have 2 items
-        let arr: Vec<String> = serde_json::from_str(&output).unwrap();
-        assert_eq!(arr.len(), 2);
-        assert_eq!(arr[0], "a");
-        assert_eq!(arr[1], "b");
-    }
 
     #[tokio::test]
-    async fn test_gather_passthrough() {
+    async fn test_gather_standalone_passthrough() {
         use crate::vfs::{MemoryFs, VfsRouter};
         use std::sync::Arc;
 
@@ -185,7 +121,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_gather_format_json() {
+    async fn test_gather_standalone_lines_flag_accepted() {
         use crate::vfs::{MemoryFs, VfsRouter};
         use std::sync::Arc;
 
@@ -195,30 +131,9 @@ mod tests {
         ctx.set_stdin("a\nb".to_string());
 
         let mut args = ToolArgs::new();
-        args.named.insert("format".to_string(), Value::String("json".to_string()));
-
+        args.flags.insert("lines".to_string());
         let result = Gather.execute(args, &mut ctx).await;
-        assert!(result.ok());
-        assert!(result.text_out().contains("["));
-        assert!(result.text_out().contains("\"a\""));
-    }
-
-    #[tokio::test]
-    async fn test_gather_first_option() {
-        use crate::vfs::{MemoryFs, VfsRouter};
-        use std::sync::Arc;
-
-        let mut vfs = VfsRouter::new();
-        vfs.mount("/", MemoryFs::new());
-        let mut ctx = ExecContext::new(Arc::new(vfs));
-        ctx.set_stdin("1\n2\n3\n4\n5".to_string());
-
-        let mut args = ToolArgs::new();
-        args.named.insert("first".to_string(), Value::Int(3));
-
-        let result = Gather.execute(args, &mut ctx).await;
-        assert!(result.ok());
-        assert_eq!(&*result.text_out(), "1\n2\n3");
+        assert!(result.ok(), "--lines must parse standalone: {}", result.err);
     }
 
     #[tokio::test]

--- a/crates/kaish-kernel/src/tools/builtin/scatter.rs
+++ b/crates/kaish-kernel/src/tools/builtin/scatter.rs
@@ -60,11 +60,16 @@ impl Tool for Scatter {
             "scatter",
             "Fan out input items for parallel processing",
             [
-                ("Parallel processing", "seq 1 10 | scatter | echo ${ITEM} | gather"),
-                ("Custom variable name", "split \"a,b,c\" \",\" | scatter --as X | echo ${X} | gather"),
-                ("Per-worker timeout", "seq 1 5 | scatter --timeout 2s | sleep 60 | gather"),
+                ("Parallel processing", "seq 1 10 | scatter | work \"$ITEM\" | gather"),
+                ("Typed record items", "jq '.jobs' jobs.json | scatter --limit 4 | deploy --id \"${ITEM[id]}\" | gather"),
+                ("Custom variable name", "split \"a,b,c\" \",\" | scatter --as X | work \"$X\" | gather"),
+                ("Per-worker timeout", "seq 1 5 | scatter --timeout 30s | slowtask \"$ITEM\" | gather"),
             ],
         )
+        // scatter/gather own their output: the runner renders JSONL/array/lines
+        // itself, and the kernel-wide --json flag must REACH the tool (it
+        // selects the array view) instead of being consumed upstream.
+        .with_owned_output()
     }
 
     async fn execute(&self, args: ToolArgs, ctx: &mut dyn ToolCtx) -> ExecResult {
@@ -105,7 +110,7 @@ impl Tool for Scatter {
             items.len(),
             opts.var_name,
             opts.limit,
-            items.join("\n")
+            items.iter().map(|i| i.label.as_str()).collect::<Vec<_>>().join("\n")
         );
 
         ExecResult::with_output(OutputData::text(output))

--- a/crates/kaish-kernel/tests/cancellation_tests.rs
+++ b/crates/kaish-kernel/tests/cancellation_tests.rs
@@ -584,16 +584,24 @@ async fn scatter_timeout_kills_stuck_workers() {
     let kernel = kernel_for_test();
     let result = kernel
         .execute(
-            r#"echo "1\n2\n3" | split "\n" | scatter --limit 3 --timeout 300ms | bash -c "sleep 60" | gather --format json"#,
+            r#"echo "1\n2\n3" | split "\n" | scatter --limit 3 --timeout 300ms | bash -c "sleep 60" | gather"#,
         )
         .await
         .expect("execute");
 
+    // GH #73: timeouts are failure rows (code 124, timed_out:true) and gather
+    // exits 123.
+    assert_eq!(result.code, 123, "timeouts count as failures: {:?}", result.err);
     let output = result.text_out();
     let trimmed = output.trim();
     assert!(
-        trimmed.contains("\"timed_out\": true"),
-        "scatter --timeout did not surface timed_out in JSON: {}",
+        trimmed.contains("\"timed_out\":true"),
+        "scatter --timeout did not surface timed_out rows: {}",
+        trimmed,
+    );
+    assert!(
+        trimmed.contains("\"code\":124"),
+        "timed-out rows report 124: {}",
         trimmed,
     );
 }

--- a/crates/kaish-kernel/tests/json_sweep_tests.rs
+++ b/crates/kaish-kernel/tests/json_sweep_tests.rs
@@ -111,8 +111,8 @@ const CASES: &[Case] = &[
     Case { name: "fromjson", setup: &[], cmd: r#"fromjson '{"a":1}' --json"#, expect: Expect::Object },
     // scatter/gather own their output (`owns_output`): `--json` passes
     // through untouched and `--format json` is the structured form.
-    Case { name: "gather", setup: &[], cmd: "seq 1 2 | scatter --as N | echo $N | gather --format json", expect: Expect::Array },
-    Case { name: "scatter", setup: &[], cmd: "seq 1 2 | scatter --as N | echo $N | gather --format json", expect: Expect::Array },
+    Case { name: "gather", setup: &[], cmd: "seq 1 2 | scatter --as N | echo $N | gather --json", expect: Expect::Array },
+    Case { name: "scatter", setup: &[], cmd: "seq 1 2 | scatter --as N | echo $N | gather --json", expect: Expect::Array },
     Case { name: "git", setup: &["git init ."], cmd: "git status --json", expect: Expect::String },
     Case { name: "glob", setup: &[], cmd: "glob 'tmp/*.json' --json", expect: Expect::Array },
     Case { name: "grep", setup: &[], cmd: "grep INFO tmp/app.log --json", expect: Expect::Array },

--- a/crates/kaish-kernel/tests/scatter_gather_jsonl_tests.rs
+++ b/crates/kaish-kernel/tests/scatter_gather_jsonl_tests.rs
@@ -1,0 +1,265 @@
+//! Kernel-routed tests for the scatter/gather typed-JSONL contract (GH #73).
+//!
+//! Ratified 2026-07-03 after a cross-model panel (docs/designing-syntax-with-llms
+//! method; raw data linked from the issue): typed `ITEM` bindings, JSONL result
+//! records (one per worker, item order, failures included), A′ exit codes
+//! (0 / 123 any-failure / 2 usage), `--lines` as the loud raw-text escape
+//! hatch, `--json` as the one-array view. Driven through `kernel.execute()` so
+//! the real pipeline split, forked workers, and flag binding all run.
+
+// Test-fixture code: unwrap/expect on known-good setup is the idiom here.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+#![cfg(feature = "localfs")]
+
+mod common;
+
+use tempfile::tempdir;
+
+use common::kernel_at;
+use kaish_kernel::Kernel;
+
+/// Run a script, returning the full ExecResult (rows live in text, code
+/// matters, err carries the failure summary).
+async fn run_full(k: &Kernel, script: &str) -> kaish_kernel::interpreter::ExecResult {
+    k.execute(script).await.expect("kernel execute")
+}
+
+fn rows(text: &str) -> Vec<serde_json::Value> {
+    text.lines()
+        .filter(|l| !l.trim().is_empty())
+        .map(|l| serde_json::from_str(l).expect("each line is one JSON record"))
+        .collect()
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// JSONL rows: schema, order, failures included
+// ═══════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn rows_carry_schema_in_item_order() {
+    let k = kernel_at(tempdir().unwrap().path());
+    let r = run_full(&k, "seq 1 3 | scatter --as N | echo $N | gather").await;
+    assert_eq!(r.code, 0, "all ok → 0: {:?}", r.err);
+    let rows = rows(&r.text_out());
+    assert_eq!(rows.len(), 3);
+    for (i, row) in rows.iter().enumerate() {
+        assert_eq!(row["i"], i, "item order");
+        assert_eq!(row["ok"], true);
+        assert_eq!(row["code"], 0);
+        assert!(row.get("err").is_some(), "err always present");
+        assert!(row.get("timed_out").is_none(), "omit-false");
+    }
+    assert_eq!(rows[0]["out"], "1");
+    assert_eq!(rows[2]["out"], "3");
+}
+
+#[tokio::test]
+async fn failed_worker_is_a_row_not_a_drop() {
+    let k = kernel_at(tempdir().unwrap().path());
+    // Worker segment is a pipeline: grep matches only item 2, so workers 1
+    // and 3 exit 1 (selective failure without any control flow).
+    let r = run_full(
+        &k,
+        r#"seq 1 3 | scatter --as N | echo $N | grep 2 | gather"#,
+    )
+    .await;
+    assert_eq!(r.code, 123, "any failure → 123: {:?}", r.err);
+    let rows = rows(&r.text_out());
+    assert_eq!(rows.len(), 3, "every worker gets a row, failures included");
+    assert_eq!(rows[0]["ok"], false);
+    assert_eq!(rows[1]["ok"], true, "item 2 matched: {rows:?}");
+    assert_eq!(rows[2]["ok"], false);
+    assert!(r.err.contains("2 of 3"), "err summarizes: {}", r.err);
+}
+
+#[tokio::test]
+async fn typed_record_items_subscript_and_ride_rows_typed() {
+    let k = kernel_at(tempdir().unwrap().path());
+    let r = run_full(
+        &k,
+        r#"jobs=$(fromjson '[{"id":1,"host":"web1"},{"id":2,"host":"db1"}]')
+values $jobs | scatter | echo "${ITEM[host]}" | gather"#,
+    )
+    .await;
+    assert_eq!(r.code, 0, "{:?}", r.err);
+    let rows = rows(&r.text_out());
+    assert_eq!(rows[0]["out"], "web1", "${{ITEM[host]}} subscripted the record");
+    assert_eq!(rows[1]["item"]["id"], 2, "row item is the TYPED record");
+}
+
+#[tokio::test]
+async fn number_and_string_items_stay_distinct() {
+    // The conflation the redesign exists to kill: 1 and "1" fan out as
+    // different types, observable via typeof in the worker AND the row item.
+    let k = kernel_at(tempdir().unwrap().path());
+    let r = run_full(
+        &k,
+        r#"mixed=$(fromjson '[1, "1"]')
+values $mixed | scatter | typeof $ITEM | gather"#,
+    )
+    .await;
+    assert_eq!(r.code, 0, "{:?}", r.err);
+    let rows = rows(&r.text_out());
+    assert_eq!(rows[0]["out"], "number", "number 1 arrives as a number");
+    assert_eq!(rows[1]["out"], "string", "string \"1\" arrives as a string");
+    assert!(rows[0]["item"].is_number());
+    assert!(rows[1]["item"].is_string());
+}
+
+#[tokio::test]
+async fn worker_structured_data_rides_the_row() {
+    let k = kernel_at(tempdir().unwrap().path());
+    let r = run_full(
+        &k,
+        r#"seq 1 1 | scatter | fromjson '{"k": 7}' | gather"#,
+    )
+    .await;
+    assert_eq!(r.code, 0, "{:?}", r.err);
+    let rows = rows(&r.text_out());
+    assert_eq!(rows[0]["data"]["k"], 7, "worker .data lands typed: {rows:?}");
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// The three views: JSONL text, --json array, typed .data iteration
+// ═══════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn json_flag_renders_one_array() {
+    let k = kernel_at(tempdir().unwrap().path());
+    let r = run_full(&k, "seq 1 2 | scatter | echo $ITEM | gather --json").await;
+    assert_eq!(r.code, 0, "{:?}", r.err);
+    let doc: serde_json::Value =
+        serde_json::from_str(&r.text_out()).expect("one JSON document");
+    let arr = doc.as_array().expect("array");
+    assert_eq!(arr.len(), 2);
+    assert_eq!(arr[0]["out"], "1");
+}
+
+#[tokio::test]
+async fn for_loop_iterates_typed_records() {
+    let k = kernel_at(tempdir().unwrap().path());
+    let r = run_full(
+        &k,
+        r#"for r in $(seq 1 3 | scatter | echo $ITEM | gather); do
+  if [[ ${r[ok]} == true ]]; then echo "row-${r[i]}:${r[out]}"; fi
+done"#,
+    )
+    .await;
+    assert_eq!(r.code, 0, "{:?}", r.err);
+    assert_eq!(r.text_out().trim(), "row-0:1\nrow-1:2\nrow-2:3");
+}
+
+#[tokio::test]
+async fn jq_streams_rows_with_dot_brackets() {
+    // kaish jq receives the records as ONE ARRAY — `.[]` streams them (the
+    // blessed idiom in help scatter; differs from real-jq-over-JSONL).
+    let k = kernel_at(tempdir().unwrap().path());
+    let r = run_full(
+        &k,
+        r#"seq 1 3 | scatter | echo $ITEM | gather | jq -r '.[] | select(.ok) | .out'"#,
+    )
+    .await;
+    assert_eq!(r.code, 0, "{:?}", r.err);
+    assert_eq!(r.text_out().trim(), "1\n2\n3");
+}
+
+#[tokio::test]
+async fn post_gather_stage_sees_typed_rows() {
+    // A post-gather pipeline stage gets the rows as structured stdin.
+    let k = kernel_at(tempdir().unwrap().path());
+    let r = run_full(
+        &k,
+        r#"seq 1 2 | scatter | echo $ITEM | gather | jq '[.[] | .i] | length'"#,
+    )
+    .await;
+    assert_eq!(r.code, 0, "{:?}", r.err);
+    assert_eq!(r.text_out().trim(), "2");
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// --lines: the loud raw-text escape hatch
+// ═══════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn lines_mode_emits_raw_outputs_in_item_order() {
+    let k = kernel_at(tempdir().unwrap().path());
+    let r = run_full(&k, "seq 1 3 | scatter | echo $ITEM | gather --lines").await;
+    assert_eq!(r.code, 0, "{:?}", r.err);
+    assert_eq!(r.text_out().trim(), "1\n2\n3", "bare outputs, no JSON");
+}
+
+#[tokio::test]
+async fn lines_mode_hard_errors_on_any_failure() {
+    let k = kernel_at(tempdir().unwrap().path());
+    let r = run_full(
+        &k,
+        r#"seq 1 2 | scatter --as N | echo $N | grep 2 | gather --lines"#,
+    )
+    .await;
+    assert_eq!(r.code, 123);
+    assert!(r.text_out().is_empty(), "no partial text: {:?}", r.text_out());
+    assert!(r.err.contains("--lines"), "hints the fix: {}", r.err);
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// Ingress guards
+// ═══════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn single_object_input_is_loud_with_hint() {
+    let k = kernel_at(tempdir().unwrap().path());
+    let r = run_full(
+        &k,
+        r#"fromjson '{"jobs":[1,2]}' | scatter | echo $ITEM | gather"#,
+    )
+    .await;
+    assert_ne!(r.code, 0);
+    assert!(r.err.contains("jq '.jobs'"), "hints the array key: {}", r.err);
+}
+
+#[tokio::test]
+async fn null_item_is_loud() {
+    let k = kernel_at(tempdir().unwrap().path());
+    let r = run_full(
+        &k,
+        r#"fromjson '[1, null, 3]' | scatter | echo $ITEM | gather"#,
+    )
+    .await;
+    assert_ne!(r.code, 0);
+    assert!(r.err.contains("null"), "{}", r.err);
+}
+
+#[tokio::test]
+async fn blank_text_lines_are_skipped() {
+    let k = kernel_at(tempdir().unwrap().path());
+    let r = run_full(&k, r#"printf 'a\n\nb\n' | scatter | echo $ITEM | gather"#).await;
+    assert_eq!(r.code, 0, "{:?}", r.err);
+    assert_eq!(rows(&r.text_out()).len(), 2, "no worker for the blank line");
+}
+
+#[tokio::test]
+async fn empty_input_is_vacuous_success() {
+    let k = kernel_at(tempdir().unwrap().path());
+    let r = run_full(&k, r#"printf '' | scatter | echo $ITEM | gather"#).await;
+    assert_eq!(r.code, 0, "{:?}", r.err);
+    assert!(r.text_out().is_empty(), "no rows");
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// Timeout rows
+// ═══════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn timed_out_worker_reports_124_and_gather_123() {
+    let k = kernel_at(tempdir().unwrap().path());
+    let r = run_full(
+        &k,
+        "seq 1 1 | scatter --timeout 200ms | sleep 5 | gather",
+    )
+    .await;
+    assert_eq!(r.code, 123, "timeout counts as failure: {:?}", r.err);
+    let rows = rows(&r.text_out());
+    assert_eq!(rows[0]["code"], 124, "timeout(1) prior");
+    assert_eq!(rows[0]["ok"], false);
+    assert_eq!(rows[0]["timed_out"], true);
+}

--- a/crates/kaish-kernel/tests/scatter_single_json_tests.rs
+++ b/crates/kaish-kernel/tests/scatter_single_json_tests.rs
@@ -22,21 +22,24 @@ fn kernel() -> Kernel {
 // Single JSON object must produce exactly 1 item (the core regression case)
 // ---------------------------------------------------------------------------
 
-/// `echo '{"k":1}' | jq . | scatter` — jq emits a single JSON object as
-/// structured data; scatter must treat it as ONE item, not split the
-/// pretty-printed lines.
+/// `echo '{"k":1}' | jq . | scatter` — a single JSON object is almost always
+/// the unselected envelope around the array the caller meant, so it's a LOUD
+/// error with a select-the-array hint (GH #73; supersedes the earlier
+/// one-item behavior). The original regression this file guards — a
+/// pretty-printed object newline-splitting into N bogus items — stays
+/// impossible: the error fires before any text splitting.
 #[tokio::test]
-async fn single_json_object_is_one_item() {
+async fn single_json_object_is_a_loud_error_with_hint() {
     let kernel = kernel();
     let r = kernel
         .execute(r#"echo '{"k":1}' | jq . | scatter"#)
         .await
         .expect("execute");
-    assert_eq!(r.code, 0, "should succeed; err={:?}", r.err);
+    assert_ne!(r.code, 0, "object input must be loud: {:?}", r.text_out());
     assert!(
-        r.text_out().contains("1 items"),
-        "expected 1 item for a single JSON object, got: {:?}",
-        r.text_out()
+        r.err.contains("single object"),
+        "should name the problem, got: {:?}",
+        r.err
     );
 }
 

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -960,40 +960,62 @@ Embedders that want isolated execution simply leave `initial_vars` empty — see
 | `scriptname` (via PATH) | isolated | ✗ no |
 | `cargo build` (external) | isolated | ✗ no |
 
-## 散・集 (San/Shū) — Scatter/Gather *(experimental)*
+## 散・集 (San/Shū) — Scatter/Gather
 
-Fan-out parallelism:
+The kaish-native **typed parallel map** (GH #73; panel-validated 2026-07-03).
+A future `xargs` builtin will own the POSIX bare-lines flavor; scatter/gather
+is unapologetically structured.
 
 ```sh
-# 散 (scatter) - fan out to parallel workers
-# 集 (gather) - collect results back
-cat items.txt | scatter --as ITEM --limit 8 | process $ITEM | gather > results.json
+# 散 (scatter) fans structured input out to workers; 集 (gather) collects
+# one JSONL result record per worker, in item order, FAILURES INCLUDED:
+cat hosts.txt | scatter --as H --limit 8 | ping -c1 "$H" | gather
+#   {"i":0,"item":"web1","ok":true,"code":0,"out":"…","err":""}
+#   {"i":1,"item":"db1","ok":false,"code":1,"out":"","err":"…"}
 
-# With progress
-cat big_list.txt \
-    | scatter --as ID --limit 4 \
-    | slow-operation --id $ID \
-    | gather --progress true
+# ITEM is TYPED — a JSON-array element keeps its real type:
+jq '.jobs' jobs.json | scatter --limit 4 \
+    | deploy --id "${ITEM[id]}" --host "${ITEM[host]}" | gather
+
+# Consume: kaish jq receives the records as ONE ARRAY — stream with .[] :
+… | gather | jq -r '.[] | select(.ok) | .out'
+# or iterate typed records:
+for r in $(… | gather); do
+  if [[ ${r[ok]} == false ]]; then retry "${r[item]}"; fi
+done
+
+… | gather --json     # one JSON array instead of JSONL
+… | gather --lines    # raw successful outputs; HARD ERROR if any worker failed
 ```
 
-Scatter's input fans out one worker per item: structured `.data` (a JSON array
-from `split`/`seq`/`glob`/`find`) spreads element-by-element, and **plain-text
-stdin splits on newlines** — one worker per line, exactly like `for line in
-$(cmd)` (whitespace within a line is never split; trailing newlines and `\r` are
-trimmed). So `cat items.txt | scatter --as ITEM ...` runs one worker per line.
+- **Row schema**: `i`, `item` (typed), `ok`, `code`, `out` (stdout, trailing
+  newline stripped), `err` (stderr, always present) on every row; `data` (the
+  worker's structured output) and `timed_out:true` when present. Timeout →
+  `code` 124.
+- **Exit codes**: `0` all workers ok · `123` any worker failed (partial or
+  total — the rows carry which) · `2` usage.
+- **Ingress**: a JSON array fans out typed, element-by-element (`1` and `"1"`
+  stay distinct); plain text is one string item per line (blank lines skipped,
+  whitespace within a line never split). A single non-array object errors
+  loudly with a select-the-array hint; `null` items and binary input error
+  loudly. Empty input exits 0 with no rows.
+- Quote `"$ITEM"` at command boundaries — a bare record at an external
+  command's argv is the usual loud boundary error.
 
 Each **scatter worker** runs in its own **parallel kernel fork**. This means
 workers can run the full resolution chain: user-defined functions, `.kai`
 scripts, and command substitutions in their arguments. Each worker gets its
 own snapshotted scope/cwd/aliases, ensuring they don't race against each
-other or the parent.
+other or the parent. A worker's `code` is its pipeline segment's last
+command's exit code; all workers run to completion (gather never
+short-circuits the rest on a failure).
 
 ## Cancellation and Timeouts
 
 Kaish has a single, uniform cancellation discipline that reaches every spawned external child:
 
 - **`timeout DURATION COMMAND`** (builtin) — runs `COMMAND` with a deadline. On elapsed, the child's process group receives **SIGTERM**, then after `kill_grace` (default 2s) **SIGKILL**, then `timeout` returns exit code **124** (coreutils convention).
-- **`scatter ... --timeout DUR ...`** — per-worker timeout. Hung workers are cancelled and their externals killed; the result is tagged `"timed_out": true` in `gather --format json`.
+- **`scatter ... --timeout DUR ...`** — per-worker timeout. Hung workers are cancelled and their externals killed; the result row is tagged `"timed_out": true` with `code` 124.
 - **`Kernel::cancel()`** (embedder API) — fires the kernel's cancellation token; running externals get SIGTERM/SIGKILL via the same path. The REPL wires this to Ctrl-C.
 - **`KernelConfig::request_timeout`** (embedder default) and **`ExecuteOptions::timeout`** (per-call) — apply at the kernel-call boundary; same kill behaviour, return code 124.
 - **`ExecuteOptions::cancel_token`** (per-call) — embedders can pass an externally-owned `tokio_util::sync::CancellationToken` that's *raced* against the kernel's internal token. The kernel does not retain it past the call.

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -14,6 +14,36 @@ before it ships.
 
 ---
 
+## scatter/gather goes typed-JSONL (2026-07-03)
+
+GH #73's silent conflation (`1`/`"1"` byte-identical inside workers) turned into
+a full redesign once Amy asked "could we lean more into JSON data?" — and the
+answer reshaped both ends. Ingress: items stay typed through the fan-out
+(`${ITEM[id]}` subscripts a record; the binding uses the for-loop's exact
+json→Value conversion). Egress: gather emits one JSONL result record per
+worker, item order, failures included — which deletes the old line mode's
+can't-represent-a-failure short-circuit hack. Same records three ways: JSONL
+text, `--json` array, typed `.data` for `for r in $(… | gather)`. `--format`
+and `--first` died (`--first` was just `head` on JSONL — both hostile reviews
+independently said delete it); `--lines` is the raw escape hatch that keeps the
+old safety property (hard error on any failure, no partial text).
+
+The panel (5 models battery + 2 hostile reviews, raw data gisted on the issue)
+earned its keep twice. First: capability tiers split cleanly on exit-code
+priors — cheap models guessed 0, frontier guessed 123 — and fable caught that
+proposal A *fought the prior it borrowed* (real xargs 123 covers all-failed
+too), which became A′: 0 / 123-any-failure / 2. Second: every model one-shot
+`${ITEM[id]}` correctly, validating typed ingress before a line of code.
+
+One divergence surfaced only at implementation: kaish jq is array-as-document
+(`seq 1 3 | jq add` depends on it), so the gather idiom is
+`jq -r '.[] | select(.ok) | .out'` — NOT the real-jq streaming form all five
+panel models wrote. Docs teach `.[]` prominently; if agents thrash on it in
+practice, a jq streaming affordance is the revisit point. The old
+"single JSON object = one item" pin (P2 sweep) reversed deliberately: an
+object is now a loud error with a select-the-array hint, and the
+pretty-print-splitting regression it guarded stays impossible.
+
 ## `help regex` — waking the ERE weights (2026-07-03)
 
 PR #65's last follow-up: the BRE-superset story lived in four places (grep


### PR DESCRIPTION
Closes #73. **BREAKING** (pre-1.0), designed and ratified on the issue, panel-validated before implementation per `docs/designing-syntax-with-llms.md` (5-model task battery + 2 hostile frontier reviews; [raw data, secret gist](https://gist.github.com/tobert/ae4caa0075dab159934067735d7127e5)).

## What

scatter/gather becomes the kaish-native **typed parallel map**; a future `xargs` (#78) owns the POSIX bare-lines flavor.

**Ingress — typed `ITEM`.** Items stay JSON values through the fan-out; workers bind via `json_to_value_no_envelope` — the for-loop's exact conversion — so `${ITEM[id]}` subscripts records, numbers stay numbers, and the `1`/`"1"` conflation (the original #73 bug) is dead. Guards: a single non-array object is a loud error with a select-the-array hint (`did you mean jq '.jobs'?`), `null` items and binary input are loud, blank text lines are skipped, empty input exits 0.

**Egress — JSONL result records.** One compact record per worker, item order, **every worker including failures** — which deletes the old line mode's can't-represent-a-failure short-circuit hack:

```jsonl
{"i":0,"item":{"id":1,"host":"web1"},"ok":true,"code":0,"out":"restarted","err":""}
{"i":1,"item":{"id":2,"host":"db1"},"ok":false,"code":7,"out":"","err":"connection refused"}
```

`i`/`item`(typed)/`ok`/`code`/`out`(raw, trailing newline stripped)/`err`(always present — omit-empty on the most-read field would make `${r[err]}` a loud missing-key on success rows) on every row; `data` (worker's structured output, typed) and `timed_out:true` when present; timeout rows report `code` 124.

**One source, three views:** JSONL text (default) · `gather --json` one array (both tools now declare `owns_output`, so the kernel-wide flag reaches the tool — `--format` deleted) · typed `.data` (so `for r in $(… | gather)` iterates records and post-gather stages get typed stdin).

**Exit codes A′:** `0` all ok · `123` any worker failed, partial or total (rows carry which) · `2` usage. The panel split by tier here — cheap models guessed 0, frontier guessed 123 — and fable caught that the original proposal A *fought the prior it borrowed* (real xargs 123 covers all-failed too), which produced A′.

**Removed:** `--format` (folded into `--json`), `--first` (both hostile reviews independently: it's `head` on JSONL unless it cancels workers; the race-to-N-successes idea is a filed follow-up). **Added:** `--lines` — raw successful outputs in item order, hard error with no partial text if any worker failed (the old safety property as an explicit flag).

## The one post-panel discovery

kaish `jq` is **array-as-document** (`seq 1 3 | jq add` depends on it), so the gather idiom is `jq -r '.[] | select(.ok) | .out'` — *not* the real-jq streaming form all five panel models wrote one-shot. The docs teach `.[]` prominently in `help scatter`; if agents thrash on it in practice, a jq streaming affordance is the revisit point (noted in devlog).

## Testing

New `scatter_gather_jsonl_tests.rs` (16 kernel-routed tests): row schema/order, failure rows + 123, typed record subscripting, conflation kill, worker `data`, `--json` array, typed for-iteration, jq `.[]` streaming, post-gather typed stdin, `--lines` happy/hard-error, object/null/blank/empty ingress guards, timeout rows (124 + gather 123). Updated pins: `scatter_single_json_tests` (object→loud, deliberate reversal of the P2-sweep pin), `cancellation_tests` (timeout row shape), `json_sweep_tests` (`--json` instead of `--format json`). Every doc example verified against the binary. `cargo test --all` + `clippy --all-targets` clean; subprocess-gated suites 16/16 + 36/36.

🤖 Generated with [Claude Code](https://claude.com/claude-code)