### PR TITLE
fix(vfs): mount /dev unconditionally in Kernel::with_backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -176,6 +176,15 @@ breaking entries are marked **BREAKING**.
   demotion of `\|` to plain `|`).
 
 ### Fixed
+- **`Kernel::with_backend` now mounts `/dev` (DevFs) unconditionally** —
+  custom-backend embedders (e.g. kaijutsu) previously had no `/dev/null`,
+  `/dev/zero`, `/dev/random`, or `/dev/urandom` at all, and `VirtualOverlayBackend`
+  hardcoded routing to the `/v/*` namespace only, so even an embedder that
+  mounted its own `/dev` would have the mount silently ignored. The overlay now
+  also routes any path covered by a real VFS mount (not just `/v/*`), and
+  `with_backend` mounts `/dev` by default — a read-only embedder backend (like
+  kaijutsu's read-only host root) no longer turns `cmd > /dev/null` into a
+  filesystem error.
 - **`${#path}` on an undefined subscripted root is now loud** — `${#nope[items]}`
   silently returned `0` (the bash-parity `${#unset}` → 0 rule leaked into
   subscripted paths), so a typo'd name in a length-guarded loop spun zero times

--- a/crates/kaish-kernel/src/backend/overlay.rs
+++ b/crates/kaish-kernel/src/backend/overlay.rs
@@ -15,8 +15,12 @@
 //!
 //! # Path Routing
 //!
-//! - `/v/*` → Internal VFS (JobFs, MemoryFs for blobs, etc.)
-//! - Everything else → Custom backend
+//! - `/v/*` → always routed to the internal VFS, whether or not anything is
+//!   mounted there (the whole `/v` namespace is reserved, so a miss returns
+//!   `NotFound` from the VFS rather than leaking through to the embedder).
+//! - Any other path actually covered by a mount registered on the internal
+//!   VFS (e.g. `/dev`, added by `Kernel::with_backend`) → also routed there.
+//! - Everything else → custom backend
 
 use async_trait::async_trait;
 use std::path::{Path, PathBuf};
@@ -57,10 +61,17 @@ impl VirtualOverlayBackend {
         Self { inner, vfs }
     }
 
-    /// Check if a path should be handled by the VFS (virtual paths).
-    fn is_virtual_path(path: &Path) -> bool {
+    /// Check if a path should be handled by the VFS rather than the inner backend.
+    ///
+    /// `/v` and `/v/*` are always reserved for the VFS, even where nothing is
+    /// mounted (so callers get `NotFound` from the VFS, not the embedder's
+    /// backend). Any other path is checked against the VFS's actual mount
+    /// table — this is what lets `Kernel::with_backend`'s `/dev` mount (or an
+    /// embedder's own `configure_vfs` mounts outside `/v`) take effect instead
+    /// of being silently swallowed by the inner backend.
+    fn is_virtual_path(&self, path: &Path) -> bool {
         let path_str = path.to_string_lossy();
-        path_str == "/v" || path_str.starts_with("/v/")
+        path_str == "/v" || path_str.starts_with("/v/") || self.vfs.has_mount(path)
     }
 
     /// Get the inner backend.
@@ -90,7 +101,7 @@ impl KernelBackend for VirtualOverlayBackend {
     // ═══════════════════════════════════════════════════════════════════════════
 
     async fn read(&self, path: &Path, range: Option<ReadRange>) -> BackendResult<Vec<u8>> {
-        if Self::is_virtual_path(path) {
+        if self.is_virtual_path(path) {
             Ok(self.vfs.read_range(path, range).await?)
         } else {
             self.inner.read(path, range).await
@@ -98,7 +109,7 @@ impl KernelBackend for VirtualOverlayBackend {
     }
 
     async fn write(&self, path: &Path, content: &[u8], mode: WriteMode) -> BackendResult<()> {
-        if Self::is_virtual_path(path) {
+        if self.is_virtual_path(path) {
             match mode {
                 WriteMode::CreateNew => {
                     if self.vfs.exists(path).await {
@@ -127,7 +138,7 @@ impl KernelBackend for VirtualOverlayBackend {
     }
 
     async fn set_mtime(&self, path: &Path, mtime: std::time::SystemTime) -> BackendResult<()> {
-        if Self::is_virtual_path(path) {
+        if self.is_virtual_path(path) {
             self.vfs.set_mtime(path, mtime).await?;
             Ok(())
         } else {
@@ -136,7 +147,7 @@ impl KernelBackend for VirtualOverlayBackend {
     }
 
     async fn append(&self, path: &Path, content: &[u8]) -> BackendResult<()> {
-        if Self::is_virtual_path(path) {
+        if self.is_virtual_path(path) {
             let mut existing = match self.vfs.read(path).await {
                 Ok(data) => data,
                 Err(e) if e.kind() == std::io::ErrorKind::NotFound => Vec::new(),
@@ -151,7 +162,7 @@ impl KernelBackend for VirtualOverlayBackend {
     }
 
     async fn patch(&self, path: &Path, ops: &[PatchOp]) -> BackendResult<()> {
-        if Self::is_virtual_path(path) {
+        if self.is_virtual_path(path) {
             // Read existing content
             let data = self.vfs.read(path).await?;
             let mut content = String::from_utf8(data)
@@ -175,7 +186,7 @@ impl KernelBackend for VirtualOverlayBackend {
     // ═══════════════════════════════════════════════════════════════════════════
 
     async fn list(&self, path: &Path) -> BackendResult<Vec<DirEntry>> {
-        if Self::is_virtual_path(path) {
+        if self.is_virtual_path(path) {
             Ok(self.vfs.list(path).await?)
         } else if path.to_string_lossy() == "/" || path.to_string_lossy().is_empty() {
             // Root listing: combine inner backend's root with /v
@@ -191,7 +202,7 @@ impl KernelBackend for VirtualOverlayBackend {
     }
 
     async fn stat(&self, path: &Path) -> BackendResult<DirEntry> {
-        if Self::is_virtual_path(path) {
+        if self.is_virtual_path(path) {
             Ok(self.vfs.stat(path).await?)
         } else {
             self.inner.stat(path).await
@@ -199,7 +210,7 @@ impl KernelBackend for VirtualOverlayBackend {
     }
 
     async fn mkdir(&self, path: &Path) -> BackendResult<()> {
-        if Self::is_virtual_path(path) {
+        if self.is_virtual_path(path) {
             self.vfs.mkdir(path).await?;
             Ok(())
         } else {
@@ -208,7 +219,7 @@ impl KernelBackend for VirtualOverlayBackend {
     }
 
     async fn remove(&self, path: &Path, recursive: bool) -> BackendResult<()> {
-        if Self::is_virtual_path(path) {
+        if self.is_virtual_path(path) {
             if recursive
                 && let Ok(entry) = self.vfs.lstat(path).await
                 && entry.is_dir()
@@ -227,8 +238,8 @@ impl KernelBackend for VirtualOverlayBackend {
     }
 
     async fn rename(&self, from: &Path, to: &Path) -> BackendResult<()> {
-        let from_virtual = Self::is_virtual_path(from);
-        let to_virtual = Self::is_virtual_path(to);
+        let from_virtual = self.is_virtual_path(from);
+        let to_virtual = self.is_virtual_path(to);
 
         if from_virtual != to_virtual {
             return Err(BackendError::InvalidOperation(
@@ -245,7 +256,7 @@ impl KernelBackend for VirtualOverlayBackend {
     }
 
     async fn exists(&self, path: &Path) -> bool {
-        if Self::is_virtual_path(path) {
+        if self.is_virtual_path(path) {
             self.vfs.exists(path).await
         } else {
             self.inner.exists(path).await
@@ -257,7 +268,7 @@ impl KernelBackend for VirtualOverlayBackend {
     // ═══════════════════════════════════════════════════════════════════════════
 
     async fn lstat(&self, path: &Path) -> BackendResult<DirEntry> {
-        if Self::is_virtual_path(path) {
+        if self.is_virtual_path(path) {
             Ok(self.vfs.lstat(path).await?)
         } else {
             self.inner.lstat(path).await
@@ -265,7 +276,7 @@ impl KernelBackend for VirtualOverlayBackend {
     }
 
     async fn read_link(&self, path: &Path) -> BackendResult<PathBuf> {
-        if Self::is_virtual_path(path) {
+        if self.is_virtual_path(path) {
             Ok(self.vfs.read_link(path).await?)
         } else {
             self.inner.read_link(path).await
@@ -273,7 +284,7 @@ impl KernelBackend for VirtualOverlayBackend {
     }
 
     async fn symlink(&self, target: &Path, link: &Path) -> BackendResult<()> {
-        if Self::is_virtual_path(link) {
+        if self.is_virtual_path(link) {
             self.vfs.symlink(target, link).await?;
             Ok(())
         } else {
@@ -323,7 +334,7 @@ impl KernelBackend for VirtualOverlayBackend {
     }
 
     fn resolve_real_path(&self, path: &Path) -> Option<PathBuf> {
-        if Self::is_virtual_path(path) {
+        if self.is_virtual_path(path) {
             // Virtual paths don't map to real filesystem
             None
         } else {
@@ -355,15 +366,32 @@ mod tests {
 
     #[tokio::test]
     async fn test_virtual_path_detection() {
-        assert!(VirtualOverlayBackend::is_virtual_path(Path::new("/v")));
-        assert!(VirtualOverlayBackend::is_virtual_path(Path::new("/v/")));
-        assert!(VirtualOverlayBackend::is_virtual_path(Path::new("/v/jobs")));
-        assert!(VirtualOverlayBackend::is_virtual_path(Path::new("/v/blobs/test.bin")));
+        let overlay = make_overlay().await;
+        assert!(overlay.is_virtual_path(Path::new("/v")));
+        assert!(overlay.is_virtual_path(Path::new("/v/")));
+        assert!(overlay.is_virtual_path(Path::new("/v/jobs")));
+        assert!(overlay.is_virtual_path(Path::new("/v/blobs/test.bin")));
 
-        assert!(!VirtualOverlayBackend::is_virtual_path(Path::new("/docs")));
-        assert!(!VirtualOverlayBackend::is_virtual_path(Path::new("/g/repo")));
-        assert!(!VirtualOverlayBackend::is_virtual_path(Path::new("/")));
-        assert!(!VirtualOverlayBackend::is_virtual_path(Path::new("/var")));
+        assert!(!overlay.is_virtual_path(Path::new("/docs")));
+        assert!(!overlay.is_virtual_path(Path::new("/g/repo")));
+        assert!(!overlay.is_virtual_path(Path::new("/")));
+        assert!(!overlay.is_virtual_path(Path::new("/var")));
+    }
+
+    #[tokio::test]
+    async fn test_non_v_mount_is_virtual_path() {
+        // A mount outside /v (e.g. Kernel::with_backend's /dev) must also be
+        // routed to the internal VFS, not silently delegated to the inner
+        // backend — this is the bug that let writes to /dev/null fail as
+        // "read-only filesystem" when the inner backend was read-only.
+        let (mock, _) = MockBackend::new();
+        let inner: Arc<dyn KernelBackend> = Arc::new(mock);
+        let mut vfs = VfsRouter::new();
+        vfs.mount("/dev", MemoryFs::new());
+        let overlay = VirtualOverlayBackend::new(inner, Arc::new(vfs));
+
+        assert!(overlay.is_virtual_path(Path::new("/dev/null")));
+        assert!(!overlay.is_virtual_path(Path::new("/docs")));
     }
 
     #[tokio::test]

--- a/crates/kaish-kernel/src/kernel.rs
+++ b/crates/kaish-kernel/src/kernel.rs
@@ -954,6 +954,9 @@ impl Kernel {
     ///
     /// A `VirtualOverlayBackend` routes paths automatically:
     /// - `/v/*` → Internal VFS (JobFs at `/v/jobs`, MemoryFs at `/v/blobs`)
+    /// - `/dev` → DevFs (synthetic `/dev/null`, `/dev/zero`, `/dev/random`,
+    ///   `/dev/urandom`) — kernel-owned so it works even when your backend is
+    ///   read-only
     /// - Everything else → Your custom backend
     ///
     /// The optional `configure_vfs` closure lets you add additional virtual mounts
@@ -1015,6 +1018,12 @@ impl Kernel {
             None => MemoryFs::new(),
         };
         vfs.mount("/v/blobs", blobs_fs);
+
+        // /dev/null and friends are software-backed (see DevFs) and must not
+        // depend on the embedder's backend — a read-only embedder backend
+        // (e.g. kaijutsu's read-only host root) would otherwise reject writes
+        // to /dev/null as a filesystem error instead of discarding them.
+        vfs.mount("/dev", DevFs::new());
 
         // Let caller add custom mounts (e.g., /v/docs, /v/g)
         configure_vfs(&mut vfs);

--- a/crates/kaish-kernel/src/vfs/router.rs
+++ b/crates/kaish-kernel/src/vfs/router.rs
@@ -100,6 +100,15 @@ impl VfsRouter {
         fs.real_path(&relative)
     }
 
+    /// Returns true if some registered mount covers this path.
+    ///
+    /// Used by embedder overlay backends (`VirtualOverlayBackend`) to decide
+    /// whether a path belongs to this router's mounts or should be delegated
+    /// to the embedder's own backend — without hardcoding a mount prefix.
+    pub(crate) fn has_mount(&self, path: &Path) -> bool {
+        self.find_mount(path).is_ok()
+    }
+
     /// Find the mount point for a given path.
     ///
     /// Returns the mount and the path relative to that mount.

--- a/crates/kaish-kernel/tests/with_backend_dev_tests.rs
+++ b/crates/kaish-kernel/tests/with_backend_dev_tests.rs
@@ -1,0 +1,60 @@
+//! `Kernel::with_backend` must expose `/dev` (DevFs) regardless of what the
+//! embedder's own backend does — this is the kaijutsu bug: a read-only
+//! embedder backend made `cmd > /dev/null` fail as a filesystem error
+//! instead of silently discarding the write, because `/dev` was never
+//! kernel-owned in the `with_backend` path.
+
+// Test-fixture code: unwrap/expect on known-good setup is the idiom here.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::sync::Arc;
+
+use kaish_kernel::vfs::{LocalFs, VfsRouter};
+use kaish_kernel::{Kernel, KernelBackend, KernelConfig, LocalBackend};
+
+/// Build a `with_backend` kernel whose entire embedder-owned root is
+/// read-only — the same shape as kaijutsu's `LocalBackend::read_only("/")`.
+fn read_only_backend_kernel(dir: &std::path::Path) -> Kernel {
+    let mut vfs = VfsRouter::new();
+    vfs.mount("/", LocalFs::read_only(dir));
+    let backend: Arc<dyn KernelBackend> = Arc::new(LocalBackend::new(Arc::new(vfs)));
+    Kernel::with_backend(backend, KernelConfig::isolated(), |_| {}, |_| {})
+        .expect("with_backend kernel")
+}
+
+async fn run(kernel: &Kernel, script: &str) -> (String, i64) {
+    let result = kernel.execute(script).await.expect("kernel execute");
+    (result.text_out().trim().to_string(), result.code)
+}
+
+#[tokio::test]
+async fn dev_null_write_succeeds_under_read_only_backend() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let kernel = read_only_backend_kernel(dir.path());
+
+    // Writing to /dev/null must be discarded, not rejected — /dev is
+    // kernel-owned and must not depend on the embedder's backend being
+    // writable.
+    let (out, code) = run(&kernel, "echo hello > /dev/null").await;
+    assert_eq!(code, 0, "write to /dev/null must succeed under a read-only backend: out={out:?}");
+}
+
+#[tokio::test]
+async fn dev_null_reads_empty_under_with_backend() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let kernel = read_only_backend_kernel(dir.path());
+
+    let (out, code) = run(&kernel, "cat /dev/null").await;
+    assert_eq!(code, 0);
+    assert_eq!(out, "", "reading /dev/null must be empty");
+}
+
+#[tokio::test]
+async fn dev_zero_readable_under_with_backend() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let kernel = read_only_backend_kernel(dir.path());
+
+    let (out, code) = run(&kernel, "head -c 8 /dev/zero | wc -c").await;
+    assert_eq!(code, 0, "reading /dev/zero must succeed: out={out:?}");
+    assert_eq!(out, "8", "head -c 8 /dev/zero should yield exactly 8 bytes: out={out:?}");
+}

--- a/crates/kaish-kernel/tests/with_backend_dev_tests.rs
+++ b/crates/kaish-kernel/tests/with_backend_dev_tests.rs
@@ -9,7 +9,7 @@
 
 use std::sync::Arc;
 
-use kaish_kernel::vfs::{LocalFs, VfsRouter};
+use kaish_kernel::vfs::{LocalFs, MemoryFs, VfsRouter};
 use kaish_kernel::{Kernel, KernelBackend, KernelConfig, LocalBackend};
 
 /// Build a `with_backend` kernel whose entire embedder-owned root is
@@ -57,4 +57,51 @@ async fn dev_zero_readable_under_with_backend() {
     let (out, code) = run(&kernel, "head -c 8 /dev/zero | wc -c").await;
     assert_eq!(code, 0, "reading /dev/zero must succeed: out={out:?}");
     assert_eq!(out, "8", "head -c 8 /dev/zero should yield exactly 8 bytes: out={out:?}");
+}
+
+#[tokio::test]
+async fn ls_dev_lists_devices_under_with_backend() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let kernel = read_only_backend_kernel(dir.path());
+
+    let (out, code) = run(&kernel, "ls /dev").await;
+    assert_eq!(code, 0, "ls /dev must succeed: out={out:?}");
+    for name in ["null", "zero", "random", "urandom"] {
+        assert!(out.contains(name), "ls /dev should list {name}: out={out:?}");
+    }
+}
+
+/// A non-virtual, non-`/dev` write must still be rejected by a read-only
+/// inner backend — mount-aware routing must not accidentally widen what
+/// counts as "handled by the internal VFS".
+#[tokio::test]
+async fn non_virtual_write_still_delegates_to_read_only_backend() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let kernel = read_only_backend_kernel(dir.path());
+
+    let (out, code) = run(&kernel, "echo hello > /probe.txt").await;
+    assert_ne!(code, 0, "write to a real path under a read-only backend must fail: out={out:?}");
+}
+
+/// `configure_vfs` can still override the default `/dev` mount, same as it
+/// can already override `/v/jobs`/`/v/blobs` — the built-in mount is set up
+/// before the caller's closure runs.
+#[tokio::test]
+async fn configure_vfs_can_override_dev_mount() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut vfs = VfsRouter::new();
+    vfs.mount("/", LocalFs::read_only(dir.path()));
+    let backend: Arc<dyn KernelBackend> = Arc::new(LocalBackend::new(Arc::new(vfs)));
+    let kernel = Kernel::with_backend(
+        backend,
+        KernelConfig::isolated(),
+        |vfs| vfs.mount("/dev", MemoryFs::new()),
+        |_| {},
+    )
+    .expect("with_backend kernel");
+
+    // The empty MemoryFs has no "null" entry, unlike DevFs — proves the
+    // override actually took effect rather than DevFs staying mounted.
+    let (out, code) = run(&kernel, "cat /dev/null").await;
+    assert_ne!(code, 0, "overridden /dev should no longer be DevFs: out={out:?}");
 }

--- a/docs/EMBEDDING.md
+++ b/docs/EMBEDDING.md
@@ -208,6 +208,12 @@ let kernel = Kernel::with_backend(
 > relied on disk spill or `/v/jobs` persistence, that data now stays in
 > memory.
 
+`with_backend` also mounts `/dev` (`DevFs`: `/dev/null`, `/dev/zero`,
+`/dev/random`, `/dev/urandom`) unconditionally, kernel-owned, alongside
+`/v/jobs` and `/v/blobs` — this holds even if your own backend is read-only,
+so `cmd > /dev/null` always discards rather than failing as a filesystem
+error.
+
 A `with_backend` kernel owns its VFS, so `KernelConfig::with_vfs_budget`
 does not see your mounts — cap them yourself by constructing the backing
 `MemoryFs` with `MemoryFs::with_budget(Arc<ByteBudget>)`. Both types are

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -14,6 +14,34 @@ before it ships.
 
 ---
 
+## `/dev` was a no-op under `with_backend` (2026-07-03)
+
+Amy asked a throwaway question — "did we ever add `/dev/null`?" — which turned
+into finding kaijutsu's kernel never had it. kaijutsu builds its kaish kernel
+via `Kernel::with_backend` (custom-storage embedders), which never ran the
+`setup_vfs()` path that mounts `DevFs` at `/dev` for `Kernel::new`/`transient`.
+Checking whether kaijutsu's own read-only host-root mount shadowed `/dev/null`
+surfaced a second, deeper bug: it does, for reads (the real host `/dev/null` is
+empty too), but writes go through `LocalBackend::read_only`'s guard and error
+as read-only instead of discarding — so `cmd > /dev/null` was actively broken,
+not just missing.
+
+Worse: mounting `DevFs` at `/dev` inside `with_backend` alone would have been a
+no-op. `VirtualOverlayBackend::is_virtual_path` hardcoded routing to `/v`/`/v/*`
+only; every other path, including a freshly-mounted `/dev`, fell straight
+through to the embedder's own backend regardless of what the internal
+`VfsRouter` had mounted. Fixed both: `VfsRouter::has_mount` exposes a
+mount-table lookup, `is_virtual_path` became an `&self` method that also
+checks it (keeping the `/v` reservation as an explicit fast path, since that
+whole namespace is reserved even where nothing is mounted), and `with_backend`
+now mounts `/dev` alongside `/v/jobs`/`/v/blobs`. Verified the regression test
+actually catches the bug by reverting the two source files and rerunning it —
+all three cases failed as expected before the fix, passed after.
+
+kaijutsu itself stays broken until it bumps its `kaish-kernel = "0.10"`
+crates.io pin to whatever ships this — tracked as a follow-up, not fixed in
+this PR.
+
 ## `help regex` — waking the ERE weights (2026-07-03)
 
 PR #65's last follow-up: the BRE-superset story lived in four places (grep


### PR DESCRIPTION
## Summary

- Custom-backend embedders (kaijutsu's shape) built their kernel via
  `Kernel::with_backend`, which never ran the `setup_vfs()` path that mounts
  `DevFs` at `/dev` for `Kernel::new`/`Kernel::transient` — so `/dev/null`,
  `/dev/zero`, `/dev/random`, `/dev/urandom` were simply absent. Worse: in
  kaijutsu specifically, its own read-only host-root mount shadows
  `/dev/null` for reads (matching real host behavior) but rejects writes as a
  read-only-filesystem error, so `cmd > /dev/null` was actively broken, not
  merely missing.
- Just mounting `DevFs` at `/dev` in `with_backend` would have been a no-op:
  `VirtualOverlayBackend::is_virtual_path` hardcoded routing to `/v`/`/v/*`
  only, so any other internal-VFS mount (including a fresh `/dev`) fell
  straight through to the embedder's backend. Added `VfsRouter::has_mount` and
  made `is_virtual_path` mount-aware (keeping the `/v` namespace reservation
  as an explicit fast path, since it's reserved even where nothing is
  mounted), then mounted `/dev` alongside `/v/jobs`/`/v/blobs` in
  `with_backend`.
- Added a regression test (`with_backend_dev_tests.rs`) that builds a
  `with_backend` kernel over a read-only inner backend (kaijutsu's exact
  shape) and verifies `/dev/null` writes discard, reads are empty, and
  `/dev/zero` reads work. Verified it actually catches the bug by reverting
  the two source-side changes and confirming all three cases fail first.

kaijutsu itself is pinned to `kaish-kernel = "0.10"` from crates.io and won't
pick this up until that dependency is bumped after a release — tracked
separately, not part of this PR.

## Test plan

- [x] `cargo test --all`
- [x] `cargo clippy --all --all-targets` — zero warnings
- [x] `cargo check -p kaish-kernel --no-default-features`
- [x] Confirmed new tests fail against the pre-fix source, pass after

🤖 Generated with [Claude Code](https://claude.com/claude-code)