### PR TITLE
fix(kernel): render .data-only $(cmd) as compact JSON in string interpolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -193,6 +193,13 @@ breaking entries are marked **BREAKING**.
   demotion of `\|` to plain `|`).
 
 ### Fixed
+- **`"$(cmd)"` no longer drops a `.data`-only result to `""`** — quoted command
+  substitution used to read only a command's `.out` text; a tool that set
+  structured `.data` (a list/record) but left `.out` empty interpolated to
+  nothing, silently losing the collection. It now falls back to rendering
+  `.data` the same way a bare `"$x"` renders a collection-valued variable
+  (compact JSON for lists/records, plain form for scalars); non-empty `.out`
+  still wins unchanged.
 - **`Kernel::with_backend` now mounts `/dev` (DevFs) unconditionally** —
   custom-backend embedders (e.g. kaijutsu) previously had no `/dev/null`,
   `/dev/zero`, `/dev/random`, or `/dev/urandom` at all, and `VirtualOverlayBackend`

--- a/crates/kaish-kernel/src/kernel.rs
+++ b/crates/kaish-kernel/src/kernel.rs
@@ -4140,7 +4140,22 @@ impl Kernel {
                 // Embedding binary into a string is a text context: fail loud
                 // rather than splice in U+FFFD garbage.
                 match result.try_text_out() {
-                    Ok(s) => Ok(s.trim_end_matches('\n').to_string()),
+                    // Text wins when present — unchanged behavior.
+                    Ok(s) if !s.is_empty() => Ok(s.trim_end_matches('\n').to_string()),
+                    // `.out` is empty: a builtin/tool that set only structured
+                    // `.data` must not silently evaporate to "" (SILENT DATA
+                    // LOSS). Render it the same way a bare `"$x"`
+                    // collection-valued variable renders — compact JSON for
+                    // lists/records, plain form for scalars — by reusing
+                    // `value_to_string` (the exact `StringPart::Var` helper
+                    // above) so `"$(cmd)"` and `x=$(cmd); "$x"` display
+                    // identically. No trailing-newline trim here: that's a
+                    // text-path artifact, not applicable to a freshly
+                    // rendered JSON/scalar string.
+                    Ok(_) => match &result.data {
+                        Some(data) => Ok(value_to_string(data)),
+                        None => Ok(String::new()),
+                    },
                     Err(e) => anyhow::bail!(
                         "command substitution in a string produced binary data ({e}) — \
                          pipe through base64/xxd"

--- a/crates/kaish-kernel/tests/cmdsubst_data_interpolation_tests.rs
+++ b/crates/kaish-kernel/tests/cmdsubst_data_interpolation_tests.rs
@@ -1,0 +1,214 @@
+//! Regression tests for the SILENT DATA LOSS bug: `"...$(cmd)..."` used to read
+//! only `.out` via `try_text_out()` (`kernel.rs`, `StringPart::CommandSubst`).
+//! A tool/builtin that sets structured `.data` but leaves `.out` empty (the
+//! shape `ExecResult::from_parts(0, "", "", Some(data))` produces directly)
+//! interpolated to `""` — the collection silently evaporated instead of
+//! rendering, even though a bare `"$x"` on the same value renders it as
+//! compact JSON (or the plain scalar form).
+//!
+//! kaish's own shipped builtins (`fromjson`, `keys`, `values`) all populate
+//! `.out` via `ExecResult::success_data`, so they never hit this hole in
+//! practice today — the fixture tools below construct the `.data`-only,
+//! empty-`.out` shape directly (the same shape a `KernelBackend`-registered
+//! embedder tool can produce via `ToolResult::with_data("", json)`), to pin
+//! the fix at the exact seam it protects.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use kaish_kernel::tools::{ToolArgs, ToolCtx, ToolSchema};
+use kaish_kernel::vfs::{MemoryFs, VfsRouter};
+use kaish_kernel::{Kernel, KernelBackend, KernelConfig, LocalBackend, Tool};
+use kaish_types::{ExecResult, Value};
+
+/// Returns a record (`{"a":1,"b":2}`) as `.data` only — `.out` is empty text.
+struct RecordDataTool;
+
+#[async_trait]
+impl Tool for RecordDataTool {
+    fn name(&self) -> &str {
+        "recdata"
+    }
+
+    fn schema(&self) -> ToolSchema {
+        ToolSchema::new("recdata", "test fixture: record in .data, empty .out")
+    }
+
+    async fn execute(&self, _args: ToolArgs, _ctx: &mut dyn ToolCtx) -> ExecResult {
+        let data = Value::Json(serde_json::json!({"a": 1, "b": 2}));
+        ExecResult::from_parts(0, String::new(), String::new(), Some(data))
+    }
+}
+
+/// Returns a list (`[1,2,3]`) as `.data` only — `.out` is empty text.
+struct ListDataTool;
+
+#[async_trait]
+impl Tool for ListDataTool {
+    fn name(&self) -> &str {
+        "listdata"
+    }
+
+    fn schema(&self) -> ToolSchema {
+        ToolSchema::new("listdata", "test fixture: list in .data, empty .out")
+    }
+
+    async fn execute(&self, _args: ToolArgs, _ctx: &mut dyn ToolCtx) -> ExecResult {
+        let data = Value::Json(serde_json::json!([1, 2, 3]));
+        ExecResult::from_parts(0, String::new(), String::new(), Some(data))
+    }
+}
+
+/// Returns a scalar string (`hello`) as `.data` only — `.out` is empty text.
+/// The scalar case proves the fix reuses `value_to_string` (unquoted `String`
+/// rendering), not a naive `serde_json::to_string` of the `.data` (which
+/// would quote it as `"hello"`).
+struct ScalarDataTool;
+
+#[async_trait]
+impl Tool for ScalarDataTool {
+    fn name(&self) -> &str {
+        "scalardata"
+    }
+
+    fn schema(&self) -> ToolSchema {
+        ToolSchema::new("scalardata", "test fixture: scalar string in .data, empty .out")
+    }
+
+    async fn execute(&self, _args: ToolArgs, _ctx: &mut dyn ToolCtx) -> ExecResult {
+        let data = Value::String("hello".to_string());
+        ExecResult::from_parts(0, String::new(), String::new(), Some(data))
+    }
+}
+
+/// Sets BOTH non-empty `.out` and `.data` (a differing collection) — proves
+/// text still wins when present; the `.data` fallback must never override it.
+struct OutWinsTool;
+
+#[async_trait]
+impl Tool for OutWinsTool {
+    fn name(&self) -> &str {
+        "outwins"
+    }
+
+    fn schema(&self) -> ToolSchema {
+        ToolSchema::new("outwins", "test fixture: non-empty .out plus .data")
+    }
+
+    async fn execute(&self, _args: ToolArgs, _ctx: &mut dyn ToolCtx) -> ExecResult {
+        let data = Value::Json(serde_json::json!({"should_not_render": true}));
+        ExecResult::from_parts(0, "TEXT-WINS".to_string(), String::new(), Some(data))
+    }
+}
+
+fn kernel_with_tools() -> Arc<Kernel> {
+    let mut vfs = VfsRouter::new();
+    vfs.mount("/", MemoryFs::new());
+    let backend: Arc<dyn KernelBackend> = Arc::new(LocalBackend::new(Arc::new(vfs)));
+    Kernel::with_backend(backend, KernelConfig::isolated(), |_| {}, |tools| {
+        tools.register(RecordDataTool);
+        tools.register(ListDataTool);
+        tools.register(ScalarDataTool);
+        tools.register(OutWinsTool);
+    })
+    .expect("with_backend kernel")
+    .into_arc()
+}
+
+/// The bug, pinned: a record-valued `.data`-only result must render as
+/// compact JSON inside a quoted string, not evaporate to "".
+#[tokio::test]
+async fn record_data_only_result_renders_as_compact_json_in_string() {
+    let kernel = kernel_with_tools();
+    let r = kernel
+        .execute(r#"msg="parsed: $(recdata) done"; echo "$msg""#)
+        .await
+        .expect("execute");
+    assert_eq!(r.code, 0);
+    assert_eq!(r.text_out().trim(), r#"parsed: {"a":1,"b":2} done"#);
+}
+
+/// Same bug, list shape.
+#[tokio::test]
+async fn list_data_only_result_renders_as_compact_json_in_string() {
+    let kernel = kernel_with_tools();
+    let r = kernel
+        .execute(r#"msg="items: $(listdata) done"; echo "$msg""#)
+        .await
+        .expect("execute");
+    assert_eq!(r.code, 0);
+    assert_eq!(r.text_out().trim(), "items: [1,2,3] done");
+}
+
+/// A record `.data`-only result must render identically whether captured via
+/// `"$(cmd)"` directly or round-tripped through a bare `"$x"` — same helper,
+/// same output, per the decided fix (reuse `value_to_string`).
+#[tokio::test]
+async fn cmdsubst_and_bare_var_render_a_collection_identically() {
+    let kernel = kernel_with_tools();
+    let direct = kernel
+        .execute(r#"echo "got: $(recdata)""#)
+        .await
+        .expect("execute");
+    let via_var = kernel
+        .execute(r#"x=$(recdata); echo "got: $x""#)
+        .await
+        .expect("execute");
+    assert_eq!(direct.text_out().trim(), via_var.text_out().trim());
+}
+
+/// Scalar `.data`-only result: renders as the plain scalar (unquoted), not
+/// JSON-quoted — proving reuse of `value_to_string`, not raw JSON serialization
+/// of `.data`.
+#[tokio::test]
+async fn scalar_data_only_result_renders_unquoted_in_string() {
+    let kernel = kernel_with_tools();
+    let r = kernel
+        .execute(r#"msg="say: $(scalardata) done"; echo "$msg""#)
+        .await
+        .expect("execute");
+    assert_eq!(r.code, 0);
+    assert_eq!(r.text_out().trim(), "say: hello done");
+}
+
+/// Non-empty `.out` still wins over `.data` — existing/unchanged behavior.
+#[tokio::test]
+async fn nonempty_out_wins_over_data_in_string() {
+    let kernel = kernel_with_tools();
+    let r = kernel
+        .execute(r#"msg="result: $(outwins) done"; echo "$msg""#)
+        .await
+        .expect("execute");
+    assert_eq!(r.code, 0);
+    assert_eq!(r.text_out().trim(), "result: TEXT-WINS done");
+}
+
+/// A shipped builtin's `.data`-only success (`fromjson` on a record) already
+/// populates `.out` via `ExecResult::success_data`, so this exercises the
+/// unchanged text-wins path end-to-end through a real builtin, not just the
+/// fixture tools above.
+#[tokio::test]
+async fn fromjson_record_in_string_interpolation() {
+    let kernel = kernel_with_tools();
+    let r = kernel
+        .execute(r#"j='{"a":1,"b":2}'; msg="parsed: $(fromjson <<< $j) done"; echo "$msg""#)
+        .await
+        .expect("execute");
+    assert_eq!(r.code, 0);
+    assert_eq!(r.text_out().trim(), r#"parsed: {"a":1,"b":2} done"#);
+}
+
+/// `keys` on a record is also `.data`-only via `success_data` — same
+/// unchanged-text-wins coverage for a list-shaped result.
+#[tokio::test]
+async fn keys_list_in_string_interpolation() {
+    let kernel = kernel_with_tools();
+    let r = kernel
+        .execute(r#"h={"a": 1, "b": 2}; msg="keys: $(keys $h) done"; echo "$msg""#)
+        .await
+        .expect("execute");
+    assert_eq!(r.code, 0);
+    assert_eq!(r.text_out().trim(), r#"keys: ["a","b"] done"#);
+}


### PR DESCRIPTION
## Summary

- Fixes the P3 SILENT-DATA-LOSS item from `docs/issues.md`: quoted command
  substitution (`"...$(cmd)..."`) read a command's result through
  `try_text_out()` alone (`kernel.rs`, `StringPart::CommandSubst`). A
  tool/builtin that sets only structured `.data` with an empty `.out`
  interpolated to `""` — the collection silently evaporated instead of
  rendering or erroring.
- **Decision (Amy):** when `.out` is empty but `.data` is present, render it
  exactly the way a bare `"$x"` collection-valued variable renders — compact
  JSON for lists/records, plain form for scalars — by **reusing
  `value_to_string`**, the same helper `StringPart::Var` already calls. So
  `"$(cmd)"` and `x=$(cmd); "$x"` now display identically; no duplicated
  rendering logic. Non-empty `.out` still wins unchanged, and the
  trailing-newline trim only applies to the text path, not the
  freshly-rendered JSON/scalar string. The existing binary-data loud-error
  branch (`Err(e) => bail!(...)`) is untouched.

## Discovery along the way

Kaish's own `success_data()`-based builtins (`fromjson`, `keys`, `values`)
already populate `.out` with compact JSON, so they never actually hit this
hole in practice today (verified via REPL repro before writing any test).
The genuinely reachable case is a `KernelBackend`-registered embedder tool
returning `ToolResult::with_data("", data)` (or any future core builtin using
`ExecResult::from_parts` directly) — same empty-`.out`/`Some(.data)` shape,
same silent loss. Tests pin that shape directly via fixture `Tool`s registered
through `Kernel::with_backend`, rather than relying on a shipped builtin that
doesn't reproduce it.

**Sync twin checked, not touched:** `scheduler/pipeline.rs::eval_string_parts_sync`
does not have the same hole — its `StringPart::CommandSubst` arm skips
entirely ("requires async"), a separate pre-existing limitation. Left alone
per the note that another agent is working on that function's error
channels.

**Deferred, not fixed here (found but out of scope):** in
`kernel.rs::execute_command_depth`'s backend-tool fallback (~line 2976-2984,
"Try backend-registered tools"), `tool_result.data` is never copied onto the
resulting `ExecResult` at all — an embedder tool's `.data` is dropped outright
in that specific path, distinct from and more severe than the bug this PR
fixes (there `.data` reaches `ExecResult` but renders as `""`; there it never
reaches `ExecResult` in the first place). Worth its own issue/PR.

## Test plan

New file `crates/kaish-kernel/tests/cmdsubst_data_interpolation_tests.rs`,
kernel-routed via `kernel.execute(...)`:
- `record_data_only_result_renders_as_compact_json_in_string` — fixture tool,
  record `.data`, empty `.out` → renders as `{"a":1,"b":2}` (fails before fix).
- `list_data_only_result_renders_as_compact_json_in_string` — same, list shape
  (fails before fix).
- `scalar_data_only_result_renders_unquoted_in_string` — scalar `String`
  `.data` renders unquoted (`hello`, not `"hello"`), proving reuse of
  `value_to_string` rather than a naive JSON stringify (fails before fix).
- `cmdsubst_and_bare_var_render_a_collection_identically` — `"$(cmd)"` vs
  `x=$(cmd); "$x"` produce the same string (fails before fix).
- `nonempty_out_wins_over_data_in_string` — non-empty `.out` always wins over
  `.data` (passes before and after; pins unchanged behavior).
- `fromjson_record_in_string_interpolation` / `keys_list_in_string_interpolation`
  — real shipped builtins through the same path (passes before and after).

Confirmed manually: reverted the `kernel.rs` hunk, the four "fails before fix"
tests failed with the exact `""`-drop symptom (`"parsed:  done"`,
`"items:  done"`, `"say:  done"`, `"got:"`), then restored the fix and all 7
passed.

Gates run clean:
- [x] `cargo test --all`
- [x] `cargo clippy --all --all-targets` (zero warnings)

- [x] `CHANGELOG.md` — one bullet under `## [Unreleased]` → `### Fixed`

Not merging — leaving for review per repo convention (kaibo/code-review before merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)