### PR TITLE
docs(help): document collections known limitations for 0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,12 @@ breaking entries are marked **BREAKING**.
   stale since list/record literals landed. Membership (`in`/`not in`) is now
   always shown inside a full `if [[ … ]]; then … fi`, never a bare standalone
   test line (a prior regression against the shell's own teaching-note rule).
+- **`help collections` documents the one remaining 0.11.0 known limitation** —
+  `push` only accepts a top-level bareword target; a bracket-path target
+  (`push services[web][tags] item`) fails loudly instead of appending, with the
+  read/push/assign-back workaround shown inline. Two other suspected gaps
+  (deeply-nested glued list literals, nested `${#path}`/`${path:-default}`)
+  turned out already fixed on re-verification and needed no documentation.
 
 ### Added
 - **`help regex`** — a compact syntax section (also in `help syntax`/`syntax.md`)

--- a/crates/kaish-help/content/en/syntax.md
+++ b/crates/kaish-help/content/en/syntax.md
@@ -106,6 +106,14 @@ user.email=x              # error — brackets only, use `user[email]=x`
 # push appends to a top-level LIST in place — takes the NAME (like read/unset)
 push xs date               # xs is now [...,"date"]
 push xs $rec               # values push as typed Values, not stringified text
+
+# KNOWN LIMITATION — push only takes a top-level bareword target; a bracket
+# path target fuses into a glob and fails loudly ("no matches") instead of
+# pushing. Read the nested list out, push, assign it back:
+push services[web][tags] item   # ERROR — no matches: services[web][tags]
+tmp=${services[web][tags]}      # workaround
+push tmp item
+services[web][tags]=$tmp
 ```
 
 ## Paths

--- a/crates/kaish-help/src/fragments.rs
+++ b/crates/kaish-help/src/fragments.rs
@@ -361,6 +361,14 @@ user.email=x              # error — brackets only, use `user[email]=x`
 # push appends to a top-level LIST in place — takes the NAME (like read/unset)
 push xs date               # xs is now [...,"date"]
 push xs $rec               # values push as typed Values, not stringified text
+
+# KNOWN LIMITATION — push only takes a top-level bareword target; a bracket
+# path target fuses into a glob and fails loudly ("no matches") instead of
+# pushing. Read the nested list out, push, assign it back:
+push services[web][tags] item   # ERROR — no matches: services[web][tags]
+tmp=${services[web][tags]}      # workaround
+push tmp item
+services[web][tags]=$tmp
 ```"#,
     ),
     syntax_section(

--- a/crates/kaish-kernel/src/lexer.rs
+++ b/crates/kaish-kernel/src/lexer.rs
@@ -1751,10 +1751,13 @@ fn mergeable_text(token: &Token) -> Option<String> {
 /// `$(x=[a b])` is still `test_depth == 0` and correctly does. This replaces
 /// the earlier pending-`for`/`case` counter entirely.
 ///
-/// `bracket_depth`/`brace_depth` are simple counters, not a real stack —
-/// deeply-nested *glued* literals (e.g. `x=[[a] [b]]`) are a documented
-/// deferral (see docs/issues.md); spaced nesting (`[ [a] [b] ]`) was never
-/// glued in the first place and is unaffected.
+/// `bracket_depth`/`brace_depth` are simple counters, not a real stack, but
+/// that's sufficient here: the `!currently_value` guard on `[[` detection
+/// above means a glued nested literal (`x=[[a] [b]]`) never gets mistaken for
+/// a `[[ ]]` test opener once bracket_depth is already > 0, so deeply-nested
+/// *glued* literals parse identically to spaced nesting (`[ [a] [b] ]`) at any
+/// depth — see `deeply_nested_glued_list_literal_matches_spaced_nesting` in
+/// `collection_literals_tests.rs`.
 #[derive(Clone, Copy, Default)]
 struct ValueContext {
     /// Inside (or opening) a value-position `[`/`{` literal — suppresses

--- a/crates/kaish-kernel/tests/collection_literals_tests.rs
+++ b/crates/kaish-kernel/tests/collection_literals_tests.rs
@@ -233,6 +233,30 @@ async fn nested_record_in_record() {
 }
 
 #[tokio::test]
+async fn deeply_nested_glued_list_literal_matches_spaced_nesting() {
+    // `x=[[a] [b]]` was flagged in docs/issues.md P3 as a deferred loud error —
+    // "deeply-nested glued literals aren't unfused by the lexer's value-position
+    // suppression." That was true against the pending-counter suppression this
+    // file's nesting tests were written under; the later `[[ ]]` test-depth
+    // rewrite (lexer.rs `compute_value_context`, commit 09c1a89) fixed it as a
+    // side effect: the `!currently_value` guard on `[[` detection means a glued
+    // nested run is never mistaken for a test opener. Pin it here — glued and
+    // spaced nesting must parse identically, at depth 2 and 3.
+    let k = setup().await;
+    let (out_glued, code_glued, err) = run(&k, "x=[[a] [b]]; echo $x").await;
+    assert_eq!(code_glued, 0, "err: {err}");
+    let (out_spaced, code_spaced, err) = run(&k, "x=[ [a] [b] ]; echo $x").await;
+    assert_eq!(code_spaced, 0, "err: {err}");
+    assert_eq!(out_glued, out_spaced);
+    assert_eq!(out_glued, r#"[["a"],["b"]]"#);
+
+    // Depth 3, still glued.
+    let (out_deep, code_deep, err) = run(&k, "x=[[[a] [b]] [c]]; echo $x").await;
+    assert_eq!(code_deep, 0, "err: {err}");
+    assert_eq!(out_deep, r#"[[["a"],["b"]],["c"]]"#);
+}
+
+#[tokio::test]
 async fn spread_flattens_a_list() {
     let k = setup().await;
     let (out, code, err) = run(&k, "xs=[a b c]; new=[...$xs date]; echo $new").await;

--- a/docs/arrays-and-hashes.md
+++ b/docs/arrays-and-hashes.md
@@ -158,6 +158,45 @@ for svc in $(values $to_restart); do
 done
 ```
 
+## Known limitations (0.11.0)
+
+Verification pass 2026-07-03, ahead of the 0.11.0 collections release, re-checked every
+gap `docs/issues.md` had flagged as "loud, ship as documented limitation if not closed."
+Two of the three no longer reproduce — they were fixed in passing by later work and the
+docs/issues.md entries were simply never updated:
+
+- **Deeply-nested *glued* list literals** (`x=[[a] [b]]`) — **FIXED.** The
+  `test_depth`-based rewrite of `lexer::compute_value_context` (commit `09c1a89`,
+  landed the same day as the original deferral) also fixed this as a side effect. Both
+  glued (`x=[[a] [b]]`) and spaced (`x=[ [a] [b] ]`) nesting now parse identically, at
+  any depth — pinned by `deeply_nested_glued_list_literal_matches_spaced_nesting` in
+  `collection_literals_tests.rs`.
+- **Nested `${#path}` and `${path:-default}`** (`${#u[tags]}`, `${u[missing]:-fallback}`)
+  — **FIXED.** Shipped in `28ec480` ("`feat(#6): path-aware ${#path} and ${path:-default}
+  with decision-A semantics`"), before the literal-syntax work that first flagged this as
+  a gap. Both forms resolve correctly in expression position, inside interpolated
+  strings, and on assignment RHS — see `collection_access_tests.rs`
+  (`length_of_a_subscripted_path_is_the_element_count`,
+  `default_on_a_missing_key_yields_the_default`, etc.). The one caveat: **`${#var}` length
+  syntax isn't recognized inside `$(( ))` arithmetic at all**, nested or not (a
+  pre-existing, general arithmetic gap unrelated to path-nesting — see `docs/issues.md`
+  P4). `$(( xs[i] ))` variable-subscript reads work fine; only the `${#…}` spelling is
+  unsupported there.
+- **Bracket-path `push` target** (`push services[web][tags] item`) — **confirmed, still
+  open.** `push` only accepts a top-level bareword target; a bracket path fuses into a
+  glob word and fails loudly (`no matches: services[web][tags]`) before `push` runs.
+  Workaround — read the nested list out, push, assign it back:
+  ```sh
+  tmp=${services[web][tags]}
+  push tmp item
+  services[web][tags]=$tmp
+  ```
+  Tracked as a real gap in `docs/issues.md` (P3, "Bracket-path `push` target"); needs its
+  own lexer/parser pass (a `push`-aware trigger, or routing `push`'s target through the
+  argv-position bracket-path grammar) before it can close.
+
+See also `help collections` for the same limitation in cheat-sheet form.
+
 ## Decisions, and the evidence behind them
 
 We stress-tested candidate syntaxes against four models (DeepSeek V4-Pro/Flash, Gemini
@@ -627,11 +666,12 @@ fixed three-token `for`-loop shape (`For Ident In`) to keep `for x in [a]` fusin
 glob; (2) the bracket-pair suppression only fires for runs that actually contain an
 `LBracket`/`RBracket` pair, so a pure `Star`/`Question` glob at value position
 (`X=*.txt`) is untouched and still evaluates to a literal string, exactly as before
-literals existed. Deferred, as flagged below: deeply-nested *glued* literals
-(`x=[[a] [b]]`) — spaced nesting (`[ [a] [b] ]`) was never glued and is unaffected; see
-`docs/issues.md` P3. The multi-word bareword record-value error
+literals existed. Deferred at the time: deeply-nested *glued* literals (`x=[[a] [b]]`)
+— spaced nesting (`[ [a] [b] ]`) was never glued and is unaffected. **FIXED as a side
+effect of `09c1a89`** (the `[[ ]]` test-depth rewrite below) — see "Known limitations
+(0.11.0)" above. The multi-word bareword record-value error
 (`{msg: hello world}`) is a loud parse error but with chumsky's generic message, not
-the hand-crafted "quote it" wording sketched in Teaching note #10 — also P3.
+the hand-crafted "quote it" wording sketched in Teaching note #10 — still open, `docs/issues.md` P3.
 
 - **Glob-merge is the big lexer collision — including one the first draft missed.**
   Space-separated literals are safe: the glob-run merger only fuses **span-adjacent** tokens
@@ -725,10 +765,10 @@ the hand-crafted "quote it" wording sketched in Teaching note #10 — also P3.
   shared with command names (`some-tool`) and must keep accepting those.
 - **`${#…}` length**: consolidated 2026-07-02 onto the shared `value_length` helper across all
   four sites (`kernel.rs` `Expr::VarLength` + in-string, `eval.rs` sync, `scheduler/pipeline.rs`
-  reduced sync — the last of which was still `value_to_string(value).len()`). The remaining length
-  work is *nested* length (`${#u[tags]}`): the `VarLength(String)` node carries a bare name, so it
-  can't reach a subscript — it's a loud "bind first" error until the node carries a `VarPath` (do
-  it with the resolver extraction below).
+  reduced sync — the last of which was still `value_to_string(value).len()`). This bullet
+  originally flagged *nested* length (`${#u[tags]}`) as remaining work — **shipped later the
+  same day in `28ec480`** (`VarLength`/`VarWithDefault` now carry a `VarPath`; see the `#6`
+  section below and "Known limitations (0.11.0)" above).
 - **`[[ in ]]`** — LANDED 2026-07-02. Routes through the async test path (`eval_test_async` in
   `kernel.rs`) so it is VFS/backend-aware; `TestExpr` gained `In`/`NotIn`; RHS shape-dispatches on
   `Value::Json` (array → element membership; object → key membership; string RHS → loud error).

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -38,13 +38,21 @@ consciously ship-as-known-limitation before the release:
 - **[SILENT] reduced sync path coalesces bad/subscripted collection access** in
   scatter/gather workers (`${#u[tags]}` → silent-0, bad subscript → dropped arg).
   Detail under P2 (collection read-access follow-ups) and the #6 resolver entry.
-- **[LOUD gaps — OK to ship documented]** bracket-path `push` target
-  (`push a[b] x`), deeply-nested glued list literals (`x=[[a] [b]]`), and
-  nested `${#path}` / `${path:-default}` (blocked on the #6 resolver). All fail
-  loudly today; ship as known limitations if not closed.
+- **[LOUD gap — documented 2026-07-03]** bracket-path `push` target
+  (`push a[b] x`) fails loudly (glob-expands, "no matches") and doesn't work.
+  Documented as a known limitation with a working alternative in `help
+  collections` and `arrays-and-hashes.md`; the real fix stays open under P3
+  ("Bracket-path `push` target").
+  **Re-verified 2026-07-03 and dropped from this list, already fixed:**
+  deeply-nested glued list literals (`x=[[a] [b]]` — fixed as a side effect of
+  the `[[ ]]` test-depth lexer rewrite, `09c1a89`; regression test added) and
+  nested `${#path}` / `${path:-default}` (shipped in `28ec480`, before this
+  list was written). Neither was actually a live gap by the time this section
+  called for a decision — corrected in `arrays-and-hashes.md` ("Known
+  limitations (0.11.0)").
 
-Recommendation: land the two silent items; document the loud gaps in
-`help collections` / `arrays-and-hashes.md` and defer.
+Recommendation: land the two silent items above; the one remaining loud gap
+(`push` bracket-path target) is documented, not fixed.
 
 ---
 
@@ -149,30 +157,33 @@ Read access, membership, and lvalue writes shipped, but they lean on
 (O(n²) for `for k in $(keys $u)` with per-element `${u[$k]}`); the write side needs
 `&mut` serde navigation and can't reuse it. Extract **Bind**
 `(VarPath, &Scope) → Result<Vec<ConcreteStep>, PathError>` + **Walk** over
-`&serde_json::Value`. Folds in: `VarLength`/`VarWithDefault` → `VarPath` (unblocks
-nested `${#path}` and `${path:-default}`, plus widening the lexer `VarLength` regex
-to accept `[`), arithmetic's hand-collected brackets, and full-path error messages.
-**Decisions settled (2026-07-02):** `PathError` splits into `UndefinedRoot`/`Absence`/
+`&serde_json::Value`. **Correction 2026-07-03:** the "folds in" list this entry
+originally carried — `VarLength`/`VarWithDefault` → `VarPath`, the lexer `VarLength`
+regex widening, arithmetic's own path building, and full-path error messages — all
+shipped in `28ec480`, before this entry's decisions were even recorded below; nested
+`${#path}` and `${path:-default}` are working forms today, not blocked on this
+extraction. **This entry is now purely the `apply_segment` O(n²)-clone perf
+extraction** (killing the per-hop `clone()` by walking a borrowed root instead), which
+is genuinely still open. **Decisions settled (2026-07-02, already reflected in the
+shipped read-side resolver):** `PathError` splits into `UndefinedRoot`/`Absence`/
 `Shape`; `${path:-default}` is lenient on absence (unset root, missing key, OOB,
-empty → default) but loud on shape errors; `${#path}` stays loud "bind first" until
-path-aware. Full writeup: [arrays-and-hashes.md](arrays-and-hashes.md) ("Two-phase
-bind/walk resolver"). This entry is now purely the resolver extraction — the
-`for k in $record` / E012 question is out of scope (iteration stays `$()`-only).
+empty → default) but loud on shape errors. Full writeup:
+[arrays-and-hashes.md](arrays-and-hashes.md) ("#6 — the shared per-hop resolver").
+The `for k in $record` / E012 question is out of scope (iteration stays `$()`-only).
 
-Riders on #6 (currently loud, become nicer once it lands):
+Riders on #6 (currently loud, become nicer once the perf extraction lands):
 - **Reduced sync path still coalesces** (also the P3 entry below): the subscripted-name
   loud guard lands in `eval.rs` (sync) + `kernel.rs` (async), but
   `scheduler/pipeline.rs`'s `eval_string_parts_sync` has no error channel, so
   `${#u[tags]}` there is silent-0. **[SILENT — 0.11.0 candidate]**
-- **Expression-position `${#u[tags]}` gives a poor message.** In-string
-  `"${#u[tags]}"` gets the "bind it first" guard, but `echo ${#u[tags]}` never becomes
-  a `VarLength` node (the lexer regex excludes `[`), falling to `VarRef` root `#u` →
-  loud but bare "undefined variable". Fix rides #6 (widen the regex / route
-  `#`-prefixed `VarRef` through the length path).
 - **P3/P4 tail** (loud/cosmetic): `fromjson` on an already-typed value stringifies-
   then-reparses and loses `Value::Bytes` (short-circuit typed values); async `VarRef`
   "undefined variable" omits the name while sync includes it; missing-key errors could
   list available keys; `${.a}`/`${a.}` empty dot segments resolve as `${a}` silently.
+  Separately, `${#var}` length syntax (nested or not) isn't recognized at all inside
+  `$(( ))` arithmetic — `arithmetic.rs` never hand-collects a `#`-prefixed subscript;
+  `$(( xs[i] ))` variable-subscript reads work, only the `${#…}` spelling doesn't.
+  (P4 — pre-existing, general arithmetic gap, unrelated to path-nesting.)
 
 ### Collection read-access follow-ups
 - **P3 — reduced sync arg path coalesces a loud path error to skip.** The four primary
@@ -264,16 +275,14 @@ collection evaporates before reaching a process edge. Fix: when `.out` is empty 
 display) or fail loud — decide which; do NOT leave the silent `""`. **[0.11.0
 candidate — clearest crash-beats-corrupt item on the collections surface.]**
 
-### Collection literals: deeply-nested *glued* brackets + generic error text
-- **Deeply-nested glued list literals** (`x=[[a] [b]]`) aren't unfused by the lexer's
-  value-position suppression — only a flat/glued-single/empty run (`[dog]`, `[]`,
-  `[1]`) is exempt from `GlobWord` fusion. Spaced nesting (`[ [a] [b] ]`) works. Fix:
-  extend `lexer::compute_value_context`'s depth tracking to unfuse an inner glued run
-  once already inside an open value literal.
+### Collection literals: generic record-value error text
 - **Unquoted multi-word record value** (`{msg: hello world}`) is already a loud parse
   error (never silently split), but the message is chumsky's generic "expected `:`/`}`"
   rather than the crafted "quote it" wording. Fix: a `try_map` guard in
   `record_literal_parser` peeking for a stray bareword not followed by `:`.
+  (Deeply-nested *glued* list literals, `x=[[a] [b]]`, used to be listed here too —
+  fixed as a side effect of the `[[ ]]` test-depth lexer rewrite, `09c1a89`;
+  see `arrays-and-hashes.md` "Known limitations (0.11.0)".)
 
 ### Bracket-path `push` target (`push services[web][tags] item`) — deferred
 Lvalue *assignment* (`xs[0]=9`, deep paths) and `push` shipped, but `push` only
@@ -283,7 +292,9 @@ into a `GlobWord` and glob-expands (loud "no matches") before `push` runs. Loud,
 silent, but the feature doesn't work. Needs its own lexer/parser pass: a `push`-aware
 lexer trigger, or routing `push`'s target through the argv-position bracket-path
 grammar. The design intended `push` to accept bracket paths, so this is a real gap.
-**[0.11.0 loud gap — document as known limitation if not closed.]**
+**[0.11.0 loud gap — documented 2026-07-03 as a known limitation** in `help
+collections` and `arrays-and-hashes.md`, with the read/push/assign-back
+workaround; this entry stays open for the actual fix.**]**
 
 ### `JobManager` output-stream reads hold the jobs lock across `await`
 `read_stdout`/`read_stderr` (`scheduler/job.rs`, the `/v/jobs/{id}/stdout|stderr`


### PR DESCRIPTION
## Summary

`docs/issues.md`'s "Before 0.11.0" section flagged three loud gaps on the
collections surface to either fix or ship as documented known limitations
before release. Per the task, I verified each empirically against `main`
(REPL runs + existing test coverage) before writing anything down — and only
one turned out to still be a live gap:

- **Bracket-path `push` target** (`push services[web][tags] item`) —
  **confirmed, still broken.** It fuses into a glob word and fails loudly
  ("no matches") before `push` runs. Documented in `help collections`
  (`crates/kaish-help/src/fragments.rs`, regenerated `syntax.md`) and in a new
  `arrays-and-hashes.md` "Known limitations (0.11.0)" section, with the
  verified workaround: read the nested list into a temp var, `push`, assign
  it back. The actual fix stays open under `docs/issues.md` P3.
- **Deeply-nested glued list literals** (`x=[[a] [b]]`) — **already fixed.**
  Traced to commit `09c1a89` (the `[[ ]]` test-depth rewrite of
  `lexer::compute_value_context`), which fixed this as an unintentional side
  effect the same day the original deferral was written — nobody credited it.
  Added a regression test (`deeply_nested_glued_list_literal_matches_spaced_nesting`)
  pinning glued vs. spaced nesting at depth 2 and 3, corrected the stale
  comment above `struct ValueContext` in `lexer.rs`, and corrected the stale
  claims in `arrays-and-hashes.md` / `docs/issues.md`.
- **Nested `${#path}` / `${path:-default}`** — **already fixed.** Shipped in
  `28ec480` before the "Before 0.11.0" list was even written, and already
  fully covered by `collection_access_tests.rs`. While verifying this I found
  one adjacent, previously-undocumented gap: `${#var}` length syntax (nested
  or not) isn't recognized at all inside `$(( ))` arithmetic — recorded as a
  new P4 bullet in `docs/issues.md` rather than silently dropped.

Corrected the `docs/issues.md` entries that described the two fixed items as
still-open (the P2 "STRUCTURAL #6 resolver" entry's "folds in" clause and
"riders" list, and the P3 "Collection literals" entry), so the backlog now
reflects only real open work: the one documented `push` limitation, the
reduced-sync silent-coalesce items, and the `"$(cmd)"` data-loss item.

## Test plan

- [x] `cargo test --all` — clean (104 test binaries/doctests, all `ok`,
      including the `kaish-help` drift test `syntax_md_matches_fragments` and
      the new `collection_literals_tests::deeply_nested_glued_list_literal_matches_spaced_nesting`)
- [x] `cargo clippy --all --all-targets` — zero warnings, zero errors
- [x] `cargo run -p kaish-help --example regen_syntax` — regenerated
      `content/en/syntax.md`, no drift
- [x] Manually verified `help collections` renders the new limitation note
      end-to-end via `kaish-repl -c 'help collections'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)