### PR TITLE
fix(scheduler): loud errors for collection path failures in the sync eval path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -250,6 +250,13 @@ breaking entries are marked **BREAKING**.
     default on a *subscripted* path — `${#u[tags]}`, `${cfg[port]:-8080}` — were
     briefly a loud "bind it first" error; they are now fully path-aware, see
     Added.)
+- **`scatter`/`gather`'s own flag values (`--as`, `--limit`, …) now fail loud on
+  a bad/subscripted collection access** — the reduced sync arg binder they use
+  (it runs once, before workers fork, so it can't recurse through the async
+  pipeline) used to discard a missing-key/shape `PathError` as a silently
+  dropped flag or an omitted `${#…}` length instead of erroring, unlike `echo`,
+  assignment, `$(( ))`, and `"${…}"`. A bad `scatter --as ${u[nope]}` now fails
+  the whole pipeline instead of quietly falling back to a bare boolean flag.
 - **A bare collection reaching an external command's argv or a redirect
   target silently JSON-serialized** (e.g. `curl -d $cfg` or `echo x > $cfg`);
   every process-boundary sink now refuses it with a `$(tojson $x)` hint. This

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -256,7 +256,9 @@ breaking entries are marked **BREAKING**.
   pipeline) used to discard a missing-key/shape `PathError` as a silently
   dropped flag or an omitted `${#…}` length instead of erroring, unlike `echo`,
   assignment, `$(( ))`, and `"${…}"`. A bad `scatter --as ${u[nope]}` now fails
-  the whole pipeline instead of quietly falling back to a bare boolean flag.
+  the whole pipeline instead of quietly falling back to a bare boolean flag; a
+  subscripted path on an entirely undefined root (`${nope[key]}`) is loud too,
+  while a bare undefined `$VAR` keeps the bash-compatible coalesce.
 - **A bare collection reaching an external command's argv or a redirect
   target silently JSON-serialized** (e.g. `curl -d $cfg` or `echo x > $cfg`);
   every process-boundary sink now refuses it with a `$(tojson $x)` hint. This

--- a/crates/kaish-kernel/src/dispatch.rs
+++ b/crates/kaish-kernel/src/dispatch.rs
@@ -427,9 +427,13 @@ impl CommandDispatcher for BackendDispatcher {
             _ => {}
         }
 
-        // Build tool args with schema-aware parsing (sync — no command substitution)
+        // Build tool args with schema-aware parsing (sync — no command substitution).
+        // A bad/subscripted collection access is a genuine PathError here too —
+        // propagate it via `?` rather than swallowing, same as the production
+        // Kernel::dispatch_command's `execute_command(..).await?`.
         let schema = self.tools.get(&cmd.name).map(|t| t.schema());
-        let tool_args = build_tool_args(&cmd.args, ctx, schema.as_ref());
+        let tool_args = build_tool_args(&cmd.args, ctx, schema.as_ref())
+            .map_err(|e| anyhow::anyhow!(e))?;
 
         // Honor --json before the tool runs so a parse failure inside the
         // builtin doesn't drop the format on the floor. See kernel.rs for the
@@ -478,6 +482,7 @@ impl CommandDispatcher for BackendDispatcher {
     /// test dispatcher's documented "no async argument evaluation" limit.
     async fn eval_expr(&self, expr: &Expr, ctx: &ExecContext) -> Result<Value> {
         crate::scheduler::pipeline::eval_simple_expr(expr, ctx)
+            .map_err(|e| anyhow::anyhow!(e))?
             .ok_or_else(|| anyhow::anyhow!("cannot evaluate expression in test dispatcher"))
     }
 

--- a/crates/kaish-kernel/src/interpreter.rs
+++ b/crates/kaish-kernel/src/interpreter.rs
@@ -40,3 +40,6 @@ pub use control_flow::ControlFlow;
 pub use eval::{eval_expr, expand_tilde, is_collection, resolve_default, resolve_length, scalar_test_operand_error, strip_leading_tabs, structured_boundary_error, structured_export_error, value_defaults_on_emptiness, value_to_bool, value_to_exit_code, value_length, value_to_string, value_to_string_with_tilde, EvalError, EvalResult, Evaluator, Executor, HeredocAssembler, NoOpExecutor};
 pub use result::{apply_output_format, hex_dump, json_to_value, json_to_value_no_envelope, value_to_json, EntryType, ExecResult, LatchRequest, OutputData, OutputFormat, OutputNode, OutputPayload};
 pub use scope::{PathError, Scope};
+// Crate-internal: the reduced sync evaluator (scheduler/pipeline.rs) reuses the
+// resolver error-message shape without widening the public API.
+pub(crate) use eval::format_path;

--- a/crates/kaish-kernel/src/interpreter/eval.rs
+++ b/crates/kaish-kernel/src/interpreter/eval.rs
@@ -943,8 +943,11 @@ pub fn value_to_string_with_tilde(value: &Value, home: Option<&str>) -> String {
     }
 }
 
-/// Format a VarPath for error messages.
-fn format_path(path: &VarPath) -> String {
+/// Format a VarPath for error messages. `pub(crate)` so the scheduler's
+/// reduced sync evaluator (`scheduler/pipeline.rs::eval_simple_expr`) can
+/// emit the same "${x[key]}: undefined variable" shape [`resolve_length`]
+/// uses for a subscripted path on an undefined root.
+pub(crate) fn format_path(path: &VarPath) -> String {
     use crate::ast::VarSegment;
     let mut result = String::from("${");
     for (i, seg) in path.segments.iter().enumerate() {

--- a/crates/kaish-kernel/src/scheduler/pipeline.rs
+++ b/crates/kaish-kernel/src/scheduler/pipeline.rs
@@ -972,9 +972,17 @@ pub(crate) fn eval_simple_expr(expr: &Expr, ctx: &ExecContext) -> Result<Option<
         Expr::Literal(value) => Ok(Some(eval_literal(value, ctx))),
         Expr::VarRef(path) => match ctx.scope.resolve_path(path) {
             Ok(v) => Ok(Some(v)),
-            // Unset bare variable: coalesces like the async positional-arg
-            // path's `Ok(None)`/skip convention for this reduced context.
-            Err(PathError::UndefinedRoot(_)) => Ok(None),
+            // Unset BARE variable: coalesces (skip-the-arg) — this reduced
+            // context's bash-compatible convention. Bare-only on purpose: an
+            // undefined root under a SUBSCRIPTED path is loud below, the same
+            // split `resolve_length` draws — `scatter --as ${x[key]}` with a
+            // typo'd root must not silently drop the flag (kaibo review
+            // finding, PR #85).
+            Err(PathError::UndefinedRoot(_)) if path.segments.len() <= 1 => Ok(None),
+            Err(PathError::UndefinedRoot(_)) => Err(format!(
+                "{}: undefined variable",
+                crate::interpreter::format_path(path)
+            )),
             // A loud path error (absence or shape) carries its own actionable
             // message — never swallowed.
             Err(PathError::Absence(msg)) | Err(PathError::Shape(msg)) => Err(msg),
@@ -1046,6 +1054,13 @@ fn eval_string_parts_sync(parts: &[crate::ast::StringPart], ctx: &ExecContext) -
             crate::ast::StringPart::Literal(s) => result.push_str(s),
             crate::ast::StringPart::Var(path) => match ctx.scope.resolve_path(path) {
                 Ok(value) => result.push_str(&value_to_string(&value)),
+                // Unconditional (even subscripted) on purpose: in STRING
+                // context both primary sites — async `eval_string_part_async`
+                // (kernel.rs) and sync `eval_interpolated` (eval.rs) — expand
+                // an undefined root to empty, bash-compatibly ("a${nope[k]}b"
+                // → "ab"). The bare-only restriction applies to the
+                // whole-token `Expr::VarRef` arm above, matching the primary
+                // sites' loud whole-token behavior.
                 Err(PathError::UndefinedRoot(_)) => {}
                 Err(PathError::Absence(msg)) | Err(PathError::Shape(msg)) => return Err(msg),
             },

--- a/crates/kaish-kernel/src/scheduler/pipeline.rs
+++ b/crates/kaish-kernel/src/scheduler/pipeline.rs
@@ -12,7 +12,7 @@ use std::collections::HashMap;
 use crate::arithmetic;
 use crate::ast::{Arg, Command, Expr, Redirect, RedirectKind, Value};
 use crate::dispatch::{CommandDispatcher, PipelinePosition};
-use crate::interpreter::ExecResult;
+use crate::interpreter::{ExecResult, PathError};
 use crate::tools::{ExecContext, ToolArgs, ToolRegistry, ToolSchema};
 use tokio::io::AsyncWriteExt;
 
@@ -165,7 +165,7 @@ async fn eval_redirect_target(expr: &Expr, ctx: &ExecContext) -> Result<String, 
     let value = if let Some(dispatcher) = &ctx.dispatcher {
         dispatcher.eval_expr(expr, ctx).await.map_err(|e| e.to_string())?
     } else {
-        eval_simple_expr(expr, ctx)
+        eval_simple_expr(expr, ctx)?
             .ok_or_else(|| "could not evaluate redirect target".to_string())?
     };
     // Decision D: a bare collection can't be a redirect target either — same
@@ -326,11 +326,23 @@ impl PipelineRunner {
         let post_gather = &commands[gather_idx + 1..];
 
         // Parse options from scatter and gather commands
-        // These are builtins with simple key=value syntax, no schema-driven parsing needed
+        // These are builtins with simple key=value syntax, no schema-driven parsing needed.
+        // build_tool_args is fallible: a bad/subscripted collection access in a
+        // scatter/gather flag value (`scatter --as ${u[nope]}`) must fail loud here,
+        // not silently coalesce to a dropped flag (see docs/issues.md's now-closed
+        // "reduced sync path" entry). Mirrors run_single's dispatch-error handling.
         let scatter_schema = self.tools.get("scatter").map(|t| t.schema());
         let gather_schema = self.tools.get("gather").map(|t| t.schema());
-        let scatter_opts = parse_scatter_options(&build_tool_args(&scatter_cmd.args, ctx, scatter_schema.as_ref()));
-        let gather_opts = parse_gather_options(&build_tool_args(&gather_cmd.args, ctx, gather_schema.as_ref()));
+        let scatter_args = match build_tool_args(&scatter_cmd.args, ctx, scatter_schema.as_ref()) {
+            Ok(args) => args,
+            Err(e) => return ExecResult::failure(1, format!("scatter: {e}")),
+        };
+        let gather_args = match build_tool_args(&gather_cmd.args, ctx, gather_schema.as_ref()) {
+            Ok(args) => args,
+            Err(e) => return ExecResult::failure(1, format!("gather: {e}")),
+        };
+        let scatter_opts = parse_scatter_options(&scatter_args);
+        let gather_opts = parse_gather_options(&gather_args);
 
         // We need an `Arc<dyn CommandDispatcher>` to hand to `ScatterGatherRunner`.
         // `fork_attached` produces a subkernel whose cancellation token is a
@@ -732,7 +744,16 @@ pub fn is_bool_type(param_type: &str) -> bool {
 /// - For `--flag` where schema says type is bool (or unknown): treat as boolean flag
 ///
 /// This enables natural shell syntax like `mcp_tool --query "test" --limit 10`.
-pub fn build_tool_args(args: &[Arg], ctx: &ExecContext, schema: Option<&ToolSchema>) -> ToolArgs {
+///
+/// Fallible: a bad/subscripted collection access (`${u[nope]}` on a record
+/// without that key, a subscript on a scalar, `${#u[tags]}` on an undefined
+/// subscripted root) must fail loud here too, matching the four primary eval
+/// sites (`echo`, assignment, `$(( ))`, `"${…}"`) — see [`eval_simple_expr`].
+pub fn build_tool_args(
+    args: &[Arg],
+    ctx: &ExecContext,
+    schema: Option<&ToolSchema>,
+) -> Result<ToolArgs, String> {
     let mut tool_args = ToolArgs::new();
     let param_lookup = schema.map(schema_param_lookup).unwrap_or_default();
     let accepts_word_assign = schema
@@ -763,18 +784,18 @@ pub fn build_tool_args(args: &[Arg], ctx: &ExecContext, schema: Option<&ToolSche
             Arg::Positional(expr) => {
                 // Check if this positional was consumed by a preceding flag
                 if !consumed_positionals.contains(&i)
-                    && let Some(value) = eval_simple_expr(expr, ctx)
+                    && let Some(value) = eval_simple_expr(expr, ctx)?
                 {
                     tool_args.positional.push(value);
                 }
             }
             Arg::Named { key, value } => {
-                if let Some(val) = eval_simple_expr(value, ctx) {
+                if let Some(val) = eval_simple_expr(value, ctx)? {
                     tool_args.named.insert(key.clone(), val);
                 }
             }
             Arg::WordAssign { key, value } => {
-                if let Some(val) = eval_simple_expr(value, ctx) {
+                if let Some(val) = eval_simple_expr(value, ctx)? {
                     if accepts_word_assign {
                         tool_args.named.insert(key.clone(), val);
                     } else {
@@ -805,7 +826,7 @@ pub fn build_tool_args(args: &[Arg], ctx: &ExecContext, schema: Option<&ToolSche
                             .find(|(idx, _)| *idx > i && !consumed_positionals.contains(idx));
 
                         if let Some((pos_idx, expr)) = next_positional {
-                            if let Some(value) = eval_simple_expr(expr, ctx) {
+                            if let Some(value) = eval_simple_expr(expr, ctx)? {
                                 tool_args.named.insert(canonical.to_string(), value);
                                 consumed_positionals.insert(*pos_idx);
                             } else {
@@ -824,7 +845,7 @@ pub fn build_tool_args(args: &[Arg], ctx: &ExecContext, schema: Option<&ToolSche
                             .iter()
                             .find(|(idx, _)| *idx > i && !consumed_positionals.contains(idx));
                         if let Some((pos_idx, expr)) = next_positional {
-                            if let Some(value) = eval_simple_expr(expr, ctx) {
+                            if let Some(value) = eval_simple_expr(expr, ctx)? {
                                 tool_args.named.insert(canonical.to_string(), value);
                                 consumed_positionals.insert(*pos_idx);
                             } else {
@@ -868,7 +889,7 @@ pub fn build_tool_args(args: &[Arg], ctx: &ExecContext, schema: Option<&ToolSche
                             .find(|(idx, _)| *idx > i && !consumed_positionals.contains(idx));
 
                         if let Some((pos_idx, expr)) = next_positional {
-                            if let Some(value) = eval_simple_expr(expr, ctx) {
+                            if let Some(value) = eval_simple_expr(expr, ctx)? {
                                 tool_args.named.insert(canonical.to_string(), value);
                                 consumed_positionals.insert(*pos_idx);
                             } else {
@@ -931,76 +952,48 @@ pub fn build_tool_args(args: &[Arg], ctx: &ExecContext, schema: Option<&ToolSche
         tool_args.positional = remaining;
     }
 
-    tool_args
+    Ok(tool_args)
 }
 
 /// Simple expression evaluation for args (without full scope access).
-pub(crate) fn eval_simple_expr(expr: &Expr, ctx: &ExecContext) -> Option<Value> {
+///
+/// `Ok(None)` means "not representable in this reduced sync context" (binary
+/// ops, command substitution — these need the async kernel path; callers
+/// treat that the same as before, e.g. falling back to a bare flag). `Err`
+/// means a genuine [`PathError`] — undefined-subscripted-root, a missing key,
+/// or a shape mismatch — and MUST propagate loud, the same as the async
+/// `build_args_async`/`eval_expr_async` (`kernel.rs`) and the sync
+/// interpreter (`eval.rs`) treat it. Before this, every arm here discarded
+/// the error via `.ok()`/`if let Ok(..)`, so a bad subscript in a scatter/gather
+/// flag value silently dropped the argument instead of failing (docs/issues.md,
+/// now closed).
+pub(crate) fn eval_simple_expr(expr: &Expr, ctx: &ExecContext) -> Result<Option<Value>, String> {
     match expr {
-        Expr::Literal(value) => Some(eval_literal(value, ctx)),
-        // This reduced sync path coalesces any resolution failure to None
-        // (undefined or a loud path error alike); the async kernel paths carry
-        // the loud collection-access errors.
-        Expr::VarRef(path) => ctx.scope.resolve_path(path).ok(),
-        Expr::Interpolated(parts) => {
-            let mut result = String::new();
-            for part in parts {
-                match part {
-                    crate::ast::StringPart::Literal(s) => result.push_str(s),
-                    crate::ast::StringPart::Var(path) => {
-                        if let Ok(value) = ctx.scope.resolve_path(path) {
-                            result.push_str(&value_to_string(&value));
-                        }
-                    }
-                    crate::ast::StringPart::VarWithDefault { path, default } => {
-                        // Reduced-sync path has no error channel, so a shape error
-                        // coalesces (skipped) here — the known reduced-sync gap
-                        // (issues.md P3). Absence still yields the default.
-                        match crate::interpreter::resolve_default(&ctx.scope, path) {
-                            Ok(Some(value)) => result.push_str(&value_to_string(&value)),
-                            Ok(None) => result.push_str(&eval_string_parts_sync(default, ctx)),
-                            Err(_) => {}
-                        }
-                    }
-                    crate::ast::StringPart::VarLength(path) => {
-                        // Element/key count for collections, byte count for binary;
-                        // unset root → 0. A shape/absence error coalesces to nothing
-                        // (reduced-sync gap, P3).
-                        if let Ok(len) = crate::interpreter::resolve_length(&ctx.scope, path) {
-                            result.push_str(&len.to_string());
-                        }
-                    }
-                    crate::ast::StringPart::Positional(n) => {
-                        if let Some(s) = ctx.scope.get_positional(*n) {
-                            result.push_str(s);
-                        }
-                    }
-                    crate::ast::StringPart::AllArgs => {
-                        result.push_str(&ctx.scope.all_args().join(" "));
-                    }
-                    crate::ast::StringPart::ArgCount => {
-                        result.push_str(&ctx.scope.arg_count().to_string());
-                    }
-                    crate::ast::StringPart::Arithmetic(expr) => {
-                        // Evaluate arithmetic in pipeline context
-                        if let Ok(value) = arithmetic::eval_arithmetic(expr, &ctx.scope) {
-                            result.push_str(&value.to_string());
-                        }
-                    }
-                    crate::ast::StringPart::CommandSubst(_) => {
-                        // Command substitution requires async - skip in sync context
-                    }
-                    crate::ast::StringPart::LastExitCode => {
-                        result.push_str(&ctx.scope.last_result().code.to_string());
-                    }
-                    crate::ast::StringPart::CurrentPid => {
-                        result.push_str(&ctx.scope.pid().to_string());
-                    }
-                }
-            }
-            Some(Value::String(result))
+        Expr::Literal(value) => Ok(Some(eval_literal(value, ctx))),
+        Expr::VarRef(path) => match ctx.scope.resolve_path(path) {
+            Ok(v) => Ok(Some(v)),
+            // Unset bare variable: coalesces like the async positional-arg
+            // path's `Ok(None)`/skip convention for this reduced context.
+            Err(PathError::UndefinedRoot(_)) => Ok(None),
+            // A loud path error (absence or shape) carries its own actionable
+            // message — never swallowed.
+            Err(PathError::Absence(msg)) | Err(PathError::Shape(msg)) => Err(msg),
+        },
+        Expr::Interpolated(parts) => Ok(Some(Value::String(eval_string_parts_sync(parts, ctx)?))),
+        // Bare (unquoted whole-token) forms — `scatter --limit ${#tags}`,
+        // `scatter --as ${cfg[name]:-N}` — reuse the same shared path resolver
+        // the async path calls (`eval_expr_async`'s `VarLength`/`VarWithDefault`
+        // arms), so length/default semantics agree between the two paths.
+        Expr::VarLength(path) => {
+            crate::interpreter::resolve_length(&ctx.scope, path).map(|n| Some(Value::Int(n)))
         }
-        Expr::GlobPattern(s) => Some(Value::String(s.clone())),
+        Expr::VarWithDefault { path, default } => {
+            match crate::interpreter::resolve_default(&ctx.scope, path)? {
+                Some(value) => Ok(Some(value)),
+                None => Ok(Some(Value::String(eval_string_parts_sync(default, ctx)?))),
+            }
+        }
+        Expr::GlobPattern(s) => Ok(Some(Value::String(s.clone()))),
         Expr::HereDocBody { parts, strip_tabs } => {
             // Heredoc body materialization for redirect targets. `<<-` tab
             // stripping applies to the literal source, not to tabs from a
@@ -1009,15 +1002,15 @@ pub(crate) fn eval_simple_expr(expr: &Expr, ctx: &ExecContext) -> Option<Value> 
             for sp in parts {
                 match &sp.part {
                     crate::ast::StringPart::Literal(s) => asm.push_literal(s),
-                    other => asm.push_interpolated(&eval_string_parts_sync(
-                        std::slice::from_ref(other),
-                        ctx,
-                    )),
+                    other => {
+                        let s = eval_string_parts_sync(std::slice::from_ref(other), ctx)?;
+                        asm.push_interpolated(&s);
+                    }
                 }
             }
-            Some(Value::String(asm.into_string()))
+            Ok(Some(Value::String(asm.into_string())))
         }
-        _ => None, // Binary ops and command subst need more context
+        _ => Ok(None), // Binary ops and command subst need more context
     }
 }
 
@@ -1040,31 +1033,35 @@ fn value_to_string(value: &Value) -> String {
 }
 
 /// Evaluate string parts synchronously (for pipeline context).
-/// Command substitutions are skipped as they require async.
-fn eval_string_parts_sync(parts: &[crate::ast::StringPart], ctx: &ExecContext) -> String {
+///
+/// Command substitutions are skipped as they require async. A [`PathError`]
+/// (absence or shape) from a subscripted `$var`, `${…:-default}`, or `${#…}`
+/// propagates loud via `Err` — matching the async `eval_string_part_async`
+/// (`kernel.rs`) and the sync `Interpreter::eval_interpolated` (`eval.rs`).
+/// An unset BARE root still expands to empty (bash-compatible), unchanged.
+fn eval_string_parts_sync(parts: &[crate::ast::StringPart], ctx: &ExecContext) -> Result<String, String> {
     let mut result = String::new();
     for part in parts {
         match part {
             crate::ast::StringPart::Literal(s) => result.push_str(s),
-            crate::ast::StringPart::Var(path) => {
-                if let Ok(value) = ctx.scope.resolve_path(path) {
-                    result.push_str(&value_to_string(&value));
-                }
-            }
+            crate::ast::StringPart::Var(path) => match ctx.scope.resolve_path(path) {
+                Ok(value) => result.push_str(&value_to_string(&value)),
+                Err(PathError::UndefinedRoot(_)) => {}
+                Err(PathError::Absence(msg)) | Err(PathError::Shape(msg)) => return Err(msg),
+            },
             crate::ast::StringPart::VarWithDefault { path, default } => {
-                // Reduced-sync path: a shape error coalesces (issues.md P3);
-                // absence still yields the default.
-                match crate::interpreter::resolve_default(&ctx.scope, path) {
-                    Ok(Some(value)) => result.push_str(&value_to_string(&value)),
-                    Ok(None) => result.push_str(&eval_string_parts_sync(default, ctx)),
-                    Err(_) => {}
+                match crate::interpreter::resolve_default(&ctx.scope, path)? {
+                    Some(value) => result.push_str(&value_to_string(&value)),
+                    None => result.push_str(&eval_string_parts_sync(default, ctx)?),
                 }
             }
             crate::ast::StringPart::VarLength(path) => {
-                // Unset root → 0; shape/absence coalesces to nothing (P3).
-                if let Ok(len) = crate::interpreter::resolve_length(&ctx.scope, path) {
-                    result.push_str(&len.to_string());
-                }
+                // Element/key count for collections, byte count for binary;
+                // unset BARE root → 0 (bash parity). A shape/absence error on a
+                // SUBSCRIPTED path now propagates loud instead of silently
+                // omitting the length (the fixed "silent 0" gap).
+                let len = crate::interpreter::resolve_length(&ctx.scope, path)?;
+                result.push_str(&len.to_string());
             }
             crate::ast::StringPart::Positional(n) => {
                 if let Some(s) = ctx.scope.get_positional(*n) {
@@ -1078,6 +1075,9 @@ fn eval_string_parts_sync(parts: &[crate::ast::StringPart], ctx: &ExecContext) -
                 result.push_str(&ctx.scope.arg_count().to_string());
             }
             crate::ast::StringPart::Arithmetic(expr) => {
+                // Arithmetic errors in this reduced sync context are a
+                // separate, pre-existing swallow (not a collection PathError)
+                // — out of scope here; tracked in docs/issues.md.
                 if let Ok(value) = arithmetic::eval_arithmetic(expr, &ctx.scope) {
                     result.push_str(&value.to_string());
                 }
@@ -1093,7 +1093,7 @@ fn eval_string_parts_sync(parts: &[crate::ast::StringPart], ctx: &ExecContext) -
             }
         }
     }
-    result
+    Ok(result)
 }
 
 /// Find scatter and gather commands in a pipeline.
@@ -1683,7 +1683,7 @@ mod tests {
         let schema = make_test_schema();
         let ctx = make_minimal_ctx();
 
-        let tool_args = build_tool_args(&args, &ctx, Some(&schema));
+        let tool_args = build_tool_args(&args, &ctx, Some(&schema)).expect("build_tool_args");
 
         assert!(tool_args.flags.is_empty(), "No flags should be set");
         assert!(tool_args.positional.is_empty(), "No positionals - consumed by --query");
@@ -1703,7 +1703,7 @@ mod tests {
         let schema = make_test_schema();
         let ctx = make_minimal_ctx();
 
-        let tool_args = build_tool_args(&args, &ctx, Some(&schema));
+        let tool_args = build_tool_args(&args, &ctx, Some(&schema)).expect("build_tool_args");
 
         assert!(tool_args.flags.contains("verbose"), "--verbose should be a flag");
         assert!(tool_args.named.is_empty(), "No named args");
@@ -1723,7 +1723,7 @@ mod tests {
         let schema = make_test_schema();
         let ctx = make_minimal_ctx();
 
-        let tool_args = build_tool_args(&args, &ctx, Some(&schema));
+        let tool_args = build_tool_args(&args, &ctx, Some(&schema)).expect("build_tool_args");
 
         assert!(tool_args.positional.is_empty(), "file.txt consumed as query param");
         assert_eq!(
@@ -1752,7 +1752,7 @@ mod tests {
         let schema = make_test_schema();
         let ctx = make_minimal_ctx();
 
-        let tool_args = build_tool_args(&args, &ctx, Some(&schema));
+        let tool_args = build_tool_args(&args, &ctx, Some(&schema)).expect("build_tool_args");
 
         assert!(tool_args.positional.is_empty(), "All positionals consumed");
         assert_eq!(
@@ -1783,7 +1783,7 @@ mod tests {
         let schema = make_test_schema();
         let ctx = make_minimal_ctx();
 
-        let tool_args = build_tool_args(&args, &ctx, Some(&schema));
+        let tool_args = build_tool_args(&args, &ctx, Some(&schema)).expect("build_tool_args");
 
         assert_eq!(
             tool_args.named.get("output"),
@@ -1805,7 +1805,7 @@ mod tests {
         ];
         let ctx = make_minimal_ctx();
 
-        let tool_args = build_tool_args(&args, &ctx, None);
+        let tool_args = build_tool_args(&args, &ctx, None).expect("build_tool_args");
 
         // Without schema, --query is a flag and "test" is a positional
         assert!(tool_args.flags.contains("query"), "--query should be a flag");
@@ -1826,7 +1826,7 @@ mod tests {
         let schema = make_test_schema();
         let ctx = make_minimal_ctx();
 
-        let tool_args = build_tool_args(&args, &ctx, Some(&schema));
+        let tool_args = build_tool_args(&args, &ctx, Some(&schema)).expect("build_tool_args");
 
         assert!(tool_args.flags.contains("unknown"));
         assert!(tool_args.positional.is_empty(), "value consumed as query param");
@@ -1849,7 +1849,7 @@ mod tests {
         let schema = make_test_schema();
         let ctx = make_minimal_ctx();
 
-        let tool_args = build_tool_args(&args, &ctx, Some(&schema));
+        let tool_args = build_tool_args(&args, &ctx, Some(&schema)).expect("build_tool_args");
 
         assert_eq!(
             tool_args.named.get("query"),
@@ -1868,7 +1868,7 @@ mod tests {
         let schema = make_test_schema();
         let ctx = make_minimal_ctx();
 
-        let tool_args = build_tool_args(&args, &ctx, Some(&schema));
+        let tool_args = build_tool_args(&args, &ctx, Some(&schema)).expect("build_tool_args");
 
         assert!(tool_args.flags.contains("l"));
         assert!(tool_args.flags.contains("a"));
@@ -1890,7 +1890,7 @@ mod tests {
         let schema = make_test_schema();
         let ctx = make_minimal_ctx();
 
-        let tool_args = build_tool_args(&args, &ctx, Some(&schema));
+        let tool_args = build_tool_args(&args, &ctx, Some(&schema)).expect("build_tool_args");
 
         // output expects a value but none available after it, so it becomes a flag
         assert!(tool_args.flags.contains("output"));
@@ -1927,7 +1927,7 @@ mod tests {
         ];
         let ctx = make_minimal_ctx();
 
-        let tool_args = build_tool_args(&args, &ctx, Some(&schema));
+        let tool_args = build_tool_args(&args, &ctx, Some(&schema)).expect("build_tool_args");
 
         assert_eq!(
             tool_args.named.get("query"),
@@ -1953,7 +1953,7 @@ mod tests {
         let schema = make_test_schema(); // query, limit(int), verbose(bool), output
         let ctx = make_minimal_ctx();
 
-        let tool_args = build_tool_args(&args, &ctx, Some(&schema));
+        let tool_args = build_tool_args(&args, &ctx, Some(&schema)).expect("build_tool_args");
 
         // val1 → query, val2 → limit (int param but receives string — tool decides),
         // val3 → output
@@ -1985,7 +1985,7 @@ mod tests {
         ];
         let ctx = make_minimal_ctx();
 
-        let tool_args = build_tool_args(&args, &ctx, Some(&schema));
+        let tool_args = build_tool_args(&args, &ctx, Some(&schema)).expect("build_tool_args");
 
         assert_eq!(
             tool_args.named.get("name"),
@@ -2011,7 +2011,7 @@ mod tests {
         let schema = make_test_schema();
         let ctx = make_minimal_ctx();
 
-        let tool_args = build_tool_args(&args, &ctx, Some(&schema));
+        let tool_args = build_tool_args(&args, &ctx, Some(&schema)).expect("build_tool_args");
 
         assert_eq!(
             tool_args.named.get("query"),
@@ -2037,7 +2037,7 @@ mod tests {
         let schema = make_test_schema();
         let ctx = make_minimal_ctx();
 
-        let tool_args = build_tool_args(&args, &ctx, Some(&schema));
+        let tool_args = build_tool_args(&args, &ctx, Some(&schema)).expect("build_tool_args");
 
         assert_eq!(
             tool_args.named.get("query"),
@@ -2062,7 +2062,7 @@ mod tests {
         let schema = make_test_schema();
         let ctx = make_minimal_ctx();
 
-        let tool_args = build_tool_args(&args, &ctx, Some(&schema));
+        let tool_args = build_tool_args(&args, &ctx, Some(&schema)).expect("build_tool_args");
 
         assert_eq!(
             tool_args.named.get("output"),
@@ -2089,7 +2089,7 @@ mod tests {
         ];
         let ctx = make_minimal_ctx();
 
-        let tool_args = build_tool_args(&args, &ctx, Some(&schema));
+        let tool_args = build_tool_args(&args, &ctx, Some(&schema)).expect("build_tool_args");
 
         assert_eq!(
             tool_args.named.get("query"),
@@ -2115,7 +2115,7 @@ mod tests {
         ];
         let ctx = make_minimal_ctx();
 
-        let tool_args = build_tool_args(&args, &ctx, Some(&schema));
+        let tool_args = build_tool_args(&args, &ctx, Some(&schema)).expect("build_tool_args");
 
         // Positionals should NOT be consumed as named params
         assert_eq!(
@@ -2142,7 +2142,7 @@ mod tests {
         ];
         let ctx = make_minimal_ctx();
 
-        let tool_args = build_tool_args(&args, &ctx, Some(&schema));
+        let tool_args = build_tool_args(&args, &ctx, Some(&schema)).expect("build_tool_args");
 
         assert!(tool_args.flags.is_empty(), "no boolean flags: {:?}", tool_args.flags);
         assert_eq!(tool_args.named.get("lines"), Some(&Value::Int(5)), "should resolve alias to canonical name");

--- a/crates/kaish-kernel/tests/scatter_gather_jsonl_tests.rs
+++ b/crates/kaish-kernel/tests/scatter_gather_jsonl_tests.rs
@@ -263,3 +263,102 @@ async fn timed_out_worker_reports_124_and_gather_123() {
     assert_eq!(rows[0]["ok"], false);
     assert_eq!(rows[0]["timed_out"], true);
 }
+
+// ═══════════════════════════════════════════════════════════════════════
+// Reduced sync arg path: `scatter`/`gather`'s OWN flag values (`--as`,
+// `--limit`, …) bind through a sync twin of the async arg binder
+// (`build_tool_args`/`eval_simple_expr` in `scheduler/pipeline.rs`) because
+// it runs once, before any worker forks — it can't recurse back into
+// `PipelineRunner::run`. Before this fix that twin discarded a bad or
+// subscripted collection access (`PathError`) as a silently-skipped
+// flag/arg instead of failing, unlike the four primary eval sites (`echo`,
+// assignment, `$(( ))`, `"${…}"`). See docs/issues.md (closed by this fix)
+// and CHANGELOG.md.
+// ═══════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn bad_subscript_in_scatter_flag_value_is_a_loud_error() {
+    // `--as ${u[nope]}` — a missing key on a record. Before the fix this
+    // silently dropped `--as`'s value (falling back to a bare boolean flag
+    // and orphaning the bad expression as an unused positional) instead of
+    // failing the pipeline.
+    let k = kernel_at(tempdir().unwrap().path());
+    let r = run_full(
+        &k,
+        r#"u=$(fromjson '{"name":"amy"}')
+seq 1 2 | scatter --as ${u[nope]} | echo $N | gather"#,
+    )
+    .await;
+    assert_ne!(r.code, 0, "a bad subscript in a scatter flag value must fail, not silently proceed");
+    assert!(r.err.contains("no such key"), "got: {}", r.err);
+}
+
+#[tokio::test]
+async fn shape_error_in_scatter_flag_value_is_a_loud_error() {
+    // An integer index on a record is misuse, not absence — loud either way.
+    let k = kernel_at(tempdir().unwrap().path());
+    let r = run_full(
+        &k,
+        r#"cfg=$(fromjson '{"port":9000}')
+seq 1 2 | scatter --as ${cfg[0]} | echo $N | gather"#,
+    )
+    .await;
+    assert_ne!(r.code, 0, "a shape error in a scatter flag value must fail loud");
+    assert!(r.err.contains("record keys are strings"), "got: {}", r.err);
+}
+
+#[tokio::test]
+async fn length_of_a_missing_subscripted_key_in_scatter_flag_is_loud_not_silent() {
+    // `${#u[nope]}` inside an interpolated `--as` value: `eval_string_parts_sync`
+    // used to discard the `PathError` from `resolve_length` and push nothing,
+    // silently producing a working-but-WRONG `--as n` (the digit just missing)
+    // instead of failing on the bad subscript. `echo $n` matches that mangled
+    // fallback name on purpose — if the bug regresses, the worker binds fine
+    // and this assertion is the only thing that catches it.
+    let k = kernel_at(tempdir().unwrap().path());
+    let r = run_full(
+        &k,
+        r#"u=$(fromjson '{"tags":["a","b"]}')
+seq 1 2 | scatter --as "n${#u[nope]}" | echo $n | gather"#,
+    )
+    .await;
+    assert_ne!(r.code, 0, "a bad ${{#...}} subscript must fail, not silently produce a mangled var name");
+}
+
+#[tokio::test]
+async fn valid_subscripted_flag_value_still_works() {
+    // Happy path: a VALID subscripted access as a scatter option value must
+    // keep working through the reduced sync path.
+    let k = kernel_at(tempdir().unwrap().path());
+    let r = run_full(
+        &k,
+        r#"cfg=$(fromjson '{"varname":"N"}')
+seq 1 2 | scatter --as ${cfg[varname]} | echo $N | gather"#,
+    )
+    .await;
+    assert_eq!(r.code, 0, "{:?}", r.err);
+    let rows = rows(&r.text_out());
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0]["out"], "1");
+    assert_eq!(rows[1]["out"], "2");
+}
+
+#[tokio::test]
+async fn valid_length_in_scatter_flag_value_resolves_the_real_count() {
+    // Happy path for `${#...}`: a valid subscripted length must resolve to
+    // the real element count, never a silently-dropped/omitted digit. If the
+    // length were swallowed (old bug), the var name would come out as bare
+    // "n" and `$n3` would be undefined, failing the pipeline instead of
+    // matching here.
+    let k = kernel_at(tempdir().unwrap().path());
+    let r = run_full(
+        &k,
+        r#"u=$(fromjson '{"tags":["a","b","c"]}')
+seq 1 2 | scatter --as "n${#u[tags]}" | echo $n3 | gather"#,
+    )
+    .await;
+    assert_eq!(r.code, 0, "{:?}", r.err);
+    let rows = rows(&r.text_out());
+    assert_eq!(rows[0]["out"], "1", "var name resolved to n3, the real tag count");
+    assert_eq!(rows[1]["out"], "2");
+}

--- a/crates/kaish-kernel/tests/scatter_gather_jsonl_tests.rs
+++ b/crates/kaish-kernel/tests/scatter_gather_jsonl_tests.rs
@@ -362,3 +362,94 @@ seq 1 2 | scatter --as "n${#u[tags]}" | echo $n3 | gather"#,
     assert_eq!(rows[0]["out"], "1", "var name resolved to n3, the real tag count");
     assert_eq!(rows[1]["out"], "2");
 }
+
+#[tokio::test]
+async fn undefined_root_subscript_in_scatter_flag_value_is_loud() {
+    // kaibo review finding (PR #85): `${nope[key]}` where the ROOT is entirely
+    // undefined is `PathError::UndefinedRoot`, not `Absence` — the first cut
+    // coalesced ALL UndefinedRoot to a skipped flag, so a typo'd root still
+    // silently dropped `--as`'s value. Only a BARE undefined var may coalesce;
+    // a subscripted path on an undefined root errors, same split
+    // `resolve_length` draws.
+    let k = kernel_at(tempdir().unwrap().path());
+    let r = run_full(
+        &k,
+        r#"seq 1 2 | scatter --as ${nope[key]} | echo $ITEM | gather"#,
+    )
+    .await;
+    assert_ne!(r.code, 0, "typo'd root in a subscripted flag value must fail loud");
+    assert!(r.err.contains("undefined variable"), "got: {}", r.err);
+}
+
+#[tokio::test]
+async fn bare_undefined_var_in_scatter_flag_still_coalesces() {
+    // The bash-compatible convention this reduced context keeps: a BARE
+    // undefined `$VAR` coalesces (the flag falls back to boolean, `--as`
+    // keeps its ITEM default) rather than erroring. Only subscripted paths
+    // went loud in the fix above.
+    let k = kernel_at(tempdir().unwrap().path());
+    let r = run_full(
+        &k,
+        r#"seq 1 2 | scatter --as $KAISH_TEST_UNSET_VAR | echo $ITEM | gather"#,
+    )
+    .await;
+    assert_eq!(r.code, 0, "bare undefined var keeps coalescing: {:?}", r.err);
+    let rows = rows(&r.text_out());
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0]["out"], "1", "ITEM default binding still in effect");
+}
+
+#[tokio::test]
+async fn bare_length_bad_subscript_in_scatter_flag_is_loud() {
+    // Bare (unquoted whole-token) `${#u[nope]}` parses as `Expr::VarLength`,
+    // which used to fall through `eval_simple_expr`'s `_ => None` catch-all —
+    // silently dropping the flag and letting the pipeline proceed. Reaching a
+    // loud error here proves the new bare `VarLength` arm is wired: if the
+    // arm regressed to the catch-all, this pipeline would succeed.
+    let k = kernel_at(tempdir().unwrap().path());
+    let r = run_full(
+        &k,
+        r#"u=$(fromjson '{"tags":["a","b"]}')
+seq 1 2 | scatter --limit ${#u[nope]} | echo $ITEM | gather"#,
+    )
+    .await;
+    assert_ne!(r.code, 0, "bad bare ${{#...}} flag value must fail, not be silently dropped");
+    assert!(r.err.contains("no such key"), "got: {}", r.err);
+}
+
+#[tokio::test]
+async fn bare_length_in_scatter_flag_value_succeeds() {
+    // Happy path for the bare `Expr::VarLength` arm: `--limit ${#u[tags]}`
+    // resolves to a valid limit (3) and the pipeline runs. Pairs with the
+    // loud-error test above, which is what proves the arm is reachable.
+    let k = kernel_at(tempdir().unwrap().path());
+    let r = run_full(
+        &k,
+        r#"u=$(fromjson '{"tags":["a","b","c"]}')
+seq 1 2 | scatter --limit ${#u[tags]} | echo $ITEM | gather"#,
+    )
+    .await;
+    assert_eq!(r.code, 0, "{:?}", r.err);
+    assert_eq!(rows(&r.text_out()).len(), 2);
+}
+
+#[tokio::test]
+async fn bare_default_in_scatter_flag_value_binds_the_var_name() {
+    // Bare (unquoted whole-token) `${cfg[name]:-W}` parses as
+    // `Expr::VarWithDefault`, which also used to fall through the `_ => None`
+    // catch-all. Observable proof the arm is wired: the missing key folds to
+    // the default `W`, workers read `$W`, rows come out. If the arm regressed
+    // to the catch-all, the flag would drop, the binding would stay ITEM, and
+    // the workers' `$W` would fail loud (exit 123).
+    let k = kernel_at(tempdir().unwrap().path());
+    let r = run_full(
+        &k,
+        r#"cfg=$(fromjson '{"other":1}')
+seq 1 2 | scatter --as ${cfg[name]:-W} | echo $W | gather"#,
+    )
+    .await;
+    assert_eq!(r.code, 0, "{:?}", r.err);
+    let rows = rows(&r.text_out());
+    assert_eq!(rows[0]["out"], "1", "default var name W bound the items");
+    assert_eq!(rows[1]["out"], "2");
+}

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -64,6 +64,27 @@ silent-fallback name, so it's a real red/green pair now. Left the parallel
 symptom class, but a distinct `anyhow` error type (not `PathError`), so out of
 this fix's scope; recorded in issues.md for the next pass.
 
+kaibo's post-PR review caught a hole in the first cut: `eval_simple_expr`'s
+`Expr::VarRef` arm coalesced `PathError::UndefinedRoot` to `Ok(None)`
+*unconditionally*, so `scatter --as ${x[key]}` with a typo'd (entirely
+undefined) root still silently dropped the flag — UndefinedRoot isn't
+`Absence`. Follow-up commit restricts the coalesce to bare paths
+(`path.segments.len() <= 1`), erroring on subscripted paths with the same
+`"${x[key]}: undefined variable"` shape `resolve_length` uses (exported
+`format_path` as `pub(crate)` for it). Deliberately did NOT apply the same
+restriction to `eval_string_parts_sync`'s `StringPart::Var`: verified
+empirically that both primary string-interpolation sites (async
+`eval_string_part_async`, sync `eval_interpolated`) expand an undefined root
+to empty even when subscripted (`echo "a${nope[k]}b"` → `ab`, bash-compatible)
+— restricting only the sync twin would have made it *stricter* than the
+primaries, diverging the other way. The whole-token/string-context split is
+the shipped contract; the sync path now matches it on both sides. Also
+confirmed the bare `Expr::VarLength`/`VarWithDefault` arms added in the first
+cut are genuinely reachable (parser emits both variants in expression
+position, `parser.rs:2307`/`:48`) and pinned them with observable tests —
+the `VarWithDefault` one exploits the fact that a dropped `--as` leaves the
+ITEM binding in place, so the workers' `$W` fails loud if the arm regresses.
+
 ---
 
 ## `/dev` was a no-op under `with_backend` (2026-07-03)

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -14,6 +14,58 @@ before it ships.
 
 ---
 
+## scatter/gather's own flag values could silently drop a bad subscript (2026-07-03)
+
+A 0.11.0 pre-release punch-list item: `scatter`/`gather` bind their OWN flag
+values (`--as`, `--limit`, `--timeout`) through a *sync* twin of the real
+argument binder — `build_tool_args`/`eval_simple_expr` in
+`scheduler/pipeline.rs` — because `run_scatter_gather` parses those flags once,
+before any worker forks, and can't recurse back through the async
+`PipelineRunner::run` → `Kernel::dispatch` chain to get there. Every real
+command's arguments bind through the async `build_args_async` (`kernel.rs`),
+which already surfaces a `PathError` (missing key, shape mismatch, undefined
+subscripted root) loudly — matching the other three primary eval sites
+(assignment, `$(( ))`, `"${…}"`). The sync twin never got that treatment: every
+arm discarded the error via `.ok()` / `if let Ok(..)`, so `scatter --as
+${u[nope]}` silently fell back to treating `--as` as a bare boolean flag
+(dropping the intended value and stranding the bad expression as an unused
+positional) instead of failing, and `${#u[tags]}` on a bad subscript inside an
+interpolated flag value silently omitted the length instead of erroring.
+
+Confirmed `build_tool_args` has exactly one production call site —
+`run_scatter_gather`'s two calls parsing the `scatter`/`gather` commands'
+own args — everywhere else it's `#[cfg(test)]` (`BackendDispatcher`) or the
+~19 unit tests inside `pipeline.rs` itself. Gave `eval_simple_expr` and
+`eval_string_parts_sync` a real `Result` error channel: `Ok(Some(value))` on
+success, `Ok(None)` unchanged for "not representable in this reduced sync
+context" (binary ops, command substitution — still the documented, deferred
+"eliminate the sync twin" gap), and `Err(msg)` for a genuine `PathError`
+(absence/shape), propagated with the same message text the async path uses.
+Also noticed `eval_simple_expr`'s top-level match had no arm at all for a
+*bare* (unquoted, whole-token) `Expr::VarLength`/`Expr::VarWithDefault` —
+`scatter --limit ${#tags}` fell to the catch-all `_ => None` — so added those
+two arms routing through the same `resolve_length`/`resolve_default` the async
+path and the in-string arms already call. `build_tool_args` is now fallible;
+`run_scatter_gather` converts an `Err` into `ExecResult::failure(1, …)` at the
+same architectural boundary `run_single` already uses for a dispatch error, so
+the failure surfaces as a normal loud pipeline error, not a panic. Along the
+way, deduped `eval_simple_expr`'s `Expr::Interpolated` arm (it had its own
+~60-line copy of `eval_string_parts_sync`'s loop) down to a single call.
+
+TDD: wrote the new tests first against the unmodified source (verified two of
+them failed as expected — a bad subscript and a shape error in `--as` both
+silently exit 0), then applied the fix and confirmed all pass. One test needed
+a second pass — its worker read `$N` while the buggy fallback actually bound
+`$n` (a mangled but working var name), so it was accidentally passing "for
+free" on the old code for an unrelated reason (the worker's *own* command args
+already error loud via the async path); fixed to read `$n`, matching the
+silent-fallback name, so it's a real red/green pair now. Left the parallel
+`StringPart::Arithmetic` swallow in the same two functions alone — same
+symptom class, but a distinct `anyhow` error type (not `PathError`), so out of
+this fix's scope; recorded in issues.md for the next pass.
+
+---
+
 ## `/dev` was a no-op under `with_backend` (2026-07-03)
 
 Amy asked a throwaway question — "did we ever add `/dev/null`?" — which turned

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -35,9 +35,6 @@ consciously ship-as-known-limitation before the release:
 
 - **[SILENT DATA LOSS] `"$(cmd)"` drops a `.data`-only collection to `""`** — the
   clearest "crash-beats-corrupt" violation on the new surface. Detail under P3.
-- **[SILENT] reduced sync path coalesces bad/subscripted collection access** in
-  scatter/gather workers (`${#u[tags]}` → silent-0, bad subscript → dropped arg).
-  Detail under P2 (collection read-access follow-ups) and the #6 resolver entry.
 - **[LOUD gap — documented 2026-07-03]** bracket-path `push` target
   (`push a[b] x`) fails loudly (glob-expands, "no matches") and doesn't work.
   Documented as a known limitation with a working alternative in `help
@@ -49,10 +46,11 @@ consciously ship-as-known-limitation before the release:
   nested `${#path}` / `${path:-default}` (shipped in `28ec480`, before this
   list was written). Neither was actually a live gap by the time this section
   called for a decision — corrected in `arrays-and-hashes.md` ("Known
-  limitations (0.11.0)").
+  limitations (0.11.0)"). The sync-path silent coalescing (bad subscripts in
+  scatter/gather flag values) was fixed 2026-07-03 and dropped from this list.
 
-Recommendation: land the two silent items above; the one remaining loud gap
-(`push` bracket-path target) is documented, not fixed.
+Recommendation: land the remaining silent item (`"$(cmd)"` interpolation); the
+one remaining loud gap (`push` bracket-path target) is documented, not fixed.
 
 ---
 
@@ -172,10 +170,6 @@ empty → default) but loud on shape errors. Full writeup:
 The `for k in $record` / E012 question is out of scope (iteration stays `$()`-only).
 
 Riders on #6 (currently loud, become nicer once the perf extraction lands):
-- **Reduced sync path still coalesces** (also the P3 entry below): the subscripted-name
-  loud guard lands in `eval.rs` (sync) + `kernel.rs` (async), but
-  `scheduler/pipeline.rs`'s `eval_string_parts_sync` has no error channel, so
-  `${#u[tags]}` there is silent-0. **[SILENT — 0.11.0 candidate]**
 - **P3/P4 tail** (loud/cosmetic): `fromjson` on an already-typed value stringifies-
   then-reparses and loses `Value::Bytes` (short-circuit typed values); async `VarRef`
   "undefined variable" omits the name while sync includes it; missing-key errors could
@@ -186,18 +180,18 @@ Riders on #6 (currently loud, become nicer once the perf extraction lands):
   (P4 — pre-existing, general arithmetic gap, unrelated to path-nesting.)
 
 ### Collection read-access follow-ups
-- **P3 — reduced sync arg path coalesces a loud path error to skip.** The four primary
-  eval sites (`echo`, assignment, `$(( ))`, `"${…}"`) surface `PathError` loudly, but
-  the reduced sync pipeline path (`eval_simple_expr`/`eval_string_parts_sync`,
-  `pipeline.rs:943/950/1051`) coalesces resolution failure to None/skip — a bad
-  subscript in a scatter/gather worker's arg silently drops the arg. Give those sync
-  helpers an error channel (or route through the async resolver) when the
-  scatter/gather arg path is next touched. **[SILENT — 0.11.0 candidate]**
 - **P4 — a `]` inside a quoted subscript key is mishandled.** The lexer's bracket
   collector (`lexer.rs` `parse_var_ref`) scans to the first `]` with no quote
   awareness, so `${r["weird]key"]}` doesn't resolve the intended key. It errors (not
   silent), but cryptically. Fix: quote-aware bracket collector, or a clear diagnostic.
   (Same root cause bounds the empty-subscript `${r[]}` → `Key("")` oddity.)
+- **P4 — `scheduler/pipeline.rs`'s reduced sync path still silently swallows an
+  `Expr::Arithmetic`/`StringPart::Arithmetic` error** (`eval_simple_expr`,
+  `eval_string_parts_sync`) — a distinct pre-existing swallow from the
+  `PathError` one just closed (arithmetic errors are generic `anyhow`, not
+  `PathError`), noticed while fixing the collection-access case. Same class of
+  bug (a bad `scatter --limit $((1/0))` would silently omit the digits), lower
+  frequency. Give it the same `?`-propagation treatment when next touched.
 
 ### Streaming file reads — remaining
 - **`base64`** — deferred; only a pipe-case win, the 3-byte/4-char carry is fiddly.


### PR DESCRIPTION
## Summary

0.11.0 pre-release punch-list item (docs/issues.md, now closed): `scatter`/`gather`
bind their own flag values (`--as`, `--limit`, `--timeout`) through a *sync* twin
of the real async argument binder — `build_tool_args`/`eval_simple_expr` in
`scheduler/pipeline.rs` — because `run_scatter_gather` parses those flags once,
before any worker forks, and can't recurse back through the async
`PipelineRunner::run` → `Kernel::dispatch` chain to get there.

Every real command's arguments bind through the async `build_args_async`
(`kernel.rs`), which already surfaces a `PathError` (missing key, shape
mismatch, undefined subscripted root) loudly — matching the other three
primary eval sites (assignment, `$(( ))`, `"${…}"`). The sync twin never got
that treatment: every arm discarded the error via `.ok()`/`if let Ok(..)`, so
`scatter --as ${u[nope]}` silently fell back to treating `--as` as a bare
boolean flag (dropping the intended value and stranding the bad expression as
an unused positional) instead of failing, and `${#u[tags]}` on a bad subscript
inside an interpolated flag value silently omitted the length instead of
erroring.

## What changed

- `build_tool_args` is now `Result<ToolArgs, String>`; `eval_simple_expr` is
  now `Result<Option<Value>, String>`; `eval_string_parts_sync` is now
  `Result<String, String>`. `Ok(None)` still means "not representable in this
  reduced sync context" (binary ops, command substitution — the documented,
  deferred "eliminate the sync twin" gap); `Err(msg)` is a genuine `PathError`
  (absence/shape), propagated with the same message text the async path uses.
  An unset *bare* root still coalesces (bash-compatible), unchanged.
- `run_scatter_gather`'s two `build_tool_args` calls now convert an `Err` into
  `ExecResult::failure(1, …)` — the same architectural boundary `run_single`
  already uses for a dispatch error.
- Added two previously-missing `eval_simple_expr` match arms for *bare*
  (unquoted whole-token) `Expr::VarLength`/`Expr::VarWithDefault` —
  `scatter --limit ${#tags}` used to fall through to the catch-all `_ => None`
  (silently dropping the flag entirely). They now route through the shared
  `resolve_length`/`resolve_default` the async path already calls.
- Deduped `eval_simple_expr`'s `Expr::Interpolated` arm, which had its own
  ~60-line copy of `eval_string_parts_sync`'s loop, down to a single call.
- Updated the test-only `BackendDispatcher` (`dispatch.rs`) and its ~19
  in-file unit tests in `pipeline.rs` to the new fallible signature.

Confirmed `build_tool_args` has exactly one production call site — the two
calls in `run_scatter_gather` — everywhere else is `#[cfg(test)]` or
`pipeline.rs`'s own unit tests, so this closes the silent-corruption surface
without touching the deferred larger "eliminate the sync twin" refactor.

## Decisions

- Kept `PathError::UndefinedRoot` on a *bare* variable coalescing to
  empty/skip (matches bash and the async path's string-interpolation
  convention) — only `Absence`/`Shape` on a *subscripted* path are loud, same
  split the async path and `interpreter/eval.rs` already use.
- Left the parallel `StringPart::Arithmetic` swallow in the same two
  functions alone — same symptom class (a bad `scatter --limit $((1/0))`
  would silently omit the digits), but a distinct `anyhow` error type, not
  `PathError` — out of this fix's scope. Recorded in `docs/issues.md` for the
  next pass.

## Test plan

- [x] TDD: wrote the new kernel-routed tests in
      `crates/kaish-kernel/tests/scatter_gather_jsonl_tests.rs` against the
      unmodified source first; confirmed 2 failed as expected (a bad
      subscript and a shape error in `--as` both silently exited 0). A third
      test needed a second pass — its worker read `$N` while the buggy
      fallback actually bound `$n`, so it was accidentally passing "for free"
      for an unrelated reason; fixed to read `$n` and reconfirmed red on old
      code, green after the fix.
- [x] `cargo test --all` — clean
- [x] `cargo clippy --all --all-targets` — zero warnings
- [x] `cargo check -p kaish-kernel --no-default-features` — clean
- [x] kaibo review (deepseek cast) — couldn't check out the branch (known
      sandbox limitation), so it did a predictive semantic-trace review
      against `main` + this PR's description instead of a live diff; every
      item it flagged as "must verify" (UndefinedRoot/Absence/Shape split,
      `.map_err`/anyhow wrapping in `dispatch.rs`, `?` placement, `Ok(...)`
      wrapping, the `PathError` import, test `.expect()` calls, error-string
      preservation in `run_scatter_gather`) checks out against the actual diff.
- [x] `CHANGELOG.md` bullet under `Fixed`; `docs/issues.md` entries closed;
      `docs/devlog.md` entry added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Supersedes #85** (identical content rebased onto main past the #82/#83 merges — the repo's force-push guard makes a fresh branch the sanctioned path). The kaibo (deepseek) review, its one applied finding (subscripted-path undefined roots now loud in `eval_simple_expr`, bare stays bash-lenient), and the deliberate `StringPart::Var` non-change rationale are on #85's thread: https://github.com/tobert/kaish/pull/85#issuecomment-4879692047. Only rebase conflicts were in `docs/issues.md` (both #83 and this PR pruned the same sections — resolved to the union). Gates re-run green on the rebased tip: `cargo test --all` clean, `cargo clippy --all --all-targets` zero warnings.
