### PR TITLE
feat(#80): fromjsonl/tojsonl JSONL doors; jq gets real -s and hint errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,28 @@ breaking entries are marked **BREAKING**.
 
 ## [Unreleased]
 
+### Added
+- **`fromjsonl` / `tojsonl`** — the JSONL (NDJSON) doors, GH #80. `fromjsonl`
+  parses strictly line-oriented JSONL text (one JSON document per line, blank
+  lines skipped, any bad line — including a truncated trailing one — a loud
+  error naming the line number; empty input is a legitimate zero-document
+  stream → `[]`) into a typed list in `.data`. `tojsonl` is the egress mirror:
+  a list in, one compact JSON document per line out (a record/scalar is one
+  document — that's `tojson`'s job). Unlocks `curl … | fromjsonl | scatter`
+  and re-ingesting kaish's own `gather` output (`cat results.jsonl | fromjsonl
+  | jq …`).
+
 ### Changed
+- **`jq -s`/`--slurp` is now real jq slurp semantics**, not a no-op (GH #80).
+  On the text path it parses the whole whitespace-separated document stream
+  and always wraps the result in an array — even a single document
+  (`printf '{"a":1}' | jq -s length` → `1`, the array length, not a no-op's
+  accidental key count). On the `.data` pipeline path `-s` stays a no-op (the
+  upstream stage already handed over one structured value). Plain `jq` (no
+  `-s`) on JSONL-shaped text now names the document count and points at
+  `fromjsonl`/`jq -s` instead of a bare "trailing characters" parse error; the
+  runtime `cannot index [...] with ...` error gains a `.[] | …` hint (kaish
+  jq is always-slurped).
 - **BREAKING: scatter/gather is now the typed parallel map** (GH #73,
   panel-validated). `gather` emits one JSONL result record per worker, in item
   order, failures included — `{"i":N,"item":<typed>,"ok":…,"code":…,"out":…,
@@ -206,6 +227,11 @@ breaking entries are marked **BREAKING**.
   `.data` the same way a bare `"$x"` renders a collection-valued variable
   (compact JSON for lists/records, plain form for scalars); non-empty `.out`
   still wins unchanged.
+- **`gather`'s own trailing redirect (`… | gather > file`) is no longer silently
+  dropped.** Found while wiring up the JSONL doors (GH #80): the scatter/gather
+  special-cased pipeline path never applied `gather`'s redirects when it was
+  the pipeline's last command — the JSONL rows landed back in the result
+  instead of the file.
 - **`Kernel::with_backend` now mounts `/dev` (DevFs) unconditionally** —
   custom-backend embedders (e.g. kaijutsu) previously had no `/dev/null`,
   `/dev/zero`, `/dev/random`, or `/dev/urandom` at all, and `VirtualOverlayBackend`

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ everywhere, a `jq` that always uses the same filter syntax, an `awk` that never 
 |----------|-------|
 | **Text** | awk, base64, cut, diff, grep, head, sed, sort, split, tac, tail, tr, uniq, wc, xxd |
 | **Files** | basename, cat, cd, checksum, cmp, cp, dd, dirname, file, find, glob, ln, ls, mkdir, mktemp, mv, patch, pwd, readlink, realpath, rm, stat, tee, touch, tree, write |
-| **JSON** | fromjson, jq, keys, tojson, typeof, values |
+| **JSON** | fromjson, fromjsonl, jq, keys, tojson, tojsonl, typeof, values |
 | **System** | alias, bg, date, echo, env, exec, export, fg, help, hostname, jobs, kill, printf, ps, push, read, seq, set, sleep, spawn, timeout, tokens, uname, unalias, unset, wait, which |
 | **Parallel** | scatter, gather |
 | **Meta** | assert, false, true |

--- a/crates/kaish-help/content/en/scatter.md
+++ b/crates/kaish-help/content/en/scatter.md
@@ -28,7 +28,9 @@ worker binds the real element — `${ITEM[id]}` subscripts a record, numbers sta
 numbers, `1` ≠ `"1"`. From plain text, one string item per line (blank lines
 skipped). Quote it at command boundaries: `work "$ITEM"` (a record renders as
 compact JSON). A single non-array object, a `null` element, or binary input is
-a loud error.
+a loud error. External JSONL (an API stream, a log file) fans out **typed**
+only through `fromjsonl` first — `curl … | fromjsonl | scatter …` — see
+`help fromjsonl`.
 
 ## Consuming results
 
@@ -46,6 +48,11 @@ done
 … | gather --json    # same records as one pretty JSON array
 … | gather --lines   # raw successful outputs only, item order — HARD ERROR
                      # (exit 123, no partial text) if ANY worker failed
+
+# gather's JSONL rows round-trip through a file:
+… | gather > results.jsonl
+cat results.jsonl | fromjsonl | jq '.[] | select(.ok | not)'    # re-read, typed
+cat results.jsonl | fromjsonl | scatter | retry ${ITEM[item][host]} | gather  # re-fan-out
 ```
 
 ## Exit codes

--- a/crates/kaish-help/content/en/syntax.md
+++ b/crates/kaish-help/content/en/syntax.md
@@ -92,6 +92,7 @@ elif [[ -list $data ]]; then
 fi
 
 tojson $u                 # serialize back to JSON text (--pretty to indent)
+# A stream of many documents (JSONL/NDJSON) is fromjsonl/tojsonl, not fromjson/tojson.
 
 # ASSIGNMENT — the same bracket paths write, in place, no spaces around `=`.
 # No autovivification — every intermediate must already exist with the right

--- a/crates/kaish-help/src/fragments.rs
+++ b/crates/kaish-help/src/fragments.rs
@@ -347,6 +347,7 @@ elif [[ -list $data ]]; then
 fi
 
 tojson $u                 # serialize back to JSON text (--pretty to indent)
+# A stream of many documents (JSONL/NDJSON) is fromjsonl/tojsonl, not fromjson/tojson.
 
 # ASSIGNMENT — the same bracket paths write, in place, no spaces around `=`.
 # No autovivification — every intermediate must already exist with the right

--- a/crates/kaish-kernel/src/scheduler/pipeline.rs
+++ b/crates/kaish-kernel/src/scheduler/pipeline.rs
@@ -351,7 +351,7 @@ impl PipelineRunner {
         let sequential_dispatcher: Arc<dyn CommandDispatcher> = dispatcher.fork_attached().await;
 
         let runner = ScatterGatherRunner::new(self.tools.clone(), sequential_dispatcher);
-        runner
+        let result = runner
             .run(
                 pre_scatter,
                 scatter_opts,
@@ -360,7 +360,21 @@ impl PipelineRunner {
                 post_gather,
                 ctx,
             )
-            .await
+            .await;
+
+        // `gather`'s own trailing redirect (`… | gather > results.jsonl`, GH
+        // #80's canonical egress-to-file flow) is only meaningful when gather
+        // is the pipeline's last command — `runner.run` splices post_gather
+        // stages through the normal `run_sequential` path, which already
+        // applies each of *their* redirects. Without this, `gather`'s
+        // redirect was silently dropped (the rows landed in `result.out`
+        // instead of the file) because `ScatterGatherRunner::run` only sees
+        // `gather_opts` (parsed flags), never `gather_cmd.redirects`.
+        if post_gather.is_empty() {
+            apply_redirects(result, &gather_cmd.redirects, ctx).await
+        } else {
+            result
+        }
     }
 
     /// Run a single command with optional stdin.

--- a/crates/kaish-kernel/src/tools/builtin/fromjsonl.rs
+++ b/crates/kaish-kernel/src/tools/builtin/fromjsonl.rs
@@ -95,9 +95,11 @@ impl Tool for FromJsonl {
                 Ok(s) => s.to_string(),
                 Err(_) => return ExecResult::failure(1, "fromjsonl: input is binary, not text"),
             },
-            // An already-structured value: re-serialize its JSON text so
-            // fromjsonl is idempotent on values that are already typed (it
-            // becomes a single-line, one-element document stream).
+            // An already-structured value: re-serialize its compact JSON text,
+            // which then parses as a single-line, ONE-document stream — so
+            // `fromjsonl $v` yields `[$v]` (a one-element wrap), not `$v`
+            // back. Typed values that want to stay themselves don't need a
+            // door at all.
             Some(other) => kaish_types::value_to_json(other).to_string(),
             None => match ctx.read_stdin_to_text().await {
                 Ok(Some(s)) => s,

--- a/crates/kaish-kernel/src/tools/builtin/fromjsonl.rs
+++ b/crates/kaish-kernel/src/tools/builtin/fromjsonl.rs
@@ -1,0 +1,171 @@
+//! fromjsonl — parse strictly line-oriented JSONL text into a typed list.
+//!
+//! The JSONL *ingress* half of the stream-boundary door pair (the egress half
+//! is [`super::tojsonl`]). GH #80, worked back from scatter/gather (#73):
+//! external NDJSON (an API stream, a log file, kaish's own `gather` output)
+//! has no path into typed `.data` today — `fromjson`/`jq` both hard-reject
+//! multi-document text. `fromjsonl` is that door.
+//!
+//! Mirrors `fromjson`'s conventions (see that module for the sibling
+//! ingress half): string positional or piped stdin text, envelope-free
+//! conversion, `.data` out. The differences are the whole point:
+//!
+//! - **Strictly line-oriented** (the name is the contract): each non-blank
+//!   line parses as exactly one complete JSON document → one element of the
+//!   output list. A pretty-printed, multi-line document is a loud error
+//!   pointing at `fromjson` (one document) or `jq -s` (many) — that's not
+//!   what this tool is for.
+//! - **Blank lines are skipped**, same rule as scatter's text ingress.
+//! - **Any unparseable line — including a truncated trailing line — is a
+//!   loud error naming the line number.** Never a silent skip.
+//! - **`null` elements are allowed** — it's data; scatter guards nulls at its
+//!   own boundary.
+//! - **Empty input → empty list, exit 0.** A stream of zero documents is a
+//!   legitimate stream. This is a deliberate asymmetry with `fromjson`
+//!   (where empty input is loud) — it falls out naturally here because an
+//!   empty document stream is just "every line was blank" (there are none).
+//!
+//! # Examples
+//!
+//! ```kaish
+//! curl -s api/events.ndjson | fromjsonl | scatter -j8 -- restart ${ITEM[host]}
+//! cat results.jsonl | fromjsonl | jq '.[] | select(.ok | not)'
+//! ```
+
+use async_trait::async_trait;
+use clap::{CommandFactory, Parser};
+
+use crate::ast::Value;
+use crate::interpreter::ExecResult;
+use crate::tools::{schema_from_clap, ExecContext, GlobalFlags, Tool, ToolArgs, ToolCtx, ToolSchema};
+
+/// fromjsonl tool: parse JSONL text into a typed list.
+pub struct FromJsonl;
+
+/// clap-derived argv layer for fromjsonl.
+#[derive(Parser, Debug)]
+#[command(name = "fromjsonl", about = "Parse JSONL text (one document per line) into a list")]
+struct FromJsonlArgs {
+    #[command(flatten)]
+    global: GlobalFlags,
+
+    /// JSONL text to parse (or pipe it on stdin). Hidden sink — the real
+    /// value is read off `args.positional` per the Value-typed positional
+    /// rule.
+    #[arg(hide = true)]
+    input: Vec<String>,
+}
+
+#[async_trait]
+impl Tool for FromJsonl {
+    fn name(&self) -> &str {
+        "fromjsonl"
+    }
+
+    fn schema(&self) -> ToolSchema {
+        schema_from_clap(
+            &FromJsonlArgs::command(),
+            "fromjsonl",
+            "Parse JSONL text (one JSON document per line) into a typed list (in .data)",
+            [
+                ("Fan a JSONL stream out to workers", "curl -s api/events.ndjson | fromjsonl | scatter"),
+                ("Re-read kaish's own gather output", "cat results.jsonl | fromjsonl | jq '.[] | select(.ok | not)'"),
+                ("Parse a literal string", "fromjsonl $'{\"a\":1}\\n{\"a\":2}'"),
+            ],
+        )
+    }
+
+    async fn execute(&self, args: ToolArgs, ctx: &mut dyn ToolCtx) -> ExecResult {
+        let Some(ctx) = ctx.as_any_mut().downcast_mut::<ExecContext>() else {
+            return ExecResult::failure(1, "internal error: kernel builtin requires ExecContext");
+        };
+        let parsed = match FromJsonlArgs::try_parse_from(
+            std::iter::once("fromjsonl".to_string()).chain(args.to_argv()),
+        ) {
+            Ok(p) => p,
+            Err(e) => return ExecResult::failure(2, format!("fromjsonl: {e}")),
+        };
+        parsed.global.apply(ctx);
+
+        // Input text: an explicit positional argument wins; otherwise stdin.
+        // Mirrors fromjson's resolution exactly (see that module).
+        let input = match args.positional.first() {
+            Some(Value::String(s)) => s.clone(),
+            Some(Value::Bytes(b)) => match std::str::from_utf8(b) {
+                Ok(s) => s.to_string(),
+                Err(_) => return ExecResult::failure(1, "fromjsonl: input is binary, not text"),
+            },
+            // An already-structured value: re-serialize its JSON text so
+            // fromjsonl is idempotent on values that are already typed (it
+            // becomes a single-line, one-element document stream).
+            Some(other) => kaish_types::value_to_json(other).to_string(),
+            None => match ctx.read_stdin_to_text().await {
+                Ok(Some(s)) => s,
+                // No stdin connected at all (as opposed to an empty pipe,
+                // which is legitimate zero-document input) is a usage error.
+                Ok(None) => {
+                    return ExecResult::failure(
+                        1,
+                        "fromjsonl: no input (pass JSONL text or pipe stdin)",
+                    )
+                }
+                Err(e) => return ExecResult::failure(2, format!("fromjsonl: {e}")),
+            },
+        };
+
+        let mut elements: Vec<serde_json::Value> = Vec::new();
+        let mut offset = 0usize;
+        let mut line_no = 0usize;
+        for raw_line in input.split_inclusive('\n') {
+            line_no += 1;
+            let start = offset;
+            offset += raw_line.len();
+
+            let line = raw_line.strip_suffix('\n').unwrap_or(raw_line);
+            let line = line.strip_suffix('\r').unwrap_or(line);
+            if line.trim().is_empty() {
+                continue;
+            }
+
+            match serde_json::from_str::<serde_json::Value>(line) {
+                Ok(v) => elements.push(v),
+                Err(e) => {
+                    return ExecResult::failure(1, diagnose_line_error(&input[start..], line_no, &e));
+                }
+            }
+        }
+
+        // Envelope-free, same law as fromjson: an envelope-shaped object
+        // stays a plain record inside the list, never silently decoded to
+        // Value::Bytes.
+        let list = kaish_types::json_to_value_no_envelope(serde_json::Value::Array(elements));
+        ExecResult::success_data(list)
+    }
+}
+
+/// Diagnose a per-line JSON parse failure.
+///
+/// `remaining` is the original input starting at the byte offset of the
+/// failing line. If the failure is actually the start of a valid JSON value
+/// that only completes further down the input — a pretty-printed multi-line
+/// document — say so explicitly and point at `fromjson` (one document) or
+/// `jq -s` (many) rather than reporting a bare per-line parse error. Genuine
+/// garbage (including a truncated trailing line) falls through to the plain
+/// line-numbered message.
+fn diagnose_line_error(remaining: &str, line_no: usize, err: &serde_json::Error) -> String {
+    let first_line_len = remaining.lines().next().map(str::len).unwrap_or(0);
+    let mut stream = serde_json::Deserializer::from_str(remaining).into_iter::<serde_json::Value>();
+    let spans_further_lines =
+        matches!(stream.next(), Some(Ok(_))) && stream.byte_offset() > first_line_len;
+
+    if spans_further_lines {
+        format!(
+            "fromjsonl: line {line_no}: looks like a multi-line pretty-printed JSON document — \
+             fromjsonl is strictly line-oriented (one JSON document per line); use `fromjson` \
+             for a single document, or `jq -s` to slurp multiple documents"
+        )
+    } else {
+        format!("fromjsonl: line {line_no}: invalid JSON: {err}")
+    }
+}
+

--- a/crates/kaish-kernel/src/tools/builtin/jq_native.rs
+++ b/crates/kaish-kernel/src/tools/builtin/jq_native.rs
@@ -54,6 +54,13 @@ struct JqArgs {
     #[arg(short = 'n', long = "null-input", visible_alias = "null_input")]
     null_input: bool,
 
+    /// Slurp mode (-s): read the whole input as a document stream and wrap
+    /// it in one array — always, even for a single document (real jq
+    /// semantics; see module docs "jq — stays one-document, gets louder").
+    /// A no-op on the `.data` path, where the pipeline is already slurped.
+    #[arg(short = 's', long = "slurp")]
+    slurp: bool,
+
     /// Read from VFS file instead of stdin.
     #[arg(long = "path")]
     path: Option<String>,
@@ -209,7 +216,19 @@ fn execute_filter_json(
                 values.push(val_to_json(&val));
             }
             Err(e) => {
-                return Err(format!("jq runtime error: {e}"));
+                let msg = e.to_string();
+                // jaq's own array-index error renders as `cannot index [...]
+                // with ...` (the array prints as its JSON text). That's the
+                // exact signature of writing real-jq's per-row streaming
+                // form (`.foo`) against kaish's always-slurped array input
+                // (GH #80's `.[]` watch item from scatter/gather) — hint the
+                // fix rather than leaving the agent to guess.
+                let hint = if msg.starts_with("cannot index [") {
+                    " — kaish jq is always-slurped — try '.[] | …'"
+                } else {
+                    ""
+                };
+                return Err(format!("jq runtime error: {msg}{hint}"));
             }
         }
     }
@@ -420,6 +439,10 @@ impl Tool for JqNative {
                     "Bind a kaish variable into the filter",
                     r#"R='{"x":42}'; jq -n --argjson r "$R" '$r.x'"#,
                 ),
+                (
+                    "Slurp a document stream into one array",
+                    "cat results.jsonl | jq -s 'length'",
+                ),
             ],
         );
         // Bump consumes=2 for arg/argjson: clap layer parses them as
@@ -522,6 +545,7 @@ impl Tool for JqNative {
         let compact = parsed.compact || args.has_flag("compact") || args.has_flag("c");
         let null_input =
             parsed.null_input || args.has_flag("null-input") || args.has_flag("n");
+        let slurp = parsed.slurp || args.has_flag("slurp") || args.has_flag("s");
 
         // Get input JSON. `-n` / `--null-input` skips stdin entirely and feeds
         // `null` to the filter — same as real jq. Otherwise: fast path through
@@ -545,9 +569,25 @@ impl Tool for JqNative {
                                 )
                             }
                         };
-                        match serde_json::from_str(&text) {
-                            Ok(json) => json,
-                            Err(e) => return ExecResult::failure(1, format!("jq: invalid JSON in {}: {}", path, e)),
+                        if slurp {
+                            match parse_document_stream(&text) {
+                                Ok(docs) => serde_json::Value::Array(docs),
+                                Err(e) => {
+                                    return ExecResult::failure(1, format!("jq: -s: {}: {}", path, e))
+                                }
+                            }
+                        } else {
+                            match serde_json::from_str(&text) {
+                                Ok(json) => json,
+                                Err(e) => {
+                                    let hint =
+                                        jsonl_hint_for_trailing_error(&text, &e).unwrap_or_default();
+                                    return ExecResult::failure(
+                                        1,
+                                        format!("jq: invalid JSON in {}: {}{}", path, e, hint),
+                                    );
+                                }
+                            }
                         }
                     }
                     Err(e) => {
@@ -555,41 +595,15 @@ impl Tool for JqNative {
                     }
                 }
             } else {
-                // Resolve stdin: structured `.data` from the pipeline if the
-                // upstream produced it, else the raw text. resolve_stdin drains
-                // the pipe before awaiting the data sideband — no startup race.
-                let (data, text) = match ctx.resolve_stdin().await {
-                    Ok(pair) => pair,
-                    Err(e) => return ExecResult::failure(2, format!("jq: {e}")),
-                };
-                if let Some(data) = data {
-                    ast_value_to_json(&data)
-                } else {
-                    if text.is_empty() {
-                        return ExecResult::failure(1, "jq: no input provided");
-                    }
-                    match serde_json::from_str(&text) {
-                        Ok(json) => json,
-                        Err(e) => return ExecResult::failure(1, format!("jq: invalid JSON input: {}", e)),
-                    }
+                match resolve_stdin_json(ctx, slurp).await {
+                    Ok(json) => json,
+                    Err((code, msg)) => return ExecResult::failure(code, msg),
                 }
             }
         } else {
-            // Same structured-or-text resolution as the no-files branch above.
-            let (data, text) = match ctx.resolve_stdin().await {
-                Ok(pair) => pair,
-                Err(e) => return ExecResult::failure(2, format!("jq: {e}")),
-            };
-            if let Some(data) = data {
-                ast_value_to_json(&data)
-            } else {
-                if text.is_empty() {
-                    return ExecResult::failure(1, "jq: no input provided");
-                }
-                match serde_json::from_str(&text) {
-                    Ok(json) => json,
-                    Err(e) => return ExecResult::failure(1, format!("jq: invalid JSON input: {}", e)),
-                }
+            match resolve_stdin_json(ctx, slurp).await {
+                Ok(json) => json,
+                Err((code, msg)) => return ExecResult::failure(code, msg),
             }
         };
 
@@ -693,6 +707,76 @@ fn build_exec_result(run: JqRun) -> ExecResult {
         }
     }
     ExecResult::success_with_data(text, Value::Json(serde_json::Value::Array(values)))
+}
+
+/// Parse a whitespace-separated stream of JSON documents (real-jq slurp
+/// framing — `serde_json`'s `StreamDeserializer` tolerates the pretty-printed
+/// multi-line case, unlike a strict line-oriented split).
+///
+/// Used both by `-s`/`--slurp` (GH #80) and by the JSONL-hint diagnosis
+/// below, which needs to know how many documents actually parse.
+fn parse_document_stream(text: &str) -> Result<Vec<serde_json::Value>, String> {
+    let mut docs = Vec::new();
+    for item in serde_json::Deserializer::from_str(text).into_iter::<serde_json::Value>() {
+        match item {
+            Ok(v) => docs.push(v),
+            Err(e) => return Err(format!("invalid JSON in document stream: {e}")),
+        }
+    }
+    Ok(docs)
+}
+
+/// After a single-document parse failure, check whether the remainder is
+/// actually more JSON documents (JSONL-shaped input) rather than plain
+/// garbage. kaish jq is one-document-only (GH #80) — this turns the
+/// confusing raw "trailing characters" error into a pointer at the real fix:
+/// `fromjsonl` upstream, or `jq -s` in place. Returns `None` (no hint) for
+/// any other parse error, or when the stream doesn't fully parse (genuine
+/// garbage, not a document stream).
+fn jsonl_hint_for_trailing_error(text: &str, err: &serde_json::Error) -> Option<String> {
+    if !err.to_string().contains("trailing characters") {
+        return None;
+    }
+    let docs = parse_document_stream(text).ok()?;
+    (docs.len() >= 2).then(|| {
+        format!(
+            " — input looks like JSONL ({} documents) — kaish jq takes one document; \
+             use fromjsonl upstream, or jq -s",
+            docs.len()
+        )
+    })
+}
+
+/// Resolve the pipeline's stdin (no `--path` file) into the JSON fed to the
+/// filter, shared by both the bare-stdin and empty-`--path=` branches of
+/// `execute`. Returns `(exit_code, message)` on failure so the caller can
+/// preserve the existing 1-vs-2 exit-code split (parse/runtime vs. plumbing).
+async fn resolve_stdin_json(ctx: &mut ExecContext, slurp: bool) -> Result<serde_json::Value, (i64, String)> {
+    let (data, text) = ctx.resolve_stdin().await.map_err(|e| (2, format!("jq: {e}")))?;
+    if let Some(data) = data {
+        // `.data` path: `-s` is a no-op — the upstream stage (scatter/gather,
+        // fromjson, …) already handed over one structured value.
+        return Ok(ast_value_to_json(&data));
+    }
+    if text.is_empty() {
+        return if slurp {
+            // A stream of zero documents slurps to an empty array (matches
+            // real jq: `printf '' | jq -s .` → `[]`).
+            Ok(serde_json::Value::Array(Vec::new()))
+        } else {
+            Err((1, "jq: no input provided".to_string()))
+        };
+    }
+    if slurp {
+        parse_document_stream(&text)
+            .map(serde_json::Value::Array)
+            .map_err(|e| (1, format!("jq: -s: {e}")))
+    } else {
+        serde_json::from_str(&text).map_err(|e| {
+            let hint = jsonl_hint_for_trailing_error(&text, &e).unwrap_or_default();
+            (1, format!("jq: invalid JSON input: {e}{hint}"))
+        })
+    }
 }
 
 /// Validate a jq filter expression without executing it.

--- a/crates/kaish-kernel/src/tools/builtin/mod.rs
+++ b/crates/kaish-kernel/src/tools/builtin/mod.rs
@@ -33,6 +33,7 @@ mod export;
 mod fg;
 mod file;
 mod fromjson;
+mod fromjsonl;
 mod glob;
 mod find;
 pub(crate) mod format_string;
@@ -85,6 +86,7 @@ mod tail;
 mod tee;
 mod timeout;
 mod tojson;
+mod tojsonl;
 #[cfg(feature = "tokens")]
 mod tokens;
 mod touch;
@@ -162,6 +164,7 @@ pub fn register_builtins(registry: &mut ToolRegistry) {
     registry.register(fg::Fg);
     registry.register(file::File);
     registry.register(fromjson::FromJson);
+    registry.register(fromjsonl::FromJsonl);
     registry.register(glob::Glob);
     registry.register(find::Find);
     registry.register(gather::Gather);
@@ -215,6 +218,7 @@ pub fn register_builtins(registry: &mut ToolRegistry) {
     #[cfg(feature = "tokens")]
     registry.register(tokens::Tokens);
     registry.register(tojson::ToJson);
+    registry.register(tojsonl::ToJsonl);
     registry.register(touch::Touch);
     registry.register(tr::Tr);
     registry.register(tree::Tree);

--- a/crates/kaish-kernel/src/tools/builtin/tojsonl.rs
+++ b/crates/kaish-kernel/src/tools/builtin/tojsonl.rs
@@ -1,0 +1,145 @@
+//! tojsonl — serialize a kaish list to compact JSONL text, one document per line.
+//!
+//! The JSONL *egress* half of the stream-boundary door pair (the ingress half
+//! is [`super::fromjsonl`]); GH #80, worked back from scatter/gather (#73)
+//! needing a lingua franca to hand its typed rows back out as line-oriented
+//! text. Mirrors `tojson`'s conventions (see that module for the sibling
+//! egress half) for the list shape specifically:
+//!
+//! - **Input must be a list.** A record or scalar is one JSON document —
+//!   that's `tojson`'s job, or wrap it in a list first (`[$x]`). Loud error
+//!   naming the fix, never a silent single-line fallback.
+//! - **One Value positional, or piped `.data`** — read off `args.positional`
+//!   per the Value-typed positional rule when given explicitly; otherwise
+//!   pull the upstream pipeline's structured `.data` so `tojsonl` composes
+//!   as a real pipeline stage (`curl … | fromjson | tojsonl`), not just a
+//!   `$(…)`-capture-then-serialize step.
+//! - **Text out, no `.data`** — the whole point is the JSONL *text* form;
+//!   setting `.data` would make `$(tojsonl …)` round-trip straight back to
+//!   a value instead of producing text.
+//! - **Always compact, no `--pretty`** — pretty-printed JSONL isn't a thing.
+//! - **`Value::Bytes` is a loud error** — bytes are not JSON.
+//! - **Empty list → empty output, exit 0** — round-trips with `fromjsonl`.
+//!
+//! # Examples
+//!
+//! ```kaish
+//! xs=$(fromjson '[1,2,3]')
+//! tojsonl $xs                                # "1\n2\n3\n"
+//! cat results.jsonl | fromjsonl | tojsonl    # round-trip
+//! ```
+
+use async_trait::async_trait;
+use clap::{CommandFactory, Parser};
+
+use crate::ast::Value;
+use crate::interpreter::ExecResult;
+use crate::tools::{schema_from_clap, ExecContext, GlobalFlags, Tool, ToolArgs, ToolCtx, ToolSchema};
+
+use super::keys::describe_kind;
+
+/// tojsonl tool: serialize a list to compact JSONL text.
+pub struct ToJsonl;
+
+/// clap-derived argv layer for tojsonl.
+#[derive(Parser, Debug)]
+#[command(name = "tojsonl", about = "Serialize a list to JSONL text, one document per line")]
+struct ToJsonlArgs {
+    #[command(flatten)]
+    global: GlobalFlags,
+
+    /// The list to serialize. Hidden sink — the real value is read off
+    /// `args.positional` per the Value-typed positional rule.
+    #[arg(hide = true)]
+    value: Vec<String>,
+}
+
+#[async_trait]
+impl Tool for ToJsonl {
+    fn name(&self) -> &str {
+        "tojsonl"
+    }
+
+    fn schema(&self) -> ToolSchema {
+        schema_from_clap(
+            &ToJsonlArgs::command(),
+            "tojsonl",
+            "Serialize a list to JSONL text, one compact document per line (text out)",
+            [
+                ("Serialize a list", "tojsonl $xs"),
+                ("Round-trip through fromjsonl", "cat results.jsonl | fromjsonl | tojsonl"),
+                ("A record is one document — wrap it", "tojsonl [$record]"),
+            ],
+        )
+    }
+
+    async fn execute(&self, args: ToolArgs, ctx: &mut dyn ToolCtx) -> ExecResult {
+        let Some(ctx) = ctx.as_any_mut().downcast_mut::<ExecContext>() else {
+            return ExecResult::failure(1, "internal error: kernel builtin requires ExecContext");
+        };
+        let parsed = match ToJsonlArgs::try_parse_from(
+            std::iter::once("tojsonl".to_string()).chain(args.to_argv()),
+        ) {
+            Ok(p) => p,
+            Err(e) => return ExecResult::failure(2, format!("tojsonl: {e}")),
+        };
+        parsed.global.apply(ctx);
+
+        let value = match args.positional.first() {
+            Some(v) => v.clone(),
+            None => match ctx.resolve_stdin().await {
+                Ok((Some(data), _)) => data,
+                Ok((None, _)) => {
+                    return ExecResult::failure(
+                        1,
+                        "tojsonl: no value (pass a list, or pipe .data from an upstream builtin)",
+                    )
+                }
+                Err(e) => return ExecResult::failure(2, format!("tojsonl: {e}")),
+            },
+        };
+
+        // Bytes are not JSON — refuse loudly rather than emit a base64
+        // envelope that would silently masquerade as the data (same rule as
+        // tojson).
+        if let Value::Bytes(b) = &value {
+            return ExecResult::failure(
+                1,
+                format!("tojsonl: cannot serialize {} bytes of binary — use base64", b.len()),
+            );
+        }
+
+        let elements = match &value {
+            Value::Json(serde_json::Value::Array(items)) => items,
+            other => {
+                return ExecResult::failure(
+                    1,
+                    format!(
+                        "tojsonl: expected a list, got {} — a record/scalar is one document: \
+                         use `tojson`, or wrap it in a list first",
+                        describe_kind(other)
+                    ),
+                )
+            }
+        };
+
+        let mut out = String::new();
+        for element in elements {
+            match serde_json::to_string(element) {
+                Ok(line) => {
+                    out.push_str(&line);
+                    out.push('\n');
+                }
+                // Every element originated from a serde_json::Value, which is
+                // always serializable — this is unreachable in practice, but
+                // propagate rather than silently drop the line if it ever
+                // isn't (e.g. a future NaN/Infinity float representation).
+                Err(e) => return ExecResult::failure(1, format!("tojsonl: {e}")),
+            }
+        }
+
+        // Text out only — no .data, so `$(tojsonl …)` captures the JSONL text.
+        ExecResult::success(out)
+    }
+}
+

--- a/crates/kaish-kernel/tests/json_sweep_tests.rs
+++ b/crates/kaish-kernel/tests/json_sweep_tests.rs
@@ -109,6 +109,12 @@ const CASES: &[Case] = &[
     Case { name: "file", setup: &[], cmd: "file tmp/data.json --json", expect: Expect::Array },
     Case { name: "find", setup: &[], cmd: "find src -name '*.rs' --json", expect: Expect::Array },
     Case { name: "fromjson", setup: &[], cmd: r#"fromjson '{"a":1}' --json"#, expect: Expect::Object },
+    Case {
+        name: "fromjsonl",
+        setup: &[],
+        cmd: "printf '{\"a\":1}\\n{\"a\":2}\\n' | fromjsonl --json",
+        expect: Expect::Array,
+    },
     // scatter/gather own their output (`owns_output`): `--json` passes
     // through untouched and `--format json` is the structured form.
     Case { name: "gather", setup: &[], cmd: "seq 1 2 | scatter --as N | echo $N | gather --json", expect: Expect::Array },
@@ -172,6 +178,12 @@ const CASES: &[Case] = &[
     Case { name: "tee", setup: &[], cmd: "echo hi | tee out.txt --json", expect: Expect::String },
     Case { name: "timeout", setup: &[], cmd: "timeout 5 echo hi --json", expect: Expect::String },
     Case { name: "tojson", setup: &[], cmd: "tojson hello --json", expect: Expect::String },
+    Case {
+        name: "tojsonl",
+        setup: &[],
+        cmd: r#"xs=$(fromjson '[1,2]'); tojsonl $xs --json"#,
+        expect: Expect::String,
+    },
     Case { name: "tokens", setup: &[], cmd: "echo hello | tokens --json", expect: Expect::Array },
     Case { name: "touch", setup: &[], cmd: "touch new.txt --json", expect: Expect::Empty },
     Case { name: "tr", setup: &[], cmd: "printf 'abc' | tr a x --json", expect: Expect::String },

--- a/crates/kaish-kernel/tests/jsonl_doors_tests.rs
+++ b/crates/kaish-kernel/tests/jsonl_doors_tests.rs
@@ -101,6 +101,21 @@ async fn fromjsonl_no_input_at_all_is_a_usage_error() {
     assert!(err.contains("no input"), "err: {err}");
 }
 
+#[tokio::test]
+async fn fromjsonl_accepts_crlf_line_endings() {
+    // Windows-flavored JSONL: each line's trailing \r is stripped before the
+    // per-line parse (split on \n, then strip one \r), so CRLF input
+    // round-trips identically to LF input.
+    let k = setup().await;
+    let (out, code, err) = run(
+        &k,
+        "printf '{\"a\":1}\\r\\n{\"a\":2}\\r\\n' | fromjsonl | tojsonl",
+    )
+    .await;
+    assert_eq!(code, 0, "err: {err}");
+    assert_eq!(out, "{\"a\":1}\n{\"a\":2}");
+}
+
 // ═══════════════════════════════════════════════════════════════════════
 // tojsonl — list → JSONL text
 // ═══════════════════════════════════════════════════════════════════════
@@ -127,6 +142,45 @@ async fn tojsonl_empty_list_is_empty_output() {
     let (out, code, err) = run(&k, r#"xs=$(fromjson '[]'); tojsonl $xs"#).await;
     assert_eq!(code, 0, "err: {err}");
     assert_eq!(out, "");
+}
+
+#[tokio::test]
+async fn tojsonl_bytes_is_loud_never_an_envelope() {
+    // `/w==` decodes to a single 0xFF byte — invalid UTF-8, so base64 -d
+    // yields a Bytes value. tojsonl must refuse it loudly (same law as
+    // tojson): a silent base64 envelope here would masquerade as the data.
+    let k = setup().await;
+    let (out, code, err) = run(&k, "x=$(echo '/w==' | base64 -d); tojsonl $x").await;
+    assert_ne!(code, 0);
+    assert!(err.contains("binary"), "err: {err}");
+    assert!(err.contains("base64"), "err names the escape hatch: {err}");
+    assert!(!out.contains("_type"), "no envelope leaked to stdout: {out}");
+}
+
+#[tokio::test]
+async fn tojsonl_embedded_newline_stays_one_line() {
+    // The tool's central safety property: a string element containing a real
+    // newline must serialize as exactly ONE output line, with the newline
+    // escaped as \n inside the JSON string — otherwise the "one document per
+    // line" contract breaks and fromjsonl can't re-read its own output.
+    let k = setup().await;
+    let (out, code, err) = run(
+        &k,
+        r#"xs=$(fromjson '[{"msg":"line1\nline2"}]'); tojsonl $xs"#,
+    )
+    .await;
+    assert_eq!(code, 0, "err: {err}");
+    assert_eq!(out, r#"{"msg":"line1\nline2"}"#, "one line, \\n escaped");
+    assert_eq!(out.lines().count(), 1, "exactly one output line: {out:?}");
+
+    // And the safety property closes the loop: the output re-ingests.
+    let (out2, code, err) = run(
+        &k,
+        r#"xs=$(fromjson '[{"msg":"line1\nline2"}]'); tojsonl $xs | fromjsonl | tojsonl"#,
+    )
+    .await;
+    assert_eq!(code, 0, "err: {err}");
+    assert_eq!(out2, out, "round-trips through fromjsonl unchanged");
 }
 
 #[tokio::test]

--- a/crates/kaish-kernel/tests/jsonl_doors_tests.rs
+++ b/crates/kaish-kernel/tests/jsonl_doors_tests.rs
@@ -1,0 +1,296 @@
+//! Kernel-routed tests for the JSONL doors (GH #80): `fromjsonl` / `tojsonl`,
+//! plus the accompanying jq changes (real `-s`/`--slurp`, JSONL-hint parse
+//! errors, and the "always-slurped" runtime-error hint).
+//!
+//! Driven through `kernel.execute()` (never a builtin's `.execute()`
+//! directly) per the project convention — the real dispatch chain (arg
+//! binding, `--json`, pipeline `.data` sideband) has to run for these to mean
+//! anything. Pure-data tests use `KernelConfig::isolated()` (no localfs, so
+//! the pair works in every capability build); the scatter/gather-through-a-
+//! file round trip needs `localfs` and is gated accordingly.
+
+// Test-fixture code: unwrap/expect on known-good setup is the idiom here.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::sync::Arc;
+
+use kaish_kernel::{Kernel, KernelConfig};
+
+async fn setup() -> Arc<Kernel> {
+    Kernel::new(KernelConfig::isolated().with_skip_validation(true))
+        .expect("failed to create kernel")
+        .into_arc()
+}
+
+async fn run(k: &Kernel, script: &str) -> (String, i64, String) {
+    let r = k.execute(script).await.expect("kernel execute");
+    (r.text_out().trim().to_string(), r.code, r.err.clone())
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// fromjsonl — JSONL text → typed list
+// ═══════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn fromjsonl_happy_path_typed_list() {
+    let k = setup().await;
+    // Route the parsed .data straight through tojsonl (rather than a
+    // $()-capture + tojson round trip) so this exercises the ingress door
+    // end to end as a real pipeline stage.
+    let (out, code, err) = run(&k, "printf '{\"a\":1}\\n{\"a\":2}\\n' | fromjsonl | tojsonl").await;
+    assert_eq!(code, 0, "err: {err}");
+    assert_eq!(out, "{\"a\":1}\n{\"a\":2}");
+}
+
+#[tokio::test]
+async fn fromjsonl_blank_lines_are_skipped() {
+    let k = setup().await;
+    let (out, code, err) = run(&k, "printf '1\\n\\n2\\n\\n\\n3\\n' | fromjsonl | tojsonl").await;
+    assert_eq!(code, 0, "err: {err}");
+    assert_eq!(out, "1\n2\n3");
+}
+
+#[tokio::test]
+async fn fromjsonl_truncated_trailing_line_is_loud_with_line_number() {
+    let k = setup().await;
+    let (_, code, err) = run(&k, "printf '{\"a\":1}\\n{\"a\":2' | fromjsonl").await;
+    assert_ne!(code, 0);
+    assert!(err.contains("line 2"), "err: {err}");
+}
+
+#[tokio::test]
+async fn fromjsonl_garbage_line_is_loud_with_line_number() {
+    let k = setup().await;
+    let (_, code, err) = run(&k, "printf '1\\nnot json\\n3\\n' | fromjsonl").await;
+    assert_ne!(code, 0);
+    assert!(err.contains("line 2"), "err: {err}");
+    assert!(err.contains("invalid JSON"), "err: {err}");
+}
+
+#[tokio::test]
+async fn fromjsonl_empty_input_is_empty_list_exit_0() {
+    let k = setup().await;
+    let (out, code, err) = run(&k, "printf '' | fromjsonl | tojsonl").await;
+    assert_eq!(code, 0, "empty input is a legitimate zero-document stream; err: {err}");
+    assert_eq!(out, "");
+}
+
+#[tokio::test]
+async fn fromjsonl_null_element_passes_through() {
+    let k = setup().await;
+    let (out, code, err) = run(&k, "printf '1\\nnull\\n3\\n' | fromjsonl | tojsonl").await;
+    assert_eq!(code, 0, "err: {err}");
+    assert_eq!(out, "1\nnull\n3");
+}
+
+#[tokio::test]
+async fn fromjsonl_pretty_multiline_document_is_loud_with_hint() {
+    let k = setup().await;
+    let (_, code, err) = run(&k, "printf '{\\n  \"a\": 1\\n}\\n' | fromjsonl").await;
+    assert_ne!(code, 0);
+    assert!(err.contains("fromjson"), "err should point at fromjson: {err}");
+    assert!(err.contains("jq -s"), "err should point at jq -s: {err}");
+}
+
+#[tokio::test]
+async fn fromjsonl_no_input_at_all_is_a_usage_error() {
+    // Distinct from an empty pipe: no stdin connected whatsoever.
+    let k = setup().await;
+    let (_, code, err) = run(&k, "fromjsonl").await;
+    assert_ne!(code, 0);
+    assert!(err.contains("no input"), "err: {err}");
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// tojsonl — list → JSONL text
+// ═══════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn tojsonl_list_to_lines() {
+    let k = setup().await;
+    let (out, code, err) = run(&k, r#"xs=$(fromjson '[1,"a",{"b":2}]'); tojsonl $xs"#).await;
+    assert_eq!(code, 0, "err: {err}");
+    assert_eq!(out, "1\n\"a\"\n{\"b\":2}");
+}
+
+#[tokio::test]
+async fn tojsonl_non_list_is_loud_with_fix() {
+    let k = setup().await;
+    let (_, code, err) = run(&k, r#"x=$(fromjson '{"a":1}'); tojsonl $x"#).await;
+    assert_ne!(code, 0);
+    assert!(err.contains("tojson"), "err should name the fix: {err}");
+}
+
+#[tokio::test]
+async fn tojsonl_empty_list_is_empty_output() {
+    let k = setup().await;
+    let (out, code, err) = run(&k, r#"xs=$(fromjson '[]'); tojsonl $xs"#).await;
+    assert_eq!(code, 0, "err: {err}");
+    assert_eq!(out, "");
+}
+
+#[tokio::test]
+async fn tojsonl_round_trips_with_fromjsonl() {
+    let k = setup().await;
+    let (out, code, err) = run(
+        &k,
+        "printf '{\"a\":1}\\n{\"b\":2}\\n' | fromjsonl | tojsonl",
+    )
+    .await;
+    assert_eq!(code, 0, "err: {err}");
+    assert_eq!(out, "{\"a\":1}\n{\"b\":2}");
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// jq — stays one document, gets louder, real -s
+// ═══════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn jq_single_document_text_unchanged() {
+    let k = setup().await;
+    let (out, code, err) = run(&k, r#"echo '{"name":"Alice"}' | jq -r '.name'"#).await;
+    assert_eq!(code, 0, "err: {err}");
+    assert_eq!(out, "Alice");
+}
+
+#[tokio::test]
+async fn jq_jsonl_shaped_input_gets_the_hint() {
+    let k = setup().await;
+    let (_, code, err) = run(
+        &k,
+        r#"printf '{"a":1}\n{"a":2}\n{"a":3}\n' | jq '.a'"#,
+    )
+    .await;
+    assert_ne!(code, 0);
+    assert!(err.contains("JSONL"), "err: {err}");
+    assert!(err.contains("3 documents"), "err: {err}");
+    assert!(err.contains("fromjsonl"), "err: {err}");
+    assert!(err.contains("jq -s"), "err: {err}");
+}
+
+#[tokio::test]
+async fn jq_garbage_input_stays_the_plain_error() {
+    // Not JSONL-shaped — a genuine syntax error should NOT get the JSONL hint.
+    let k = setup().await;
+    let (_, code, err) = run(&k, "echo 'not valid json at all' | jq '.'").await;
+    assert_ne!(code, 0);
+    assert!(!err.contains("JSONL"), "garbage should stay plain: {err}");
+}
+
+#[tokio::test]
+async fn jq_slurp_wraps_a_single_document_in_an_array() {
+    // The must-not-diverge case: printf '{"a":1}' | jq -s length == 1 (array
+    // length), not 1 as a coincidence of key count — a no-op -s would give
+    // the same answer here by accident, so also check a scalar document.
+    let k = setup().await;
+    let (out, code, err) = run(&k, r#"printf '{"a":1}' | jq -s 'length'"#).await;
+    assert_eq!(code, 0, "err: {err}");
+    assert_eq!(out, "1");
+
+    let (out, code, err) = run(&k, r#"printf '"hello"' | jq -sc '.'"#).await;
+    assert_eq!(code, 0, "err: {err}");
+    assert_eq!(out, r#"["hello"]"#, "single scalar doc still wraps: {out}");
+}
+
+#[tokio::test]
+async fn jq_slurp_collects_a_multi_document_stream() {
+    let k = setup().await;
+    let (out, code, err) = run(&k, r#"printf '1\n2\n3\n' | jq -s 'length'"#).await;
+    assert_eq!(code, 0, "err: {err}");
+    assert_eq!(out, "3");
+
+    let (out, code, err) = run(&k, r#"printf '1\n2\n3\n' | jq -sc '.'"#).await;
+    assert_eq!(code, 0, "err: {err}");
+    assert_eq!(out, "[1,2,3]");
+}
+
+#[tokio::test]
+async fn jq_slurp_handles_pretty_printed_multi_doc_stream() {
+    // Real-jq framing (whitespace-separated documents) tolerates pretty
+    // multi-line documents back to back — this is the `jq -s` escape hatch
+    // pointed to by fromjsonl's own pretty-doc error.
+    let k = setup().await;
+    let (out, code, err) = run(
+        &k,
+        "printf '{\n  \"a\": 1\n}\n{\n  \"a\": 2\n}\n' | jq -sc '[.[] | .a]'",
+    )
+    .await;
+    assert_eq!(code, 0, "err: {err}");
+    assert_eq!(out, "[1,2]");
+}
+
+#[tokio::test]
+async fn jq_slurp_is_a_noop_on_the_data_path() {
+    // `.data` from an upstream builtin is already one structured value —
+    // `-s` must not double-wrap it.
+    let k = setup().await;
+    // fromjson's own ExecResult carries `.data` through the pipe sideband
+    // (unlike `echo $var`, which only renders text) — the same mechanism
+    // scatter/gather's rows ride.
+    let (out, code, err) = run(&k, r#"fromjson '[1,2,3]' | jq -sc 'length'"#).await;
+    assert_eq!(code, 0, "err: {err}");
+    assert_eq!(out, "3", "-s is a no-op on .data: length is the array's, not [array]'s (1)");
+}
+
+#[tokio::test]
+async fn jq_cannot_index_array_gets_the_dot_bracket_hint() {
+    // kaish jq is always-slurped, so a real-jq per-row filter like `.foo`
+    // against an array input is the #79 watch item this hint targets.
+    let k = setup().await;
+    let (_, code, err) = run(&k, r#"printf '[1,2,3]' | jq '.foo'"#).await;
+    assert_ne!(code, 0);
+    assert!(err.contains("cannot index"), "err: {err}");
+    assert!(err.contains(".[] | "), "err should hint the fix: {err}");
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// End-to-end: gather's own JSONL egress re-ingests as typed scatter input
+// ═══════════════════════════════════════════════════════════════════════
+
+mod common;
+
+#[cfg(feature = "localfs")]
+mod localfs_tests {
+    use tempfile::tempdir;
+
+    use super::common::kernel_at;
+
+    #[tokio::test]
+    async fn gather_output_reingests_through_fromjsonl_into_scatter() {
+        let dir = tempdir().expect("tempdir");
+        let k = kernel_at(dir.path());
+
+        // Fan out three typed records, gather their JSONL rows to a file —
+        // the lingua franca #79 made the default egress.
+        let r = k
+            .execute(
+                r#"jobs=$(fromjson '[{"id":1,"host":"web1"},{"id":2,"host":"web2"}]')
+values $jobs | scatter | echo "${ITEM[host]}" | gather > out.jsonl"#,
+            )
+            .await
+            .expect("kernel execute");
+        assert_eq!(r.code, 0, "gather stage: {:?}", r.err);
+
+        // Re-read the file kaish itself just wrote and re-fan-out typed —
+        // ${ITEM[i]}/${ITEM[item][host]} subscript the record kaish's own
+        // gather produced, proving the ingress door round-trips kaish's own
+        // egress door.
+        let r = k
+            .execute(
+                r#"cat out.jsonl | fromjsonl | scatter | echo "row-${ITEM[i]}:${ITEM[item][host]}:${ITEM[out]}" | gather"#,
+            )
+            .await
+            .expect("kernel execute");
+        assert_eq!(r.code, 0, "re-scatter stage: {:?}", r.err);
+
+        let rows: Vec<serde_json::Value> = r
+            .text_out()
+            .lines()
+            .filter(|l| !l.trim().is_empty())
+            .map(|l| serde_json::from_str(l).expect("each line is one JSON row"))
+            .collect();
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0]["out"], "row-0:web1:web1");
+        assert_eq!(rows[1]["out"], "row-1:web2:web2");
+    }
+}

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -423,6 +423,34 @@ jq -n --arg a one --arg b two -r '$a + "-" + $b'
 Both flags are repeatable. `--argjson` errors loudly on malformed JSON
 (matching real jq).
 
+### The text boundary — one document vs. many (JSONL)
+
+`fromjson` / `tojson` and kaish's `jq` all take **exactly one JSON document**
+of text — trailing data after it is a loud error, not a silent slurp. A
+stream of *many* documents (NDJSON/JSONL: an API response, a log file, kaish's
+own `gather` output) needs an explicit door:
+
+```sh
+curl -s api/events.ndjson | fromjsonl | scatter -- restart ${ITEM[host]}
+cat results.jsonl | fromjsonl | jq '.[] | select(.ok | not)'   # ingress: text → typed list
+xs=$(fromjson '[1,2,3]'); tojsonl $xs                          # egress: list → JSONL text
+```
+
+`fromjsonl` is strictly line-oriented (one document per line, blank lines
+skipped, any bad line — including a truncated trailing one — is a loud error
+naming the line number); a pretty-printed multi-line document is a loud error
+pointing at `fromjson` (one document) or `jq -s` (below). `tojsonl` is the
+egress mirror: a list in, one compact document per line out — a record or
+scalar is one document, so that's `tojson`'s job instead.
+
+`jq -s` / `--slurp` also reads a document stream, with real jq framing (so
+pretty multi-line documents are fine) and *always* wraps the result in an
+array — even a single document (`printf '{"a":1}' | jq -s length` → `1`, the
+array length). On the `.data` pipeline path `-s` is a no-op — the upstream
+stage already handed over one structured value. If plain `jq` (no `-s`) sees
+JSONL-shaped input, the error names the document count and points at
+`fromjsonl` or `jq -s` instead of a bare parse failure.
+
 ## Statement Chaining
 
 ```sh


### PR DESCRIPTION
## Summary

Closes #80. Worked back from scatter/gather (#79)'s own watch item: `gather`
made JSONL the default egress, but kaish had no path back in — `fromjson`/`jq`
both hard-reject multi-document text, so an NDJSON API stream, a log file, or
even kaish's own `gather > file` output had no way to re-fan-out typed.

**Decisions** (from the issue's design-review revision note, 2026-07-03):

- **Explicit named doors over implicit slurp.** Per-document jq streaming was
  considered and rejected — it would make framing depend on an invisible
  property of the upstream stage (`.[]` in-pipe via `.data` but not via text)
  and break aggregation uniformity (`jq add`, `map | length`). Landed on
  `fromjsonl` (ingress: JSONL text → typed list) / `tojsonl` (egress: list →
  JSONL text) as the explicit pair, mirroring `fromjson`/`tojson`.
- **jq stays strictly one-document.** `jq` unchanged on the default text path;
  `-s`/`--slurp` gets *real* jq semantics (parses the whole document stream,
  always wraps in an array — even a single document, so it doesn't silently
  diverge on `printf '{"a":1}' | jq -s length` → must be `1`, not the key
  count). No-op on the `.data` path (already one structured value there).
- **Louder, not smarter.** A "trailing characters" parse error now checks
  whether the remainder is actually more JSON documents and, if so, names the
  count and points at `fromjsonl`/`jq -s`; genuine garbage keeps the plain
  error. The runtime `cannot index [...] with ...` error — the actual #79
  watch item (real-jq's per-row form against kaish's always-slurped array) —
  gains a `.[] | …` hint, per the issue's specified wording.
- **`fromjsonl` is strictly line-oriented** (the name is the contract): blank
  lines skipped, any bad line including a truncated trailing one is loud with
  the line number, empty input → `[]` (a legitimate zero-document stream —
  falls out naturally from the blank-line rule, no special case needed). A
  pretty-printed multi-line document is diagnosed specifically and points at
  `fromjson`/`jq -s` instead of a bare per-line error.
- **`tojsonl` also accepts piped `.data`** (unlike `tojson`, which is
  positional-only) so it composes as a real pipeline stage
  (`curl … | fromjson | tojsonl`), not just a `$()`-capture step.

**Bug found and fixed along the way:** building the kernel-routed
`gather > file; cat file | fromjsonl | scatter` round trip surfaced that the
scatter/gather special-cased pipeline path never applied `gather`'s own
trailing redirect when gather was the pipeline's last command
(`ScatterGatherRunner` never saw `gather_cmd.redirects`, only the parsed
`--json`/`--lines` flags) — the JSONL rows landed back in the result instead
of the file. Fixed in `scheduler/pipeline.rs`'s `run_scatter_gather`, rebased
cleanly on top of #87's fallible `build_tool_args` handling in the same
function.

**Known, deferred edge case:** a redirect on `gather` combined with
`post_gather` pipeline stages (e.g. `… | gather > file | jq …`, redirect in
the middle of a pipe) still silently drops the redirect — pre-existing
behavior, unchanged by this PR, not part of #80's scope. Worth a follow-up if
it ever bites someone in practice.

## Test plan

- [x] `cargo test --all` — full suite clean on the rebased tip, including 24
      kernel-routed cases in `jsonl_doors_tests.rs` (fromjsonl happy/
      blank-skip/truncated/garbage/empty/null/pretty-multiline/CRLF; tojsonl
      list/non-list/empty/round-trip/bytes-loud/embedded-newline-safety; jq
      single-doc/JSONL-hint/-s-wrap/-s-slurp/-s-data-noop/index-hint; the
      `gather > file | fromjsonl | scatter` round trip) plus 2 new `--json`
      sweep cases.
- [x] `cargo clippy --all --all-targets` — zero warnings.
- [x] `cargo check -p kaish-kernel --no-default-features` — pure-data pair
      compiles and the new tests run without `localfs`.
- [x] `cargo insta test --check` — no pending snapshots; `syntax.md`
      regenerated after the collections fragment's one-line cross-reference.
- [x] Independent review via kaibo (deepseek cast) — no correctness bugs;
      its three low-severity test gaps and one doc nit were addressed in the
      follow-up commit (bytes-rejection, embedded-newline, and CRLF tests
      pinned; fromjsonl's "idempotent" doc comment corrected to describe the
      one-element wrap).

---

**Supersedes #86** — identical content rebased onto main past #82/#83/#87
(a hook blocks force-push; fresh-branch + superseding-PR is the convention).
The kaibo review and the addressed-findings record live on #86's thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)