### PR TITLE
feat: redirects inside $() + a stdout redirect now clears .data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ breaking entries are marked **BREAKING**.
 ## [Unreleased]
 
 ### Added
+- **Redirects now work inside `$(...)`** — `x=$(cmd > file)`, `$(cmd 2> err)`,
+  `$(cmd >> log)` and friends parse and run, matching the top-level command
+  grammar (the command-substitution body used to reject any redirect). Control
+  structures inside `$()` remain out of scope.
 - **`fromjsonl` / `tojsonl`** — the JSONL (NDJSON) doors, GH #80. `fromjsonl`
   parses strictly line-oriented JSONL text (one JSON document per line, blank
   lines skipped, any bad line — including a truncated trailing one — a loud
@@ -220,6 +224,15 @@ breaking entries are marked **BREAKING**.
   demotion of `\|` to plain `|`).
 
 ### Fixed
+- **A stdout redirect now clears the structured `.data` sideband too**, not just
+  `.out`/`.output`. `.data` is the structured view of stdout, so `> file` /
+  `>> file` / `&> file` take it along with the text: `x=$(cmd > file)` captures
+  `""` (bash parity) and `cmd > file | consumer` no longer leaks a structured
+  value past its own redirect. A pending confirmation-latch request is the one
+  exception — it is a control-plane signal, not stdout, so it survives a
+  redirect (a latched `rm precious > log` still gates). Consequence: recovering
+  a redirected command's `.data` after the fact (`cmd > /dev/null; kaish-last`)
+  no longer works — don't redirect the output you meant to capture.
 - **`"$(cmd)"` no longer drops a `.data`-only result to `""`** — quoted command
   substitution used to read only a command's `.out` text; a tool that set
   structured `.data` (a list/record) but left `.out` empty interpolated to

--- a/crates/kaish-kernel/src/parser.rs
+++ b/crates/kaish-kernel/src/parser.rs
@@ -1579,7 +1579,7 @@ where
     // (verified empirically 2026-06-07; see docs/issues.md).
     command_name
         .then(args_list_parser())
-        .then(redirect_parser().repeated().collect::<Vec<_>>())
+        .then(redirect_parser(primary_expr_parser()).repeated().collect::<Vec<_>>())
         .map(|((name, args), redirects)| Command {
             name,
             args,
@@ -1837,10 +1837,20 @@ where
 }
 
 /// Redirect: `> file`, `>> file`, `< file`, `<< heredoc`, `2> file`, `&> file`, `2>&1`
-fn redirect_parser<'tokens, I>(
+///
+/// `target` parses the file word (and here-string body). Callers pass the
+/// expression parser appropriate to their context: the top-level command
+/// grammar passes a fresh `primary_expr_parser()`, while `cmd_subst_parser`
+/// passes its *already-recursive* `expr` handle. Threading it in (rather than
+/// building `primary_expr_parser()` internally) is what lets `$(cmd > file)`
+/// parse without an unbounded `cmd_subst → redirect → primary_expr → cmd_subst`
+/// construction cycle.
+fn redirect_parser<'tokens, I, T>(
+    target: T,
 ) -> impl Parser<'tokens, I, Redirect, extra::Err<Rich<'tokens, Token, Span>>> + Clone
 where
     I: ValueInput<'tokens, Token = Token, Span = Span>,
+    T: Parser<'tokens, I, Expr, extra::Err<Rich<'tokens, Token, Span>>> + Clone + 'tokens,
 {
     // Regular redirects: >, >>, <, 2>, &>
     let regular_redirect = select! {
@@ -1850,7 +1860,7 @@ where
         Token::Stderr => RedirectKind::Stderr,
         Token::Both => RedirectKind::Both,
     }
-    .then(primary_expr_parser())
+    .then(target.clone())
     .map(|(kind, target)| Redirect { kind, target });
 
     // Here-doc redirect: << content
@@ -1901,7 +1911,7 @@ where
     // The target is any single expression; kaish's existing Expr machinery
     // handles interpolation, single-quoted literals, and command substitution.
     let herestring_redirect = just(Token::HereString)
-        .ignore_then(primary_expr_parser())
+        .ignore_then(target.clone())
         .map(|target| Redirect {
             kind: RedirectKind::HereString,
             target,
@@ -2436,7 +2446,7 @@ fn cmd_subst_parser<'tokens, I, E>(
 ) -> impl Parser<'tokens, I, Expr, extra::Err<Rich<'tokens, Token, Span>>> + Clone
 where
     I: ValueInput<'tokens, Token = Token, Span = Span>,
-    E: Parser<'tokens, I, Expr, extra::Err<Rich<'tokens, Token, Span>>> + Clone,
+    E: Parser<'tokens, I, Expr, extra::Err<Rich<'tokens, Token, Span>>> + Clone + 'tokens,
 {
     // Argument parser using the recursive expression parser
     // Long flag with value: --name=value
@@ -2465,7 +2475,7 @@ where
         .map(|(key, value)| Arg::WordAssign { key, value });
 
     // Positional argument
-    let positional = expr.map(Arg::Positional);
+    let positional = expr.clone().map(Arg::Positional);
 
     let arg = choice((
         long_flag_with_value,
@@ -2482,13 +2492,23 @@ where
         just(Token::False).to("false".to_string()),
     ));
 
-    // Command parser
+    // Command parser. Trailing redirects (`> file`, `2> file`, `>> file`, …)
+    // reuse the same `redirect_parser` combinator the top-level
+    // `command_parser` uses, so `$(cmd > file)` parses like any other command.
+    // The redirect *target* threads the recursive `expr` handle (not a fresh
+    // `primary_expr_parser()`) so the target may itself contain `$(...)` while
+    // avoiding an unbounded parser-construction cycle.
     let command = command_name
         .then(arg.repeated().collect::<Vec<_>>())
-        .map(|(name, args)| Command {
+        .then(
+            redirect_parser(expr.clone())
+                .repeated()
+                .collect::<Vec<_>>(),
+        )
+        .map(|((name, args), redirects)| Command {
             name,
             args,
-            redirects: vec![],
+            redirects,
         });
 
     // Pipeline parser
@@ -3655,6 +3675,89 @@ mod tests {
                 assert_eq!(pipeline.commands[1].name, "grep");
             }
             other => panic!("expected assignment, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_cmd_subst_with_redirect() {
+        // Regression: `cmd_subst_parser` used to hardcode `redirects: vec![]`,
+        // so a redirect inside `$()` was a parse error. A command carrying a
+        // redirect stays a `Stmt::Pipeline` (`pipeline_into_stmt` only unwraps
+        // redirect-free commands), so read it back through `subst_pipeline`.
+        let result = parse("X=$(echo hi > out.txt)").unwrap();
+        match &result.statements[0] {
+            Stmt::Assignment(a) => {
+                let pipeline = subst_pipeline(&a.value);
+                assert_eq!(pipeline.commands.len(), 1);
+                let cmd = &pipeline.commands[0];
+                assert_eq!(cmd.name, "echo");
+                assert_eq!(cmd.redirects.len(), 1);
+                assert!(matches!(
+                    cmd.redirects[0].kind,
+                    RedirectKind::StdoutOverwrite
+                ));
+            }
+            other => panic!("expected assignment, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_cmd_subst_redirect_target_with_nested_subst() {
+        // The cycle-break's sharpest case: a `$(...)` in the redirect *target*,
+        // inside a `$(...)`. This exercises cmd_subst → redirect → (recursive
+        // expr) → cmd_subst, the path that used to recurse unboundedly during
+        // parser construction (stack overflow). It must parse; the target is a
+        // nested `CommandSubst`.
+        let result = parse("X=$(echo hi > $(echo f))").unwrap();
+        match &result.statements[0] {
+            Stmt::Assignment(a) => {
+                let pipeline = subst_pipeline(&a.value);
+                assert_eq!(pipeline.commands.len(), 1);
+                let cmd = &pipeline.commands[0];
+                assert_eq!(cmd.name, "echo");
+                assert_eq!(cmd.redirects.len(), 1);
+                assert!(
+                    matches!(cmd.redirects[0].target, Expr::CommandSubst(_)),
+                    "redirect target should be a nested command substitution, got {:?}",
+                    cmd.redirects[0].target
+                );
+            }
+            other => panic!("expected assignment, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_cmd_subst_chain_with_redirect() {
+        // A redirect in a chained `$()` body binds to its own command, not to
+        // the chain: `$(a && b > f)` → AndChain{ left: a, right: (b > f) }, with
+        // the redirect on `b` only.
+        let result = parse("X=$(echo a && echo b > out.txt)").unwrap();
+        let stmts = match &result.statements[0] {
+            Stmt::Assignment(a) => match &a.value {
+                Expr::CommandSubst(s) => s,
+                other => panic!("expected command subst, got {:?}", other),
+            },
+            other => panic!("expected assignment, got {:?}", other),
+        };
+        match stmts.as_slice() {
+            [Stmt::AndChain { left, right }] => {
+                // `echo a` is redirect-free → unwrapped to Stmt::Command.
+                assert!(
+                    matches!(**left, Stmt::Command(_)),
+                    "left of && should be a bare command, got {:?}",
+                    left
+                );
+                // `echo b > out.txt` carries a redirect → stays Stmt::Pipeline.
+                match &**right {
+                    Stmt::Pipeline(p) => {
+                        assert_eq!(p.commands.len(), 1);
+                        assert_eq!(p.commands[0].name, "echo");
+                        assert_eq!(p.commands[0].redirects.len(), 1);
+                    }
+                    other => panic!("right should be a redirect-bearing pipeline, got {:?}", other),
+                }
+            }
+            other => panic!("expected a single AndChain, got {:?}", other),
         }
     }
 

--- a/crates/kaish-kernel/src/scheduler/pipeline.rs
+++ b/crates/kaish-kernel/src/scheduler/pipeline.rs
@@ -61,8 +61,14 @@ async fn apply_redirects(
                 if !result.text_out().is_empty() {
                     let out = result.text_out().into_owned();
                     result.err.push_str(&out);
-                    result.clear_out();
                 }
+                // `1>&2` is still a stdout redirect: stdout went to stderr, so
+                // drop out/output AND the .data sideband (same as a file
+                // redirect), or a structured result leaks past `x=$(cmd >&2)`
+                // and `cmd >&2 | consumer`. Unconditional so a .data-only,
+                // empty-.out result is cleared too. clear_stdout preserves a
+                // control-plane latch request.
+                result.clear_stdout();
             }
             RedirectKind::StdoutOverwrite => {
                 let path = match eval_redirect_target(&redir.target, ctx).await {
@@ -86,8 +92,8 @@ async fn apply_redirects(
                 } else if let Err(e) = redirect_write(ctx, &path, result.text_out().as_bytes()).await {
                     return ExecResult::failure(1, format!("redirect: {e}"));
                 }
-                result.clear_out();
-                result.set_output(None);
+                // stdout went to the file: drop out/output AND the .data sideband.
+                result.clear_stdout();
             }
             RedirectKind::StdoutAppend => {
                 let path = match eval_redirect_target(&redir.target, ctx).await {
@@ -111,8 +117,8 @@ async fn apply_redirects(
                 } else if let Err(e) = redirect_append(ctx, &path, result.text_out().as_bytes()).await {
                     return ExecResult::failure(1, format!("redirect: {e}"));
                 }
-                result.clear_out();
-                result.set_output(None);
+                // stdout went to the file: drop out/output AND the .data sideband.
+                result.clear_stdout();
             }
             RedirectKind::Stderr => {
                 let path = match eval_redirect_target(&redir.target, ctx).await {
@@ -139,8 +145,8 @@ async fn apply_redirects(
                 if let Err(e) = redirect_write(ctx, &path, &combined).await {
                     return ExecResult::failure(1, format!("redirect: {e}"));
                 }
-                result.clear_out();
-                result.set_output(None);
+                // both streams went to the file: drop stdout (incl. .data) + stderr.
+                result.clear_stdout();
                 result.err.clear();
             }
             // Pre-execution redirects - already handled before command execution

--- a/crates/kaish-kernel/tests/kaish_last_tests.rs
+++ b/crates/kaish-kernel/tests/kaish_last_tests.rs
@@ -17,27 +17,36 @@ async fn setup() -> Arc<Kernel> {
         .into_arc()
 }
 
+/// kaish-last runs last, so its output is the final line of the captured
+/// stream. The producer's own stdout precedes it and can no longer be silenced
+/// with `> /dev/null`: a stdout redirect now drops `.data` too (it is the
+/// structured view of stdout, so it rides the redirect to the file — see
+/// `redirect_in_cmdsubst_tests.rs`). Isolating kaish-last's contribution by the
+/// last line keeps these tests honest about that shared stream.
+fn last_line(s: &str) -> &str {
+    s.trim().lines().last().unwrap_or("")
+}
+
 #[tokio::test]
 async fn emits_data_as_json_from_jq() {
-    // Discard jq's stdout so r.text_out() reflects only kaish-last's output.
     let k = setup().await;
     let r = k
-        .execute(r#"echo '["a","b","c"]' | jq -r '.[]' > /dev/null; kaish-last"#)
+        .execute(r#"echo '["a","b","c"]' | jq -r '.[]'; kaish-last"#)
         .await
         .expect("script ran");
     assert!(r.ok(), "exit: {} err: {}", r.code, r.err);
-    assert_eq!(r.text_out().trim(), r#"["a","b","c"]"#);
+    assert_eq!(last_line(&r.text_out()), r#"["a","b","c"]"#);
 }
 
 #[tokio::test]
 async fn emits_data_as_json_from_seq() {
     let k = setup().await;
     let r = k
-        .execute(r#"seq 1 5 > /dev/null; kaish-last"#)
+        .execute(r#"seq 1 5; kaish-last"#)
         .await
         .expect("script ran");
     assert!(r.ok(), "exit: {} err: {}", r.code, r.err);
-    assert_eq!(r.text_out().trim(), "[1,2,3,4,5]");
+    assert_eq!(last_line(&r.text_out()), "[1,2,3,4,5]");
 }
 
 #[tokio::test]
@@ -46,22 +55,22 @@ async fn data_can_be_piped_into_jq() {
     // jq consumes it.
     let k = setup().await;
     let r = k
-        .execute(r#"seq 1 5 > /dev/null; kaish-last | jq '.[2]'"#)
+        .execute(r#"seq 1 5; kaish-last | jq '.[2]'"#)
         .await
         .expect("script ran");
     assert!(r.ok(), "exit: {} err: {}", r.code, r.err);
-    assert_eq!(r.text_out().trim(), "3");
+    assert_eq!(last_line(&r.text_out()), "3");
 }
 
 #[tokio::test]
 async fn capture_via_command_substitution() {
     let k = setup().await;
     let r = k
-        .execute(r#"seq 1 3 > /dev/null; DATA=$(kaish-last); echo "$DATA""#)
+        .execute(r#"seq 1 3; DATA=$(kaish-last); echo "$DATA""#)
         .await
         .expect("script ran");
     assert!(r.ok(), "exit: {} err: {}", r.code, r.err);
-    assert_eq!(r.text_out().trim(), "[1,2,3]");
+    assert_eq!(last_line(&r.text_out()), "[1,2,3]");
 }
 
 #[tokio::test]

--- a/crates/kaish-kernel/tests/latch_trash_tests.rs
+++ b/crates/kaish-kernel/tests/latch_trash_tests.rs
@@ -108,6 +108,39 @@ async fn latch_gates_rm_then_confirm_hint_deletes() {
 }
 
 #[tokio::test]
+async fn latch_survives_stdout_redirect() {
+    // A stdout redirect on a latched `rm` must NOT disable the confirmation
+    // gate. `apply_redirects` clears the *data-plane* `.data` (the structured
+    // view of stdout) on a stdout redirect — but the latch nonce is a
+    // *control-plane* signal, not stdout. Dropping it would silently turn
+    // `rm precious.txt > log` into an unconfirmable delete-in-waiting: exit 2,
+    // no recoverable nonce, file stranded. Regression guard for the
+    // `.data`-clearing that landed with redirect-inside-`$()` support.
+    let dir = tempdir();
+    std::fs::write(dir.path().join("precious.txt"), "data").expect("write");
+    let kernel = kernel_at(dir.path());
+
+    run(&kernel, "set -o latch").await;
+    let gated = run(&kernel, "rm precious.txt > out.log").await;
+
+    assert_eq!(
+        gated.code, 2,
+        "a redirect must not bypass the latch gate: {}",
+        gated.err
+    );
+    assert!(
+        gated.latch_request().is_some(),
+        "the latch nonce must survive a stdout redirect (it is control-plane, \
+         not stdout); got data: {:?}",
+        gated.data
+    );
+    assert!(
+        dir.path().join("precious.txt").exists(),
+        "file must survive the latch gate even with a redirect"
+    );
+}
+
+#[tokio::test]
 async fn latch_bogus_nonce_fails_and_file_survives() {
     let dir = tempdir();
     std::fs::write(dir.path().join("precious.txt"), "data").expect("write");

--- a/crates/kaish-kernel/tests/redirect_in_cmdsubst_tests.rs
+++ b/crates/kaish-kernel/tests/redirect_in_cmdsubst_tests.rs
@@ -1,0 +1,140 @@
+//! Redirects inside command substitution: `$(cmd > file)`.
+//!
+//! Two coupled behaviors are pinned here:
+//!
+//! 1. **Grammar** — the `$()` body accepts trailing redirects. The command-sub
+//!    grammar (`cmd_subst_parser`) used to hardcode `redirects: vec![]`, so a
+//!    `>`/`>>`/`2>` inside `$()` was a parse error even though the top-level
+//!    command grammar has accepted them all along.
+//!
+//! 2. **Capture semantics** — when a command's stdout is redirected to a file
+//!    inside `$()`, the substitution captures the empty string (bash parity:
+//!    the bytes went to the file, not to the capture). This must hold even for
+//!    structured-data builtins: `apply_redirects` clears `.out`/`.output` AND
+//!    `.data` on a stdout-overwrite/append, so a `.data`-producing command
+//!    (e.g. `fromjson`) whose stdout was redirected does not leak its `.data`
+//!    into the captured value. `Expr::CommandSubst` prefers `.data` over text,
+//!    so a stale `.data` here would reintroduce the leak in the exact opposite
+//!    direction from the quoted-`$()` interpolation bug.
+//!
+//! Real-FS via `tempfile::tempdir()` per the no-hardcoded-system-paths rule.
+
+// Test-fixture code: unwrap/expect on known-good setup is the idiom here.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+mod common;
+
+use common::kernel_at;
+
+/// The grammar half: a stdout redirect inside `$()` parses and runs, and the
+/// bytes land in the file — not the capture (which is empty, bash parity).
+#[tokio::test]
+async fn stdout_redirect_inside_cmdsubst_writes_file_and_captures_empty() {
+    let dir = tempfile::tempdir().unwrap();
+    let kernel = kernel_at(dir.path());
+
+    let r = kernel
+        .execute(r#"x=$(echo hi > out.txt); echo "[$x]""#)
+        .await
+        .expect("execute");
+    assert_eq!(r.code, 0, "{r:?}");
+    // stdout went to the file, so the capture is empty.
+    assert_eq!(r.text_out().trim(), "[]", "capture must be empty: {r:?}");
+
+    // and the file received the redirected output.
+    let f = kernel.execute("cat out.txt").await.expect("cat");
+    assert_eq!(f.text_out().trim(), "hi");
+}
+
+/// The append variant (`>>`) parses and behaves the same way for the capture.
+#[tokio::test]
+async fn stdout_append_redirect_inside_cmdsubst_captures_empty() {
+    let dir = tempfile::tempdir().unwrap();
+    let kernel = kernel_at(dir.path());
+
+    let r = kernel
+        .execute(r#"echo a > out.txt; x=$(echo b >> out.txt); echo "[$x]""#)
+        .await
+        .expect("execute");
+    assert_eq!(r.code, 0, "{r:?}");
+    assert_eq!(r.text_out().trim(), "[]", "capture must be empty: {r:?}");
+
+    let f = kernel.execute("cat out.txt").await.expect("cat");
+    assert_eq!(f.text_out(), "a\nb\n");
+}
+
+/// The capture-semantics half, at its sharpest: a real structured-data builtin
+/// (`fromjson` sets BOTH `.out` text and `.data`) whose stdout is redirected
+/// must NOT leak `.data` into the capture. Before the `.data`-clearing fix,
+/// `x` captured `[1,2,3]` (from `.data`) instead of the empty string, so this
+/// rendered `[[1,2,3]]`.
+#[tokio::test]
+async fn data_producing_builtin_redirect_inside_cmdsubst_does_not_leak_data() {
+    let dir = tempfile::tempdir().unwrap();
+    let kernel = kernel_at(dir.path());
+
+    let r = kernel
+        .execute(r#"x=$(fromjson '[1,2,3]' > out.txt); echo "[$x]""#)
+        .await
+        .expect("execute");
+    assert_eq!(r.code, 0, "{r:?}");
+    assert_eq!(
+        r.text_out().trim(),
+        "[]",
+        "fromjson's .data must not leak into the capture once stdout was redirected: {r:?}"
+    );
+
+    // The structured value still reached the file (canonical compact JSON).
+    let f = kernel.execute("cat out.txt").await.expect("cat");
+    assert_eq!(f.text_out().trim(), "[1,2,3]");
+}
+
+/// A *stderr* redirect inside `$()` must NOT touch the stdout capture: only
+/// stdout-affecting redirects clear the captured value. Guards against an
+/// over-broad clear that would empty every `$(cmd 2> file)` capture.
+#[tokio::test]
+async fn stderr_redirect_inside_cmdsubst_preserves_stdout_capture() {
+    let dir = tempfile::tempdir().unwrap();
+    let kernel = kernel_at(dir.path());
+
+    let r = kernel
+        .execute(r#"x=$(echo hi 2> err.txt); echo "[$x]""#)
+        .await
+        .expect("execute");
+    assert_eq!(r.code, 0, "{r:?}");
+    assert_eq!(
+        r.text_out().trim(),
+        "[hi]",
+        "a stderr redirect must leave the stdout capture intact: {r:?}"
+    );
+}
+
+/// `1>&2` / `>&2` merges stdout into stderr — it is still a stdout redirect for
+/// capture purposes, so a structured-data builtin's `.data` must NOT leak into
+/// the `$()` capture (bash parity: stdout went to stderr, the capture is empty).
+/// Regression guard for the `MergeStdout` arm clearing `.data`, not just `.out`.
+#[tokio::test]
+async fn merge_stdout_to_stderr_inside_cmdsubst_does_not_leak_data() {
+    let dir = tempfile::tempdir().unwrap();
+    let kernel = kernel_at(dir.path());
+
+    let r = kernel
+        .execute(r#"x=$(fromjson '[1,2,3]' >&2); echo "[$x]""#)
+        .await
+        .expect("execute");
+    assert_eq!(r.code, 0, "{r:?}");
+    assert_eq!(
+        r.text_out().trim(),
+        "[]",
+        "fromjson's .data must not leak into the capture when stdout is merged to stderr: {r:?}"
+    );
+}
+
+// The sharpest test of the parser cycle-break — a `$(...)` in the redirect
+// *target*, itself inside a `$(...)` — lives as a parser unit test
+// (`parser::tests::parse_cmd_subst_redirect_target_with_nested_subst`): the
+// hazard it guards is parser *construction* (infinite recursion / stack
+// overflow), which is a parse-layer concern. End-to-end execution of a
+// `$()`-valued redirect target on a *bare* single command is blocked by a
+// separate, pre-existing bug (the dispatcher isn't attached, so the target
+// `$()` can't run) — GH #90, orthogonal to redirect-in-`$()`.

--- a/crates/kaish-types/src/result.rs
+++ b/crates/kaish-types/src/result.rs
@@ -413,6 +413,31 @@ impl ExecResult {
         self.out = OutputPayload::Text(String::new());
     }
 
+    /// Drop every representation of stdout: the text `.out`, the structured
+    /// `.output`, and the *data-plane* `.data` sideband. Used when a stdout
+    /// redirect (`> file`, `>> file`, `&> file`) has consumed the command's
+    /// output — the bytes went to the file, so nothing flows onward to a pipe,
+    /// a `$(...)` capture, or the `.data` sideband. Clearing all three in one
+    /// place keeps them from drifting: a redirect that cleared `.out`/`.output`
+    /// but left `.data` would leak structured data past its own redirect
+    /// (`x=$(fromjson … > file)` capturing the value instead of `""`).
+    ///
+    /// A pending confirmation-latch request is the exception. `.data` is
+    /// overloaded: for `seq`/`jq`/`fromjson` it is the structured view of
+    /// stdout (clear it), but for a latched `rm` it is a *control-plane* signal
+    /// — the nonce the frontend needs to approve the operation. That is not
+    /// stdout and must survive the redirect, or `rm precious > log` becomes a
+    /// silent, unconfirmable delete-in-waiting. `latch_request()` matches only
+    /// the exact exit-2 + `LatchRequest` envelope, so ordinary structured data
+    /// is never mistaken for it.
+    pub fn clear_stdout(&mut self) {
+        self.out = OutputPayload::Text(String::new());
+        self.output = None;
+        if self.latch_request().is_none() {
+            self.data = None;
+        }
+    }
+
     /// Replace `.output`.
     pub fn set_output(&mut self, o: Option<OutputData>) {
         self.output = o;

--- a/crates/kaish-types/src/result.rs
+++ b/crates/kaish-types/src/result.rs
@@ -429,7 +429,9 @@ impl ExecResult {
     /// stdout and must survive the redirect, or `rm precious > log` becomes a
     /// silent, unconfirmable delete-in-waiting. `latch_request()` matches only
     /// the exact exit-2 + `LatchRequest` envelope, so ordinary structured data
-    /// is never mistaken for it.
+    /// is never mistaken for it. This discriminator is a bridge: once the latch
+    /// gets its own typed field (GH #92), `.data` is unambiguously data-plane
+    /// and this becomes an unconditional `self.data = None`.
     pub fn clear_stdout(&mut self) {
         self.out = OutputPayload::Text(String::new());
         self.output = None;

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -14,6 +14,54 @@ before it ships.
 
 ---
 
+## Redirects inside `$()`, and what that taught us about `.data` (2026-07-04)
+
+Started from a curiosity: a test comment said "kaish's grammar doesn't accept a
+redirect inside `$(...)`." It turned out to be a one-line gap — `cmd_subst_parser`
+hardcoded `redirects: vec![]` and never called `redirect_parser` — but wiring it
+up surfaced two deeper things.
+
+**The parser cycle.** Naively calling `redirect_parser()` from the cmd-subst body
+stack-overflowed at *parse* time: `redirect_parser` built `primary_expr_parser()`
+for its target, `primary_expr_parser` builds a `cmd_subst_parser`, which now calls
+`redirect_parser` again — an unbounded *construction* cycle. Fix: parameterize
+`redirect_parser` on its target parser. The top level passes a fresh
+`primary_expr_parser()`; the cmd-subst body passes its already-recursive `expr`
+handle, so the nested target flows through chumsky's existing `recursive` wrapper
+instead of constructing a new parser at each depth. `$(cmd > $(subst))` now parses.
+
+**What a stdout redirect means for `.data`.** The interesting part. `$()` capture
+prefers a result's structured `.data` over its text, so `x=$(seq 1 3 > file)` was
+capturing `[1,2,3]` instead of bash's `""` — the redirect sent the text to the
+file but left `.data` intact. We decided `.data` is *the structured view of
+stdout* (every builtin that sets it — seq/jq/fromjson/keys/find — does so as the
+typed form of what it wrote to stdout), so a stdout redirect must take `.data`
+with it. New `ExecResult::clear_stdout()` clears `.out`/`.output`/`.data` together;
+the three file-redirect arms and (caught in review) the `1>&2` merge arm all route
+through it. This also kills a pipe-sideband leak (`cmd > file | consumer`) and
+makes `for x in $(cmd > file)` correctly iterate zero times.
+
+**Two things this disturbed.** First, four `kaish-last` tests broke — they used
+`producer > /dev/null; kaish-last` where the `> /dev/null` was a *harness trick*
+to silence the producer's stdout in the shared capture stream (the line-22 comment
+said so), and leaned on `.data` surviving that redirect. That reliance was an
+accident of the original `.data` rollout, not a contract; rewrote them to isolate
+kaish-last's output by its last line, no redirect. Second, and more important:
+`.data` is *overloaded* — for `rm` under `set -o latch` it carries the
+confirmation nonce, a control-plane signal, not stdout. Blanket-clearing `.data`
+silently disabled the safety gate on `rm precious > log` (a TDD guard caught it).
+The scoped fix: `clear_stdout` preserves `.data` when `latch_request()` matches
+(exit-2 + the exact `LatchRequest` envelope). Amy's call: that overloading is a
+real smell, but the latch deserves a first-class typed public-API field of its
+own rather than being refactored as a rider on this change — deferred to its own
+worktree so neither feature's boundary gets weakened.
+
+Cross-family review (DeepSeek + Gemini via kaibo, whole files, no diff) converged
+independently on the one bug this text glosses: the `1>&2` arm cleared only
+`.out`, leaking `.data`. Fixed, with a guard test. Review also surfaced GH #90 —
+`$()` in a redirect *target* fails for a bare single command (dispatcher not
+attached) — a pre-existing bug, orthogonal, filed not fixed here.
+
 ## scatter/gather's own flag values could silently drop a bad subscript (2026-07-03)
 
 A 0.11.0 pre-release punch-list item: `scatter`/`gather` bind their OWN flag


### PR DESCRIPTION
## What & why

A test comment claimed *"kaish's grammar doesn't accept a redirect inside `$(...)`."* It was a one-line gap — `cmd_subst_parser` hardcoded `redirects: vec![]` — but closing it surfaced two deeper decisions.

### 1. Grammar: `$(cmd > file)` now parses

The naive fix (call the standalone `redirect_parser()` from the cmd-subst body) **stack-overflowed at parse time** via an unbounded *construction* cycle: `cmd_subst → redirect → primary_expr → cmd_subst`. Fixed by parameterizing `redirect_parser` on its target parser — the top level passes a fresh `primary_expr_parser()`, the cmd-subst body passes its already-recursive `expr` handle, so a nested target flows through chumsky's existing `recursive` wrapper instead of building a new parser at each depth. `$(cmd > $(subst))` parses (pinned by a parser unit test). Control structures inside `$()` remain out of scope.

### 2. Semantics: a stdout redirect clears the structured `.data` sideband

`$()` capture prefers a result's `.data` over its text, so `x=$(seq 1 3 > file)` captured `[1,2,3]` instead of bash's `""`. **Decision:** `.data` is the *structured view of stdout* — every builtin that sets it (`seq`/`jq`/`fromjson`/`keys`/`find`) does so as the typed form of what it wrote to stdout — so a stdout redirect must take it along. New `ExecResult::clear_stdout()` clears `.out`/`.output`/`.data` together; the three file-redirect arms **and the `1>&2` merge arm** route through it. Also stops a pipe-sideband leak (`cmd > file | consumer`) and makes `for x in $(cmd > file)` iterate zero times.

### The `.data` overload, and the latch

Under `set -o latch`, `rm` carries its confirmation nonce in `.data` — a **control-plane** signal, not stdout. A blanket clear silently disabled the safety gate on `rm precious > log` (a TDD guard caught it). The scoped fix: `clear_stdout` preserves `.data` when `latch_request()` matches (exit-2 + the exact `LatchRequest` envelope, `deny_unknown_fields` — can't false-positive on ordinary structured data).

**This overloading is a real smell.** Per maintainer call, the latch deserves a first-class typed public-API field of its own rather than being refactored as a rider on this PR — deferred to its own worktree so neither feature's boundary is weakened. This PR carries only the *minimal* latch-respecting guard.

### Tests disturbed / added

- **kaish-last (rewritten):** four tests used `producer > /dev/null; kaish-last`, where the `> /dev/null` was a harness trick to silence the producer's stdout in the shared capture stream and leaned on `.data` surviving that redirect — an accident of the original `.data` rollout, not a contract. Rewritten to isolate kaish-last's output by its last line, no redirect. Their contract (emit previous `.data`, else `.out`) is unchanged.
- **Added:** `redirect_in_cmdsubst_tests.rs` (capture-empty, append, `2>` preserves capture, `>&2` no `.data` leak), a `latch_survives_stdout_redirect` guard, and parser tests for the redirect grammar, the nested-target cycle-break, and chain+redirect binding.

### Review

Cross-family review (DeepSeek + Gemini via kaibo, whole files, no diff) **independently converged** on one bug: the `1>&2` arm cleared only `.out`, leaking `.data`. Fixed here, with a guard test. Both confirmed the parser cycle-break and the latch discriminator are sound. Review also surfaced **GH #90** (`$()` in a redirect *target* fails for a bare single command — dispatcher not attached), a pre-existing orthogonal bug, filed not fixed.

### Validation

`cargo test --all`, `cargo clippy --all --all-targets` (0 warnings), and `cargo check -p kaish-kernel --no-default-features` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)