### PR TITLE
fix(0.11.0): pre-release hardening — loud errors over silent corruption (2 AI-review rounds)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -228,7 +228,7 @@ breaking entries are marked **BREAKING**.
   `Value::Bytes` value (e.g. `b=$(cat some-binary-file)`, since `cat` emits raw
   bytes for non-UTF-8 content) used to render the placeholder `[binary: N bytes]`
   when interpolated into a string (`"x=$b"`), passed as a bare word to an external
-  command (`prog $b`), or printed by `echo`. These text sinks now error (`binary
+  command (`prog $b`), or printed by `echo`/`printf`. These text sinks now error (`binary
   data (N bytes) cannot be used as text — decode it (base64/xxd) or redirect to a
   file`); valid-UTF-8 bytes still coerce. Semantic uses (`==`, `in`, `${#…}`,
   `case`) are unchanged. Path-positional/env/redirect sinks remain a known gap.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -224,6 +224,52 @@ breaking entries are marked **BREAKING**.
   demotion of `\|` to plain `|`).
 
 ### Fixed
+- **Binary data at text sinks is loud, not a silent placeholder** — a
+  `Value::Bytes` value (e.g. `b=$(cat some-binary-file)`, since `cat` emits raw
+  bytes for non-UTF-8 content) used to render the placeholder `[binary: N bytes]`
+  when interpolated into a string (`"x=$b"`), passed as a bare word to an external
+  command (`prog $b`), or printed by `echo`. These text sinks now error (`binary
+  data (N bytes) cannot be used as text — decode it (base64/xxd) or redirect to a
+  file`); valid-UTF-8 bytes still coerce. Semantic uses (`==`, `in`, `${#…}`,
+  `case`) are unchanged. Path-positional/env/redirect sinks remain a known gap.
+- **Binary worker output no longer corrupts `gather`** — scatter/gather result
+  rows and `gather --lines` lossily UTF-8-decoded (`U+FFFD`) a worker whose stdout
+  was binary; a row now reports `ok:false` with a clear error and `--lines`
+  hard-errors (exit 123) instead of emitting mangled bytes.
+- **`scatter`/`gather` reject wrong-typed flag values loudly** — `--limit`,
+  `--as`, and `--timeout` silently fell back to their defaults when handed a
+  value of the wrong type (a string `--limit "5"` from a variable, a negative
+  `--timeout`) or a `$(...)` the reduced sync binder can't evaluate; they now
+  coerce where sensible (`--limit "5"` → 5) and otherwise fail with a usage error
+  instead of running mis-configured.
+- **`scatter` workers inherit the parent execution context** — workers ran with a
+  from-scratch context that dropped the script watchdog (so a `ctx.patient` hold
+  suspended a missing clock → false-positive request-timeout kills) and bypassed
+  the output-limit memory cap (N parallel workers could each hold unbounded
+  output). Workers now derive from the parent, carrying the watchdog, output limit
+  (with a per-worker spill boundary), aliases, and ignore/external-command policy.
+- **Backend-tool results keep their structured data across the kernel seam** — a
+  backend-registered tool's `ToolResult` → `ExecResult` conversion carried only
+  `.out`, dropping `.data`/`content_type`/`baggage` (so `x=$(embedder_tool)` lost
+  a structured/collection result and OTel baggage). A symmetric conversion now
+  preserves them, and a real backend execution error is reported as a failure
+  rather than masked as exit-127 "command not found".
+- **`source` / PATH `.kai` scripts accumulate output across statements** — they
+  used to keep only the last statement's stdout, silently discarding everything
+  earlier.
+- **`Kernel::reset()` preserves embedder state** — it silently reverted the
+  confirmation-latch/trash flags, the kernel's `$$` identity, and frontend-seeded
+  `initial_vars` (HOME/PATH), so an embedder resetting between requests lost its
+  latch gate. `reset()` now keeps all three.
+- **`jq` no longer JSON-sniffs a `Value::String` `.data` payload** — `fromjson
+  '"1"' | jq type` reported `"number"`; a string is now converted directly,
+  honouring the no-sniffing invariant.
+- **The argv door no longer panics on a non-ASCII short-flag bundle** —
+  `execute_argv("ls", ["-lé"])` sliced mid-codepoint and panicked; the classifier
+  now only accepts the lexer's real short-flag char class, falling back to a
+  literal positional.
+- **A bareword `key=value` positional after `--` parses** — `echo -- a=b` used to
+  hard-fail.
 - **A stdout redirect now clears the structured `.data` sideband too**, not just
   `.out`/`.output`. `.data` is the structured view of stdout, so `> file` /
   `>> file` / `&> file` take it along with the text: `x=$(cmd > file)` captures
@@ -414,6 +460,12 @@ breaking entries are marked **BREAKING**.
   now correctly reports source order.
 
 ### Removed
+- **BREAKING: the unused `Executor` trait and `NoOpExecutor` are removed from the
+  public `interpreter` surface.** The sync expression evaluator no longer takes an
+  executor — command substitution is resolved by the async evaluator, which
+  pre-resolves operands to literals before any sync evaluation, so the sync path's
+  command-substitution/file-test arms were dead code. Pre-1.0, breaking-in-name
+  only; nothing implemented or consumed them.
 - **BREAKING: the `test` builtin and `[` command are gone.** Use `[[ … ]]`, the one
   supported test form. The removed builtins never worked end-to-end through the
   parser anyway: `[` could not be a command name and `test`'s comparison operators

--- a/README.md
+++ b/README.md
@@ -121,7 +121,9 @@ everywhere, a `jq` that always uses the same filter syntax, an `awk` that never 
   as expected.
 - **80/20** — implement the features used 80% of the time, deliberately omit the 20% that add
   complexity without proportional value. Missing features compose via pipes.
-- **ERE everywhere** — all regex uses Extended Regular Expressions. No BRE/ERE confusion.
+- **ERE-first regex** — Extended Regular Expressions are the dialect everywhere; common GNU BRE
+  spellings (`\|`, `\(…\)`, `\{n,m\}`, `\+`, `\?`) are accepted too and rewrite to ERE, so existing
+  scripts keep working. `-E`/`-r` opts into strict ERE.
 
 | Category | Tools |
 |----------|-------|

--- a/crates/kaish-kernel/src/backend/testing.rs
+++ b/crates/kaish-kernel/src/backend/testing.rs
@@ -16,17 +16,33 @@ use crate::vfs::{DirEntry, MountInfo};
 /// Used to verify tool dispatch routes through the backend.
 pub struct MockBackend {
     pub call_count: Arc<AtomicUsize>,
+    /// Overrides `call_tool`'s return value when set — lets a test drive an
+    /// arbitrary `ToolResult` (structured `data`/`content_type`/`baggage`) or
+    /// a `BackendError` other than `ToolNotFound` through the real dispatch
+    /// path, instead of always getting `ToolResult::success("mock executed")`.
+    #[allow(clippy::type_complexity)]
+    tool_result: Option<Arc<dyn Fn(&str) -> BackendResult<ToolResult> + Send + Sync>>,
 }
 
 impl MockBackend {
     pub fn new() -> (Self, Arc<AtomicUsize>) {
         let count = Arc::new(AtomicUsize::new(0));
-        (Self { call_count: count.clone() }, count)
+        (Self { call_count: count.clone(), tool_result: None }, count)
     }
 
     /// Get the current call count.
     pub fn calls(&self) -> usize {
         self.call_count.load(Ordering::SeqCst)
+    }
+
+    /// Configure what `call_tool` returns for every invocation, keyed by the
+    /// tool name it was called with.
+    pub fn with_tool_result(
+        mut self,
+        result: impl Fn(&str) -> BackendResult<ToolResult> + Send + Sync + 'static,
+    ) -> Self {
+        self.tool_result = Some(Arc::new(result));
+        self
     }
 }
 
@@ -34,6 +50,7 @@ impl Default for MockBackend {
     fn default() -> Self {
         Self {
             call_count: Arc::new(AtomicUsize::new(0)),
+            tool_result: None,
         }
     }
 }
@@ -91,6 +108,9 @@ impl KernelBackend for MockBackend {
         _ctx: &mut dyn ToolCtx,
     ) -> BackendResult<ToolResult> {
         self.call_count.fetch_add(1, Ordering::SeqCst);
+        if let Some(f) = &self.tool_result {
+            return f(name);
+        }
         Ok(ToolResult::success(format!("mock executed: {}", name)))
     }
 

--- a/crates/kaish-kernel/src/dispatch.rs
+++ b/crates/kaish-kernel/src/dispatch.rs
@@ -205,7 +205,12 @@ impl BackendDispatcher {
                             if let Some(msg) = crate::interpreter::structured_boundary_error("a command argument", &v) {
                                 return Some(ExecResult::failure(1, msg));
                             }
-                            argv.push(crate::interpreter::value_to_string(&v));
+                            // Text sink: binary goes loud (kept in sync with
+                            // kernel.rs::build_args_flat).
+                            match crate::interpreter::value_to_text_sink(&v) {
+                                Ok(s) => argv.push(s),
+                                Err(e) => return Some(ExecResult::failure(1, e.to_string())),
+                            }
                         }
                     }
                     _ => {}

--- a/crates/kaish-kernel/src/dispatch.rs
+++ b/crates/kaish-kernel/src/dispatch.rs
@@ -213,6 +213,13 @@ impl BackendDispatcher {
                             }
                         }
                     }
+                    // Remaining literal types (Bool/Json/Null/Bytes) — kept in
+                    // sync with the production build_args_flat, which resolves
+                    // every positional through value_to_text_sink (binary loud).
+                    Expr::Literal(other) => match crate::interpreter::value_to_text_sink(other) {
+                        Ok(s) => argv.push(s),
+                        Err(e) => return Some(ExecResult::failure(1, e.to_string())),
+                    },
                     _ => {}
                 },
                 Arg::ShortFlag(f) => argv.push(format!("-{f}")),

--- a/crates/kaish-kernel/src/interpreter.rs
+++ b/crates/kaish-kernel/src/interpreter.rs
@@ -13,9 +13,11 @@
 //!
 //! # Command Substitution
 //!
-//! The evaluator supports `$(pipeline)` expressions through the `Executor` trait.
-//! Higher layers (L6: Pipes & Jobs) implement this trait to provide actual
-//! command execution. For standalone expression evaluation, use `NoOpExecutor`.
+//! `$(pipeline)` expressions are executed by the async evaluator in the kernel
+//! (`kernel.rs`), which resolves them to literal values before any synchronous
+//! expression evaluation runs. The sync [`eval_expr`] evaluator therefore never
+//! sees a `CommandSubst` node; encountering one is a loud error, not a silent
+//! empty string.
 //!
 //! # Example
 //!
@@ -37,7 +39,7 @@ mod result;
 mod scope;
 
 pub use control_flow::ControlFlow;
-pub use eval::{eval_expr, expand_tilde, is_collection, resolve_default, resolve_length, scalar_test_operand_error, strip_leading_tabs, structured_boundary_error, structured_export_error, value_defaults_on_emptiness, value_to_bool, value_to_exit_code, value_length, value_to_string, value_to_string_with_tilde, EvalError, EvalResult, Evaluator, Executor, HeredocAssembler, NoOpExecutor};
+pub use eval::{eval_expr, expand_tilde, is_collection, resolve_default, resolve_length, scalar_test_operand_error, strip_leading_tabs, structured_boundary_error, structured_export_error, value_defaults_on_emptiness, value_to_bool, value_to_exit_code, value_length, value_to_string, value_to_string_with_tilde, value_to_text_sink, EvalError, EvalResult, Evaluator, HeredocAssembler};
 pub use result::{apply_output_format, hex_dump, json_to_value, json_to_value_no_envelope, value_to_json, EntryType, ExecResult, LatchRequest, OutputData, OutputFormat, OutputNode, OutputPayload};
 pub use scope::{PathError, Scope};
 // Crate-internal: the reduced sync evaluator (scheduler/pipeline.rs) reuses the

--- a/crates/kaish-kernel/src/interpreter/eval.rs
+++ b/crates/kaish-kernel/src/interpreter/eval.rs
@@ -4,8 +4,10 @@
 //! Variable references are resolved through the Scope, and string
 //! interpolation is expanded.
 //!
-//! Command substitution (`$(pipeline)`) requires an executor, which is
-//! provided by higher layers (L6: Pipes & Jobs).
+//! Command substitution (`$(pipeline)`) is handled by the async evaluator in
+//! the kernel, which resolves each `$(...)` to a literal value before this sync
+//! evaluator runs. A `CommandSubst` node reaching the sync path is therefore a
+//! loud error, never silently executed or emptied.
 
 use std::fmt;
 
@@ -13,13 +15,10 @@ use kaish_types::json_to_value_no_envelope;
 
 use crate::arithmetic;
 use crate::ast::{
-    spread_non_list_message, BinaryOp, Expr, FileTestOp, ListElem, RecordEntry, RecordKey, Stmt,
+    spread_non_list_message, BinaryOp, Expr, ListElem, RecordEntry, RecordKey,
     StringPart, StringTestOp, TestCmpOp, TestExpr, Value, VarPath,
 };
-use crate::vfs::DirEntry;
-use std::path::Path;
 
-use super::result::ExecResult;
 use super::scope::Scope;
 
 /// Strip leading tabs from each line, per POSIX `<<-EOF` heredoc semantics.
@@ -118,7 +117,10 @@ pub enum EvalError {
     TypeError { expected: &'static str, got: String },
     /// Command substitution failed.
     CommandFailed(String),
-    /// No executor available for command substitution.
+    /// A node that only the async evaluator can handle (command substitution,
+    /// or a command used as a condition) reached the sync evaluator, which has
+    /// no way to execute pipelines. Unreachable in practice — the kernel
+    /// resolves these to literals first — but loud rather than silently empty.
     NoExecutor,
     /// Division by zero or similar arithmetic error.
     ArithmeticError(String),
@@ -139,7 +141,10 @@ impl fmt::Display for EvalError {
                 write!(f, "type error: expected {expected}, got {got}")
             }
             EvalError::CommandFailed(msg) => write!(f, "command failed: {msg}"),
-            EvalError::NoExecutor => write!(f, "no executor available for command substitution"),
+            EvalError::NoExecutor => write!(
+                f,
+                "command substitution must be resolved by the async evaluator before sync evaluation"
+            ),
             EvalError::ArithmeticError(msg) => write!(f, "arithmetic error: {msg}"),
             EvalError::RegexError(msg) => write!(f, "regex error: {msg}"),
             EvalError::Unsupported(msg) => write!(f, "{msg}"),
@@ -152,73 +157,20 @@ impl std::error::Error for EvalError {}
 /// Result type for evaluation.
 pub type EvalResult<T> = Result<T, EvalError>;
 
-/// Trait for executing pipelines (command substitution).
-///
-/// This is implemented by higher layers (L6: Pipes & Jobs) to provide
-/// actual command execution. The evaluator calls this when it encounters
-/// a `$(pipeline)` expression.
-pub trait Executor {
-    /// Execute a command-substitution body — a block of statements (the full
-    /// grammar: pipelines, `&&`/`||` chains, `;`/newline sequences) — and return
-    /// its combined result.
-    ///
-    /// The executor should:
-    /// 1. Run each statement, accumulating stdout/stderr
-    /// 2. Carry the last statement's exit code and structured data through
-    /// 3. Return an ExecResult with code, output, and parsed data
-    fn execute(&mut self, stmts: &[Stmt], scope: &mut Scope) -> EvalResult<ExecResult>;
-
-    /// Stat a file path through the VFS.
-    ///
-    /// Returns `Some(entry)` if the path exists, `None` otherwise.
-    /// Used by `[[ -d path ]]`, `[[ -f path ]]`, etc.
-    ///
-    /// Default: falls back to `std::fs::metadata` (bypasses VFS).
-    fn file_stat(&self, path: &Path) -> Option<DirEntry> {
-        std::fs::metadata(path).ok().map(|meta| {
-            if meta.is_dir() {
-                DirEntry::directory(path.file_name().unwrap_or_default().to_string_lossy())
-            } else {
-                #[allow(unused_mut)]
-                let mut entry = DirEntry::file(
-                    path.file_name().unwrap_or_default().to_string_lossy(),
-                    meta.len(),
-                );
-                #[cfg(unix)]
-                {
-                    use std::os::unix::fs::PermissionsExt;
-                    entry.permissions = Some(meta.permissions().mode());
-                }
-                entry
-            }
-        })
-    }
-}
-
-/// A stub executor that always returns an error.
-///
-/// Used in L3 before the full executor is available.
-pub struct NoOpExecutor;
-
-impl Executor for NoOpExecutor {
-    fn execute(&mut self, _stmts: &[Stmt], _scope: &mut Scope) -> EvalResult<ExecResult> {
-        Err(EvalError::NoExecutor)
-    }
-}
-
 /// Expression evaluator.
 ///
-/// Evaluates AST expressions to values, using the provided scope for
-/// variable lookup and the executor for command substitution.
-pub struct Evaluator<'a, E: Executor> {
+/// Evaluates AST expressions to values using the provided scope for variable
+/// lookup. Command substitution (`$(...)`) and command-as-condition are NOT
+/// handled here — the kernel's async evaluator resolves those to literal values
+/// first; if one reaches this sync evaluator it is a loud [`EvalError`].
+pub struct Evaluator<'a> {
     scope: &'a mut Scope,
-    executor: &'a mut E,
 }
 
-impl<'a, E: Executor> Evaluator<'a, E> {
-    /// Create a new evaluator with the given scope and executor.
-    pub fn new(scope: &'a mut Scope, executor: &'a mut E) -> Self {
-        Self { scope, executor }
+impl<'a> Evaluator<'a> {
+    /// Create a new evaluator with the given scope.
+    pub fn new(scope: &'a mut Scope) -> Self {
+        Self { scope }
     }
 
     /// Evaluate an expression to a value.
@@ -243,7 +195,10 @@ impl<'a, E: Executor> Evaluator<'a, E> {
                 Ok(Value::String(asm.into_string()))
             }
             Expr::BinaryOp { left, op, right } => self.eval_binary_op(left, *op, right),
-            Expr::CommandSubst(stmts) => self.eval_command_subst(stmts),
+            // Command substitution is resolved to a literal by the async
+            // evaluator before sync evaluation. Reaching it here is a loud
+            // error (unreachable in practice), never a silent empty string.
+            Expr::CommandSubst(_) => Err(EvalError::NoExecutor),
             Expr::Test(test_expr) => self.eval_test(test_expr),
             Expr::Positional(n) => self.eval_positional(*n),
             Expr::AllArgs => self.eval_all_args(),
@@ -318,18 +273,15 @@ impl<'a, E: Executor> Evaluator<'a, E> {
     /// Evaluate a command as a condition (exit code determines truthiness).
     fn eval_command(&mut self, cmd: &crate::ast::Command) -> EvalResult<Value> {
         // Special-case true/false builtins - they have well-known return values
-        // and don't need an executor to evaluate. Like real shells, any args are ignored.
+        // and don't need execution. Like real shells, any args are ignored.
         match cmd.name.as_str() {
-            "true" => return Ok(Value::Bool(true)),
-            "false" => return Ok(Value::Bool(false)),
-            _ => {}
+            "true" => Ok(Value::Bool(true)),
+            "false" => Ok(Value::Bool(false)),
+            // Any other command as a condition needs real execution, which only
+            // the kernel's async evaluator provides. Unreachable in practice
+            // (the async path handles command conditions); loud, not silent.
+            _ => Err(EvalError::NoExecutor),
         }
-
-        // For other commands, run the command as a one-statement block.
-        let block = [Stmt::Command(cmd.clone())];
-        let result = self.executor.execute(&block, self.scope)?;
-        // Exit code 0 = true, non-zero = false
-        Ok(Value::Bool(result.code == 0))
     }
 
     /// Evaluate arithmetic expansion: `$((expr))`
@@ -342,23 +294,16 @@ impl<'a, E: Executor> Evaluator<'a, E> {
     /// Evaluate a test expression `[[ ... ]]` to a boolean value.
     fn eval_test(&mut self, test_expr: &TestExpr) -> EvalResult<Value> {
         let result = match test_expr {
-            TestExpr::FileTest { op, path } => {
-                let path_value = self.eval(path)?;
-                let path_str = value_to_string(&path_value);
-                let path = Path::new(&path_str);
-                let entry = self.executor.file_stat(path);
-                match op {
-                    FileTestOp::Exists => entry.is_some(),
-                    FileTestOp::IsFile => entry.as_ref().is_some_and(|e| e.is_file()),
-                    FileTestOp::IsDir => entry.as_ref().is_some_and(|e| e.is_dir()),
-                    FileTestOp::Readable => entry.is_some(),
-                    FileTestOp::Writable => entry.as_ref().is_some_and(|e| {
-                        e.permissions.is_none_or(|p| p & 0o222 != 0)
-                    }),
-                    FileTestOp::Executable => entry.as_ref().is_some_and(|e| {
-                        e.permissions.is_some_and(|p| p & 0o111 != 0)
-                    }),
-                }
+            TestExpr::FileTest { .. } => {
+                // Unreachable in practice: file tests are resolved by the async
+                // `eval_test_async` (VFS-aware — it stats through the backend).
+                // The sync evaluator only ever receives Comparison/In operands
+                // pre-resolved to literals, so a FileTest here is the outside
+                // case: fail loud rather than silently stat via `std::fs` and
+                // bypass the VFS.
+                return Err(EvalError::Unsupported(
+                    "file tests must be resolved by the async evaluator".to_string(),
+                ));
             }
             TestExpr::StringTest { op, value } => match op {
                 StringTestOp::IsEmpty | StringTestOp::IsNonEmpty => {
@@ -554,7 +499,8 @@ impl<'a, E: Executor> Evaluator<'a, E> {
                 StringPart::Literal(s) => result.push_str(s),
                 StringPart::Var(path) => {
                     match self.scope.resolve_path(path) {
-                        Ok(value) => result.push_str(&value_to_string(&value)),
+                        // Text sink: binary goes loud, never the placeholder.
+                        Ok(value) => result.push_str(&value_to_text_sink(&value)?),
                         // Unset variables expand to empty string (bash-compatible).
                         Err(super::scope::PathError::UndefinedRoot(_)) => {}
                         // A loud path error (absence or shape) is surfaced, never
@@ -567,33 +513,36 @@ impl<'a, E: Executor> Evaluator<'a, E> {
                 }
                 StringPart::VarWithDefault { path, default } => {
                     let value = self.eval_var_with_default(path, default)?;
-                    result.push_str(&value_to_string(&value));
+                    result.push_str(&value_to_text_sink(&value)?);
                 }
                 StringPart::VarLength(path) => {
                     let value = self.eval_var_length(path)?;
-                    result.push_str(&value_to_string(&value));
+                    result.push_str(&value_to_text_sink(&value)?);
                 }
                 StringPart::Positional(n) => {
                     let value = self.eval_positional(*n)?;
-                    result.push_str(&value_to_string(&value));
+                    result.push_str(&value_to_text_sink(&value)?);
                 }
                 StringPart::AllArgs => {
                     let value = self.eval_all_args()?;
-                    result.push_str(&value_to_string(&value));
+                    result.push_str(&value_to_text_sink(&value)?);
                 }
                 StringPart::ArgCount => {
                     let value = self.eval_arg_count()?;
-                    result.push_str(&value_to_string(&value));
+                    result.push_str(&value_to_text_sink(&value)?);
                 }
                 StringPart::Arithmetic(expr) => {
                     // Parse and evaluate the arithmetic expression
                     let value = self.eval_arithmetic_string(expr)?;
-                    result.push_str(&value_to_string(&value));
+                    result.push_str(&value_to_text_sink(&value)?);
                 }
-                StringPart::CommandSubst(stmts) => {
-                    // Execute the statement block and capture its output
-                    let value = self.eval_command_subst(stmts)?;
-                    result.push_str(&value_to_string(&value));
+                StringPart::CommandSubst(_) => {
+                    // Command substitution must be resolved by the async
+                    // evaluator (kernel.rs) before sync evaluation — the sync
+                    // path has no executor. Unreachable in practice (operands
+                    // arrive pre-resolved as literals), but loud rather than
+                    // silently empty if a future sync embedder trips it.
+                    return Err(EvalError::NoExecutor);
                 }
                 StringPart::LastExitCode => {
                     result.push_str(&self.scope.last_result().code.to_string());
@@ -636,17 +585,6 @@ impl<'a, E: Executor> Evaluator<'a, E> {
         }
     }
 
-    /// Evaluate command substitution.
-    fn eval_command_subst(&mut self, stmts: &[Stmt]) -> EvalResult<Value> {
-        let result = self.executor.execute(stmts, self.scope)?;
-
-        // Update $? with the result
-        self.scope.set_last_result(result.clone());
-
-        // Return the result as a value (the result object itself)
-        // The caller can access .ok, .data, etc.
-        Ok(result_to_value(&result))
-    }
 }
 
 /// Convert a Value to its string representation for interpolation.
@@ -822,9 +760,43 @@ pub fn value_to_string(value: &Value) -> String {
         Value::Float(f) => f.to_string(),
         Value::String(s) => s.clone(),
         Value::Json(json) => json.to_string(),
-        // Binary in a text context: visible placeholder, not raw bytes. The
-        // loud-error guard lands with the Phase-2 arg/sink rework.
+        // Binary in a NON-sink context (case-glob matching, `==`/`in`, `${#…}`
+        // length, debug rendering): a stable, visible placeholder. Text SINKS —
+        // string interpolation and external-command argv — must NOT use this;
+        // they go through `value_to_text_sink`, which is loud on binary so the
+        // user's real bytes are never silently replaced by this placeholder.
         Value::Bytes(b) => format!("[binary: {} bytes]", b.len()),
+    }
+}
+
+/// Materialize a `Value` for a TEXT SINK — string interpolation (`"x=$b"`) or an
+/// external-command argv element (`prog $b`) — going LOUD on binary rather than
+/// emitting the `[binary: N bytes]` placeholder that [`value_to_string`] uses.
+///
+/// Splicing binary into text as a placeholder is silent data corruption: a
+/// command may already have captured the user's real bytes (e.g. `b=$(cat
+/// blob)` stores a `Value::Bytes` — `cat` emits raw bytes for non-UTF-8
+/// content), and the placeholder throws those bytes away where the data should
+/// be. Valid-UTF-8 bytes coerce (mirroring [`ExecResult::try_text_out`]);
+/// everything else is a loud error. In practice `Value::Bytes` only ever holds
+/// non-UTF-8 content (the producer coercion in `ExecResult::success_text_or_bytes`
+/// keeps valid UTF-8 as text), so this errors whenever a `Bytes` value reaches a
+/// text sink. See `docs/binary-data.md`.
+///
+/// This is deliberately NOT a global replacement for [`value_to_string`] — the
+/// infallible form stays correct for semantic/internal uses where a stable
+/// placeholder is wanted and no data crosses a text boundary.
+pub fn value_to_text_sink(value: &Value) -> EvalResult<String> {
+    match value {
+        Value::Bytes(b) => match std::str::from_utf8(b) {
+            Ok(s) => Ok(s.to_string()),
+            Err(_) => Err(EvalError::Unsupported(format!(
+                "binary data ({} bytes) cannot be used as text — decode it \
+                 (base64/xxd) or redirect to a file",
+                b.len()
+            ))),
+        },
+        other => Ok(value_to_string(other)),
     }
 }
 
@@ -1197,26 +1169,6 @@ fn type_name(value: &Value) -> &'static str {
     }
 }
 
-/// Convert an ExecResult to a Value for command substitution return.
-///
-/// Prefers structured data if available (for iteration in for loops),
-/// otherwise returns stdout (trimmed) as a string. `$?` exposes the exit
-/// code as an int; `kaish-last` exposes the previous command's structured
-/// data or stdout as text.
-fn result_to_value(result: &ExecResult) -> Value {
-    // Prefer structured data if available (enables `for i in $(cmd)` iteration)
-    if let Some(data) = &result.data {
-        return data.clone();
-    }
-    // Otherwise return stdout as single string (NO implicit splitting).
-    // Strip trailing newlines only, not all trailing whitespace — same trim as
-    // the async kernel command-subst path (`kernel.rs` Expr::CommandSubst) and
-    // the quoted `"$(…)"` interpolation, so this sync evaluator (dead today —
-    // it runs under `NoOpExecutor` — but a trap for a future non-async embedder)
-    // can't silently diverge.
-    Value::String(result.text_out().trim_end_matches('\n').to_string())
-}
-
 /// Perform regex match or not-match on two values.
 ///
 /// The left operand is the string to match against.
@@ -1250,10 +1202,12 @@ fn regex_match(left: &Value, right: &Value, negate: bool) -> EvalResult<Value> {
 
 /// Convenience function to evaluate an expression with a scope.
 ///
-/// Uses NoOpExecutor, so command substitution will fail.
+/// This is the sync evaluator: command substitution (`$(...)`) is not executed
+/// here — the kernel's async evaluator resolves those to literal values first.
+/// A `CommandSubst` (or command-as-condition) node reaching this function is a
+/// loud [`EvalError::NoExecutor`], never a silent empty value.
 pub fn eval_expr(expr: &Expr, scope: &mut Scope) -> EvalResult<Value> {
-    let mut executor = NoOpExecutor;
-    let mut evaluator = Evaluator::new(scope, &mut executor);
+    let mut evaluator = Evaluator::new(scope);
     evaluator.eval(expr)
 }
 
@@ -1261,7 +1215,8 @@ pub fn eval_expr(expr: &Expr, scope: &mut Scope) -> EvalResult<Value> {
 #[allow(clippy::approx_constant)]
 mod tests {
     use super::*;
-    use crate::ast::VarSegment;
+    use crate::ast::{Stmt, VarSegment};
+    use super::super::result::ExecResult;
 
     // Helper to create a simple variable expression
     fn var_expr(name: &str) -> Expr {
@@ -1415,7 +1370,10 @@ mod tests {
     }
 
     #[test]
-    fn eval_command_subst_fails_without_executor() {
+    fn sync_command_subst_is_loud_not_silent() {
+        // The async evaluator resolves `$(...)` to a literal before sync
+        // evaluation; a CommandSubst reaching the sync path is a loud error
+        // (never silently empty). Pins the removal of the old executor path.
         use crate::ast::Command;
 
         let mut scope = Scope::new();

--- a/crates/kaish-kernel/src/kernel.rs
+++ b/crates/kaish-kernel/src/kernel.rs
@@ -678,6 +678,10 @@ pub struct Kernel {
     runner: PipelineRunner,
     /// Execution context (cwd, stdin, etc.).
     exec_ctx: RwLock<ExecContext>,
+    /// Frontend-seeded variables (HOME/PATH/etc, from `KernelConfig::initial_vars`),
+    /// retained past construction so `reset()` can re-seed them into the fresh
+    /// scope instead of silently dropping them.
+    initial_vars: HashMap<String, Value>,
     /// Whether to skip pre-execution validation.
     skip_validation: bool,
     /// When true, standalone external commands inherit stdio for real-time output.
@@ -1118,13 +1122,14 @@ impl Kernel {
                 // Frontends (REPL, MCP) populate this from std::env::vars()
                 // for shell-like UX; embedders that want hermetic behavior
                 // simply leave it empty.
-                for (name, value) in initial_vars {
+                for (name, value) in initial_vars.clone() {
                     scope.set_exported(name, value);
                 }
                 scope.set_latch_enabled(latch_enabled);
                 scope.set_trash_enabled(trash_enabled);
                 scope
             }),
+            initial_vars,
             tools,
             user_tools: RwLock::new(HashMap::new()),
             vfs,
@@ -1262,6 +1267,7 @@ impl Kernel {
         let fork = Self {
             name: format!("{}:fork", self.name),
             scope: RwLock::new(scope_snapshot),
+            initial_vars: self.initial_vars.clone(),
             tools: Arc::clone(&self.tools),
             user_tools: RwLock::new(user_tools_snapshot),
             vfs: Arc::clone(&self.vfs),
@@ -2035,14 +2041,21 @@ impl Kernel {
                         value.err = format!("{}{}", drained_stderr, value.err);
                     }
                     on_output(&value);
-                    result = value;
+                    // A top-level `return` stops the script, like `exit` —
+                    // it must not discard prior statements' accumulated
+                    // output nor let execution continue past it.
+                    accumulate_result(&mut result, &value);
+                    if !surfaced_warnings.is_empty() {
+                        result.err = format!("{surfaced_warnings}{}", result.err);
+                    }
+                    return Ok(result);
                 }
                 ControlFlow::Break { result: mut r, .. } | ControlFlow::Continue { result: mut r, .. } => {
                     if !drained_stderr.is_empty() {
                         r.err = format!("{}{}", drained_stderr, r.err);
                     }
                     on_output(&r);
-                    result = r;
+                    accumulate_result(&mut result, &r);
                 }
             }
         }
@@ -2954,7 +2967,18 @@ impl Kernel {
                 // Clone backend and drop read lock before awaiting (may involve network I/O).
                 // Backend tools expect named JSON params, so enable positional mapping.
                 let backend = self.exec_ctx.read().await.backend.clone();
-                let tool_schema = backend.get_tool(name).await.ok().flatten().map(|t| {
+                let tool_schema = backend
+                    .get_tool(name)
+                    .await
+                    .unwrap_or_else(|e| {
+                        // Schema lookup failing just means positionals won't
+                        // get name-mapped below — `call_tool` is still
+                        // attempted. Trace it so the degradation is visible
+                        // rather than silently swallowed.
+                        tracing::debug!("backend get_tool error for {name}: {e}");
+                        None
+                    })
+                    .map(|t| {
                     let mut s = t.schema;
                     // Flat backend/MCP tools expect named JSON params, so map
                     // bare positionals onto named params. Subcommand-aware tools
@@ -2977,19 +3001,23 @@ impl Kernel {
                     Ok(tool_result) => {
                         let mut scope = self.scope.write().await;
                         *scope = ctx.scope.clone();
-                        let mut exec = ExecResult::from_output(
-                            tool_result.code as i64, tool_result.stdout, tool_result.stderr,
-                        );
-                        exec.set_output(tool_result.output);
-                        return Ok(exec);
+                        // Preserve every field (data/content_type/baggage,
+                        // not just stdout text) — this is the embedder seam:
+                        // `x=$(embedder_tool)` and structured iteration over
+                        // its result depend on `.data` surviving the crossing
+                        // back into the kernel.
+                        return Ok(ExecResult::from(tool_result));
                     }
                     Err(BackendError::ToolNotFound(_)) => {
-                        // Fall through to "command not found"
+                        // The backend confirms no such tool exists — fall
+                        // through to "command not found" below.
                     }
                     Err(e) => {
-                        // Backend dispatch is last-resort lookup — if it fails
-                        // for any reason, the command simply doesn't exist.
-                        tracing::debug!("backend error for {name}: {e}");
+                        // The tool was found (dispatch reached real
+                        // execution) but running it failed — a genuine
+                        // execution error, not "command not found". Surface
+                        // it loudly instead of masking it as exit-127.
+                        return Ok(ExecResult::failure(1, format!("{}: {}", name, e)));
                     }
                 }
 
@@ -4433,8 +4461,22 @@ impl Kernel {
             }
         };
 
-        // Execute each statement in the CURRENT scope (not isolated)
-        let mut result = ExecResult::success("");
+        // Execute each statement in the CURRENT scope (not isolated), accumulating
+        // stdout/stderr across statements like `execute_user_tool` — a sourced
+        // script's earlier statements must not be silently dropped in favor of
+        // just the last one.
+        fn push_out(buf: &mut Vec<u8>, r: &ExecResult) {
+            match r.out_bytes() {
+                Some(b) => buf.extend_from_slice(b),
+                None => buf.extend_from_slice(r.text_out().as_bytes()),
+            }
+        }
+
+        let mut accumulated_out: Vec<u8> = Vec::new();
+        let mut accumulated_err = String::new();
+        let mut last_code = 0i64;
+        let mut last_data: Option<Value> = None;
+
         for stmt in program.statements {
             if matches!(stmt, crate::ast::Stmt::Empty) {
                 continue;
@@ -4442,10 +4484,19 @@ impl Kernel {
 
             match self.execute_stmt_flow(&stmt).await {
                 Ok(flow) => {
-                    self.drain_stderr_into(&mut result).await;
+                    let drained = {
+                        let mut receiver = self.stderr_receiver.lock().await;
+                        receiver.drain_lossy()
+                    };
+                    if !drained.is_empty() {
+                        accumulated_err.push_str(&drained);
+                    }
                     match flow {
                         ControlFlow::Normal(r) => {
-                            result = r.clone();
+                            push_out(&mut accumulated_out, &r);
+                            accumulated_err.push_str(&r.err);
+                            last_code = r.code;
+                            last_data = r.data.clone();
                             self.update_last_result(&r).await;
                         }
                         ControlFlow::Break { .. } | ControlFlow::Continue { .. } => {
@@ -4455,10 +4506,19 @@ impl Kernel {
                             ));
                         }
                         ControlFlow::Return { value } => {
-                            return Ok(value);
+                            push_out(&mut accumulated_out, &value);
+                            accumulated_err.push_str(&value.err);
+                            let mut result = ExecResult::success_text_or_bytes(accumulated_out)
+                                .with_code(value.code);
+                            result.err = accumulated_err;
+                            result.data = value.data;
+                            return Ok(result);
                         }
                         ControlFlow::Exit { code } => {
-                            result.code = code;
+                            let mut result =
+                                ExecResult::success_text_or_bytes(accumulated_out).with_code(code);
+                            result.err = accumulated_err;
+                            result.data = last_data;
                             return Ok(result);
                         }
                     }
@@ -4469,6 +4529,9 @@ impl Kernel {
             }
         }
 
+        let mut result = ExecResult::success_text_or_bytes(accumulated_out).with_code(last_code);
+        result.err = accumulated_err;
+        result.data = last_data;
         Ok(result)
     }
 
@@ -4559,8 +4622,20 @@ impl Kernel {
                 std::mem::replace(&mut *scope, isolated_scope)
             };
 
-            // Execute script statements — track outcome for cleanup
-            let mut result = ExecResult::success("");
+            // Execute script statements — accumulate stdout/stderr across
+            // statements like `execute_user_tool`, rather than keeping only the
+            // last one's result.
+            fn push_out(buf: &mut Vec<u8>, r: &ExecResult) {
+                match r.out_bytes() {
+                    Some(b) => buf.extend_from_slice(b),
+                    None => buf.extend_from_slice(r.text_out().as_bytes()),
+                }
+            }
+
+            let mut accumulated_out: Vec<u8> = Vec::new();
+            let mut accumulated_err = String::new();
+            let mut last_code = 0i64;
+            let mut last_data: Option<Value> = None;
             let mut exec_error: Option<anyhow::Error> = None;
             let mut exit_code: Option<i64> = None;
 
@@ -4571,10 +4646,25 @@ impl Kernel {
 
                 match self.execute_stmt_flow(&stmt).await {
                     Ok(flow) => {
+                        let drained = {
+                            let mut receiver = self.stderr_receiver.lock().await;
+                            receiver.drain_lossy()
+                        };
+                        if !drained.is_empty() {
+                            accumulated_err.push_str(&drained);
+                        }
                         match flow {
-                            ControlFlow::Normal(r) => result = r,
+                            ControlFlow::Normal(r) => {
+                                push_out(&mut accumulated_out, &r);
+                                accumulated_err.push_str(&r.err);
+                                last_code = r.code;
+                                last_data = r.data;
+                            }
                             ControlFlow::Return { value } => {
-                                result = value;
+                                push_out(&mut accumulated_out, &value);
+                                accumulated_err.push_str(&value.err);
+                                last_code = value.code;
+                                last_data = value.data;
                                 break;
                             }
                             ControlFlow::Exit { code } => {
@@ -4582,7 +4672,10 @@ impl Kernel {
                                 break;
                             }
                             ControlFlow::Break { result: r, .. } | ControlFlow::Continue { result: r, .. } => {
-                                result = r;
+                                push_out(&mut accumulated_out, &r);
+                                accumulated_err.push_str(&r.err);
+                                last_code = r.code;
+                                last_data = r.data;
                             }
                         }
                     }
@@ -4603,11 +4696,10 @@ impl Kernel {
             if let Some(e) = exec_error {
                 return Err(e.context(format!("script: {}", script_path.display())));
             }
-            if let Some(code) = exit_code {
-                result.code = code;
-                return Ok(Some(result));
-            }
-
+            let code = exit_code.unwrap_or(last_code);
+            let mut result = ExecResult::success_text_or_bytes(accumulated_out).with_code(code);
+            result.err = accumulated_err;
+            result.data = last_data;
             return Ok(Some(result));
         }
 
@@ -5309,12 +5401,27 @@ impl Kernel {
 
     /// Reset kernel to initial state.
     ///
-    /// Clears in-memory variables and resets cwd to root.
-    /// History is not cleared (it persists across resets).
+    /// Clears in-memory variables and resets cwd to root. History is not
+    /// cleared (it persists across resets). The kernel's `$$` identity, the
+    /// confirmation latch / trash-on-delete configuration, and any
+    /// frontend-seeded `initial_vars` (HOME/PATH/etc, from `KernelConfig`)
+    /// are re-applied to the fresh scope rather than silently reverting to
+    /// defaults — an embedder that opted into `with_latch(true)` must not
+    /// find the gate quietly disabled after a `reset()` between requests.
     pub async fn reset(&self) -> Result<()> {
         {
             let mut scope = self.scope.write().await;
-            *scope = Scope::new();
+            let pid = scope.pid();
+            let latch_enabled = scope.latch_enabled();
+            let trash_enabled = scope.trash_enabled();
+            let mut fresh = Scope::new();
+            fresh.set_pid(pid);
+            for (name, value) in self.initial_vars.clone() {
+                fresh.set_exported(name, value);
+            }
+            fresh.set_latch_enabled(latch_enabled);
+            fresh.set_trash_enabled(trash_enabled);
+            *scope = fresh;
         }
         {
             let mut ctx = self.exec_ctx.write().await;
@@ -5636,12 +5743,17 @@ fn classify_argv_token(token: &Value) -> Arg {
     Arg::Positional(Expr::Literal(Value::String(s.clone())))
 }
 
-/// A short-flag word: a leading ASCII letter and no `=`. `-la`, `-A1`, `-a:`
-/// qualify (the lexer's flag token absorbs `:`/`.` and friends); `-1` (a number)
-/// and `-k=v` (`=` is the assignment operator — a parse error in the string door)
-/// do not, so they fall through to a literal positional.
+/// A short-flag word: a leading ASCII letter, then only ASCII
+/// letters/digits/`-` (the lexer's base `-[a-zA-Z][a-zA-Z0-9-]*` regex) or `:`
+/// (which `merge_flag_metachar_adjacent` glues onto a `ShortFlag` for the
+/// `awk -F:` idiom). `-la`, `-A1`, `-a:` qualify; `-1` (a number), `-k=v`
+/// (`=` is the assignment operator — a parse error in the string door), and
+/// any non-ASCII tail (never produced by the lexer, and not safe for the
+/// combined-short-flag binder's byte-index slicing) do not, so they fall
+/// through to a literal positional instead of a malformed `ShortFlag`.
 fn is_short_flag_body(s: &str) -> bool {
-    s.starts_with(|c: char| c.is_ascii_alphabetic()) && !s.contains('=')
+    s.starts_with(|c: char| c.is_ascii_alphabetic())
+        && s.chars().all(|c| c.is_ascii_alphanumeric() || c == '-' || c == ':')
 }
 
 /// Bash-style assignment-LHS identifier: `[A-Za-z_][A-Za-z0-9_]*`.
@@ -5905,6 +6017,31 @@ mod argv_classify_tests {
         // A bare dash and a number-dash are positionals (covered above too).
         assert_eq!(classify("-"), pos("-"));
         assert_eq!(classify("-9"), pos("-9"));
+        // A non-ASCII tail is not part of the lexer's short-flag char class
+        // (`-[a-zA-Z][a-zA-Z0-9-]*`, plus the `:` the metachar-merge pass
+        // absorbs) — classifying it as `ShortFlag` would hand the combined
+        // short-flag binder a byte string it (correctly, for real ASCII flag
+        // words) slices by *byte* index, panicking on a multi-byte char
+        // boundary. Fall back to a literal positional instead.
+        assert_eq!(classify("-lé"), pos("-lé"));
+        assert_eq!(classify("-é"), pos("-é"));
+    }
+
+    #[tokio::test]
+    async fn non_ascii_short_flag_bundle_does_not_panic() {
+        // Regression: `execute_argv`'s combined-short-flag loop assumed the
+        // flag body was ASCII (safe to byte-slice) because the lexer's
+        // grammar guarantees that on the *string* door. The argv door's
+        // classifier let a non-ASCII tail through as `ShortFlag`, so
+        // `execute_argv("ls", &["-lé"])` sliced mid-codepoint and panicked.
+        let kernel = Kernel::transient().expect("failed to create kernel");
+        let result = kernel
+            .execute_argv("ls", &[Value::String("-lé".into())])
+            .await
+            .expect("execute_argv must not panic on a non-ASCII short-flag token");
+        // Not a well-formed flag word, so it's a literal positional — `ls`
+        // then reports it as a missing path rather than mangling flags.
+        assert_ne!(result.code, 0);
     }
 
     proptest::proptest! {
@@ -6064,6 +6201,80 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn backend_tool_data_content_type_and_baggage_survive_into_exec_result() {
+        // The embedder seam: a backend-registered tool (kaijutsu, an MCP
+        // engine, …) returns a `ToolResult` with structured `data` — this
+        // must reach the caller's `ExecResult` intact so `x=$(embedder_tool)`
+        // and `for r in $(embedder_tool)` see the typed value, not just
+        // stdout text.
+        use crate::backend::testing::MockBackend;
+        use crate::backend::ToolResult;
+        let (mock, _calls) = MockBackend::new();
+        let backend = mock.with_tool_result(|_name| {
+            let mut baggage = std::collections::BTreeMap::new();
+            baggage.insert("trace_id".to_string(), "abc123".to_string());
+            Ok(ToolResult {
+                code: 0,
+                stdout: String::new(),
+                stderr: String::new(),
+                data: Some(serde_json::json!({"key": "value"})),
+                output: None,
+                content_type: Some("application/json".to_string()),
+                baggage,
+            })
+        });
+        let backend: Arc<dyn crate::backend::KernelBackend> = Arc::new(backend);
+        let kernel = Kernel::with_backend(backend, KernelConfig::isolated(), |_| {}, |_| {})
+            .expect("with_backend kernel");
+
+        let result = kernel
+            .execute("embedder_tool")
+            .await
+            .expect("execution failed");
+        assert!(result.ok(), "backend tool call should succeed: {result:?}");
+        assert_eq!(
+            result.data,
+            Some(Value::Json(serde_json::json!({"key": "value"}))),
+            "backend tool's structured data must survive into ExecResult, not be dropped"
+        );
+        assert_eq!(
+            result.content_type.as_deref(),
+            Some("application/json"),
+            "backend tool's content_type must survive into ExecResult"
+        );
+        assert_eq!(
+            result.baggage.get("trace_id").map(String::as_str),
+            Some("abc123"),
+            "backend tool's baggage must survive into ExecResult"
+        );
+    }
+
+    #[tokio::test]
+    async fn backend_tool_execution_error_is_not_reported_as_command_not_found() {
+        // A backend tool that IS found but fails during execution (`Io`,
+        // `PermissionDenied`, …) must surface its real error, not get
+        // misreported as exit-127 "command not found" — that masks a genuine
+        // failure as a lookup miss.
+        use crate::backend::testing::MockBackend;
+        let (mock, _calls) = MockBackend::new();
+        let backend = mock.with_tool_result(|_name| Err(BackendError::Io("disk exploded".to_string())));
+        let backend: Arc<dyn crate::backend::KernelBackend> = Arc::new(backend);
+        let kernel = Kernel::with_backend(backend, KernelConfig::isolated(), |_| {}, |_| {})
+            .expect("with_backend kernel");
+
+        let result = kernel
+            .execute("embedder_tool")
+            .await
+            .expect("execution failed");
+        assert_ne!(result.code, 127, "a real execution error must not look like command-not-found: {result:?}");
+        assert!(!result.ok());
+        assert!(
+            result.err.contains("disk exploded"),
+            "the real backend error must be visible, not masked: {result:?}"
+        );
+    }
+
+    #[tokio::test]
     async fn test_external_command_true() {
         // Use REPL config for passthrough filesystem access
         let kernel = Kernel::new(KernelConfig::repl()).expect("failed to create kernel");
@@ -6106,6 +6317,57 @@ mod tests {
 
         kernel.reset().await.expect("reset failed");
         assert!(kernel.get_var("X").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_kernel_reset_preserves_latch_and_trash_config() {
+        // An embedder configuring `with_latch(true)` must not have the
+        // confirmation gate silently disabled by a later `reset()` — that
+        // would let a destructive command through with no nonce and no
+        // error, exactly the "silent fallback" the latch exists to prevent.
+        let kernel = Kernel::new(
+            KernelConfig::transient()
+                .with_latch(true)
+                .with_skip_validation(true),
+        )
+        .expect("failed to create kernel");
+
+        // Write and rm relative to `/` (reset()'s post-reset cwd) so the file
+        // is reachable identically before and after reset.
+        kernel.execute("cd /; echo hi > latch-probe.txt").await.expect("setup write failed");
+
+        let before = kernel.execute("rm latch-probe.txt").await.expect("execute failed");
+        assert_eq!(before.code, 2, "latch should require confirmation before reset: {before:?}");
+
+        kernel.reset().await.expect("reset failed");
+
+        // reset() only clears scope/cwd (to `/`), not the VFS — the
+        // un-deleted probe file (the latch blocked the delete above) is
+        // still there.
+        let after = kernel.execute("rm latch-probe.txt").await.expect("execute failed");
+        assert_eq!(
+            after.code, 2,
+            "latch must still require confirmation after reset, not silently disable: {after:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_kernel_reset_preserves_pid_and_initial_vars() {
+        let kernel = Kernel::new(KernelConfig::transient().with_var("HOME", Value::String("/home/probe".into())))
+            .expect("failed to create kernel");
+
+        let pid_before = kernel.execute("echo $$").await.expect("execute failed").text_out().trim().to_string();
+        assert_eq!(kernel.get_var("HOME").await, Some(Value::String("/home/probe".into())));
+
+        kernel.reset().await.expect("reset failed");
+
+        let pid_after = kernel.execute("echo $$").await.expect("execute failed").text_out().trim().to_string();
+        assert_eq!(pid_before, pid_after, "$$ must stay stable across reset(), not silently renumber");
+        assert_eq!(
+            kernel.get_var("HOME").await,
+            Some(Value::String("/home/probe".into())),
+            "frontend-seeded initial vars (HOME/PATH) must survive reset(), not silently vanish"
+        );
     }
 
     #[tokio::test]

--- a/crates/kaish-kernel/src/kernel.rs
+++ b/crates/kaish-kernel/src/kernel.rs
@@ -54,7 +54,7 @@ pub use kaish_types::{CommandKind, ExecuteOptions};
 use crate::backend::{BackendError, KernelBackend};
 use kaish_glob::glob_match;
 use crate::dispatch::{CommandDispatcher, PipelinePosition};
-use crate::interpreter::{apply_output_format, eval_expr, expand_tilde, json_to_value_no_envelope, value_to_bool, value_to_string, ControlFlow, ExecResult, PathError, Scope};
+use crate::interpreter::{apply_output_format, eval_expr, expand_tilde, json_to_value_no_envelope, value_to_bool, value_to_string, value_to_text_sink, ControlFlow, ExecResult, PathError, Scope};
 use crate::parser::parse;
 use crate::scheduler::{is_bool_type, schema_param_lookup, select_leaf, stderr_stream, BoundedStream, JobManager, PipelineRunner, StderrReceiver};
 #[cfg(feature = "subprocess")]
@@ -3691,7 +3691,9 @@ impl Kernel {
                         return Err(anyhow::anyhow!(msg));
                     }
                     let value = apply_tilde_expansion(value, home.as_deref());
-                    argv.push(value_to_string(&value));
+                    // External-command argv is a text sink: a bare `$BIN` binary
+                    // word goes loud, never the `[binary: N bytes]` placeholder.
+                    argv.push(value_to_text_sink(&value).map_err(|e| anyhow::anyhow!("{e}"))?);
                 }
                 Arg::Named { key, value } => {
                     let val = self.eval_expr_async(value).await?;
@@ -3699,7 +3701,8 @@ impl Kernel {
                         return Err(anyhow::anyhow!(msg));
                     }
                     let val = apply_tilde_expansion(val, home.as_deref());
-                    argv.push(format!("--{}={}", key, value_to_string(&val)));
+                    let val_str = value_to_text_sink(&val).map_err(|e| anyhow::anyhow!("{e}"))?;
+                    argv.push(format!("--{key}={val_str}"));
                 }
                 Arg::WordAssign { key, value } => {
                     let val = self.eval_expr_async(value).await?;
@@ -3707,7 +3710,8 @@ impl Kernel {
                         return Err(anyhow::anyhow!(msg));
                     }
                     let val = apply_tilde_expansion(val, home.as_deref());
-                    argv.push(format!("{}={}", key, value_to_string(&val)));
+                    let val_str = value_to_text_sink(&val).map_err(|e| anyhow::anyhow!("{e}"))?;
+                    argv.push(format!("{key}={val_str}"));
                 }
                 Arg::ShortFlag(name) => {
                     // Preserve original format: -l, -la (combined flags)
@@ -4089,7 +4093,10 @@ impl Kernel {
                 StringPart::Var(path) => {
                     let scope = self.scope.read().await;
                     match scope.resolve_path(path) {
-                        Ok(value) => Ok(value_to_string(&value)),
+                        // Text sink: binary goes loud, never the placeholder —
+                        // a `b=$(cat blob)` capture holds real bytes; splicing
+                        // `[binary: N bytes]` into "$b" would be silent loss.
+                        Ok(value) => value_to_text_sink(&value).map_err(|e| anyhow::anyhow!("{e}")),
                         // Unset vars expand to empty; loud path errors surface.
                         Err(PathError::UndefinedRoot(_)) => Ok(String::new()),
                         Err(PathError::Absence(msg)) | Err(PathError::Shape(msg)) => {
@@ -4104,7 +4111,7 @@ impl Kernel {
                             .map_err(|msg| anyhow::anyhow!(msg))?
                     };
                     match resolved {
-                        Some(value) => Ok(value_to_string(&value)),
+                        Some(value) => value_to_text_sink(&value).map_err(|e| anyhow::anyhow!("{e}")),
                         None => self.eval_string_parts_async(default).await,
                     }
                 }

--- a/crates/kaish-kernel/src/parser.rs
+++ b/crates/kaish-kernel/src/parser.rs
@@ -1718,6 +1718,13 @@ where
             Token::ShortFlag(name) => Arg::Positional(Expr::Literal(Value::String(format!("-{}", name)))),
             Token::LongFlag(name) => Arg::Positional(Expr::Literal(Value::String(format!("--{}", name)))),
         },
+        // `name=value` — same WordAssign production used before `--`. Nothing
+        // is special after `--` (standard shell behavior), but the
+        // WordAssign→positional collapse already yields the literal
+        // `"name=value"` string for commands that don't consume shell
+        // assignments (like `echo`), so no separate literal-folding rule is
+        // needed here.
+        word_assign_arg_parser(),
         // Everything else stays the same
         primary_expr_parser().map(Arg::Positional),
     ));
@@ -1773,6 +1780,40 @@ where
     .map(|s| s.to_string())
 }
 
+/// Shell assignment in argv position: `name=value` (must not have spaces
+/// around `=`). Produces `Arg::WordAssign`; the kernel routes it through
+/// `tool_args.named` only for shell-assignment-accepting builtins (export,
+/// alias). For every other command it materialises as a `"name=value"`
+/// positional, matching bash semantics (`cat foo=bar` opens a file named
+/// `foo=bar`). Shared by the pre-`--` and post-`--` argument grammars — the
+/// `WordAssign`/positional collapse already gives `--`-following `a=b` the
+/// literal-string behavior shell users expect, so it needs no special casing
+/// after `--`.
+fn word_assign_arg_parser<'tokens, I>(
+) -> impl Parser<'tokens, I, Arg, extra::Err<Rich<'tokens, Token, Span>>> + Clone
+where
+    I: ValueInput<'tokens, Token = Token, Span = Span>,
+{
+    choice((
+        select! { Token::Ident(s) => s },
+        keyword_word(),
+    ))
+    .map_with(|s, e| -> (String, Span) { (s, e.span()) })
+    .then(just(Token::Eq).map_with(|_, e| -> Span { e.span() }))
+    .then(primary_expr_parser().map_with(|expr, e| -> (Expr, Span) { (expr, e.span()) }))
+    .try_map(|(((key, key_span), eq_span), (value, value_span)): (((String, Span), Span), (Expr, Span)), span| {
+        // Check that key ends where = starts and = ends where value starts
+        if key_span.end != eq_span.start || eq_span.end != value_span.start {
+            Err(Rich::custom(
+                span,
+                "shell assignment must not have spaces around '=' (use 'key=value' not 'key = value')",
+            ))
+        } else {
+            Ok(Arg::WordAssign { key, value })
+        }
+    })
+}
+
 /// Argument parser for arguments before `--` (normal flag handling).
 fn arg_before_double_dash_parser<'tokens, I>(
 ) -> impl Parser<'tokens, I, Arg, extra::Err<Rich<'tokens, Token, Span>>> + Clone
@@ -1798,28 +1839,7 @@ where
     };
 
     // Shell assignment in argv position: name=value (must not have spaces around =).
-    // Produces Arg::WordAssign; the kernel routes it through tool_args.named
-    // only for shell-assignment-accepting builtins (export, alias). For every
-    // other command it materialises as a `"name=value"` positional, matching
-    // bash semantics (`cat foo=bar` opens a file named `foo=bar`).
-    let named = choice((
-        select! { Token::Ident(s) => s },
-        keyword_word(),
-    ))
-    .map_with(|s, e| -> (String, Span) { (s, e.span()) })
-    .then(just(Token::Eq).map_with(|_, e| -> Span { e.span() }))
-    .then(primary_expr_parser().map_with(|expr, e| -> (Expr, Span) { (expr, e.span()) }))
-    .try_map(|(((key, key_span), eq_span), (value, value_span)): (((String, Span), Span), (Expr, Span)), span| {
-        // Check that key ends where = starts and = ends where value starts
-        if key_span.end != eq_span.start || eq_span.end != value_span.start {
-            Err(Rich::custom(
-                span,
-                "shell assignment must not have spaces around '=' (use 'key=value' not 'key = value')",
-            ))
-        } else {
-            Ok(Arg::WordAssign { key, value })
-        }
-    });
+    let named = word_assign_arg_parser();
 
     // Positional argument
     let positional = primary_expr_parser().map(Arg::Positional);
@@ -4693,6 +4713,41 @@ cmd < "input.txt"
         assert_eq!(parts.len(), 1);
         assert!(matches!(&parts[0].part, StringPart::Literal(s) if s == "\\"));
         assert_eq!(parts[0].len, 2);
+    }
+
+    #[test]
+    fn spanned_standalone_cr_continuation_realigns_span_start() {
+        // `\` + bare `\r` (old Mac line ending, no trailing `\n`) is a line
+        // continuation: 2 source bytes, consumed with no output. Pins the
+        // `current_text_start` update on that branch (parser.rs's `Some('\r')`
+        // arm in `parse_interpolated_string_spanned`) — if it failed to
+        // advance past the consumed `\`+`\r`, the following literal run would
+        // be misreported starting at byte 0 instead of byte 2, corrupting
+        // every subsequent span in the string (here, the `${x}` var's offset).
+        let parts = parse_interpolated_string_spanned("\\\rCD${x}", 0);
+        assert_eq!(parts.len(), 2);
+        assert!(matches!(&parts[0].part, StringPart::Literal(s) if s == "CD"));
+        assert_eq!(parts[0].offset, 2, "literal run must start after the consumed \\+CR");
+        assert_eq!(parts[0].len, 2);
+        assert!(matches!(&parts[1].part, StringPart::Var(_)));
+        assert_eq!(parts[1].offset, 4);
+        assert_eq!(parts[1].len, 4); // "${x}"
+    }
+
+    #[test]
+    fn spanned_standalone_cr_continuation_mid_run_keeps_span_start() {
+        // Same continuation, but hit mid-run (current_text already holds
+        // "AB") — current_text_start must stay anchored to the run's true
+        // start (0), not jump to the post-continuation position, so "AB"
+        // and "CD" merge into one literal spanning the whole source run.
+        let parts = parse_interpolated_string_spanned("AB\\\rCD${x}", 0);
+        assert_eq!(parts.len(), 2);
+        assert!(matches!(&parts[0].part, StringPart::Literal(s) if s == "ABCD"));
+        assert_eq!(parts[0].offset, 0);
+        assert_eq!(parts[0].len, 6); // "AB" + "\" + "\r" + "CD" = 6 source bytes
+        assert!(matches!(&parts[1].part, StringPart::Var(_)));
+        assert_eq!(parts[1].offset, 6);
+        assert_eq!(parts[1].len, 4); // "${x}"
     }
 
     // ── Collection literals ─────────────────────────────────────────────

--- a/crates/kaish-kernel/src/scheduler/pipeline.rs
+++ b/crates/kaish-kernel/src/scheduler/pipeline.rs
@@ -26,7 +26,7 @@ use super::scatter::{
 /// Pre-execution redirects (Stdin, HereDoc) should be handled before calling.
 /// Post-execution redirects (stdout/stderr to file, merge) applied here.
 /// Redirects are processed left-to-right per POSIX.
-async fn apply_redirects(
+pub(crate) async fn apply_redirects(
     mut result: ExecResult,
     redirects: &[Redirect],
     ctx: &ExecContext,
@@ -357,30 +357,17 @@ impl PipelineRunner {
         let sequential_dispatcher: Arc<dyn CommandDispatcher> = dispatcher.fork_attached().await;
 
         let runner = ScatterGatherRunner::new(self.tools.clone(), sequential_dispatcher);
-        let result = runner
+        runner
             .run(
                 pre_scatter,
                 scatter_opts,
                 parallel,
                 gather_opts,
+                &gather_cmd.redirects,
                 post_gather,
                 ctx,
             )
-            .await;
-
-        // `gather`'s own trailing redirect (`… | gather > results.jsonl`, GH
-        // #80's canonical egress-to-file flow) is only meaningful when gather
-        // is the pipeline's last command — `runner.run` splices post_gather
-        // stages through the normal `run_sequential` path, which already
-        // applies each of *their* redirects. Without this, `gather`'s
-        // redirect was silently dropped (the rows landed in `result.out`
-        // instead of the file) because `ScatterGatherRunner::run` only sees
-        // `gather_opts` (parsed flags), never `gather_cmd.redirects`.
-        if post_gather.is_empty() {
-            apply_redirects(result, &gather_cmd.redirects, ctx).await
-        } else {
-            result
-        }
+            .await
     }
 
     /// Run a single command with optional stdin.
@@ -1038,7 +1025,18 @@ pub(crate) fn eval_simple_expr(expr: &Expr, ctx: &ExecContext) -> Result<Option<
             }
             Ok(Some(Value::String(asm.into_string())))
         }
-        _ => Ok(None), // Binary ops and command subst need more context
+        // Command substitution can't be evaluated here (this reduced sync
+        // binder runs before any worker forks, so it can't recurse through
+        // the async pipeline) — but that must fail loud, not silently
+        // coalesce to a bare boolean flag/dropped value the way an unset
+        // bare variable does. `scatter --limit $(echo 5)` used to silently
+        // run at the default limit instead of erroring.
+        Expr::CommandSubst(_) | Expr::Command(_) => Err(
+            "command substitution `$(...)` is not supported in a scatter/gather flag value here; \
+             assign it to a variable first (e.g. `n=$(...); scatter --limit $n`)"
+                .to_string(),
+        ),
+        _ => Ok(None), // Binary ops need more context
     }
 }
 
@@ -1118,7 +1116,16 @@ fn eval_string_parts_sync(parts: &[crate::ast::StringPart], ctx: &ExecContext) -
                 }
             }
             crate::ast::StringPart::CommandSubst(_) => {
-                // Command substitution requires async - skip in sync context
+                // Command substitution can't run in this reduced sync
+                // context (see `eval_simple_expr`'s CommandSubst arm) — fail
+                // loud instead of silently splicing in nothing.
+                // `scatter --as "W$(suffix)"` used to bind the plain "W"
+                // with the substitution silently dropped.
+                return Err(
+                    "command substitution `$(...)` is not supported inside a scatter/gather \
+                     flag's interpolated value here; assign it to a variable first"
+                        .to_string(),
+                );
             }
             crate::ast::StringPart::LastExitCode => {
                 result.push_str(&ctx.scope.last_result().code.to_string());

--- a/crates/kaish-kernel/src/scheduler/pipeline.rs
+++ b/crates/kaish-kernel/src/scheduler/pipeline.rs
@@ -347,8 +347,14 @@ impl PipelineRunner {
             Ok(args) => args,
             Err(e) => return ExecResult::failure(1, format!("gather: {e}")),
         };
-        let scatter_opts = parse_scatter_options(&scatter_args);
-        let gather_opts = parse_gather_options(&gather_args);
+        let scatter_opts = match parse_scatter_options(&scatter_args) {
+            Ok(opts) => opts,
+            Err(e) => return ExecResult::failure(2, format!("scatter: {e}")),
+        };
+        let gather_opts = match parse_gather_options(&gather_args) {
+            Ok(opts) => opts,
+            Err(e) => return ExecResult::failure(2, format!("gather: {e}")),
+        };
 
         // We need an `Arc<dyn CommandDispatcher>` to hand to `ScatterGatherRunner`.
         // `fork_attached` produces a subkernel whose cancellation token is a
@@ -1071,7 +1077,12 @@ fn eval_string_parts_sync(parts: &[crate::ast::StringPart], ctx: &ExecContext) -
         match part {
             crate::ast::StringPart::Literal(s) => result.push_str(s),
             crate::ast::StringPart::Var(path) => match ctx.scope.resolve_path(path) {
-                Ok(value) => result.push_str(&value_to_string(&value)),
+                // Text sink: binary goes loud, never the `[binary: N bytes]`
+                // placeholder — matches the async `eval_string_part_async`
+                // (kernel.rs) and sync `eval_interpolated` (eval.rs).
+                Ok(value) => result.push_str(
+                    &crate::interpreter::value_to_text_sink(&value).map_err(|e| e.to_string())?,
+                ),
                 // Unconditional (even subscripted) on purpose: in STRING
                 // context both primary sites — async `eval_string_part_async`
                 // (kernel.rs) and sync `eval_interpolated` (eval.rs) — expand
@@ -1084,7 +1095,9 @@ fn eval_string_parts_sync(parts: &[crate::ast::StringPart], ctx: &ExecContext) -
             },
             crate::ast::StringPart::VarWithDefault { path, default } => {
                 match crate::interpreter::resolve_default(&ctx.scope, path)? {
-                    Some(value) => result.push_str(&value_to_string(&value)),
+                    Some(value) => result.push_str(
+                        &crate::interpreter::value_to_text_sink(&value).map_err(|e| e.to_string())?,
+                    ),
                     None => result.push_str(&eval_string_parts_sync(default, ctx)?),
                 }
             }

--- a/crates/kaish-kernel/src/scheduler/scatter.rs
+++ b/crates/kaish-kernel/src/scheduler/scatter.rs
@@ -19,13 +19,13 @@ use std::time::Duration;
 use tokio::sync::Semaphore;
 use tracing::Instrument;
 
-use crate::ast::{Command, Value};
+use crate::ast::{Command, Redirect, Value};
 use crate::dispatch::CommandDispatcher;
 use crate::duration::parse_duration;
 use crate::interpreter::ExecResult;
 use crate::tools::{ExecContext, ToolRegistry};
 
-use super::pipeline::PipelineRunner;
+use super::pipeline::{apply_redirects, PipelineRunner};
 
 /// Options for scatter operation.
 #[derive(Debug, Clone)]
@@ -147,12 +147,14 @@ impl ScatterGatherRunner {
     ///
     /// Returns the final result after all stages complete.
     #[tracing::instrument(level = "info", skip(self, pre_scatter, scatter_opts, parallel, gather_opts, post_gather, ctx), fields(item_count = tracing::field::Empty, parallelism = scatter_opts.limit))]
+    #[allow(clippy::too_many_arguments)]
     pub async fn run(
         &self,
         pre_scatter: &[Command],
         scatter_opts: ScatterOptions,
         parallel: &[Command],
         gather_opts: GatherOptions,
+        gather_redirects: &[Redirect],
         post_gather: &[Command],
         ctx: &mut ExecContext,
     ) -> ExecResult {
@@ -198,6 +200,19 @@ impl ScatterGatherRunner {
         // row per worker, failures included), or `--lines` raw text. Exit codes
         // are A′: 0 all ok · 123 any worker failed · 2 usage (clap layer).
         let gathered = gather_results(&results, &gather_opts);
+
+        // `gather`'s own trailing redirect (`… | gather > results.jsonl | …`)
+        // must apply to gather's OWN result before anything downstream sees
+        // it — matching shell semantics where a file redirect on a pipeline
+        // stage wins over the pipe (`cmd > file | next` sends cmd's real
+        // stdout to the file; `next` reads nothing from cmd). Applying it
+        // unconditionally (regardless of exit code) matches a redirect being
+        // a file-descriptor operation independent of the command's success —
+        // `false > file` still creates the file. Previously this only ran
+        // when gather was the pipeline's last command, so a trailing
+        // `gather > file | jq` silently skipped the file and let the
+        // unredirected rows flow to `jq` instead.
+        let gathered = apply_redirects(gathered, gather_redirects, ctx).await;
 
         // Run post-gather commands if any. A failed gather short-circuits —
         // feeding partial/failed output onward would propagate corruption.
@@ -248,6 +263,16 @@ impl ScatterGatherRunner {
             let base_scope = base_ctx.scope.clone();
             let backend = base_ctx.backend.clone();
             let cwd = base_ctx.cwd.clone();
+            // A worker must run with the parent's execution config, not a
+            // from-scratch default — otherwise an aliased command that works
+            // in the foreground fails 127 inside a worker, an embedder's
+            // ignore/output-limit/external-command policy is silently
+            // bypassed, and the worker starts fully re-armed even under
+            // `allow_external_commands: false`.
+            let aliases = base_ctx.aliases.clone();
+            let ignore_config = base_ctx.ignore_config.clone();
+            let output_limit = base_ctx.output_limit.clone();
+            let allow_external_commands = base_ctx.allow_external_commands;
             let parent_token = base_ctx.cancel.clone();
             let worker_token = parent_token.child_token();
 
@@ -287,6 +312,10 @@ impl ScatterGatherRunner {
                 let mut ctx = ExecContext::with_backend_and_scope(backend, scope);
                 ctx.set_cwd(cwd);
                 ctx.cancel = worker_token;
+                ctx.aliases = aliases;
+                ctx.ignore_config = ignore_config;
+                ctx.output_limit = output_limit;
+                ctx.allow_external_commands = allow_external_commands;
 
                 // Run through PipelineRunner + dispatcher (full resolution chain).
                 // Uses run_sequential to avoid async recursion and infinite future size.

--- a/crates/kaish-kernel/src/scheduler/scatter.rs
+++ b/crates/kaish-kernel/src/scheduler/scatter.rs
@@ -43,8 +43,6 @@ pub struct ScatterOptions {
 /// Options for gather operation.
 #[derive(Debug, Clone, Default)]
 pub struct GatherOptions {
-    /// Show progress indicator.
-    pub progress: bool,
     /// `--lines`: emit each successful worker's raw `out` in item order instead
     /// of JSONL rows — and HARD-ERROR (exit 123, no partial text) if any worker
     /// failed, since bare lines cannot represent a failure. The text escape
@@ -259,22 +257,34 @@ impl ScatterGatherRunner {
             // external children via the wait_or_kill discipline.
             let worker_dispatcher = self.sequential_dispatcher.fork_attached().await;
             let commands = commands.to_vec();
-            let var_name = var_name.clone();
-            let base_scope = base_ctx.scope.clone();
-            let backend = base_ctx.backend.clone();
-            let cwd = base_ctx.cwd.clone();
-            // A worker must run with the parent's execution config, not a
-            // from-scratch default — otherwise an aliased command that works
-            // in the foreground fails 127 inside a worker, an embedder's
-            // ignore/output-limit/external-command policy is silently
-            // bypassed, and the worker starts fully re-armed even under
-            // `allow_external_commands: false`.
-            let aliases = base_ctx.aliases.clone();
-            let ignore_config = base_ctx.ignore_config.clone();
-            let output_limit = base_ctx.output_limit.clone();
-            let allow_external_commands = base_ctx.allow_external_commands;
             let parent_token = base_ctx.cancel.clone();
             let worker_token = parent_token.child_token();
+
+            // Build the worker context FROM THE PARENT, not from scratch. A
+            // from-scratch `ExecContext::with_backend_and_scope` starts
+            // `watchdog = None`; `dispatch_command` then syncs that `None` INTO
+            // the subkernel (kernel.rs `ec.watchdog = ctx.watchdog.clone()`),
+            // clobbering the fork's inherited watchdog — so inside a worker the
+            // script clock is gone and any `ctx.patient` hold suspends a
+            // *missing* timer, yielding false-positive request timeouts that
+            // kill the worker. `child_for_pipeline` clones exactly what a worker
+            // needs in one shot — watchdog, vfs_budget, aliases, ignore_config,
+            // output_limit, allow_external_commands, backend, cwd, scope,
+            // dispatcher — replacing the manual field-copy that was easy to let
+            // drift (and that dropped the watchdog). `base_ctx` is a borrow (not
+            // `'static`), so the child MUST be built here and MOVED into the
+            // spawn — it cannot be constructed inside the closure.
+            let mut worker_ctx = base_ctx.child_for_pipeline();
+            // Per-worker TYPED binding — the same json→Value conversion the
+            // for-loop uses for `$(cmd)` items (GH #73), so a record element
+            // subscripts as `${ITEM[k]}`.
+            worker_ctx.scope.set(
+                &var_name,
+                crate::interpreter::json_to_value_no_envelope(item.json.clone()),
+            );
+            // Per-worker cancel token (a child of the parent's), so the timeout
+            // timer and a parent cancel both reach this worker's externals.
+            worker_ctx.cancel = worker_token.clone();
 
             // Per-worker timeout: spawn a delay task that cancels the worker's
             // child token after `opts.timeout`. The cancel cascades into the
@@ -299,28 +309,29 @@ impl ScatterGatherRunner {
             // provides the tracing parent; this provides the OTel parent.
             let handle = tokio::spawn(crate::telemetry::bind_current_context(async move {
                 let _permit = permit; // Hold permit until done
-
-                // Create context for this worker. The binding is TYPED — the
-                // same json→Value conversion the for-loop uses for `$(cmd)`
-                // items (GH #73), so a record element subscripts as ${ITEM[k]}.
-                let mut scope = base_scope;
-                scope.set(
-                    &var_name,
-                    crate::interpreter::json_to_value_no_envelope(item.json.clone()),
-                );
-
-                let mut ctx = ExecContext::with_backend_and_scope(backend, scope);
-                ctx.set_cwd(cwd);
-                ctx.cancel = worker_token;
-                ctx.aliases = aliases;
-                ctx.ignore_config = ignore_config;
-                ctx.output_limit = output_limit;
-                ctx.allow_external_commands = allow_external_commands;
+                let mut worker_ctx = worker_ctx; // moved in; built from parent above
 
                 // Run through PipelineRunner + dispatcher (full resolution chain).
                 // Uses run_sequential to avoid async recursion and infinite future size.
                 let runner = PipelineRunner::new(tools);
-                let result = runner.run_sequential(&commands, &mut ctx, &*worker_dispatcher).await;
+                let mut result =
+                    runner.run_sequential(&commands, &mut worker_ctx, &*worker_dispatcher).await;
+
+                // Per-worker spill boundary. `run_sequential` never reaches the
+                // kernel's top-level post-run spill check (kernel.rs:2704), so
+                // without this each worker holds its FULL output in memory —
+                // N concurrent workers × large output evades the sandbox
+                // `output_limit` (10 workers × 1 GB = 10 GB resident before
+                // anything spills). Cap here, where the N× multiplication lives;
+                // `child_for_pipeline` shares the parent's `output_limit`, so
+                // workers cap against the same budget.
+                if worker_ctx.output_limit.is_enabled() {
+                    let _ = crate::output_limit::spill_if_needed(
+                        &mut result,
+                        &worker_ctx.output_limit,
+                    )
+                    .await;
+                }
 
                 // Worker finished — abort the timer if still pending so it
                 // doesn't fire a now-pointless cancel and idle resources.
@@ -459,22 +470,52 @@ fn strip_one_trailing_newline(s: &str) -> &str {
 /// present (`err` deliberately so — omit-empty on the most-read field would
 /// make `${r[err]}` a loud missing-key error on every successful row). A
 /// timed-out worker reports `code` 124 (the `timeout(1)` prior) and `ok` false.
+///
+/// # Binary-output hazard
+///
+/// A worker's `out` is a `text_out()`-shaped string field, but the worker's
+/// `ExecResult` payload can be `OutputPayload::Bytes` — several builtins
+/// already produce it (`cat`/`head`/`tail`/`base64 -d`/`xxd -r`/`dd`/`tee`/
+/// external commands via `env`/`spawn`), so a worker running e.g. `cat
+/// binary.file` is not a hypothetical, it is reachable today. `text_out()`
+/// would lossily replace invalid UTF-8 with U+FFFD — silent data corruption
+/// riding through the row as if it were the worker's real text output. Per
+/// "crash beats corrupt" we go loud at row granularity instead: `try_text_out`
+/// catches it, the row is forced `ok:false` with a clear `err` (never a
+/// lossily-decoded `out`), and the OTHER rows are unaffected — see
+/// `docs/binary-data.md` for the broader binary-data plan.
 fn result_row(i: usize, r: &ScatterResult) -> serde_json::Value {
-    let ok = r.result.ok() && !r.timed_out;
-    let code = if r.timed_out { 124 } else { r.result.code };
+    let mut ok = r.result.ok() && !r.timed_out;
+    let mut code = if r.timed_out { 124 } else { r.result.code };
+
+    let (out_text, err_text) = match r.result.try_text_out() {
+        Ok(text) => (
+            strip_one_trailing_newline(&text).to_string(),
+            strip_one_trailing_newline(&r.result.err).to_string(),
+        ),
+        Err(e) => {
+            ok = false;
+            if code == 0 {
+                code = 1;
+            }
+            (
+                String::new(),
+                format!(
+                    "binary worker output not representable as text ({} bytes) — \
+                     encode it in the worker (base64/xxd)",
+                    e.len
+                ),
+            )
+        }
+    };
+
     let mut row = serde_json::Map::new();
     row.insert("i".into(), serde_json::json!(i));
     row.insert("item".into(), r.item.json.clone());
     row.insert("ok".into(), serde_json::json!(ok));
     row.insert("code".into(), serde_json::json!(code));
-    row.insert(
-        "out".into(),
-        serde_json::json!(strip_one_trailing_newline(&r.result.text_out())),
-    );
-    row.insert(
-        "err".into(),
-        serde_json::json!(strip_one_trailing_newline(&r.result.err)),
-    );
+    row.insert("out".into(), serde_json::json!(out_text));
+    row.insert("err".into(), serde_json::json!(err_text));
     if let Some(data) = &r.result.data {
         row.insert("data".into(), kaish_types::value_to_json(data));
     }
@@ -499,23 +540,41 @@ fn result_row(i: usize, r: &ScatterResult) -> serde_json::Value {
 /// Exit codes (A′): `0` all workers ok · `123` any worker failed, partial or
 /// total (timeouts count) — partial-vs-total is distinguished in the rows.
 fn gather_results(results: &[ScatterResult], opts: &GatherOptions) -> ExecResult {
-    let failed: Vec<&ScatterResult> =
-        results.iter().filter(|r| !r.result.ok() || r.timed_out).collect();
+    // A worker's binary stdout that can't decode as text is a failure for
+    // gather's purposes too — see `result_row`'s hazard doc. Folding it into
+    // `failed` here keeps the overall exit code (0 vs 123) honest: a `--lines`
+    // or JSONL caller checking `$?` must see non-zero, not a silent "0 all
+    // ok" while one row was actually corruption-guarded away.
+    let is_unrepresentable = |r: &ScatterResult| r.result.try_text_out().is_err();
+
+    let failed: Vec<&ScatterResult> = results
+        .iter()
+        .filter(|r| !r.result.ok() || r.timed_out || is_unrepresentable(r))
+        .collect();
     let code = if failed.is_empty() { 0 } else { 123 };
     let err = if failed.is_empty() {
         String::new()
     } else {
-        format!(
-            "gather: {} of {} worker(s) failed: {}",
-            failed.len(),
-            results.len(),
-            failed.iter().map(|r| r.item.label.as_str()).collect::<Vec<_>>().join(", ")
-        )
+        let names = failed
+            .iter()
+            .map(|r| {
+                if is_unrepresentable(r) {
+                    format!("{} (binary output not representable as text)", r.item.label)
+                } else {
+                    r.item.label.clone()
+                }
+            })
+            .collect::<Vec<_>>()
+            .join(", ");
+        format!("gather: {} of {} worker(s) failed: {names}", failed.len(), results.len())
     };
 
     if opts.lines {
         // Bare lines can't carry a failure — refuse with no partial text
-        // rather than silently dropping rows.
+        // rather than silently dropping rows. This also covers binary output
+        // (folded into `failed` above): `--lines` is a text-only escape
+        // hatch, and a U+FFFD-laden line would be exactly the silent
+        // corruption this hardening pass exists to prevent.
         if !failed.is_empty() {
             return ExecResult::failure(code, format!("{err} (drop --lines to get per-worker rows)"));
         }
@@ -540,47 +599,105 @@ fn gather_results(results: &[ScatterResult], opts: &GatherOptions) -> ExecResult
     ExecResult::from_parts(code, text, err, Some(Value::Json(array)))
 }
 
+/// Human-readable repr of a `Value` for a "wrong type" error message —
+/// deliberately not `Debug` (whose `String("five")` quoting/enum-tag noise
+/// reads badly to a user who just typed `--limit five`).
+fn describe_value(v: &Value) -> String {
+    match v {
+        Value::Null => "null".to_string(),
+        Value::Bool(b) => b.to_string(),
+        Value::Int(n) => n.to_string(),
+        Value::Float(f) => f.to_string(),
+        Value::String(s) => format!("{s:?}"),
+        Value::Json(j) => j.to_string(),
+        Value::Bytes(b) => format!("<{} bytes>", b.len()),
+    }
+}
+
 /// Parse scatter options from tool args.
-pub fn parse_scatter_options(args: &crate::tools::ToolArgs) -> ScatterOptions {
+///
+/// A flag key *present* in `args.named` with a value of the wrong type is a
+/// loud `Err`, never a silent fall-back to the default — `scatter --limit
+/// five` must not quietly run at the default limit, and `scatter --as 42`
+/// must not quietly bind `$ITEM`. (An *absent* or unresolved flag falls back
+/// to a bare boolean earlier, at the pipeline arg-binding layer — that lenient
+/// path is unrelated and untouched here.)
+pub fn parse_scatter_options(args: &crate::tools::ToolArgs) -> Result<ScatterOptions, String> {
     let mut opts = ScatterOptions::default();
 
-    if let Some(Value::String(name)) = args.named.get("as") {
-        opts.var_name = name.clone();
+    match args.named.get("as") {
+        None => {}
+        Some(Value::String(name)) => opts.var_name = name.clone(),
+        Some(other) => {
+            return Err(format!(
+                "scatter --as: expected a variable name, got {}",
+                describe_value(other)
+            ))
+        }
     }
 
-    if let Some(Value::Int(n)) = args.named.get("limit") {
-        let requested = *n;
-        let clamped = requested.clamp(1, SCATTER_LIMIT_MAX as i64);
-        if requested > SCATTER_LIMIT_MAX as i64 {
-            tracing::warn!(
-                target: "kaish::scatter",
-                requested = requested,
-                ceiling = SCATTER_LIMIT_MAX,
-                "scatter limit clamped to ceiling"
-            );
+    match args.named.get("limit") {
+        None => {}
+        Some(Value::Int(n)) => opts.limit = clamp_scatter_limit(*n),
+        // Values from variables often stringify (`--limit "$n"`) — coerce a
+        // numeric string the same as an int.
+        Some(Value::String(s)) => match s.trim().parse::<i64>() {
+            Ok(n) => opts.limit = clamp_scatter_limit(n),
+            Err(_) => {
+                return Err(format!(
+                    "scatter --limit: expected a positive integer, got {}",
+                    describe_value(&Value::String(s.clone()))
+                ))
+            }
+        },
+        Some(other) => {
+            return Err(format!(
+                "scatter --limit: expected a positive integer, got {}",
+                describe_value(other)
+            ))
         }
-        opts.limit = clamped as usize;
     }
 
     // --timeout DURATION: per-worker timeout. Accepts the same forms as the
-    // `timeout` builtin (30, 5s, 500ms, 2m, 1h). Invalid input is ignored
-    // with a warn so a typo doesn't silently disable cancellation.
-    if let Some(Value::String(s)) = args.named.get("timeout") {
-        match parse_duration(s) {
+    // `timeout` builtin (30, 5s, 500ms, 2m, 1h). A present-but-invalid value
+    // is a loud Err — a typo here must not silently disable cancellation.
+    match args.named.get("timeout") {
+        None => {}
+        Some(Value::String(s)) => match parse_duration(s) {
             Some(d) => opts.timeout = Some(d),
-            None => tracing::warn!(
-                target: "kaish::scatter",
-                value = %s,
-                "scatter --timeout: invalid duration (try: 30, 5s, 500ms, 2m, 1h)"
-            ),
-        }
-    } else if let Some(Value::Int(n)) = args.named.get("timeout") {
-        if *n >= 0 {
-            opts.timeout = Some(Duration::from_secs(*n as u64));
+            None => {
+                return Err(format!(
+                    "scatter --timeout: invalid duration {} (try: 30, 5s, 500ms, 2m, 1h)",
+                    describe_value(&Value::String(s.clone()))
+                ))
+            }
+        },
+        Some(Value::Int(n)) if *n >= 0 => opts.timeout = Some(Duration::from_secs(*n as u64)),
+        Some(other) => {
+            return Err(format!(
+                "scatter --timeout: expected a non-negative duration, got {}",
+                describe_value(other)
+            ))
         }
     }
 
-    opts
+    Ok(opts)
+}
+
+/// Clamp a requested `--limit` to `[1, SCATTER_LIMIT_MAX]`, warning (not
+/// erroring) when the ceiling clamps a value down — this ceiling exists to
+/// protect the host, not to reject user input, so it stays a warn+clamp.
+fn clamp_scatter_limit(requested: i64) -> usize {
+    let clamped = requested.clamp(1, SCATTER_LIMIT_MAX as i64);
+    if requested > SCATTER_LIMIT_MAX as i64 {
+        tracing::warn!(
+            target: "kaish::scatter",
+            requested = requested,
+            ceiling = SCATTER_LIMIT_MAX,
+            "scatter limit clamped to ceiling"
+        );
+    }
+    clamped as usize
 }
 
 /// Upper bound on the concurrency `scatter --limit N` accepts. Users who
@@ -589,12 +706,14 @@ pub fn parse_scatter_options(args: &crate::tools::ToolArgs) -> ScatterOptions {
 pub const SCATTER_LIMIT_MAX: usize = 10_000;
 
 /// Parse gather options from tool args.
-pub fn parse_gather_options(args: &crate::tools::ToolArgs) -> GatherOptions {
+///
+/// Returns `Err` for a present-but-wrong-typed flag value, mirroring
+/// [`parse_scatter_options`]. Today gather's only value-carrying flags are
+/// boolean (`--lines`/`--json`), so this can't yet fail — the `Result` return
+/// keeps the signature symmetric with scatter's and ready for the next
+/// value-carrying gather flag.
+pub fn parse_gather_options(args: &crate::tools::ToolArgs) -> Result<GatherOptions, String> {
     let mut opts = GatherOptions::default();
-
-    if args.has_flag("progress") {
-        opts.progress = true;
-    }
 
     if args.has_flag("lines") {
         opts.lines = true;
@@ -604,7 +723,7 @@ pub fn parse_gather_options(args: &crate::tools::ToolArgs) -> GatherOptions {
         opts.json = true;
     }
 
-    opts
+    Ok(opts)
 }
 
 #[cfg(test)]
@@ -854,7 +973,7 @@ mod tests {
         args.named.insert("as".to_string(), Value::String("URL".to_string()));
         args.named.insert("limit".to_string(), Value::Int(4));
 
-        let opts = parse_scatter_options(&args);
+        let opts = parse_scatter_options(&args).unwrap();
         assert_eq!(opts.var_name, "URL");
         assert_eq!(opts.limit, 4);
     }
@@ -866,9 +985,9 @@ mod tests {
         let mut args = ToolArgs::new();
         args.flags.insert("lines".to_string());
 
-        let opts = parse_gather_options(&args);
+        let opts = parse_gather_options(&args).unwrap();
         assert!(opts.lines);
-        assert!(!parse_gather_options(&ToolArgs::new()).lines, "default is JSONL");
+        assert!(!parse_gather_options(&ToolArgs::new()).unwrap().lines, "default is JSONL");
     }
 
     #[test]
@@ -877,7 +996,7 @@ mod tests {
 
         let mut args = ToolArgs::new();
         args.named.insert("limit".to_string(), Value::Int(999_999));
-        let opts = parse_scatter_options(&args);
+        let opts = parse_scatter_options(&args).unwrap();
         assert_eq!(opts.limit, SCATTER_LIMIT_MAX);
     }
 
@@ -887,7 +1006,7 @@ mod tests {
 
         let mut args = ToolArgs::new();
         args.named.insert("limit".to_string(), Value::Int(0));
-        let opts = parse_scatter_options(&args);
+        let opts = parse_scatter_options(&args).unwrap();
         assert_eq!(opts.limit, 1);
     }
 
@@ -897,7 +1016,7 @@ mod tests {
 
         let mut args = ToolArgs::new();
         args.named.insert("limit".to_string(), Value::Int(-42));
-        let opts = parse_scatter_options(&args);
+        let opts = parse_scatter_options(&args).unwrap();
         assert_eq!(opts.limit, 1);
     }
 
@@ -907,7 +1026,209 @@ mod tests {
 
         let mut args = ToolArgs::new();
         args.named.insert("limit".to_string(), Value::Int(500));
-        let opts = parse_scatter_options(&args);
+        let opts = parse_scatter_options(&args).unwrap();
         assert_eq!(opts.limit, 500);
+    }
+
+    // ── FIX A: loud on present-but-wrong-typed flag values ──
+
+    #[test]
+    fn scatter_limit_wrong_type_is_loud_error() {
+        use crate::tools::ToolArgs;
+
+        let mut args = ToolArgs::new();
+        args.named.insert("limit".to_string(), Value::String("five".to_string()));
+        let err = parse_scatter_options(&args).unwrap_err();
+        assert!(err.contains("--limit"), "{err}");
+        assert!(err.contains("five"), "{err}");
+    }
+
+    #[test]
+    fn scatter_limit_bool_is_loud_error() {
+        use crate::tools::ToolArgs;
+
+        let mut args = ToolArgs::new();
+        args.named.insert("limit".to_string(), Value::Bool(true));
+        let err = parse_scatter_options(&args).unwrap_err();
+        assert!(err.contains("--limit"), "{err}");
+    }
+
+    #[test]
+    fn scatter_limit_numeric_string_coerces() {
+        // Values from variables often stringify: `scatter --limit "$n"`.
+        use crate::tools::ToolArgs;
+
+        let mut args = ToolArgs::new();
+        args.named.insert("limit".to_string(), Value::String("5".to_string()));
+        let opts = parse_scatter_options(&args).unwrap();
+        assert_eq!(opts.limit, 5);
+    }
+
+    #[test]
+    fn scatter_as_wrong_type_is_loud_error() {
+        use crate::tools::ToolArgs;
+
+        let mut args = ToolArgs::new();
+        args.named.insert("as".to_string(), Value::Int(42));
+        let err = parse_scatter_options(&args).unwrap_err();
+        assert!(err.contains("--as"), "{err}");
+        assert!(err.contains("42"), "{err}");
+    }
+
+    #[test]
+    fn scatter_timeout_negative_int_is_loud_error() {
+        use crate::tools::ToolArgs;
+
+        let mut args = ToolArgs::new();
+        args.named.insert("timeout".to_string(), Value::Int(-5));
+        let err = parse_scatter_options(&args).unwrap_err();
+        assert!(err.contains("--timeout"), "{err}");
+    }
+
+    #[test]
+    fn scatter_timeout_unparseable_string_is_loud_error() {
+        use crate::tools::ToolArgs;
+
+        let mut args = ToolArgs::new();
+        args.named.insert("timeout".to_string(), Value::String("banana".to_string()));
+        let err = parse_scatter_options(&args).unwrap_err();
+        assert!(err.contains("--timeout"), "{err}");
+        assert!(err.contains("banana"), "{err}");
+    }
+
+    #[test]
+    fn scatter_timeout_valid_duration_string_parses() {
+        use crate::tools::ToolArgs;
+
+        let mut args = ToolArgs::new();
+        args.named.insert("timeout".to_string(), Value::String("5s".to_string()));
+        let opts = parse_scatter_options(&args).unwrap();
+        assert_eq!(opts.timeout, Some(Duration::from_secs(5)));
+    }
+
+    #[test]
+    fn scatter_timeout_nonnegative_int_is_seconds() {
+        use crate::tools::ToolArgs;
+
+        let mut args = ToolArgs::new();
+        args.named.insert("timeout".to_string(), Value::Int(30));
+        let opts = parse_scatter_options(&args).unwrap();
+        assert_eq!(opts.timeout, Some(Duration::from_secs(30)));
+    }
+
+    // ── FIX C: binary worker output must not silently corrupt to U+FFFD ──
+
+    fn binary_result(invalid_utf8: Vec<u8>) -> ExecResult {
+        ExecResult::success_bytes(invalid_utf8)
+    }
+
+    #[test]
+    fn gather_row_goes_loud_not_lossy_on_binary_out() {
+        // 0xFF is never valid UTF-8 on its own — text_out() would replace it
+        // with U+FFFD; try_text_out() must catch it instead.
+        let results = vec![ScatterResult {
+            item: item("bin"),
+            result: binary_result(vec![0xFF, 0xFE, 0x00, 0x01]),
+            timed_out: false,
+        }];
+        let out = gather_results(&results, &GatherOptions::default());
+        assert_eq!(out.code, 123, "a binary row flips the overall exit code too");
+        let row: serde_json::Value =
+            serde_json::from_str(out.text_out().lines().next().unwrap()).unwrap();
+        assert_eq!(row["ok"], false, "binary output must not be silently ok:true");
+        assert_ne!(row["code"], 0, "must carry a nonzero code");
+        assert!(row["out"].as_str().unwrap().is_empty(), "no lossy text in out");
+        let err_text = row["err"].as_str().unwrap();
+        assert!(err_text.contains("binary"), "{err_text}");
+        assert!(!err_text.contains('\u{FFFD}'), "must not carry U+FFFD: {err_text}");
+    }
+
+    #[test]
+    fn gather_lines_hard_errors_on_binary_out() {
+        // --lines is the raw-text escape hatch; binary must hard-error the
+        // whole gather rather than emit a U+FFFD-laden line.
+        let results = vec![
+            ScatterResult { item: item("a"), result: ExecResult::success("good"), timed_out: false },
+            ScatterResult {
+                item: item("bin"),
+                result: binary_result(vec![0xFF, 0xFE]),
+                timed_out: false,
+            },
+        ];
+        let out = gather_results(&results, &GatherOptions { lines: true, ..Default::default() });
+        assert_eq!(out.code, 123);
+        assert!(out.text_out().is_empty(), "no partial/lossy text on binary --lines failure");
+        assert!(!out.err.contains('\u{FFFD}'), "must not carry U+FFFD: {}", out.err);
+        assert!(out.err.contains("binary") || out.err.contains("bin"), "{}", out.err);
+    }
+
+    // ── FIX D: workers must inherit the parent's watchdog ──
+
+    fn ctx_with_memory_fs() -> ExecContext {
+        use crate::vfs::{MemoryFs, VfsRouter};
+        use std::sync::Arc;
+        let mut vfs = VfsRouter::new();
+        vfs.mount("/", MemoryFs::new());
+        ExecContext::new(Arc::new(vfs))
+    }
+
+    #[test]
+    fn worker_ctx_inherits_parent_watchdog() {
+        use crate::watchdog::Watchdog;
+        use std::sync::Arc;
+
+        let mut parent = ctx_with_memory_fs();
+        parent.watchdog = Some(Arc::new(Watchdog::new(Duration::from_secs(30))));
+
+        // The fix: workers are built via `child_for_pipeline`, which clones the
+        // parent's watchdog. The old from-scratch `with_backend_and_scope`
+        // path (below) dropped it — this test would fail against that path.
+        let worker_ctx = parent.child_for_pipeline();
+        assert!(
+            worker_ctx.watchdog.is_some(),
+            "worker must carry the parent's script watchdog, not None"
+        );
+
+        // Document the trap the fix closes: the old construction starts with a
+        // None watchdog, which dispatch_command then syncs into the subkernel.
+        let from_scratch =
+            ExecContext::with_backend_and_scope(parent.backend.clone(), parent.scope.clone());
+        assert!(
+            from_scratch.watchdog.is_none(),
+            "the abandoned from-scratch path is exactly why the worker lost its watchdog"
+        );
+    }
+
+    // ── FIX E: workers cap output against the shared spill budget ──
+
+    #[tokio::test]
+    async fn worker_spills_over_the_shared_output_limit() {
+        use crate::output_limit::{spill_if_needed, OutputLimitConfig};
+
+        // Small in-memory limit (no disk writes in tests — CLAUDE.md).
+        let mut cfg = OutputLimitConfig::agent().in_memory();
+        cfg.set_limit(Some(64));
+
+        let mut parent = ctx_with_memory_fs();
+        parent.output_limit = cfg;
+
+        // `child_for_pipeline` shares the parent's output_limit, so the worker
+        // caps against the same budget — this is exactly what the worker path
+        // now reads (`worker_ctx.output_limit`) before building its
+        // ScatterResult.
+        let worker_ctx = parent.child_for_pipeline();
+        assert!(worker_ctx.output_limit.is_enabled(), "budget must reach the worker");
+
+        // Mirror the worker sequence: a large result, then the per-worker spill.
+        let mut result = ExecResult::success("x".repeat(4096));
+        assert!(worker_ctx.output_limit.is_enabled());
+        let _ = spill_if_needed(&mut result, &worker_ctx.output_limit).await;
+
+        assert!(result.did_spill, "worker output over the limit must spill, not stay resident");
+        assert!(
+            result.text_out().len() < 4096,
+            "spilled output must be truncated, not the full payload: {} bytes",
+            result.text_out().len()
+        );
     }
 }

--- a/crates/kaish-kernel/src/tools/builtin/echo.rs
+++ b/crates/kaish-kernel/src/tools/builtin/echo.rs
@@ -3,7 +3,6 @@
 use async_trait::async_trait;
 use clap::{CommandFactory, Parser};
 
-use crate::ast::Value;
 use crate::interpreter::{ExecResult, OutputData};
 use crate::tools::{schema_from_clap, ExecContext, ToolCtx, GlobalFlags, Tool, ToolArgs, ToolSchema};
 
@@ -49,8 +48,19 @@ impl Tool for Echo {
         };
         // Preserve the original Value rendering (true/false/3.14/etc.) before
         // collapsing through to_argv()'s string layer — echo formats numerics
-        // specially and we don't want clap to re-stringify them.
-        let words: Vec<String> = args.positional.iter().map(value_to_string).collect();
+        // specially and we don't want clap to re-stringify them. `echo` is a
+        // pure TEXT SINK, so a binary (`Value::Bytes`) positional goes LOUD via
+        // `value_to_text_sink` rather than rendering the `[binary: N bytes]`
+        // placeholder — printing that placeholder where the user's real bytes
+        // should be is silent corruption. (Path-coercing builtins like `mkdir`
+        // and env export remain deferred — the binary-at-text-sinks cluster.)
+        let mut words = Vec::with_capacity(args.positional.len());
+        for value in &args.positional {
+            match crate::interpreter::value_to_text_sink(value) {
+                Ok(s) => words.push(s),
+                Err(e) => return ExecResult::failure(1, format!("echo: {e}")),
+            }
+        }
 
         let parsed = match EchoArgs::try_parse_from(
             std::iter::once("echo".to_string()).chain(args.to_argv()),
@@ -69,23 +79,11 @@ impl Tool for Echo {
     }
 }
 
-/// Convert a value to its string representation for echo.
-fn value_to_string(value: &Value) -> String {
-    match value {
-        Value::Null => "null".to_string(),
-        Value::Bool(b) => b.to_string(),
-        Value::Int(i) => i.to_string(),
-        Value::Float(f) => f.to_string(),
-        Value::String(s) => s.clone(),
-        Value::Json(json) => json.to_string(),
-        Value::Bytes(b) => format!("[binary: {} bytes]", b.len()),
-    }
-}
-
 #[cfg(test)]
 #[allow(clippy::approx_constant)]
 mod tests {
     use super::*;
+    use crate::ast::Value;
     use crate::vfs::{MemoryFs, VfsRouter};
     use std::sync::Arc;
 

--- a/crates/kaish-kernel/src/tools/builtin/gather.rs
+++ b/crates/kaish-kernel/src/tools/builtin/gather.rs
@@ -84,7 +84,9 @@ impl Tool for Gather {
 
         // Validate flags even standalone (parse_gather_options is the runner's
         // reader; here it only needs to not reject).
-        let _opts = parse_gather_options(&args);
+        if let Err(e) = parse_gather_options(&args) {
+            return ExecResult::failure(2, format!("gather: {e}"));
+        }
 
         // Standalone (not in a scatter/gather pipeline): pass stdin through.
         // The real result-record rendering lives in the ScatterGatherRunner.

--- a/crates/kaish-kernel/src/tools/builtin/jq_native.rs
+++ b/crates/kaish-kernel/src/tools/builtin/jq_native.rs
@@ -362,9 +362,14 @@ fn render_value(val: &Val, raw_output: bool, compact: bool) -> String {
 
 /// Convert ast::Value to serde_json::Value for jq processing.
 ///
-/// This is smarter than the generic value_to_json because it handles the case
-/// where Value::String contains serialized JSON (for legacy compatibility).
 /// Value::Json is returned directly as it's already a serde_json::Value.
+/// Value::String converts to a JSON string verbatim — it is never re-parsed
+/// as a JSON document. `.data` structure is opt-in (set by an upstream
+/// producer like `fromjson`), never sniffed from string content: a
+/// `Value::String("1")` is the kaish string `1`, and must stay the JSON
+/// string `"1"` here, not become the JSON number `1` (see
+/// `docs/arch_no_json_sniffing` / CLAUDE.md's ".data is opt-in, never
+/// inferred from stdout text" invariant).
 fn ast_value_to_json(value: &Value) -> serde_json::Value {
     match value {
         Value::Null => serde_json::Value::Null,
@@ -375,10 +380,7 @@ fn ast_value_to_json(value: &Value) -> serde_json::Value {
                 .map(serde_json::Value::Number)
                 .unwrap_or(serde_json::Value::Null)
         }
-        Value::String(s) => {
-            // Try to parse as JSON first - for backwards compatibility with serialized JSON in strings
-            serde_json::from_str(s).unwrap_or_else(|_| serde_json::Value::String(s.clone()))
-        }
+        Value::String(s) => serde_json::Value::String(s.clone()),
         Value::Json(json) => json.clone(),
         // Binary jq input surfaces as the self-describing base64 envelope.
         Value::Bytes(b) => kaish_types::bytes_to_envelope(b),

--- a/crates/kaish-kernel/src/tools/builtin/printf.rs
+++ b/crates/kaish-kernel/src/tools/builtin/printf.rs
@@ -31,7 +31,9 @@ impl FormatArg for Value {
             Value::Bool(b) => b.to_string(),
             Value::Null => String::new(),
             Value::Json(json) => json.to_string(),
-            Value::Bytes(b) => format!("[binary: {} bytes]", b.len()),
+            // Non-UTF-8 bytes are rejected loud at printf's arg gate before we
+            // get here; valid-UTF-8 bytes render as their text.
+            Value::Bytes(b) => String::from_utf8_lossy(b).into_owned(),
         }
     }
 
@@ -99,6 +101,14 @@ impl Tool for Printf {
         };
 
         let format_args: Vec<&Value> = args.positional.iter().skip(1).collect();
+        // printf is a text sink: a binary (non-UTF-8) operand is loud, never a
+        // silent `[binary: N bytes]` placeholder (kept in sync with `echo` and
+        // the interpolation/argv sinks). Valid-UTF-8 bytes coerce below.
+        for &v in &format_args {
+            if let Err(e) = crate::interpreter::value_to_text_sink(v) {
+                return ExecResult::failure(1, format!("printf: {e}"));
+            }
+        }
         // POSIX printf reuses the format until all operands are consumed.
         let output = format_string::format_string_cycling(&format, &format_args);
 

--- a/crates/kaish-kernel/src/tools/builtin/scatter.rs
+++ b/crates/kaish-kernel/src/tools/builtin/scatter.rs
@@ -85,7 +85,10 @@ impl Tool for Scatter {
         parsed.global.apply(ctx);
 
         // Parse options for reporting (reads args.named to preserve Value::Int etc.)
-        let opts = parse_scatter_options(&args);
+        let opts = match parse_scatter_options(&args) {
+            Ok(opts) => opts,
+            Err(e) => return ExecResult::failure(2, format!("scatter: {e}")),
+        };
 
         // Get structured data and text from stdin (drains the pipe first, then
         // resolves the structured-data sideband — no startup race).

--- a/crates/kaish-kernel/tests/binary_text_sink_tests.rs
+++ b/crates/kaish-kernel/tests/binary_text_sink_tests.rs
@@ -67,6 +67,13 @@ async fn bare_word_binary_into_echo_is_loud() {
 }
 
 #[tokio::test]
+async fn binary_arg_into_printf_is_loud() {
+    // `printf` is a pure text-output sink like `echo`; a binary operand goes
+    // loud instead of the `[binary: N bytes]` placeholder (kaibo C1).
+    assert_loud_binary(r#"b=$(cat src.bin); printf "val=%s\n" "$b""#).await;
+}
+
+#[tokio::test]
 async fn binary_in_default_expansion_is_loud() {
     // `${b:-fallback}` where b is present-and-binary must also go loud, not
     // render the placeholder (the value is present, so the default never fires).

--- a/crates/kaish-kernel/tests/binary_text_sink_tests.rs
+++ b/crates/kaish-kernel/tests/binary_text_sink_tests.rs
@@ -1,0 +1,102 @@
+//! Kernel-routed regression tests for binary (`Value::Bytes`) at TEXT SINKS.
+//!
+//! A binary value captured via `$(...)` (e.g. `b=$(cat blob)` — `cat` of a
+//! non-UTF-8 file yields `Value::Bytes`) must go LOUD when it reaches a text
+//! sink — string interpolation (`"x=$b"`), a bare word into an external-command
+//! argv (`prog $b`), or the `echo` text-output builtin — never render the
+//! `[binary: N bytes]` placeholder. The placeholder where the user's real bytes
+//! should be is silent data corruption (crash beats corrupt).
+//!
+//! All tests route through `kernel.execute()` so the full dispatch chain runs.
+
+// Test-fixture code: unwrap/expect on known-good setup is the idiom.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+#![cfg(feature = "localfs")]
+
+mod common;
+
+use common::kernel_at;
+use std::fs;
+use tempfile::tempdir;
+
+/// Invalid-UTF-8 octets so `cat` marks the capture binary (`Value::Bytes`)
+/// rather than a `String` — that's the path that used to reach the placeholder.
+const BIN: &[u8] = b"\xff\x00\xfe\x80\x01\xc0kaish\xf5";
+
+/// Assert a script ran loud: either `execute` returned `Err`, or it returned a
+/// nonzero `ExecResult` whose error names the binary problem — and in NO case
+/// did the `[binary: N bytes]` placeholder leak into stdout.
+async fn assert_loud_binary(script: &str) {
+    let dir = tempdir().unwrap();
+    fs::write(dir.path().join("src.bin"), BIN).unwrap();
+    let kernel = kernel_at(dir.path());
+    match kernel.execute(script).await {
+        Ok(r) => {
+            assert_ne!(r.code, 0, "binary at a text sink must be a nonzero exit: {script:?}");
+            assert!(
+                r.err.contains("binary"),
+                "error should name the binary problem, got err={:?} for {script:?}",
+                r.err
+            );
+            assert!(
+                !r.text_out().contains("[binary"),
+                "the placeholder must NOT leak to stdout: {:?}",
+                r.text_out()
+            );
+        }
+        Err(e) => {
+            let msg = e.to_string();
+            assert!(
+                msg.contains("binary"),
+                "execute error should name the binary problem, got {msg:?} for {script:?}"
+            );
+        }
+    }
+}
+
+#[tokio::test]
+async fn interpolating_a_binary_capture_is_loud_not_placeholder() {
+    // The primary live bug: capture bytes, then splice into a string.
+    assert_loud_binary(r#"b=$(cat src.bin); echo "x=$b""#).await;
+}
+
+#[tokio::test]
+async fn bare_word_binary_into_echo_is_loud() {
+    // `echo` is a pure text-output sink; a bare `$b` binary word goes loud.
+    assert_loud_binary("b=$(cat src.bin); echo $b").await;
+}
+
+#[tokio::test]
+async fn binary_in_default_expansion_is_loud() {
+    // `${b:-fallback}` where b is present-and-binary must also go loud, not
+    // render the placeholder (the value is present, so the default never fires).
+    assert_loud_binary(r#"b=$(cat src.bin); echo "v=${b:-none}""#).await;
+}
+
+#[tokio::test]
+async fn text_capture_interpolation_is_unaffected() {
+    // Control: a normal text var still interpolates fine.
+    let dir = tempdir().unwrap();
+    let kernel = kernel_at(dir.path());
+    let result = kernel.execute(r#"t=$(echo hi); echo "x=$t""#).await.unwrap();
+    assert_eq!(result.code, 0, "text var must still work: {}", result.err);
+    assert_eq!(result.text_out().trim(), "x=hi");
+}
+
+#[tokio::test]
+async fn text_capture_bare_word_is_unaffected() {
+    let dir = tempdir().unwrap();
+    let kernel = kernel_at(dir.path());
+    let result = kernel.execute("t=$(echo hi); echo $t").await.unwrap();
+    assert_eq!(result.code, 0, "text var must still work: {}", result.err);
+    assert_eq!(result.text_out().trim(), "hi");
+}
+
+/// External-command argv (`build_args_flat`): a bare `$b` binary word must go
+/// loud crossing the process boundary. Gated on Linux + subprocess because it
+/// spawns a real `/bin/echo`.
+#[cfg(all(target_os = "linux", feature = "subprocess"))]
+#[tokio::test]
+async fn bare_word_binary_into_external_argv_is_loud() {
+    assert_loud_binary("b=$(cat src.bin); /bin/echo $b").await;
+}

--- a/crates/kaish-kernel/tests/builtin_kernel_tests.rs
+++ b/crates/kaish-kernel/tests/builtin_kernel_tests.rs
@@ -268,6 +268,31 @@ async fn source_alias_still_works_in_command_position() {
 }
 
 #[tokio::test]
+async fn source_accumulates_every_statements_stdout_not_just_the_last() {
+    let dir = tempdir().unwrap();
+    touch(dir.path(), "multi.kai", "echo one\necho two\necho three\n");
+    let kernel = kernel_at(dir.path());
+    let (out, code) = run(&kernel, "source multi.kai").await;
+    assert_eq!(code, 0, "source should succeed: {out:?}");
+    assert!(out.contains("one"), "source dropped first statement's output: {out:?}");
+    assert!(out.contains("two"), "source dropped second statement's output: {out:?}");
+    assert!(out.contains("three"), "source should keep the last statement's output: {out:?}");
+}
+
+#[tokio::test]
+async fn path_kai_script_accumulates_every_statements_stdout() {
+    let dir = tempdir().unwrap();
+    touch(dir.path(), "multi.kai", "echo one\necho two\necho three\n");
+    let kernel = kernel_at(dir.path());
+    let script = format!("PATH={}; multi", dir.path().display());
+    let (out, code) = run(&kernel, &script).await;
+    assert_eq!(code, 0, "PATH .kai script should succeed: {out:?}");
+    assert!(out.contains("one"), "script dropped first statement's output: {out:?}");
+    assert!(out.contains("two"), "script dropped second statement's output: {out:?}");
+    assert!(out.contains("three"), "script should keep the last statement's output: {out:?}");
+}
+
+#[tokio::test]
 async fn find_name_filters_to_matches_recursively() {
     let dir = tempdir().unwrap();
     touch(dir.path(), "keep.log", "");

--- a/crates/kaish-kernel/tests/collections_lvalue_tests.rs
+++ b/crates/kaish-kernel/tests/collections_lvalue_tests.rs
@@ -164,6 +164,21 @@ async fn dotted_assignment_target_is_rejected_with_bracket_suggestion() {
     );
 }
 
+#[tokio::test]
+async fn dotted_env_prefix_assignment_target_is_also_rejected() {
+    // Env-prefix assignments (`NAME=value cmd`) build an `Assignment` the same
+    // way a bare assignment does (`Stmt::EnvScoped` validates each entry via
+    // the same `validate_assignment`), so a dotted root here must be caught
+    // too — not just the bare-statement form.
+    let k = setup().await;
+    let err = loud_err(&k, "X.Y=v echo hi").await;
+    assert!(err.contains("E017"), "got: {err}");
+    assert!(
+        err.contains("X[Y]"),
+        "expected the bracket-form suggestion: {err}"
+    );
+}
+
 // ── push ───────────────────────────────────────────────────────────────────
 
 #[tokio::test]

--- a/crates/kaish-kernel/tests/jq_tests.rs
+++ b/crates/kaish-kernel/tests/jq_tests.rs
@@ -413,3 +413,65 @@ async fn jq_pretty_output_is_two_space_indented() {
         .expect("ran");
     assert_eq!(r.text_out(), "{\n  \"a\": 1\n}\n");
 }
+
+// ============================================================================
+// Value::String .data must not be JSON-sniffed on the way into jq
+// ============================================================================
+//
+// jq's `.data`-path stdin resolution (`ast_value_to_json`, feeding
+// `resolve_stdin_json`) converts kaish's typed `Value` into the
+// `serde_json::Value` jq operates on. `Value::String(s)` is a *string*, full
+// stop — it must become a JSON string, never be re-parsed as a JSON document.
+// Re-parsing is the project's banned "JSON-sniffing" (docs/arch_no_json_sniffing
+// invariant): `.data` is opt-in structure, never inferred from text content.
+// `fromjson '"1"'` is the sharpest reproduction: it produces `Value::String("1")`
+// — the *decoded contents* of the JSON string `"1"`, i.e. the one-character
+// string `1`, not the bare number 1. Piping that into `jq 'type'` must report
+// "string", not "number".
+
+#[tokio::test]
+async fn jq_type_does_not_json_sniff_a_data_string() {
+    let k = setup().await;
+    let r = k
+        .execute(r#"fromjson '"1"' | jq 'type'"#)
+        .await
+        .expect("script ran");
+    assert!(r.ok(), "exit: {} err: {}", r.code, r.err);
+    assert_eq!(r.text_out().trim(), "\"string\"");
+}
+
+#[tokio::test]
+async fn jq_identity_does_not_json_sniff_a_data_string() {
+    // Same bug, checked via the identity filter and quoting: the string "1"
+    // fed through `jq '.'` must render as the JSON string `"1"`, not the bare
+    // JSON number `1`.
+    let k = setup().await;
+    let r = k
+        .execute(r#"fromjson '"1"' | jq '.'"#)
+        .await
+        .expect("script ran");
+    assert!(r.ok(), "exit: {} err: {}", r.code, r.err);
+    assert_eq!(r.text_out().trim(), "\"1\"");
+}
+
+#[tokio::test]
+async fn jq_type_does_not_json_sniff_other_json_looking_strings() {
+    // The sniffing bug only fires when the string *happens* to parse as JSON
+    // — pin down a few more shapes so a partial fix can't slip through.
+    let k = setup().await;
+    for (literal, expected) in [
+        (r#"'"true"'"#, "\"string\""),
+        (r#"'"null"'"#, "\"string\""),
+        (r#"'"[1,2]"'"#, "\"string\""),
+        (r#"'"8"'"#, "\"string\""),
+    ] {
+        let script = format!("fromjson {literal} | jq 'type'");
+        let r = k.execute(&script).await.expect("script ran");
+        assert!(r.ok(), "script: {script}, exit: {}, err: {}", r.code, r.err);
+        assert_eq!(
+            r.text_out().trim(),
+            expected,
+            "script: {script}"
+        );
+    }
+}

--- a/crates/kaish-kernel/tests/scatter_gather_jsonl_tests.rs
+++ b/crates/kaish-kernel/tests/scatter_gather_jsonl_tests.rs
@@ -453,3 +453,72 @@ seq 1 2 | scatter --as ${cfg[name]:-W} | echo $W | gather"#,
     assert_eq!(rows[0]["out"], "1", "default var name W bound the items");
     assert_eq!(rows[1]["out"], "2");
 }
+
+// ═══════════════════════════════════════════════════════════════════════
+// Scatter workers must inherit the parent's execution config (aliases,
+// ignore filters, output limits, external-command policy), not run against
+// a from-scratch context — an aliased command that works in the foreground
+// must also work inside a scatter worker.
+// ═══════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn scatter_worker_sees_parent_aliases() {
+    let k = kernel_at(tempdir().unwrap().path());
+    let r = run_full(
+        &k,
+        r#"alias greet='echo hi'
+seq 1 2 | scatter | greet | gather"#,
+    )
+    .await;
+    assert_eq!(r.code, 0, "{:?}", r.err);
+    let rows = rows(&r.text_out());
+    assert_eq!(rows.len(), 2);
+    for row in &rows {
+        assert_eq!(row["ok"], true, "aliased command must resolve inside a worker: {row:?}");
+        assert_ne!(row["code"], 127, "must not be command-not-found: {row:?}");
+        assert_eq!(row["out"], "hi");
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// `gather`'s own trailing redirect must apply even when the pipeline
+// continues past it — matching shell semantics where a file redirect on a
+// stage wins over the pipe (`cmd > file | next` sends `cmd`'s real stdout to
+// the file; `next` gets nothing from `cmd`).
+// ═══════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn gather_redirect_applies_even_with_trailing_pipeline_stages() {
+    let dir = tempdir().unwrap();
+    let k = kernel_at(dir.path());
+    let r = run_full(&k, "seq 1 2 | scatter | echo $ITEM | gather > audit.jsonl | wc -c").await;
+    assert_eq!(r.code, 0, "{:?}", r.err);
+    assert_eq!(
+        r.text_out().trim(),
+        "0",
+        "gather's redirect must send rows to the file, not the downstream pipe: out={:?} err={:?}",
+        r.text_out(),
+        r.err
+    );
+    let audit = std::fs::read_to_string(dir.path().join("audit.jsonl"))
+        .expect("gather's redirect should have created audit.jsonl");
+    assert!(audit.contains(r#""out":"1""#), "audit file missing row 1: {audit}");
+    assert!(audit.contains(r#""out":"2""#), "audit file missing row 2: {audit}");
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// A `$(...)` scatter/gather flag value can't be evaluated by the reduced
+// sync arg binder (`build_tool_args`/`eval_simple_expr` run before any
+// worker forks, so they can't recurse through the async pipeline) — but it
+// must fail loud, not silently coalesce to a bare boolean flag/default limit.
+// ═══════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn scatter_flag_value_command_substitution_is_loud_not_silently_dropped() {
+    let k = kernel_at(tempdir().unwrap().path());
+    let r = run_full(&k, "seq 1 3 | scatter --limit $(echo 2) | echo $ITEM | gather").await;
+    assert_ne!(
+        r.code, 0,
+        "a $(...) scatter flag value must fail loud, not silently coalesce to the default limit: {r:?}"
+    );
+}

--- a/crates/kaish-kernel/tests/shell_bugs_tests.rs
+++ b/crates/kaish-kernel/tests/shell_bugs_tests.rs
@@ -678,6 +678,37 @@ async fn test_source_alias_with_space_still_works() {
 }
 
 // ============================================================================
+// Top-level `return` in a skip-validation embedder context must stop the
+// script and keep prior statements' accumulated output, like `exit` — not
+// silently discard it and keep running. Ordinary kernels reject a top-level
+// `return` at validation time (`ReturnOutsideFunction`), but an embedder that
+// opts into `with_skip_validation(true)` (a supported, commonly-used config —
+// see the many test files that build kernels this way) can still reach this
+// path, so `execute_streaming_inner`'s handling of it must be correct too.
+// ============================================================================
+
+#[tokio::test]
+async fn test_top_level_return_keeps_prior_output_and_stops_execution() {
+    use kaish_kernel::KernelConfig;
+    let kernel = Kernel::new(KernelConfig::transient().with_skip_validation(true)).unwrap();
+    let result = kernel
+        .execute("echo setup-ok; return 0; echo after")
+        .await
+        .expect("skip-validation kernel should run a top-level return");
+    assert_eq!(result.code, 0);
+    assert!(
+        result.text_out().contains("setup-ok"),
+        "return must not discard prior statements' output: {:?}",
+        result.text_out()
+    );
+    assert!(
+        !result.text_out().contains("after"),
+        "return must stop execution of subsequent statements: {:?}",
+        result.text_out()
+    );
+}
+
+// ============================================================================
 // `!` precedence in `[[ ]]` — `!` binds tighter than `&&`/`||`
 //
 // Regression for the 2026-06-09 finding: the parser bound `!` to the entire
@@ -756,3 +787,28 @@ async fn test_double_dash_protects_multiple_dash_words() {
     let result = kernel.execute("echo -- -a-b -c-d").await.unwrap();
     assert_eq!(result.text_out().trim(), "-a-b -c-d");
 }
+
+// ============================================================================
+// `--` end-of-flags does not choke on an assignment-shaped word.
+//
+// After `--`, nothing is special — including `=` — so `a=b` is one literal
+// positional word, matching standard shell behavior. The post-`--` argument
+// grammar previously had no rule to absorb a bareword `key=value` token
+// (`Arg::WordAssign`'s `Ident`+`Eq`+expr production only ran pre-`--`), so the
+// parser hard-failed on the unhandled `=` instead of producing a positional.
+// ============================================================================
+
+#[tokio::test]
+async fn test_double_dash_allows_bareword_assignment() {
+    let kernel = Kernel::transient().unwrap();
+    let result = kernel.execute("echo -- a=b").await.unwrap();
+    assert_eq!(result.text_out().trim(), "a=b");
+}
+
+#[tokio::test]
+async fn test_double_dash_allows_multiple_bareword_assignments() {
+    let kernel = Kernel::transient().unwrap();
+    let result = kernel.execute("echo -- a=b c=d").await.unwrap();
+    assert_eq!(result.text_out().trim(), "a=b c=d");
+}
+

--- a/crates/kaish-types/src/backend.rs
+++ b/crates/kaish-types/src/backend.rs
@@ -299,7 +299,19 @@ impl From<ExecResult> for ToolResult {
         // Saturating cast: codes outside i32 range clamp to i32::MIN/MAX
         let code = exec.code.clamp(i32::MIN as i64, i32::MAX as i64) as i32;
 
-        // Materialize text before moving fields out
+        // HAZARD: `text_out()` is the infallible/lossy decoder — a binary
+        // `OutputPayload::Bytes` (already produced by `cat`/`head`/`tail`/
+        // `base64 -d`/`xxd -r`/`dd`/`tee`/external commands, so this is real
+        // today, not merely a future risk) gets its invalid-UTF-8 bytes
+        // replaced with U+FFFD here. This `From` impl is infallible by
+        // signature, so it cannot fail loud the way `try_text_out()` does —
+        // this is an accepted, deliberate exception, not an oversight. The
+        // binary survives losslessly in the preserved `output: Option<OutputData>`
+        // field below; a structured/binary-aware consumer MUST read `output`,
+        // never `stdout`, to avoid the lossy decode. If a future embedder seam
+        // needs a fallible conversion here, add a `TryFrom` (or a bytes-carrying
+        // field) rather than changing this `From`'s behavior. See
+        // `docs/binary-data.md`.
         let stdout = exec.text_out().into_owned();
         let output = exec.take_output();
 

--- a/crates/kaish-types/src/backend.rs
+++ b/crates/kaish-types/src/backend.rs
@@ -10,7 +10,7 @@ use serde_json::Value as JsonValue;
 use thiserror::Error;
 
 use crate::output::OutputData;
-use crate::result::{value_to_json, ExecResult};
+use crate::result::{json_to_value_no_envelope, value_to_json, ExecResult};
 use crate::tool::ToolSchema;
 
 /// Result type for backend operations.
@@ -315,6 +315,28 @@ impl From<ExecResult> for ToolResult {
             content_type: exec.content_type,
             baggage: exec.baggage,
         }
+    }
+}
+
+impl From<ToolResult> for ExecResult {
+    /// The symmetric peer of `From<ExecResult> for ToolResult` above — every
+    /// field that direction preserves, this direction must preserve too, or a
+    /// backend-registered tool's structured `data`/`content_type`/`baggage`
+    /// silently vanishes crossing back into the kernel (the embedder seam:
+    /// `x=$(embedder_tool)` and `for r in $(embedder_tool)` need `.data` to
+    /// see typed results, not just stdout text).
+    ///
+    /// `data` uses [`json_to_value_no_envelope`] rather than the internal
+    /// round-trip conversion: a backend tool's JSON is external input, so an
+    /// object shaped like the byte envelope must stay a plain record, never
+    /// silently auto-decode to `Value::Bytes`.
+    fn from(result: ToolResult) -> Self {
+        let mut exec = ExecResult::from_output(result.code as i64, result.stdout, result.stderr);
+        exec.set_output(result.output);
+        exec.data = result.data.map(json_to_value_no_envelope);
+        exec.content_type = result.content_type;
+        exec.baggage = result.baggage;
+        exec
     }
 }
 

--- a/crates/kaish-types/src/result.rs
+++ b/crates/kaish-types/src/result.rs
@@ -332,11 +332,12 @@ impl ExecResult {
     /// `OutputData::to_canonical_string()`. This is the canonical way to
     /// get text for pipes, command substitution, and file redirects.
     ///
-    /// **Binary payloads** decode lossily here (`U+FFFD` for invalid UTF-8). No
-    /// builtin produces a `Bytes` payload yet (Phase 1), so this lossy path is
-    /// unreachable in practice; the loud-error guard for binary lives in
-    /// [`Self::try_text_out`], which the Phase-2 text sinks adopt. See
-    /// `docs/binary-data.md`.
+    /// **Binary payloads** decode lossily here (`U+FFFD` for invalid UTF-8).
+    /// Several builtins already produce a `Bytes` payload (`cat`/`head`/`tail`/
+    /// `base64 -d`/`xxd -r`/`dd`/`tee`/external commands), so this lossy path
+    /// IS reachable — callers that need to catch binary rather than silently
+    /// mangle it should use [`Self::try_text_out`] instead, which loud-errors
+    /// with [`BinaryNotText`] on invalid UTF-8. See `docs/binary-data.md`.
     pub fn text_out(&self) -> Cow<'_, str> {
         match &self.out {
             OutputPayload::Text(s) if !s.is_empty() => Cow::Borrowed(s),

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -345,8 +345,10 @@ filter is requested but `info`/the field is `None`. (Inverse of the PR-#41 bug.)
 - **Scheduler:** concurrent stages/workers use `Vec<JoinHandle>` (not `JoinSet`) with no
   abort — bounded leak, not unbounded (join-all + `fork_attached` cancellation cascade);
   the redirect "stream-to-disk" comment overstates (materializes in memory first); the
-  sync `build_tool_args` drops a `$()`-valued scatter/gather *option* (folds into the
-  "eliminate the sync twin" item). (`scheduler/{pipeline,scatter}.rs`)
+  sync `build_tool_args` still can't *evaluate* a `$()`-valued scatter/gather option — it
+  now fails loud instead of silently dropping the value (0.11.0 hardening pass), but
+  actually supporting command substitution here still needs the "eliminate the sync
+  twin" refactor. (`scheduler/{pipeline,scatter}.rs`)
 - **Scatter/gather structured-data pre-read:** the scatter runner
   (`scheduler/scatter.rs:136`) still uses the old one-shot `take_stdin_data` rather than
   the `resolve_stdin()` drain-then-await the main consumers adopted. Latent — fold it in

--- a/docs/multicall.md
+++ b/docs/multicall.md
@@ -112,7 +112,7 @@ using the same schema-driven flag/value/repeatable/`consumes` consumption that
 `Expr` evaluation step (tokens are already values). From `ToolArgs` onward it
 reuses **everything**: validation, `--json` (`GlobalFlags::apply_from_args`),
 latch/nonce, `owns_output`, the snapshot/dispatch block
-(`execute_command_depth`). No changes to the 70+ builtins. Effort: small — one
+(`execute_command_depth`). No changes to the 90+ builtins. Effort: small — one
 helper plus a thin public method.
 
 ### The one honest wrinkle


### PR DESCRIPTION
## Why

Before cutting 0.11.0 we hardened the release surface (collections + scatter/gather + the kernel↔backend seam + the interpreter) against silent data corruption, in the release's own spirit: **loud errors, never silent fallbacks; crash beats corrupt.** The work came out of **two rounds of independent, cross-model AI review**:

- **Round 1** — overnight batch reviews (Anthropic "fable" + Gemini Pro) of everything shipped since v0.10.0. Landed as the first commit here.
- **Round 2** — fresh DeepSeek + Gemini Pro reviews of *round 1's own fixes* and the surrounding scatter/gather + interpreter code. The two models were genuinely complementary — each caught real defects the other missed.

Every finding was **verified against the code before trusting it** (a round-1 lesson: one "silent corruption" claim turned out to be the deliberate, tested `kaish-last` feature). Notably, two scary-sounding claims were investigated and found **already-correct**, so left untouched: `gather --json` "bypassing the error envelope" (it deliberately owns its output; per-row `ok`/`code`/`err` *is* the error surface) and `scatter --timeout` "not cancelling a hung worker" (the timer → `worker_token` → `ctx.cancel` → `try_execute_external` chain is intact).

## What's fixed

**scatter / gather (scheduler):**
- Wrong-typed `--limit`/`--as`/`--timeout` values (a string `--limit "5"` from a variable, a negative `--timeout`, a `$(…)` the reduced sync binder can't evaluate) **fail loud** instead of silently falling back to the default. Numeric-string `--limit "5"` coerces.
- Removed the dead `--progress` flag (parsed into an unread field, not even in the clap schema).
- Binary worker output no longer corrupts `gather`: rows and `--lines` used to lossily UTF-8-decode (`U+FFFD`) a worker whose stdout was binary — now a row is `ok:false` with a clear error and `--lines` hard-errors (exit 123). **Live bug**, not latent — `cat`/`head`/`tail`/`base64 -d`/`xxd -r`/`dd`/`tee` already emit binary output.
- Workers now derive their context from `child_for_pipeline()` instead of a from-scratch `ExecContext`, so they keep the parent's **script watchdog** (a from-scratch `None` was clobbering the fork's watchdog → `ctx.patient` holds suspended a missing clock → false-positive request-timeout kills) and honour the **output-limit memory cap** (added a per-worker spill boundary; N parallel workers could each hold unbounded output).

**interpreter — binary at text sinks:** the live async `$()` capture preserves binary as `Value::Bytes`, so `b=$(cat blob)` is genuinely binary. A new fallible `value_to_text_sink()` makes such a value go **loud** at string interpolation (`"x=$b"`), bare-word external argv (`prog $b`), and `echo` — instead of rendering the `[binary: N bytes]` placeholder where the real bytes should be. Valid-UTF-8 bytes still coerce; `==`/`in`/`${#…}`/`case` are unchanged. Remaining sinks (path-positionals, env, redirect target, semantic ops) are tracked for 0.11.1 (#93).

**interpreter — dead-code removal:** deleted the `Executor` trait, `NoOpExecutor`, `eval_command_subst`, and the lossy `result_to_value`. The sync `Evaluator` is only ever built with `NoOpExecutor`, and its live callers pre-resolve every operand to a literal via the async evaluator before sync evaluation — so the sync command-substitution / `eval_command` / FileTest arms were unreachable (and `result_to_value` was a latent lossy-`Bytes` trap). `Evaluator` is now non-generic; the three unreachable arms **fail loud on the outside case** rather than silently no-op'ing or stat'ing via `std::fs` (a VFS bypass). Drops the unused `Executor`/`NoOpExecutor` from the public `interpreter` surface (pre-1.0, breaking-in-name only — nothing implemented or consumed them).

**Round 1** (first commit) also fixed: backend `ToolResult`→`ExecResult` dropping `.data`/`content_type`/`baggage` (and masking a real backend error as exit-127); `source`/PATH `.kai` scripts keeping only the last statement's stdout; `Kernel::reset()` reverting latch/trash/`$$`/`initial_vars`; `jq` JSON-sniffing a `Value::String` `.data`; a non-ASCII short-flag argv bundle panicking mid-codepoint; a bareword `key=value` after `--` failing to parse; and `gather`'s own trailing redirect being dropped mid-pipeline.

## Notes

- **Rebased onto `main` (incl. #91 redirect-in-`$()` / clears-`.data`).** No textual conflicts; I re-verified the semantic seam by hand — #91's features and these guards coexist correctly.
- **Deferred to #93** (0.11.1): the binary-at-remaining-sinks cluster (a live but broader class), `jq -s` scalar-`.data` parity, `did_spill`/`original_code` across the `ToolResult` seam, and two LOW edges.
- Gates green: `cargo test --all` (0 failures), `cargo clippy --all --all-targets` (0 warnings), `cargo insta test --check`. Loud paths verified against the real binary.

A final kaibo review of the whole diff is running; its findings + any remediation will be posted as PR comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
