### PR TITLE
feat(#92): the confirmation latch becomes a first-class, fulfillable API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ breaking entries are marked **BREAKING**.
 ## [Unreleased]
 
 ### Added
+- **The confirmation latch is now a first-class typed field with a
+  fulfillment API** (GH #92). A gated destructive op returns exit 2 with the
+  request on a dedicated `ExecResult.latch: Option<Box<LatchRequest>>`
+  (control-plane), no longer serialized into the data-plane `.data`. Read it via
+  `ExecResult::latch_request()` (unchanged); fulfill it via the new
+  `Kernel::confirm(&LatchRequest)`, which replays the **exact captured argv**
+  (`LatchRequest.tool` + `.argv`, new fields) with `--confirm=<nonce>` — precise
+  even for paths with spaces/globs, where the human `hint` string can't round
+  trip. **BREAKING (embedders/`--json`):** a latched `--json` result now surfaces
+  the nonce under a `latch` key in the error envelope, not nested under `data`;
+  embedders reading the nonce out of `.data` must switch to `latch_request()`.
 - **Redirects now work inside `$(...)`** — `x=$(cmd > file)`, `$(cmd 2> err)`,
   `$(cmd >> log)` and friends parse and run, matching the top-level command
   grammar (the command-substitution body used to reject any redirect). Control

--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ sniffing stdout. The exit code is something agents can branch on:
 |--------|---------|----------|
 | 0 | Success | — |
 | 1 | Failure | Read `stderr` |
-| 2 | Confirmation required (`set -o latch`) | Re-run with `--confirm="<nonce>"` — the nonce is in the `To confirm, run:` line and in `data` |
+| 2 | Confirmation required (`set -o latch`) | Re-run with `--confirm="<nonce>"` — embedders read the typed `ExecResult.latch` (or call `Kernel::confirm`); the `To confirm, run:` line shows it for humans |
 | 3 | Output truncated by the output limit | `original_code` holds the real exit code; the message names the spill file — `cat` it, or narrow the query |
 | 124 | Timeout (`timeout_ms`, default 30 s) | — |
 | 130 | Cancelled | — |

--- a/crates/kaish-help/content/en/syntax.md
+++ b/crates/kaish-help/content/en/syntax.md
@@ -330,8 +330,8 @@ Confirmed paths must be subset of authorized paths. Exit code 2 = needs confirma
 Applies to `rm` and to truncating overwrites (`tee`, `patch`, `sed -i`) —
 confirm those with `--confirm=<nonce>`. `tee -a` append, new files, and
 `patch --dry-run` don't gate. The prompt prints to stderr (stdout stays empty);
-the nonce is on the result's `data` field — nested under `data` in the error
-envelope when `--json` is on.
+the nonce is on the result's typed `latch` field — surfaced under a `latch` key
+in the error envelope when `--json` is on.
 
 **Trash:** Files <= 10MB and directories always trash. `/tmp`, `/v/*` excluded.
 A truncating overwrite under `trash` snapshots the file's prior content first

--- a/crates/kaish-help/src/fragments.rs
+++ b/crates/kaish-help/src/fragments.rs
@@ -597,8 +597,8 @@ Confirmed paths must be subset of authorized paths. Exit code 2 = needs confirma
 Applies to `rm` and to truncating overwrites (`tee`, `patch`, `sed -i`) —
 confirm those with `--confirm=<nonce>`. `tee -a` append, new files, and
 `patch --dry-run` don't gate. The prompt prints to stderr (stdout stays empty);
-the nonce is on the result's `data` field — nested under `data` in the error
-envelope when `--json` is on.
+the nonce is on the result's typed `latch` field — surfaced under a `latch` key
+in the error envelope when `--json` is on.
 
 **Trash:** Files <= 10MB and directories always trash. `/tmp`, `/v/*` excluded.
 A truncating overwrite under `trash` snapshots the file's prior content first

--- a/crates/kaish-kernel/src/dispatch.rs
+++ b/crates/kaish-kernel/src/dispatch.rs
@@ -464,6 +464,7 @@ impl CommandDispatcher for BackendDispatcher {
                 exec.set_output(tool_result.output);
                 exec.content_type = tool_result.content_type;
                 exec.baggage = tool_result.baggage;
+                exec.latch = tool_result.latch;
                 // Restore structured data from ToolResult (preserved through backend roundtrip)
                 if let Some(json_data) = tool_result.data {
                     exec.data = Some(Value::Json(json_data));

--- a/crates/kaish-kernel/src/kernel.rs
+++ b/crates/kaish-kernel/src/kernel.rs
@@ -6231,6 +6231,7 @@ mod tests {
                 output: None,
                 content_type: Some("application/json".to_string()),
                 baggage,
+                latch: None,
             })
         });
         let backend: Arc<dyn crate::backend::KernelBackend> = Arc::new(backend);

--- a/crates/kaish-kernel/src/kernel.rs
+++ b/crates/kaish-kernel/src/kernel.rs
@@ -3152,13 +3152,16 @@ impl Kernel {
         // for a precise `Kernel::confirm` replay — no re-parsing of the human
         // `hint`. `to_argv()` is computed before `tool_args` moves into execute.
         //
-        // Gated on `latch_enabled`: a latch can only fire when armed, so in the
-        // common (latch-off) case this stays out of the hot dispatch path —
-        // no allocation and no extra frame weight for deep `$()`/recursion,
-        // which would otherwise cost stack headroom (GH #46/#47).
-        if ctx.scope.latch_enabled() {
-            ctx.current_invocation = Some(Box::new((name.to_string(), tool_args.to_argv())));
-        }
+        // Captured unconditionally, NOT gated on `latch_enabled`: `kaish-trash
+        // empty` gates every time (it's inherently destructive, independent of
+        // `set -o latch`), so a `latch_enabled`-only gate would leave its
+        // `tool`/`argv` empty and break `confirm`. The cost is a small argv
+        // clone per command — marginal beside the per-command ExecContext
+        // snapshot above — and it does NOT reintroduce the deep-`$()` stack
+        // overflow (that was the inline `LatchRequest` in `ExecResult`, now
+        // boxed; the capture's temporaries don't survive into the recursive
+        // `tool.execute` below).
+        ctx.current_invocation = Some(Box::new((name.to_string(), tool_args.to_argv())));
 
         let result = tool.execute(tool_args, &mut ctx).await;
 

--- a/crates/kaish-kernel/src/kernel.rs
+++ b/crates/kaish-kernel/src/kernel.rs
@@ -54,7 +54,7 @@ pub use kaish_types::{CommandKind, ExecuteOptions};
 use crate::backend::{BackendError, KernelBackend};
 use kaish_glob::glob_match;
 use crate::dispatch::{CommandDispatcher, PipelinePosition};
-use crate::interpreter::{apply_output_format, eval_expr, expand_tilde, json_to_value_no_envelope, value_to_bool, value_to_string, value_to_text_sink, ControlFlow, ExecResult, PathError, Scope};
+use crate::interpreter::{apply_output_format, eval_expr, expand_tilde, json_to_value_no_envelope, value_to_bool, value_to_string, value_to_text_sink, ControlFlow, ExecResult, LatchRequest, PathError, Scope};
 use crate::parser::parse;
 use crate::scheduler::{is_bool_type, schema_param_lookup, select_leaf, stderr_stream, BoundedStream, JobManager, PipelineRunner, StderrReceiver};
 #[cfg(feature = "subprocess")]
@@ -1473,6 +1473,36 @@ impl Kernel {
         Ok(result)
     }
 
+    /// Fulfill a confirmation latch by replaying its exact captured invocation
+    /// with the nonce — the highest-fidelity approval path.
+    ///
+    /// Inspect a gated result with [`ExecResult::latch_request`]; apply whatever
+    /// policy (allowlist, model review) over `req.command`/`req.paths`; then call
+    /// this to approve. It replays `execute_argv(req.tool, req.argv)` with
+    /// `--confirm=<nonce>` prepended — no re-parsing of the human `hint`, so a
+    /// path with spaces or glob characters round-trips exactly. Share the nonce
+    /// store ([`KernelConfig::with_nonce_store`]) to confirm from a *later*
+    /// kernel call than the one that produced the latch.
+    ///
+    /// Errors (exit 2) if the latch carries no captured invocation — a latch
+    /// produced outside a dispatch seam (a direct `tool.execute` in a unit
+    /// test). Those are confirmable only by re-running with `--confirm=<nonce>`.
+    pub async fn confirm(&self, latch: &LatchRequest) -> Result<ExecResult> {
+        if latch.tool.is_empty() {
+            return Ok(ExecResult::failure(
+                2,
+                "confirm: latch carries no captured invocation to replay — \
+                 re-run the command with --confirm=<nonce> instead",
+            ));
+        }
+        // Prepend the nonce as a `--confirm=` flag: `to_argv()` trails a `--`
+        // positional terminator, so appending would let it swallow the flag.
+        let mut argv: Vec<Value> = Vec::with_capacity(latch.argv.len() + 1);
+        argv.push(Value::String(format!("--confirm={}", latch.nonce)));
+        argv.extend(latch.argv.iter().map(|a| Value::String(a.clone())));
+        self.execute_argv(&latch.tool, &argv).await
+    }
+
     /// Run `work` under the movable-deadline watchdog for `timeout`, shared by the
     /// string door ([`Self::execute_with_options`]) and the argv door
     /// ([`Self::execute_argv`]).
@@ -2679,6 +2709,7 @@ impl Kernel {
                     token.clone()
                 },
                 output_format: None,
+                current_invocation: None,
                 vfs_budget: self.vfs_budget.clone(),
                 watchdog: ec.watchdog.clone(),
                 #[cfg(all(feature = "localfs", feature = "overlay"))]
@@ -3090,6 +3121,7 @@ impl Kernel {
                 // default fresh token from a non-dispatch path.
                 cancel: ec.cancel.clone(),
                 output_format: None,
+                current_invocation: None,
                 vfs_budget: self.vfs_budget.clone(),
                 watchdog: ec.watchdog.clone(),
                 #[cfg(all(feature = "localfs", feature = "overlay"))]
@@ -3114,6 +3146,19 @@ impl Kernel {
         // --json on the floor when `try_parse_from` returns Err early).
         // The builtin's own `parsed.global.apply(ctx)` becomes idempotent.
         GlobalFlags::apply_from_args(&tool_args, &mut ctx);
+
+        // Capture the exact invocation at the dispatch seam so a latch producer
+        // (`latch_result`/`gate_overwrites`) can stamp it into the LatchRequest
+        // for a precise `Kernel::confirm` replay — no re-parsing of the human
+        // `hint`. `to_argv()` is computed before `tool_args` moves into execute.
+        //
+        // Gated on `latch_enabled`: a latch can only fire when armed, so in the
+        // common (latch-off) case this stays out of the hot dispatch path —
+        // no allocation and no extra frame weight for deep `$()`/recursion,
+        // which would otherwise cost stack headroom (GH #46/#47).
+        if ctx.scope.latch_enabled() {
+            ctx.current_invocation = Some(Box::new((name.to_string(), tool_args.to_argv())));
+        }
 
         let result = tool.execute(tool_args, &mut ctx).await;
 

--- a/crates/kaish-kernel/src/kernel.rs
+++ b/crates/kaish-kernel/src/kernel.rs
@@ -3001,7 +3001,7 @@ impl Kernel {
                     Ok(tool_result) => {
                         let mut scope = self.scope.write().await;
                         *scope = ctx.scope.clone();
-                        // Preserve every field (data/content_type/baggage,
+                        // Preserve every field (data/content_type/baggage/latch,
                         // not just stdout text) — this is the embedder seam:
                         // `x=$(embedder_tool)` and structured iteration over
                         // its result depend on `.data` surviving the crossing
@@ -5622,6 +5622,9 @@ fn accumulate_result(accumulated: &mut ExecResult, new: &ExecResult) {
     accumulated.original_code = new.original_code;
     accumulated.content_type = new.content_type.clone();
     accumulated.baggage.clone_from(&new.baggage);
+    // A latch gate (exit-2 + nonce) is the last statement's result; carry its
+    // control-plane field through accumulation or the confirmation is lost.
+    accumulated.latch = new.latch.clone();
 }
 
 /// Fold a loop's accumulated output into a break/continue signal that is

--- a/crates/kaish-kernel/src/tools/builtin/rm.rs
+++ b/crates/kaish-kernel/src/tools/builtin/rm.rs
@@ -437,24 +437,15 @@ mod tests {
         assert!(result.err.contains("Authorized: /file.txt"));
         assert!(result.err.contains("--confirm="));
         assert!(result.err.contains("60 seconds"));
-        // Structured latch data should be present
-        let data = result.data.as_ref().expect("latch result should have data");
-        if let Value::Json(json) = data {
-            assert!(json["nonce"].is_string());
-            assert_eq!(json["command"], "rm");
-            assert_eq!(json["paths"], serde_json::json!(["/file.txt"]));
-            assert_eq!(json["ttl"], 60);
-            assert!(json["hint"].as_str().unwrap().contains("--confirm="));
-        } else {
-            panic!("expected Value::Json, got {:?}", data);
-        }
         // File should still exist
         assert!(ctx.backend.exists(Path::new("/file.txt")).await);
 
-        // The typed accessor must decode the same payload — this ties the
-        // kernel-side `latch_result` construction to `LatchRequest` so the keys
-        // can't drift apart silently. (Embedders hook this seam.)
-        let req = result.latch_request().expect("a latch request from exit-2 + nonce data");
+        // The latch rides its own typed control-plane field; the accessor ties
+        // `latch_result` construction to `LatchRequest` so the keys can't drift
+        // apart silently. (Embedders hook this seam.) The data-plane `.data`
+        // stays empty — a latch is not stdout.
+        assert!(result.data.is_none(), "latch must not use the data-plane .data");
+        let req = result.latch_request().expect("a latch request on the .latch field");
         assert_eq!(req.command, "rm");
         assert_eq!(req.paths, vec!["/file.txt".to_string()]);
         assert_eq!(req.ttl, 60);

--- a/crates/kaish-kernel/src/tools/context.rs
+++ b/crates/kaish-kernel/src/tools/context.rs
@@ -737,21 +737,15 @@ impl ExecContext {
         let mut result = ExecResult::failure(2, format!(
             "{command}: confirmation required ({reason}){authorized}\nTo confirm, run: {hint}\nNonce expires in {ttl} seconds."
         ));
-        // The struct is the single source of truth for the payload shape; the
-        // typed accessor `ExecResult::latch_request` deserializes exactly this.
-        let request = crate::interpreter::LatchRequest {
+        // The latch request rides its own typed control-plane field, distinct
+        // from the data-plane `.data`. `ExecResult::latch_request` reads it back.
+        result.latch = Some(crate::interpreter::LatchRequest {
             nonce,
             command: command.to_string(),
             paths: paths.iter().map(|p| (*p).to_string()).collect(),
             hint,
             ttl,
-        };
-        // Infallible: every field is String/Vec<String>/u64 (see NonceStore for
-        // the same allow on a genuinely-unreachable error).
-        #[allow(clippy::expect_used)]
-        let payload = serde_json::to_value(&request)
-            .expect("LatchRequest serializes infallibly (String/Vec<String>/u64)");
-        result.data = Some(Value::Json(payload));
+        });
         result
     }
 

--- a/crates/kaish-kernel/src/tools/context.rs
+++ b/crates/kaish-kernel/src/tools/context.rs
@@ -141,6 +141,19 @@ pub struct ExecContext {
     /// don't touch it.
     pub output_format: Option<OutputFormat>,
 
+    /// The command currently executing, captured at the dispatch seam as
+    /// `(dispatch_name, argv)` where `argv` is the canonical `ToolArgs::to_argv`.
+    /// A latch producer (`latch_result`/`gate_overwrites`) stamps this into the
+    /// `LatchRequest` so `Kernel::confirm` can replay the *exact* invocation with
+    /// `--confirm=<nonce>` — no re-parsing of the human `hint`. `None` for a
+    /// direct `tool.execute` call in a unit test (no dispatch seam ran).
+    ///
+    /// Boxed to keep `ExecContext` lean: it is cloned/rebuilt at every recursion
+    /// level (pipeline stages, `$(...)`, functions), so an inline `(String,
+    /// Vec<String>)` would grow every frame and eat into the interpreter's stack
+    /// headroom (see GH #46/#47). The box is allocated once per gated command.
+    pub current_invocation: Option<Box<(String, Vec<String>)>>,
+
     /// Shared VFS memory budget for this kernel's `MemoryFs` mounts.
     ///
     /// `Arc`-cloned from the owning `Kernel` (or its fork parent) so all
@@ -297,6 +310,7 @@ impl ExecContext {
             dispatcher: None,
             cancel: CancellationToken::new(),
             output_format: None,
+            current_invocation: None,
             vfs_budget: None,
             watchdog: None,
             #[cfg(all(feature = "localfs", feature = "overlay"))]
@@ -336,6 +350,7 @@ impl ExecContext {
             dispatcher: None,
             cancel: CancellationToken::new(),
             output_format: None,
+            current_invocation: None,
             vfs_budget: None,
             watchdog: None,
             #[cfg(all(feature = "localfs", feature = "overlay"))]
@@ -372,6 +387,7 @@ impl ExecContext {
             dispatcher: None,
             cancel: CancellationToken::new(),
             output_format: None,
+            current_invocation: None,
             vfs_budget: None,
             watchdog: None,
             #[cfg(all(feature = "localfs", feature = "overlay"))]
@@ -408,6 +424,7 @@ impl ExecContext {
             dispatcher: None,
             cancel: CancellationToken::new(),
             output_format: None,
+            current_invocation: None,
             vfs_budget: None,
             watchdog: None,
             #[cfg(all(feature = "localfs", feature = "overlay"))]
@@ -447,6 +464,7 @@ impl ExecContext {
             dispatcher: None,
             cancel: CancellationToken::new(),
             output_format: None,
+            current_invocation: None,
             vfs_budget: None,
             watchdog: None,
             #[cfg(all(feature = "localfs", feature = "overlay"))]
@@ -483,6 +501,7 @@ impl ExecContext {
             dispatcher: None,
             cancel: CancellationToken::new(),
             output_format: None,
+            current_invocation: None,
             vfs_budget: None,
             watchdog: None,
             #[cfg(all(feature = "localfs", feature = "overlay"))]
@@ -681,6 +700,8 @@ impl ExecContext {
             cancel: self.cancel.clone(),
             // Output format is per-execution; child pipeline stages start fresh.
             output_format: None,
+            // Per-command; each pipeline stage stamps its own at the dispatch seam.
+            current_invocation: None,
             // Budget is shared: the child draws from the same pool as the parent.
             vfs_budget: self.vfs_budget.clone(),
             // Watchdog is shared: a patient hold in a pipeline stage or fork
@@ -737,15 +758,22 @@ impl ExecContext {
         let mut result = ExecResult::failure(2, format!(
             "{command}: confirmation required ({reason}){authorized}\nTo confirm, run: {hint}\nNonce expires in {ttl} seconds."
         ));
+        // Stamp the exact invocation captured at the dispatch seam so
+        // `Kernel::confirm` can replay it precisely. `None` (a direct
+        // `tool.execute` in a unit test, no seam) leaves tool/argv empty — such
+        // a latch is confirmable only via the `hint` string, not `confirm`.
+        let (tool, argv) = self.current_invocation.as_deref().cloned().unwrap_or_default();
         // The latch request rides its own typed control-plane field, distinct
         // from the data-plane `.data`. `ExecResult::latch_request` reads it back.
-        result.latch = Some(crate::interpreter::LatchRequest {
+        result.latch = Some(Box::new(crate::interpreter::LatchRequest {
             nonce,
             command: command.to_string(),
             paths: paths.iter().map(|p| (*p).to_string()).collect(),
             hint,
+            tool,
+            argv,
             ttl,
-        });
+        }));
         result
     }
 

--- a/crates/kaish-kernel/tests/latch_trash_tests.rs
+++ b/crates/kaish-kernel/tests/latch_trash_tests.rs
@@ -49,7 +49,7 @@ async fn run(kernel: &Kernel, script: &str) -> ExecResult {
     kernel.execute(script).await.expect("kernel execute")
 }
 
-/// Pull a string field out of a latch result's structured `.data`.
+/// Pull a string field out of a latch result's typed `.latch` request.
 fn latch_data_str(result: &ExecResult, key: &str) -> String {
     let req = result
         .latch_request()

--- a/crates/kaish-kernel/tests/latch_trash_tests.rs
+++ b/crates/kaish-kernel/tests/latch_trash_tests.rs
@@ -265,6 +265,33 @@ async fn confirm_replays_a_gate_overwrite() {
 }
 
 #[tokio::test]
+async fn confirm_replays_a_subcommand_gate() {
+    // `kaish-trash empty` gates *unconditionally* (inherently destructive — no
+    // `set -o latch` needed), and its dispatch name ("kaish-trash") differs from
+    // its display command ("kaish-trash empty"). Two things to prove: the seam
+    // captures the argv even with latch off (so `confirm` has tool/argv), and
+    // replaying `execute_argv("kaish-trash", ["--confirm=N", "--", "empty"])`
+    // recomputes the same command scope the nonce was issued under, so it
+    // validates.
+    let dir = tempdir();
+    let mock = Arc::new(MockTrash::default());
+    let kernel = kernel_with_trash(dir.path(), &mock);
+
+    let gated = run(&kernel, "kaish-trash empty").await;
+    assert_eq!(gated.code, 2, "empty gates unconditionally: {}", gated.err);
+    let req = gated.latch_request().expect("a latch request");
+    assert_eq!(req.tool, "kaish-trash", "dispatch name for replay");
+    assert!(
+        req.argv.iter().any(|a| a == "empty"),
+        "the subcommand token must be captured in argv: {:?}",
+        req.argv
+    );
+
+    let done = kernel.confirm(&req).await.expect("confirm executes");
+    assert_eq!(done.code, 0, "confirm should empty the trash: {}", done.err);
+}
+
+#[tokio::test]
 async fn confirm_without_captured_invocation_errors() {
     // A latch with no captured argv (produced outside a dispatch seam) can't be
     // replayed — `confirm` fails loud (exit 2) rather than silently no-op.

--- a/crates/kaish-kernel/tests/latch_trash_tests.rs
+++ b/crates/kaish-kernel/tests/latch_trash_tests.rs
@@ -171,6 +171,120 @@ async fn latch_survives_stdout_redirect() {
 }
 
 #[tokio::test]
+async fn latch_captures_the_exact_invocation() {
+    // The latch stamps the dispatch name + exact argv captured at the seam, so
+    // an embedder can inspect precisely what `confirm` will replay.
+    let dir = tempdir();
+    std::fs::write(dir.path().join("precious.txt"), "data").expect("write");
+    let kernel = kernel_at(dir.path());
+
+    run(&kernel, "set -o latch").await;
+    let gated = run(&kernel, "rm precious.txt").await;
+    let req = gated.latch_request().expect("a latch request");
+
+    assert_eq!(req.tool, "rm", "dispatch name should be the argv0 for replay");
+    assert!(
+        req.argv.iter().any(|a| a == "precious.txt"),
+        "captured argv must contain the operand: {:?}",
+        req.argv
+    );
+}
+
+#[tokio::test]
+async fn confirm_replays_rm_and_deletes() {
+    // The whole point: inspect the latch, then fulfill it by replaying the exact
+    // captured invocation — no hint string, no manual argv reconstruction.
+    let dir = tempdir();
+    std::fs::write(dir.path().join("precious.txt"), "data").expect("write");
+    let kernel = kernel_at(dir.path());
+
+    run(&kernel, "set -o latch").await;
+    let gated = run(&kernel, "rm precious.txt").await;
+    assert_eq!(gated.code, 2, "err: {}", gated.err);
+    let req = gated.latch_request().expect("a latch request");
+
+    let done = kernel.confirm(&req).await.expect("confirm executes");
+    assert_eq!(done.code, 0, "confirm should succeed: {}", done.err);
+    assert!(
+        !dir.path().join("precious.txt").exists(),
+        "confirm should have deleted the file"
+    );
+}
+
+#[tokio::test]
+async fn confirm_replays_a_path_with_spaces_the_hint_cannot() {
+    // The payoff of capturing argv over the hint string: a path with a space
+    // round-trips exactly through `confirm` (execute_argv, no re-parse), whereas
+    // the hint (`rm --confirm="N" a b.txt`, unquoted) would re-parse as two
+    // paths. This is why argv capture matters.
+    let dir = tempdir();
+    std::fs::write(dir.path().join("a b.txt"), "data").expect("write");
+    let kernel = kernel_at(dir.path());
+
+    run(&kernel, "set -o latch").await;
+    let gated = run(&kernel, r#"rm "a b.txt""#).await;
+    assert_eq!(gated.code, 2, "err: {}", gated.err);
+    let req = gated.latch_request().expect("a latch request");
+    assert!(
+        req.argv.iter().any(|a| a == "a b.txt"),
+        "the space-bearing path must survive as one argv token: {:?}",
+        req.argv
+    );
+
+    let done = kernel.confirm(&req).await.expect("confirm executes");
+    assert_eq!(done.code, 0, "confirm should succeed: {}", done.err);
+    assert!(
+        !dir.path().join("a b.txt").exists(),
+        "confirm should have deleted the space-named file"
+    );
+}
+
+#[tokio::test]
+async fn confirm_replays_a_gate_overwrite() {
+    // The overwrite gate (`cp`/`mv`/`tee`/…) goes through `gate_overwrites`, a
+    // different producer than `rm` — the dispatch-seam capture covers it too.
+    let dir = tempdir();
+    std::fs::write(dir.path().join("src.txt"), "fresh").expect("write");
+    std::fs::write(dir.path().join("dst.txt"), "old").expect("write");
+    let mock = Arc::new(MockTrash::default());
+    let kernel = kernel_with_trash(dir.path(), &mock);
+
+    run(&kernel, "set -o latch").await;
+    let gated = run(&kernel, "cp src.txt dst.txt").await;
+    assert_eq!(gated.code, 2, "err: {}", gated.err);
+    let req = gated.latch_request().expect("a latch request");
+    assert_eq!(req.tool, "cp");
+
+    let done = kernel.confirm(&req).await.expect("confirm executes");
+    assert_eq!(done.code, 0, "confirm should succeed: {}", done.err);
+    assert_eq!(
+        std::fs::read_to_string(dir.path().join("dst.txt")).unwrap(),
+        "fresh",
+        "confirm should have completed the overwrite"
+    );
+}
+
+#[tokio::test]
+async fn confirm_without_captured_invocation_errors() {
+    // A latch with no captured argv (produced outside a dispatch seam) can't be
+    // replayed — `confirm` fails loud (exit 2) rather than silently no-op.
+    let dir = tempdir();
+    let kernel = kernel_at(dir.path());
+    let bare = kaish_kernel::interpreter::LatchRequest {
+        nonce: "deadbeef".to_string(),
+        command: "rm".to_string(),
+        paths: vec!["x".to_string()],
+        hint: "rm --confirm=deadbeef x".to_string(),
+        tool: String::new(),
+        argv: vec![],
+        ttl: 60,
+    };
+    let r = kernel.confirm(&bare).await.expect("confirm returns");
+    assert_eq!(r.code, 2, "must not silently succeed: {r:?}");
+    assert!(r.err.contains("no captured invocation"), "err: {}", r.err);
+}
+
+#[tokio::test]
 async fn latch_bogus_nonce_fails_and_file_survives() {
     let dir = tempdir();
     std::fs::write(dir.path().join("precious.txt"), "data").expect("write");

--- a/crates/kaish-kernel/tests/latch_trash_tests.rs
+++ b/crates/kaish-kernel/tests/latch_trash_tests.rs
@@ -22,7 +22,6 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
-use kaish_kernel::ast::Value;
 use kaish_kernel::interpreter::ExecResult;
 use kaish_kernel::trash::{TrashBackend, TrashEntry, TrashError};
 use kaish_kernel::{Kernel, KernelConfig};
@@ -52,16 +51,14 @@ async fn run(kernel: &Kernel, script: &str) -> ExecResult {
 
 /// Pull a string field out of a latch result's structured `.data`.
 fn latch_data_str(result: &ExecResult, key: &str) -> String {
-    let data = result
-        .data
-        .as_ref()
-        .expect("latch exit-2 result carries structured data");
-    match data {
-        Value::Json(json) => json[key]
-            .as_str()
-            .unwrap_or_else(|| panic!("latch data {key:?} should be a string: {json}"))
-            .to_string(),
-        other => panic!("expected Value::Json latch data, got {other:?}"),
+    let req = result
+        .latch_request()
+        .expect("latch exit-2 result carries a typed LatchRequest");
+    match key {
+        "hint" => req.hint,
+        "nonce" => req.nonce,
+        "command" => req.command,
+        other => panic!("latch field {other:?} is not a string field"),
     }
 }
 
@@ -104,6 +101,39 @@ async fn latch_gates_rm_then_confirm_hint_deletes() {
     assert!(
         !dir.path().join("precious.txt").exists(),
         "file should be deleted after confirmation"
+    );
+}
+
+#[tokio::test]
+async fn latch_json_surfaces_nonce_under_latch_key() {
+    // `--json` on a gated op surfaces the confirmation request under a dedicated
+    // `latch` key in the error envelope — control-plane, never folded into
+    // `data`. And `.latch` survives formatting, so latch_request() still works
+    // on the --json'd result.
+    let dir = tempdir();
+    std::fs::write(dir.path().join("precious.txt"), "data").expect("write");
+    let kernel = kernel_at(dir.path());
+
+    run(&kernel, "set -o latch").await;
+    let gated = run(&kernel, "rm precious.txt --json").await;
+    assert_eq!(gated.code, 2, "err: {}", gated.err);
+
+    let envelope: serde_json::Value =
+        serde_json::from_str(gated.text_out().trim()).expect("a JSON error envelope");
+    assert_eq!(envelope["code"], 2, "envelope: {envelope}");
+    assert!(envelope["error"].is_string(), "envelope: {envelope}");
+    assert!(
+        envelope["latch"]["nonce"].is_string(),
+        "nonce must be under the `latch` key: {envelope}"
+    );
+    assert_eq!(envelope["latch"]["command"], "rm", "envelope: {envelope}");
+    assert!(
+        envelope.get("data").is_none(),
+        "the latch must not be folded under `data`: {envelope}"
+    );
+    assert!(
+        gated.latch_request().is_some(),
+        "the typed latch must survive --json formatting"
     );
 }
 

--- a/crates/kaish-types/src/backend.rs
+++ b/crates/kaish-types/src/backend.rs
@@ -10,7 +10,7 @@ use serde_json::Value as JsonValue;
 use thiserror::Error;
 
 use crate::output::OutputData;
-use crate::result::{json_to_value_no_envelope, value_to_json, ExecResult};
+use crate::result::{json_to_value_no_envelope, value_to_json, ExecResult, LatchRequest};
 use crate::tool::ToolSchema;
 
 /// Result type for backend operations.
@@ -246,6 +246,10 @@ pub struct ToolResult {
     pub content_type: Option<String>,
     /// Opaque key-value context (propagated from ExecResult).
     pub baggage: BTreeMap<String, String>,
+    /// A pending confirmation-latch request (propagated from ExecResult), so a
+    /// backend-tool latch survives the ExecResult↔ToolResult roundtrip. Its own
+    /// typed field — never folded into `data`.
+    pub latch: Option<LatchRequest>,
 }
 
 impl ToolResult {
@@ -259,6 +263,7 @@ impl ToolResult {
             output: None,
             content_type: None,
             baggage: BTreeMap::new(),
+            latch: None,
         }
     }
 
@@ -272,6 +277,7 @@ impl ToolResult {
             output: None,
             content_type: None,
             baggage: BTreeMap::new(),
+            latch: None,
         }
     }
 
@@ -285,6 +291,7 @@ impl ToolResult {
             output: None,
             content_type: None,
             baggage: BTreeMap::new(),
+            latch: None,
         }
     }
 
@@ -326,6 +333,7 @@ impl From<ExecResult> for ToolResult {
             output,
             content_type: exec.content_type,
             baggage: exec.baggage,
+            latch: exec.latch,
         }
     }
 }
@@ -348,6 +356,7 @@ impl From<ToolResult> for ExecResult {
         exec.data = result.data.map(json_to_value_no_envelope);
         exec.content_type = result.content_type;
         exec.baggage = result.baggage;
+        exec.latch = result.latch;
         exec
     }
 }

--- a/crates/kaish-types/src/backend.rs
+++ b/crates/kaish-types/src/backend.rs
@@ -248,8 +248,9 @@ pub struct ToolResult {
     pub baggage: BTreeMap<String, String>,
     /// A pending confirmation-latch request (propagated from ExecResult), so a
     /// backend-tool latch survives the ExecResult↔ToolResult roundtrip. Its own
-    /// typed field — never folded into `data`.
-    pub latch: Option<LatchRequest>,
+    /// typed field — never folded into `data`. Boxed to match `ExecResult.latch`
+    /// (keeps the roundtrip a direct move; see that field for why).
+    pub latch: Option<Box<LatchRequest>>,
 }
 
 impl ToolResult {

--- a/crates/kaish-types/src/output.rs
+++ b/crates/kaish-types/src/output.rs
@@ -564,14 +564,21 @@ pub fn apply_output_format(mut result: ExecResult, format: OutputFormat) -> Exec
                         "error": result.err,
                         "code": result.code,
                     });
-                    // A tool that attached structured data to an error result —
-                    // notably the latch nonce payload {nonce, command, paths,
-                    // hint, ttl} from `ToolCtx::latch_result` — must keep it
-                    // reachable under --json. Nest it under `data` so the error
-                    // envelope holds the diagnostic *and* the structured truth
-                    // instead of clobbering one with the other.
+                    // A tool that attached structured data to an error result
+                    // must keep it reachable under --json — nest it under `data`
+                    // so the envelope holds the diagnostic *and* the structured
+                    // truth instead of clobbering one with the other.
                     if let Some(data) = &result.data {
                         obj["data"] = crate::result::value_to_json(data);
+                    }
+                    // A confirmation-latch request is control-plane, not stdout
+                    // data — surface it under its own `latch` key (the nonce the
+                    // caller re-runs with `--confirm=<nonce>`), never folded into
+                    // `data`. Infallible: LatchRequest is String/Vec<String>/u64.
+                    if let Some(latch) = &result.latch {
+                        if let Ok(v) = serde_json::to_value(latch) {
+                            obj["latch"] = v;
+                        }
                     }
                     let out =
                         serde_json::to_string(&obj).unwrap_or_else(|_| "null".to_string());

--- a/crates/kaish-types/src/result.rs
+++ b/crates/kaish-types/src/result.rs
@@ -75,11 +75,27 @@ pub struct LatchRequest {
     /// Confirmation nonce — pass back as `--confirm=<nonce>` on the same command.
     pub nonce: String,
     /// The canonical command being gated (e.g. `"rm"`, `"kaish-trash empty"`).
+    /// A human/display label — for a precise machine replay use `tool` + `argv`.
     pub command: String,
     /// The resolved paths the operation would touch. Empty for command-only ops.
     pub paths: Vec<String>,
-    /// A ready-to-run confirmation command string (informational).
+    /// A ready-to-run confirmation command string (informational, for humans).
+    /// Machine fulfillment should prefer `Kernel::confirm` (which replays the
+    /// captured `tool`/`argv`); the hint is a display string and does not
+    /// robustly quote paths with spaces or glob characters.
     pub hint: String,
+    /// The dispatch name of the gated tool (e.g. `"rm"`, `"kaish-trash"`), as
+    /// resolved at the dispatch seam — the argv0 for a replay via
+    /// `Kernel::execute_argv`. Empty only when the latch was produced outside a
+    /// dispatch (a direct `tool.execute` in a unit test).
+    #[serde(default)]
+    pub tool: String,
+    /// The exact captured argv (`ToolArgs::to_argv`) of the gated invocation,
+    /// minus the tool name and the `--confirm` nonce. `Kernel::confirm` prepends
+    /// `--confirm=<nonce>` and replays `execute_argv(tool, argv)` — the
+    /// highest-fidelity fulfillment, with no re-parsing of the `hint`.
+    #[serde(default)]
+    pub argv: Vec<String>,
     /// Seconds until the nonce expires.
     pub ttl: u64,
 }
@@ -156,8 +172,14 @@ pub struct ExecResult {
     /// from the data-plane `.data`: a stdout redirect clears `.data` but never
     /// this. Read it via [`Self::latch_request`]; set it via
     /// `ToolCtx::latch_result`.
+    ///
+    /// Boxed: `ExecResult` is returned up every level of deep `$()`/pipeline
+    /// recursion, and `LatchRequest` is ~150 bytes — inline it would fatten
+    /// every stack frame and cost interpreter stack headroom (GH #46/#47). The
+    /// box is allocated only when a latch actually fires. Serializes identically
+    /// to an unboxed `Option` (Box is transparent to serde).
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub latch: Option<LatchRequest>,
+    pub latch: Option<Box<LatchRequest>>,
 }
 
 impl ExecResult {
@@ -497,7 +519,7 @@ impl ExecResult {
     /// latch) returns `None`. Unlike the data-plane `.data`, `.latch` survives
     /// `--json` formatting, so this is safe to call before or after it.
     pub fn latch_request(&self) -> Option<LatchRequest> {
-        self.latch.clone()
+        self.latch.as_deref().cloned()
     }
 
     /// Set content type hint, returning self for chaining.
@@ -886,6 +908,8 @@ mod tests {
             command: "rm".to_string(),
             paths: paths.iter().map(|p| (*p).to_string()).collect(),
             hint: "rm --confirm=\"a3f7b2c1\" important.dat".to_string(),
+            tool: "rm".to_string(),
+            argv: paths.iter().map(|p| (*p).to_string()).collect(),
             ttl: 60,
         }
     }
@@ -893,7 +917,7 @@ mod tests {
     #[test]
     fn latch_request_reads_the_latch_field() {
         let mut result = ExecResult::failure(2, "rm: confirmation required (latch enabled)");
-        result.latch = Some(latch_req(&["important.dat"]));
+        result.latch = Some(Box::new(latch_req(&["important.dat"])));
 
         let req = result.latch_request().expect("a latch request");
         assert_eq!(req.nonce, "a3f7b2c1");
@@ -906,13 +930,15 @@ mod tests {
     #[test]
     fn latch_request_handles_command_only_empty_paths() {
         let mut result = ExecResult::failure(2, "kaish-trash empty: confirmation required");
-        result.latch = Some(LatchRequest {
+        result.latch = Some(Box::new(LatchRequest {
             nonce: "deadbeef".to_string(),
             command: "kaish-trash empty".to_string(),
             paths: vec![],
             hint: "kaish-trash empty --confirm=deadbeef".to_string(),
+            tool: "kaish-trash".to_string(),
+            argv: vec!["--".to_string(), "empty".to_string()],
             ttl: 60,
-        });
+        }));
 
         let req = result.latch_request().expect("a latch request");
         assert_eq!(req.command, "kaish-trash empty");
@@ -943,7 +969,7 @@ mod tests {
         // control-plane latch on its own field survives (rm precious > log still
         // gates). Guards the plane split at the type level.
         let mut result = ExecResult::success_data(Value::Json(serde_json::json!([1, 2, 3])));
-        result.latch = Some(latch_req(&["precious.txt"]));
+        result.latch = Some(Box::new(latch_req(&["precious.txt"])));
         result.clear_stdout();
         assert!(result.data.is_none(), "data-plane .data must clear");
         assert!(

--- a/crates/kaish-types/src/result.rs
+++ b/crates/kaish-types/src/result.rs
@@ -58,11 +58,13 @@ impl<'de> serde::Deserialize<'de> for OutputPayload {
 /// A pending confirmation-latch request, decoded from a latched [`ExecResult`].
 ///
 /// When the confirmation latch (`set -o latch`) gates a destructive operation,
-/// the kernel returns exit code 2 and attaches this payload to
-/// [`ExecResult::data`] as JSON. Embedders recover it as a typed struct via
-/// [`ExecResult::latch_request`] instead of reaching into the JSON by key — the
-/// seam an embedder hooks to apply preapproval policy or a model review before
-/// approving the operation.
+/// the kernel returns exit code 2 with this typed payload on the dedicated
+/// [`ExecResult::latch`] field. Embedders read it via
+/// [`ExecResult::latch_request`] — the seam to apply preapproval policy or a
+/// model review before approving the operation. It is deliberately *not* the
+/// data-plane [`ExecResult::data`]: a stdout redirect clears `.data` but never
+/// this control-plane signal, and it survives `--json` formatting (surfaced
+/// under a `latch` key in the error envelope).
 ///
 /// To approve, re-run the *same argv* with `--confirm=<nonce>` (the `hint`
 /// shows the exact form). The nonce is command- and path-scoped, so it cannot
@@ -148,6 +150,14 @@ pub struct ExecResult {
     /// application-level hints, etc.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub baggage: BTreeMap<String, String>,
+    /// A pending confirmation-latch request — the *control-plane* signal a
+    /// gated destructive op (`rm`/`kaish-trash`/an overwrite under `set -o
+    /// latch`) raises alongside exit code 2. First-class and typed, distinct
+    /// from the data-plane `.data`: a stdout redirect clears `.data` but never
+    /// this. Read it via [`Self::latch_request`]; set it via
+    /// `ToolCtx::latch_result`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub latch: Option<LatchRequest>,
 }
 
 impl ExecResult {
@@ -163,6 +173,7 @@ impl ExecResult {
             original_code: None,
             content_type: None,
             baggage: BTreeMap::new(),
+            latch: None,
         }
     }
 
@@ -185,6 +196,7 @@ impl ExecResult {
                 original_code: None,
                 content_type: None,
                 baggage: BTreeMap::new(),
+                latch: None,
             },
         }
     }
@@ -221,6 +233,7 @@ impl ExecResult {
             original_code: None,
             content_type: None,
             baggage: BTreeMap::new(),
+            latch: None,
         }
     }
 
@@ -243,6 +256,7 @@ impl ExecResult {
             original_code: None,
             content_type: None,
             baggage: BTreeMap::new(),
+            latch: None,
         }
     }
 
@@ -258,6 +272,7 @@ impl ExecResult {
             original_code: None,
             content_type: None,
             baggage: BTreeMap::new(),
+            latch: None,
         }
     }
 
@@ -277,6 +292,7 @@ impl ExecResult {
             original_code: None,
             content_type: None,
             baggage: BTreeMap::new(),
+            latch: None,
         }
     }
 
@@ -295,6 +311,7 @@ impl ExecResult {
             original_code: None,
             content_type: None,
             baggage: BTreeMap::new(),
+            latch: None,
         }
     }
 
@@ -315,6 +332,7 @@ impl ExecResult {
             original_code: None,
             content_type: None,
             baggage: BTreeMap::new(),
+            latch: None,
         }
     }
 
@@ -415,30 +433,22 @@ impl ExecResult {
     }
 
     /// Drop every representation of stdout: the text `.out`, the structured
-    /// `.output`, and the *data-plane* `.data` sideband. Used when a stdout
-    /// redirect (`> file`, `>> file`, `&> file`) has consumed the command's
-    /// output — the bytes went to the file, so nothing flows onward to a pipe,
-    /// a `$(...)` capture, or the `.data` sideband. Clearing all three in one
-    /// place keeps them from drifting: a redirect that cleared `.out`/`.output`
-    /// but left `.data` would leak structured data past its own redirect
-    /// (`x=$(fromjson … > file)` capturing the value instead of `""`).
+    /// `.output`, and the data-plane `.data` sideband. Used when a stdout
+    /// redirect (`> file`, `>> file`, `&> file`, `1>&2`) has consumed the
+    /// command's output — the bytes went to the file (or stderr), so nothing
+    /// flows onward to a pipe, a `$(...)` capture, or the `.data` sideband.
+    /// Clearing all three together keeps them from drifting: a redirect that
+    /// cleared `.out`/`.output` but left `.data` would leak structured data past
+    /// its own redirect (`x=$(fromjson … > file)` capturing the value instead
+    /// of `""`).
     ///
-    /// A pending confirmation-latch request is the exception. `.data` is
-    /// overloaded: for `seq`/`jq`/`fromjson` it is the structured view of
-    /// stdout (clear it), but for a latched `rm` it is a *control-plane* signal
-    /// — the nonce the frontend needs to approve the operation. That is not
-    /// stdout and must survive the redirect, or `rm precious > log` becomes a
-    /// silent, unconfirmable delete-in-waiting. `latch_request()` matches only
-    /// the exact exit-2 + `LatchRequest` envelope, so ordinary structured data
-    /// is never mistaken for it. This discriminator is a bridge: once the latch
-    /// gets its own typed field (GH #92), `.data` is unambiguously data-plane
-    /// and this becomes an unconditional `self.data = None`.
+    /// The confirmation-latch request is untouched by design: it is a
+    /// *control-plane* signal on the dedicated `.latch` field, not stdout, so a
+    /// redirect can't drop it — `rm precious > log` still gates.
     pub fn clear_stdout(&mut self) {
         self.out = OutputPayload::Text(String::new());
         self.output = None;
-        if self.latch_request().is_none() {
-            self.data = None;
-        }
+        self.data = None;
     }
 
     /// Replace `.output`.
@@ -477,25 +487,17 @@ impl ExecResult {
         self.code == 0
     }
 
-    /// Decode a confirmation-latch request from this result, if it is one.
+    /// The pending confirmation-latch request, if this result is a latch gate.
     ///
-    /// Returns `Some` only when the result is a latch gate: exit code 2 carrying
-    /// the structured nonce payload the latch system attaches to `.data`. This
-    /// is the typed seam an embedder hooks to apply preapproval policy or a
-    /// model review before re-running the command with `--confirm=<nonce>` —
-    /// instead of string-matching the error or digging the JSON by key. A plain
-    /// usage error (also exit 2, but no nonce payload) returns `None`.
-    ///
-    /// Call this on the raw result from `execute()`, before any `--json` output
-    /// formatting (which re-nests `.data` under an error envelope).
+    /// A gated destructive op (`rm`/`kaish-trash`/an overwrite under `set -o
+    /// latch`) returns exit code 2 with the typed request on the `.latch` field.
+    /// This is the seam an embedder hooks to apply preapproval policy or a model
+    /// review before re-running the command with `--confirm=<nonce>`, instead of
+    /// string-matching the error. A plain usage error (also exit 2, but no
+    /// latch) returns `None`. Unlike the data-plane `.data`, `.latch` survives
+    /// `--json` formatting, so this is safe to call before or after it.
     pub fn latch_request(&self) -> Option<LatchRequest> {
-        if self.code != 2 {
-            return None;
-        }
-        match self.data.as_ref()? {
-            Value::Json(payload) => serde_json::from_value(payload.clone()).ok(),
-            _ => None,
-        }
+        self.latch.clone()
     }
 
     /// Set content type hint, returning self for chaining.
@@ -878,20 +880,20 @@ mod tests {
         assert!(json_result.data.is_none());
     }
 
-    fn latch_payload(paths: &[&str]) -> Value {
-        Value::Json(serde_json::json!({
-            "nonce": "a3f7b2c1",
-            "command": "rm",
-            "paths": paths,
-            "hint": "rm --confirm=\"a3f7b2c1\" important.dat",
-            "ttl": 60,
-        }))
+    fn latch_req(paths: &[&str]) -> LatchRequest {
+        LatchRequest {
+            nonce: "a3f7b2c1".to_string(),
+            command: "rm".to_string(),
+            paths: paths.iter().map(|p| (*p).to_string()).collect(),
+            hint: "rm --confirm=\"a3f7b2c1\" important.dat".to_string(),
+            ttl: 60,
+        }
     }
 
     #[test]
-    fn latch_request_decodes_latch_result() {
+    fn latch_request_reads_the_latch_field() {
         let mut result = ExecResult::failure(2, "rm: confirmation required (latch enabled)");
-        result.data = Some(latch_payload(&["important.dat"]));
+        result.latch = Some(latch_req(&["important.dat"]));
 
         let req = result.latch_request().expect("a latch request");
         assert_eq!(req.nonce, "a3f7b2c1");
@@ -904,13 +906,13 @@ mod tests {
     #[test]
     fn latch_request_handles_command_only_empty_paths() {
         let mut result = ExecResult::failure(2, "kaish-trash empty: confirmation required");
-        result.data = Some(Value::Json(serde_json::json!({
-            "nonce": "deadbeef",
-            "command": "kaish-trash empty",
-            "paths": [],
-            "hint": "kaish-trash empty --confirm=deadbeef",
-            "ttl": 60,
-        })));
+        result.latch = Some(LatchRequest {
+            nonce: "deadbeef".to_string(),
+            command: "kaish-trash empty".to_string(),
+            paths: vec![],
+            hint: "kaish-trash empty --confirm=deadbeef".to_string(),
+            ttl: 60,
+        });
 
         let req = result.latch_request().expect("a latch request");
         assert_eq!(req.command, "kaish-trash empty");
@@ -918,26 +920,36 @@ mod tests {
     }
 
     #[test]
-    fn latch_request_none_for_success() {
-        // Same payload shape, but exit 0 is not a latch gate.
-        let mut result = ExecResult::success("");
-        result.data = Some(latch_payload(&["important.dat"]));
-        assert!(result.latch_request().is_none());
+    fn latch_request_none_when_no_latch_set() {
+        // A success result and a plain exit-2 usage error both carry no latch.
+        assert!(ExecResult::success("").latch_request().is_none());
+        assert!(ExecResult::failure(2, "rm: unknown flag --bogus")
+            .latch_request()
+            .is_none());
     }
 
     #[test]
-    fn latch_request_none_for_usage_error() {
-        // A plain exit-2 usage error carries no nonce payload.
-        let result = ExecResult::failure(2, "rm: unknown flag --bogus");
-        assert!(result.latch_request().is_none());
-    }
-
-    #[test]
-    fn latch_request_none_for_unrelated_data() {
-        // Exit 2 with some other structured data is not a latch request.
+    fn latch_request_ignores_data_plane_data() {
+        // Data-plane `.data` (even on an exit-2 result) is never a latch — the
+        // latch lives on its own field. Structural guarantee, pinned.
         let mut result = ExecResult::failure(2, "boom");
         result.data = Some(Value::Json(serde_json::json!({"count": 3})));
         assert!(result.latch_request().is_none());
+    }
+
+    #[test]
+    fn clear_stdout_drops_data_but_never_the_latch() {
+        // A stdout redirect clears the data-plane .data unconditionally, but the
+        // control-plane latch on its own field survives (rm precious > log still
+        // gates). Guards the plane split at the type level.
+        let mut result = ExecResult::success_data(Value::Json(serde_json::json!([1, 2, 3])));
+        result.latch = Some(latch_req(&["precious.txt"]));
+        result.clear_stdout();
+        assert!(result.data.is_none(), "data-plane .data must clear");
+        assert!(
+            result.latch_request().is_some(),
+            "control-plane latch must survive a stdout redirect"
+        );
     }
 
     #[test]

--- a/docs/EMBEDDING.md
+++ b/docs/EMBEDDING.md
@@ -146,19 +146,14 @@ overwrites. The output contract:
 - **`ExecResult.err`** (which a frontend routes to stderr) carries the
   human-readable prompt;
 - **stdout** is empty (nothing happened, so there is no success output);
-- **`ExecResult.data`** carries the nonce as structured JSON — read it here
-  rather than parsing the `err` text:
-
-  ```json
-  { "nonce": "a3f7b2c1", "command": "rm",
-    "paths": ["important.dat"], "hint": "...", "ttl": 60 }
-  ```
-
-  From Rust, prefer the typed accessor over reaching into `.data` by key:
+- **`ExecResult.latch`** carries the request as a first-class typed field —
+  `Option<LatchRequest>`, control-plane and distinct from the data-plane
+  `.data`. Read it via the typed accessor:
 
   ```rust
-  // Returns Some(LatchRequest { nonce, command, paths, hint, ttl }) only for a
-  // latch gate (exit 2 + nonce payload); None for a plain usage error.
+  // Some(LatchRequest { nonce, command, paths, hint, ttl }) only for a latch
+  // gate (exit 2 + a request on .latch); None for a plain usage error. Safe to
+  // call before or after --json formatting — .latch survives it.
   if let Some(req) = result.latch_request() {
       // apply preapproval policy / model review over (req.command, req.paths) …
       // approve → re-run the same argv with `--confirm=<req.nonce>`.
@@ -168,14 +163,16 @@ overwrites. The output contract:
   This is the seam to hook embedder-side policy: check a preapproval allowlist or
   ask a model to review the resolved `(command, paths)` before re-running. The
   kernel owns the *mechanism* (issuing/validating the path- and command-scoped
-  nonce); the embedder owns the *judgment*. Call it on the raw result, before any
-  `--json` formatting.
+  nonce); the embedder owns the *judgment*. The latch is **never** folded into
+  `.data` — a stdout redirect (`rm big > log`) clears the data-plane `.data` but
+  can't touch the control-plane `.latch`, so the gate can't be silently bypassed.
 
   If you executed with `--json` (`OutputFormat::Json`), this is a non-zero exit
   with a diagnostic, so the result is wrapped in the standard JSON error envelope
-  and the nonce payload is nested one level down, under `data`:
-  `{ "error": "...", "code": 2, "data": { "nonce": ... } }`. Reading
-  `ExecResult.data` from the struct without `--json` gives you the bare payload.
+  and the request is surfaced under its own `latch` key:
+  `{ "error": "...", "code": 2, "latch": { "nonce": ..., "command": ..., "paths":
+  [...], "hint": ..., "ttl": 60 } }`. The typed `latch_request()` accessor works
+  the same either way, so it's the recommended path.
 
 Nonces are scoped to `(command, paths)`, expire after 60s, and are not consumed
 on use (idempotent retries). To confirm a nonce issued in one `execute()` call
@@ -363,8 +360,8 @@ Semantics:
   the string door at the shared dispatch chain.
 - **Same tail as the string door.** Command resolution (aliases, user tools,
   `.kai` scripts, externals, backend tools), `--json`, and the confirmation latch
-  all apply, so a latched `rm` still returns exit 2 with a nonce in
-  `ExecResult.data` (see [Destructive-op rails](#destructive-op-rails-reading-the-latch-nonce)).
+  all apply, so a latched `rm` still returns exit 2 with a request on
+  `ExecResult.latch` (see [Destructive-op rails](#destructive-op-rails-reading-the-latch-nonce)).
   The kernel's pre-execution *syntax* validator does not run — argv carries no
   shell syntax — but a tool's own `validate()`/clap parse still does.
 - **Typed-passthrough caveat.** Because builtins re-parse their own `to_argv()`

--- a/docs/EMBEDDING.md
+++ b/docs/EMBEDDING.md
@@ -133,46 +133,85 @@ rails — see below), `.with_vfs_budget(bytes)` / `.without_vfs_budget()` (cap
 in-memory VFS growth), `.with_skip_validation(bool)`, `.with_initial_vars(map)`
 (below).
 
-#### Destructive-op rails: reading the latch nonce
+#### Destructive-op rails: inspecting and fulfilling the latch
 
 With `.with_latch(true)`, a destructive op (`rm`'s delete, and the truncating
 overwrite behind `tee` / `patch` / `sed -i` / `write` / `cp` / `mv` / `dd of=`)
 does not run on first call — it returns an `ExecResult` with **exit code 2** and a
-confirmation nonce. The re-run is the same argv plus `--confirm=<nonce>` (`dd` uses
-its `confirm=<nonce>` key=value idiom). Copying or moving *into* a directory, and
-recursive `cp -r`/`mv` of a tree, gate only the named destination, not per-child
-overwrites. The output contract:
+confirmation request. Copying or moving *into* a directory, and recursive
+`cp -r`/`mv` of a tree, gate only the named destination, not per-child overwrites.
+The output contract:
 
 - **`ExecResult.err`** (which a frontend routes to stderr) carries the
   human-readable prompt;
 - **stdout** is empty (nothing happened, so there is no success output);
 - **`ExecResult.latch`** carries the request as a first-class typed field —
-  `Option<LatchRequest>`, control-plane and distinct from the data-plane
-  `.data`. Read it via the typed accessor:
+  `Option<Box<LatchRequest>>`, control-plane and distinct from the data-plane
+  `.data`.
 
-  ```rust
-  // Some(LatchRequest { nonce, command, paths, hint, ttl }) only for a latch
-  // gate (exit 2 + a request on .latch); None for a plain usage error. Safe to
-  // call before or after --json formatting — .latch survives it.
-  if let Some(req) = result.latch_request() {
-      // apply preapproval policy / model review over (req.command, req.paths) …
-      // approve → re-run the same argv with `--confirm=<req.nonce>`.
-  }
-  ```
+`LatchRequest` is the whole inspect+fulfill contract:
 
-  This is the seam to hook embedder-side policy: check a preapproval allowlist or
-  ask a model to review the resolved `(command, paths)` before re-running. The
-  kernel owns the *mechanism* (issuing/validating the path- and command-scoped
-  nonce); the embedder owns the *judgment*. The latch is **never** folded into
-  `.data` — a stdout redirect (`rm big > log`) clears the data-plane `.data` but
-  can't touch the control-plane `.latch`, so the gate can't be silently bypassed.
+```rust
+pub struct LatchRequest {
+    pub nonce: String,        // pass back as --confirm=<nonce>
+    pub command: String,      // display label, e.g. "rm", "kaish-trash empty"
+    pub paths: Vec<String>,   // resolved paths the op would touch (for policy)
+    pub hint: String,         // human re-run string (display only)
+    pub tool: String,         // dispatch name — argv0 for a precise replay
+    pub argv: Vec<String>,    // the EXACT captured argv (minus the nonce)
+    pub ttl: u64,             // seconds until the nonce expires
+}
+```
 
-  If you executed with `--json` (`OutputFormat::Json`), this is a non-zero exit
-  with a diagnostic, so the result is wrapped in the standard JSON error envelope
-  and the request is surfaced under its own `latch` key:
-  `{ "error": "...", "code": 2, "latch": { "nonce": ..., "command": ..., "paths":
-  [...], "hint": ..., "ttl": 60 } }`. The typed `latch_request()` accessor works
-  the same either way, so it's the recommended path.
+**Inspect** with the typed accessor (works before or after `--json` — `.latch`
+survives formatting):
+
+```rust
+if let Some(req) = result.latch_request() {
+    // apply preapproval policy / model review over (req.command, req.paths),
+    // or inspect the exact req.argv that a confirm will replay …
+}
+```
+
+**Fulfill** with `Kernel::confirm` — the highest-fidelity path. It replays the
+*exact captured argv* (`req.tool` + `req.argv`) with `--confirm=<nonce>`
+prepended, via the argv door — no re-parsing, so paths with spaces or glob
+characters round-trip precisely:
+
+```rust
+let gated = kernel.execute("rm 'my notes.txt'").await?;
+if let Some(req) = gated.latch_request() {
+    if approve(&req) {                       // your policy
+        let done = kernel.confirm(&req).await?;   // replays exactly, deletes
+    }
+}
+```
+
+Prefer `confirm` over hand-building the re-run. The `hint` field is a
+*human-display* string and does **not** robustly quote paths (`rm --confirm="N"
+my notes.txt` re-parses as two paths); `confirm` sidesteps that entirely. If you
+must build it yourself, use the argv door: `execute_argv(req.tool, [..req.argv,
+"--confirm=<nonce>"])`.
+
+The kernel owns the *mechanism* (issuing/validating the path- and command-scoped
+nonce, capturing the argv at the dispatch seam); the embedder owns the
+*judgment*. The latch is **never** folded into `.data` — a stdout redirect
+(`rm big > log`) clears the data-plane `.data` but can't touch the control-plane
+`.latch`, so the gate can't be silently bypassed.
+
+> **Note:** the argv is captured at the kernel's dispatch seam, so it's present
+> for every kaish builtin and any tool you register in the kernel's registry
+> (the `Kernel::with_backend` tools closure). A tool served *only* by a custom
+> `KernelBackend::call_tool` that raises its own latch leaves `tool`/`argv`
+> empty; `confirm` then fails loud (exit 2) — fulfill those via the `hint` or a
+> manually reconstructed argv.
+
+If you executed with `--json` (`OutputFormat::Json`), the gate is a non-zero exit
+with a diagnostic, so the result is wrapped in the standard JSON error envelope
+and the request is surfaced under its own `latch` key:
+`{ "error": "...", "code": 2, "latch": { "nonce": ..., "tool": ..., "argv":
+[...], "paths": [...], "hint": ..., "ttl": 60 } }`. The typed `latch_request()`
+accessor works the same either way, so it's the recommended path.
 
 Nonces are scoped to `(command, paths)`, expire after 60s, and are not consumed
 on use (idempotent retries). To confirm a nonce issued in one `execute()` call

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -745,30 +745,29 @@ Nonce expires in 60 seconds.
 
 **Latch output contract.** The prompt above is written to the result's **`err`
 channel** (what a frontend renders to stderr); **stdout is empty** — nothing was
-deleted, so there is no success output. The nonce is also attached as structured
-data, so a program driving the shell reads it from the result rather than scraping
-the stderr text. Where it lands depends on the output format:
+deleted, so there is no success output. The nonce is also attached as a
+first-class typed field, so a program driving the shell reads it from the result
+rather than scraping the stderr text. It is control-plane, distinct from the
+data-plane `.data`:
 
-- **No `--json`** — `ExecResult.data` is the bare nonce payload:
-
-  ```json
-  { "nonce": "a3f7b2c1", "command": "rm",
-    "paths": ["important.dat"], "hint": "...", "ttl": 60 }
-  ```
+- **No `--json`** — `ExecResult.latch` is the typed request
+  `Some(LatchRequest { nonce, command, paths, hint, ttl })` (embedders read it
+  via `latch_request()`).
 
 - **`--json`** — the result is a non-zero exit with a diagnostic, so it's wrapped
-  in the standard JSON error envelope; the nonce payload is nested under `data`:
+  in the standard JSON error envelope; the request is surfaced under its own
+  `latch` key (never folded into `data`):
 
   ```json
   { "error": "rm: confirmation required (latch enabled)…",
     "code": 2,
-    "data": { "nonce": "a3f7b2c1", "command": "rm", "paths": ["important.dat"],
-              "hint": "...", "ttl": 60 } }
+    "latch": { "nonce": "a3f7b2c1", "command": "rm", "paths": ["important.dat"],
+               "hint": "...", "ttl": 60 } }
   ```
 
 The same contract holds for the truncating-overwrite gate (`tee`, `patch`,
 `sed -i`, `write`, `cp`, `mv`, `dd of=`): exit 2, human prompt on the `err`
-channel, nonce on `.data` (nested under `--json`). `dd` confirms with its
+channel, request on `.latch` (under the `latch` key with `--json`). `dd` confirms with its
 `confirm=<nonce>` key=value idiom rather than `--confirm=`; copying or moving
 *into* a directory (and recursive `cp -r`/`mv` of a tree) gates the named
 destination, not each child file.

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -14,6 +14,47 @@ before it ships.
 
 ---
 
+## The confirmation latch becomes a first-class, fulfillable API (2026-07-04)
+
+Fell out of the redirect-in-`$()` work above. That change had to special-case
+`clear_stdout` so a stdout redirect wouldn't clear the `rm` latch nonce — because
+the nonce rode inside `ExecResult.data` as serialized JSON, overloading the
+data-plane `.data` (structured stdout) with a control-plane signal. Amy's call:
+don't slime the latch through another feature's field with a runtime shape-check
+— give it a first-class typed home.
+
+**The field.** `ExecResult.latch: Option<Box<LatchRequest>>`. `latch_result`
+sets it typed (no serialize round-trip); `latch_request()` reads it; `clear_stdout`
+drops the discriminator and clears `.data` unconditionally. Threaded through the
+`ExecResult`↔`ToolResult` backend roundtrip (which #94 had just converted to
+symmetric `From` impls, fixing the old #84 field-drop) and through
+`accumulate_result` — a single `rm x` statement flows through accumulation, so
+forgetting `.latch` there lost every gate (a test caught it). `--json` surfaces
+it under a dedicated `latch` key, never folded into `data`.
+
+**Then Amy pushed on fulfillment.** Inspection was first-class (`latch_request()`),
+but *fulfilling* a latch meant re-running with `--confirm=<nonce>` — via the
+`hint` string, which is `format!`-built and doesn't quote paths (a space breaks
+it), or by manually rebuilding argv. She wanted the latch to hold the exact state
+for a precise replay. So: capture the exact argv at the dispatch seam
+(`(dispatch_name, ToolArgs::to_argv())`) into `LatchRequest.tool`/`.argv`, and add
+`Kernel::confirm(&LatchRequest)` that replays `execute_argv(tool, argv)` with
+`--confirm` **prepended** (appending would let `to_argv`'s trailing `--`
+terminator swallow the flag). A path with a space now round-trips exactly where
+the hint can't — the payoff, pinned by a test. The seam capture is gated on
+`latch_enabled` so it's free when the latch is off.
+
+**Two stack-size lessons, the hard way.** `ExecContext` and `ExecResult` are both
+rebuilt/returned at every level of deep `$()` recursion. Adding an inline
+`(String, Vec<String>)` to `ExecContext`, and growing the inline `LatchRequest`
+inside `ExecResult` by two fields, fattened every frame enough to overflow the
+stack on `deeply_nested_command_substitution` — but only under `cargo test --all`
+(parallel binaries, tighter thread stacks; it passed in isolation). Boxing both
+(`Box<(String, Vec<String>)>`, `Option<Box<LatchRequest>>`) kept the hot structs
+lean and fixed it. Lesson: a ~150-byte field on a stack-hot, deeply-recursive
+struct wants a box (see GH #46/#47). Docs (EMBEDDING.md, LANGUAGE.md, README,
+the syntax fragment) reworked to teach the typed field + `confirm`.
+
 ## Redirects inside `$()`, and what that taught us about `.data` (2026-07-04)
 
 Started from a curiosity: a test comment said "kaish's grammar doesn't accept a


### PR DESCRIPTION
Closes #92.

The confirmation-latch nonce used to ride inside `ExecResult.data` as serialized JSON — overloading the data-plane `.data` (structured stdout) with a control-plane safety signal. PR #91 had to paper over that with a runtime shape-check in `clear_stdout` so a stdout redirect wouldn't clear the `rm` latch. This gives the latch a first-class typed home **and** makes it precisely fulfillable, which kaijutsu needs.

## Inspect: a typed field

- `ExecResult.latch: Option<Box<LatchRequest>>` — control-plane, distinct from data-plane `.data`. `latch_request()` reads it; `clear_stdout()` now clears `.data` unconditionally (the shape-check discriminator is gone).
- Threaded through the `ExecResult`↔`ToolResult` backend roundtrip (both `From` impls — #94 had just made these symmetric, fixing #84) and `accumulate_result`. A single `rm x` flows through accumulation, so dropping `.latch` there lost every gate — a test guards it.
- `--json` surfaces the request under a dedicated `latch` key in the error envelope, never folded into `data`.

## Fulfill: exact-argv capture + `Kernel::confirm`

Inspection was first-class; fulfillment meant re-running with `--confirm` via the `hint` string (a `format!`-built display string that can't quote paths — a space breaks it). So the latch now **holds the exact invocation**:

- `LatchRequest` gains `tool` (dispatch name) + `argv` (exact `ToolArgs::to_argv()`), captured at the dispatch seam and stamped in by `latch_result`. Under `--json` these ride the `latch` key too, so an embedder sees precisely what a confirm will replay.
- `Kernel::confirm(&LatchRequest)` replays `execute_argv(tool, argv)` with `--confirm=<nonce>` **prepended** (`to_argv` trails a `--` terminator that would swallow an appended flag). A path with spaces round-trips exactly where the hint can't — the payoff, pinned by a test alongside `rm` / `cp` (gate_overwrites) / `kaish-trash empty` (subcommand) / a no-invocation loud-fail case.

## Two bugs caught building it

- **Deep-`$()` stack overflow** (only under parallel `cargo test --all`): `ExecResult`/`ExecContext` are rebuilt at every recursion level; a ~150-byte inline `LatchRequest` (and an inline argv tuple) fattened every frame. Boxing both fixed it — the branch's `ExecResult` is now *smaller* than before this work (boxed 8-byte latch vs the old ~104-byte inline). See GH #46/#47 for the underlying fragility.
- **`confirm` broke on `kaish-trash empty`**: it gates *unconditionally* (independent of `set -o latch`), but the argv capture was gated on `latch_enabled` → empty `tool`/`argv`. Capture is now unconditional (the cost is marginal beside the per-command `ExecContext` snapshot; it does not reintroduce the overflow).

## **BREAKING** (embedders / `--json`)

A latched `--json` result now surfaces the nonce under a `latch` key, not nested under `data`. Embedders reading the nonce out of `.data` must switch to `latch_request()` (the sanctioned accessor, unchanged).

## Review

Cross-model review (DeepSeek via kaibo; Gemini 503'd on provider overload, proceeded on DeepSeek per maintainer call). Clean — it verified `.latch` survives every propagation path (accumulate_result, all control-flow, both `From` conversions, `clear_stdout`, `--json`, `$()`, pipeline, scatter, timeout) and independently confirmed the confirm replay for cases beyond the tests (empty argv, `rm -r dir`). One structural gap surfaced and filed as **#96** (background jobs store `.latch` but no consumer surfaces it — out of scope, degrades safely). Docs (EMBEDDING/LANGUAGE/README/syntax fragment) reworked for inspect+fulfill.

## Validation

`cargo test --all`, `cargo clippy --all --all-targets` (0 warnings), `cargo check -p kaish-kernel --no-default-features` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)