### PR TITLE
deps: migrate chumsky off the dead-ended 1.0.0-alpha line (alpha.8 → 0.13)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,11 @@ breaking entries are marked **BREAKING**.
   | jq …`).
 
 ### Changed
+- **Parser dependency migrated off a dead-ended prerelease**: chumsky
+  `1.0.0-alpha.8` → `0.13` (GH #98). Zero code changes — kaish's combinator
+  surface survived the upstream stabilization intact (verified by the full
+  gate suite passing unchanged, snapshots included). Embedders see a smaller
+  dependency tree (two stale transitive regex crates drop out).
 - **`jq -s`/`--slurp` is now real jq slurp semantics**, not a no-op (GH #80).
   On the text path it parses the whole whitespace-separated document stream
   and always wraps the result in an array — even a single document

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -188,7 +188,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
 dependencies = [
  "memchr",
- "regex-automata 0.4.13",
+ "regex-automata",
  "serde",
 ]
 
@@ -251,12 +251,12 @@ dependencies = [
 
 [[package]]
 name = "chumsky"
-version = "1.0.0-alpha.8"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e82d74e6c83060ec269fe9e0d408d6de4a1645d525f9a0bbbb841ba4efd91ac"
+checksum = "e0d2bfadce76f963d776feff99db6dc33783829539258314776383b33e2a00f8"
 dependencies = [
  "hashbrown 0.15.5",
- "regex-automata 0.3.9",
+ "regex-automata",
  "serde",
  "stacker",
  "unicode-ident",
@@ -526,8 +526,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "531e46835a22af56d1e3b66f04844bed63158bc094a628bec1d321d9b4c44bf2"
 dependencies = [
  "bit-set 0.5.3",
- "regex-automata 0.4.13",
- "regex-syntax 0.8.8",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -699,8 +699,8 @@ dependencies = [
  "aho-corasick",
  "bstr",
  "log",
- "regex-automata 0.4.13",
- "regex-syntax 0.8.8",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -721,8 +721,8 @@ dependencies = [
  "bstr",
  "grep-matcher",
  "log",
- "regex-automata 0.4.13",
- "regex-syntax 0.8.8",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -818,7 +818,7 @@ dependencies = [
  "globset",
  "log",
  "memchr",
- "regex-automata 0.4.13",
+ "regex-automata",
  "same-file",
  "walkdir",
  "winapi-util",
@@ -1193,8 +1193,8 @@ dependencies = [
  "fnv",
  "proc-macro2",
  "quote",
- "regex-automata 0.4.13",
- "regex-syntax 0.8.8",
+ "regex-automata",
+ "regex-syntax",
  "syn",
 ]
 
@@ -1213,7 +1213,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
- "regex-automata 0.4.13",
+ "regex-automata",
 ]
 
 [[package]]
@@ -1581,7 +1581,7 @@ dependencies = [
  "rand",
  "rand_chacha",
  "rand_xorshift",
- "regex-syntax 0.8.8",
+ "regex-syntax",
  "rusty-fork",
  "tempfile",
  "unarray",
@@ -1714,19 +1714,8 @@ checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.13",
- "regex-syntax 0.8.8",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59b23e92ee4318893fa3fe3e6fb365258efbfe6ac6ab30f090cdcbb7aa37efa9"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax 0.7.5",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -1737,7 +1726,7 @@ checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.8",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -1745,12 +1734,6 @@ name = "regex-bites"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6a15a2fa0bfda9361941c45550896ae87b15cc6c8c939ea350079670332e211"
-
-[[package]]
-name = "regex-syntax"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
 name = "regex-syntax"
@@ -2329,7 +2312,7 @@ dependencies = [
  "matchers",
  "nu-ansi-term",
  "once_cell",
- "regex-automata 0.4.13",
+ "regex-automata",
  "sharded-slab",
  "smallvec",
  "thread_local",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ tracing-opentelemetry = "0.32"
 
 # Lexer/Parser (L1-L2)
 logos = "0.16"
-chumsky = "1.0.0-alpha.8"
+chumsky = "0.13"
 ariadne = "0.6"
 
 # CLI arg parsing (used inside builtins via the clap-migration recipe)

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -1191,5 +1191,4 @@ These are documented limitations of the current implementation:
 
 ### Build/Development
 
-- **chumsky parser is pre-1.0** — The parser combinator library is the crates.io `1.0.0-alpha` series; kaish will move to stable chumsky 1.0 before its own 1.0.
 - **Fuzz tests require nightly** — The fuzz testing infrastructure requires Rust nightly compiler.

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -586,8 +586,6 @@ so they bite only once a builtin exposes a `-L`/`--follow` flag.
 - **Extract `skip_quoted_content()`** shared by `preprocess_arithmetic()` and
   `preprocess_heredocs()` (~150 lines each of duplicated quote/escape tracking).
 - **`parse_interpolated_string` is ~200 lines** — split into helpers.
-- **chumsky alpha → 1.0 before kaish 1.0**: on `1.0.0-alpha.8`; upgrade when stable
-  ships.
 
 ### REPL polish
 Syntax highlighting (chumsky already produces structured tokens), abbreviation


### PR DESCRIPTION
Closes #98.

## Problem

The dependency audit riding the #95 lexer-rewrite planning found the workspace's one true prerelease: **chumsky `1.0.0-alpha.8`** (Jan 2025) — the tip of a line upstream abandoned. The alpha API shipped as **stable 0.10 in March 2025** and stable development continued through **0.13.0 (May 2026)**. We were ~16 months behind on a branch that will never see another fix.

## Change

One line in the workspace `Cargo.toml` (`1.0.0-alpha.8` → `0.13`), the lockfile fallout, and a CHANGELOG bullet. **Zero code changes** — kaish's combinator surface (`ValueInput`, `extra::Err<Rich>`, `select!`, the nano_rust mapped-slice input, ~25 stock combinators, single `.parse()` entry point) survived the upstream stabilization untouched.

Bonus: two stale transitive deps only the alpha needed drop out (`regex-automata 0.3.9`, `regex-syntax 0.7.5`) — the tree gets *smaller*.

## Verification

Probed first in a throwaway worktree (results on #98), then re-run on this branch:

- `cargo test --all` — **4,337 passed / 0 failed** (includes every parse-error message test)
- `cargo clippy --all --all-targets` — **0 warnings**
- `cargo insta test --check` — snapshots byte-identical
- `cargo check -p kaish-kernel --no-default-features` — clean
- `cargo build -p kaish-wasi --target wasm32-wasip1` — clean

Residual risk is limited to `Rich` error-Display drift on messages no test pins; everything pinned passed unchanged.

## Decision

Amy's call: land this **before 0.11.0** (revising the earlier post-release sequencing) — the probe was green end-to-end, so 0.11.0 ships on a live upstream line instead of a dead branch. Independent of #94 and of the #95 lexer rewrite (the lexer↔parser seam is pure `Vec<Spanned<Token>>` data).

🤖 Generated with [Claude Code](https://claude.com/claude-code)