### PR TITLE
feat(test): the `test` builtin — VFS-aware `[[` semantics as a command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,20 @@ breaking entries are marked **BREAKING**.
 ## [Unreleased]
 
 ### Added
+- **`test` builtin** — POSIX condition evaluation as a command, following
+  kaish's `[[` semantics (exit `0` true / `1` false / `2` usage-or-type error).
+  File tests (`-e -f -d -r -w -x`) stat through the VFS, not the host FS; string
+  equality (`= == !=`) is literal; numeric (`-eq -ne -gt -lt -ge -le`) uses
+  kaish (JSON) number semantics, so floats compare (identical to `[[`) and a
+  non-numeric operand is loud. Negation is a single leading `!`. Deliberately
+  **no `-a`/`-o`/`( )`** (rejected loudly — chain with shell `&&`/`||` or use
+  `[[ ]]`) and **no arg-count magic** (an operator missing its operand is a loud
+  error, not a surprise-true). Replaces the previous shell-out to `/usr/bin/test`.
+  Membership/regex/shape-guards remain `[[ ]]`-only.
+- **`ToolSchema.raw_argv`** (embedder API) — a tool can opt into receiving its
+  argv in source order with `Value` types preserved (no flag/positional split),
+  for position-sensitive commands whose operands may look like flags (`test $x =
+  -n`, `test 0 -gt -5`). Used by the `test` builtin.
 - **The confirmation latch is now a first-class typed field with a
   fulfillment API** (GH #92). A gated destructive op returns exit 2 with the
   request on a dedicated `ExecResult.latch: Option<Box<LatchRequest>>`
@@ -37,6 +51,12 @@ breaking entries are marked **BREAKING**.
   | jq …`).
 
 ### Changed
+- **Comparison/negation operators reach commands as literal argv.** The command
+  grammar now accepts `=`, `==`, `!=`, and `!` as literal positional words, so
+  POSIX `test a = b` / `test ! -f x` reach the `test` command. As a side effect,
+  a *spaced* `cmd key = value` now parses as `cmd` with three arguments (like
+  bash) instead of a parse error; a *glued* `key=value` is still a shell
+  assignment. The angle brackets `< > <= >=` remain redirection (unchanged).
 - **Parser dependency migrated off a dead-ended prerelease**: chumsky
   `1.0.0-alpha.8` → `0.13` (GH #98). Zero code changes — kaish's combinator
   surface survived the upstream stabilization intact (verified by the full
@@ -238,6 +258,11 @@ breaking entries are marked **BREAKING**.
   `-F '\|'`, `FS="\\|"`, and `split(s, a, "\\|")` split on a literal pipe (the
   rewrite runs before the single-char-FS-is-literal rule, matching gawk's
   demotion of `\|` to plain `|`).
+
+### Removed
+- Validator advisory **W006** (`PosixTestCommand`, which steered `test`/`[`
+  toward `[[ ]]`) is retired — `test` is a first-class builtin now and validates
+  through the registry like any other command.
 
 ### Fixed
 - **Binary data at text sinks is loud, not a silent placeholder** — a

--- a/crates/kaish-help/content/en/limits.md
+++ b/crates/kaish-help/content/en/limits.md
@@ -9,19 +9,17 @@
 | Backticks `` `cmd` `` (lexer error, not silently tolerated) | `$(cmd)` |
 | `eval` | Write explicit code |
 | Implicit word splitting on whitespace | `split "$VAR"` (for-loop `$(cmd)` does split on newlines — see Bash vs kaish below) |
-| `test` / `[ … ]` conditional commands | `[[ … ]]` (the one supported test form) |
+| `[ … ]` single-bracket conditional | `test …` or `[[ … ]]` |
 
-There is no `test` builtin and no `[` command — conditionals go through `[[ … ]]`.
-This is deliberate: `[[ … ]]` is real syntax the parser understands, so kaish can
-**validate it before running** (catch a malformed test, an unknown operator, an
-unquoted expansion). `test`/`[` are ordinary commands whose operators are just
-string arguments, invisible to the validator until runtime — exactly the kind of
-late-failure footgun kaish avoids. Use `[[ -f x ]]`, `[[ $a = $b ]]`, `[[ -z $s ]]`.
-
-A `test` builtin might return someday if a compelling case appears. `[` will not:
-the bracket belongs to kaish — `[[ … ]]` and native list literals (`xs=[a b c]`,
-see `help syntax` → Collections) — and invoking an external `[` binary isn't
-supported either.
+`test` is a real builtin (VFS-aware, following `[[`'s semantics), so both
+`test -f x` and `[[ -f x ]]` work. There is no `[` command, though: the bracket
+belongs to kaish — `[[ … ]]` and native list literals (`xs=[a b c]`, see
+`help syntax` → Collections) — so `[ -f x ]` is a parse error. Prefer `[[ … ]]`:
+it is real syntax the parser understands, so kaish can **validate it before
+running** (catch a malformed test, an unknown operator, an unquoted expansion),
+and it carries the richer tests (membership, regex, shape guards) plus compound
+`&&`/`||`/`!` in one construct. Reach for `test` for muscle memory or where a
+plain command is wanted — `test -f x && echo yes`, `if test "$a" = "$b"; then`.
 
 ## Lexer/Parser Limitations
 

--- a/crates/kaish-kernel/src/interpreter.rs
+++ b/crates/kaish-kernel/src/interpreter.rs
@@ -39,7 +39,7 @@ mod result;
 mod scope;
 
 pub use control_flow::ControlFlow;
-pub use eval::{eval_expr, expand_tilde, is_collection, resolve_default, resolve_length, scalar_test_operand_error, strip_leading_tabs, structured_boundary_error, structured_export_error, value_defaults_on_emptiness, value_to_bool, value_to_exit_code, value_length, value_to_string, value_to_string_with_tilde, value_to_text_sink, EvalError, EvalResult, Evaluator, HeredocAssembler};
+pub use eval::{eval_expr, expand_tilde, is_collection, numeric_compare, resolve_default, resolve_length, scalar_test_operand_error, strip_leading_tabs, structured_boundary_error, structured_export_error, value_defaults_on_emptiness, values_equal, value_to_bool, value_to_exit_code, value_length, value_to_string, value_to_string_with_tilde, value_to_text_sink, EvalError, EvalResult, Evaluator, HeredocAssembler};
 pub use result::{apply_output_format, hex_dump, json_to_value, json_to_value_no_envelope, value_to_json, EntryType, ExecResult, LatchRequest, OutputData, OutputFormat, OutputNode, OutputPayload};
 pub use scope::{PathError, Scope};
 // Crate-internal: the reduced sync evaluator (scheduler/pipeline.rs) reuses the

--- a/crates/kaish-kernel/src/interpreter/eval.rs
+++ b/crates/kaish-kernel/src/interpreter/eval.rs
@@ -968,7 +968,7 @@ fn is_truthy(value: &Value) -> bool {
 /// `[[ "01" == 1 ]]` returned true via parse-as-int while `[[ "01" == "1" ]]`
 /// returned false. Users wanting numeric equality across stringified
 /// numbers should use `-eq`, which coerces via `numeric_compare`.
-fn values_equal(left: &Value, right: &Value) -> EvalResult<bool> {
+pub fn values_equal(left: &Value, right: &Value) -> EvalResult<bool> {
     match (left, right) {
         (Value::Null, Value::Null) => Ok(true),
         (Value::Bool(a), Value::Bool(b)) => Ok(a == b),
@@ -1138,8 +1138,10 @@ fn value_to_num(value: &Value) -> EvalResult<Num> {
 }
 
 /// Numeric ordering for `[[ -eq ]]`/`-gt`/`-lt`/`-ge`/`-le`/`-ne`.
-/// Coerces string operands via `value_to_num`.
-fn numeric_compare(left: &Value, right: &Value) -> EvalResult<std::cmp::Ordering> {
+/// Coerces string operands via `value_to_num`. Shared verbatim with the `test`
+/// builtin so `test`'s numeric ops match `[[` exactly (JSON-number semantics,
+/// floats included — not POSIX integer-only).
+pub fn numeric_compare(left: &Value, right: &Value) -> EvalResult<std::cmp::Ordering> {
     let l = value_to_num(left)?;
     let r = value_to_num(right)?;
     match (l, r) {

--- a/crates/kaish-kernel/src/kernel.rs
+++ b/crates/kaish-kernel/src/kernel.rs
@@ -3331,6 +3331,85 @@ impl Kernel {
     async fn build_args_async(&self, args: &[Arg], schema: Option<&crate::tools::ToolSchema>) -> Result<ToolArgs> {
         let mut tool_args = ToolArgs::new();
         let home = self.scope_home().await;
+
+        // Raw-argv fast path (POSIX `test`): bind every argument to `positional`
+        // in source order with types preserved — operators (`-f`, `=`, `!`) as
+        // strings, operands keeping their `Value` — leaving `flags`/`named`
+        // empty. A position-sensitive command needs the *true* argv: an operand
+        // that looks like a flag (`test $x = -n`, `test 0 -gt -5`) must not be
+        // hoisted into the unordered flag set the normal binder splits into.
+        // Globs still expand and `~` still resolves, matching normal positional
+        // binding — so `test -f *.rs` errors on too many args, not a literal
+        // pattern stat.
+        if schema.is_some_and(|s| s.raw_argv) {
+            for arg in args {
+                match arg {
+                    Arg::Positional(expr) => {
+                        let glob = if let Expr::GlobPattern(p) = expr {
+                            self.scope.read().await.glob_enabled().then(|| p.clone())
+                        } else {
+                            None
+                        };
+                        if let Some(pattern) = glob {
+                            let (paths, cwd) = {
+                                let ctx = self.exec_ctx.read().await;
+                                let paths = ctx
+                                    .expand_glob(&pattern)
+                                    .await
+                                    .map_err(|e| anyhow::anyhow!("glob: {}", e))?;
+                                let cwd = ctx.resolve_path(".");
+                                (paths, cwd)
+                            };
+                            if paths.is_empty() {
+                                return Err(anyhow::anyhow!("no matches: {}", pattern));
+                            }
+                            for path in paths {
+                                let display = if !pattern.starts_with('/') {
+                                    path.strip_prefix(&cwd)
+                                        .unwrap_or(&path)
+                                        .to_string_lossy()
+                                        .into_owned()
+                                } else {
+                                    path.to_string_lossy().into_owned()
+                                };
+                                tool_args.positional.push(Value::String(display));
+                            }
+                        } else {
+                            let value = self.eval_expr_async(expr).await?;
+                            let value = apply_tilde_expansion(value, home.as_deref());
+                            tool_args.positional.push(value);
+                        }
+                    }
+                    Arg::ShortFlag(name) => {
+                        tool_args.positional.push(Value::String(format!("-{name}")));
+                    }
+                    Arg::LongFlag(name) => {
+                        tool_args.positional.push(Value::String(format!("--{name}")));
+                    }
+                    Arg::Named { key, value } => {
+                        let val = self.eval_expr_async(value).await?;
+                        let val = apply_tilde_expansion(val, home.as_deref());
+                        tool_args.positional.push(Value::String(format!(
+                            "--{key}={}",
+                            crate::interpreter::value_to_string(&val)
+                        )));
+                    }
+                    Arg::WordAssign { key, value } => {
+                        let val = self.eval_expr_async(value).await?;
+                        let val = apply_tilde_expansion(val, home.as_deref());
+                        tool_args.positional.push(Value::String(format!(
+                            "{key}={}",
+                            crate::interpreter::value_to_string(&val)
+                        )));
+                    }
+                    Arg::DoubleDash => {
+                        tool_args.positional.push(Value::String("--".to_string()));
+                    }
+                }
+            }
+            return Ok(tool_args);
+        }
+
         // Subcommand-aware tools (e.g. `kj context list`) expose a tree of
         // schemas; pick the leaf the leading positionals route to and bind
         // flags against *its* params. Flat tools return the root. select_leaf

--- a/crates/kaish-kernel/src/parser.rs
+++ b/crates/kaish-kernel/src/parser.rs
@@ -1725,6 +1725,8 @@ where
         // assignments (like `echo`), so no separate literal-folding rule is
         // needed here.
         word_assign_arg_parser(),
+        // `test`/`[` operators stay literal after `--` too (`test -- a = b`).
+        test_operator_arg_parser(),
         // Everything else stays the same
         primary_expr_parser().map(Arg::Positional),
     ));
@@ -1814,6 +1816,36 @@ where
     })
 }
 
+/// The `test`/`[` comparison and negation operators (`=`, `==`, `!=`, `!`) as
+/// ordinary positional argv words.
+///
+/// POSIX `test` is a *command*, so its operators must reach it flat as argv —
+/// but kaish lexes `=`/`==`/`!=`/`!` as shell-significant tokens, so at
+/// command-argument position they used to parse-error before ever reaching a
+/// command (`test a = b`). This production makes each a literal-string
+/// positional. It is name-agnostic: like bash, `echo a = b` prints `a = b` —
+/// no command name is special-cased (that would be fragile under aliases).
+///
+/// Deliberately EXCLUDES the angle brackets `<` `>` `<=` `>=`: those stay
+/// redirection (making them argv would shadow redirects) and remain
+/// `[[ ]]`-only. Ordered after the flag/`word_assign` productions so a glued
+/// `name=value` still binds as a `WordAssign` — this bare-operator rule only
+/// fires once the current token IS the standalone operator (a spaced `a = b`,
+/// where `word_assign`'s span-adjacency check has already declined).
+fn test_operator_arg_parser<'tokens, I>(
+) -> impl Parser<'tokens, I, Arg, extra::Err<Rich<'tokens, Token, Span>>> + Clone
+where
+    I: ValueInput<'tokens, Token = Token, Span = Span>,
+{
+    select! {
+        Token::Eq => "=",
+        Token::EqEq => "==",
+        Token::NotEq => "!=",
+        Token::Bang => "!",
+    }
+    .map(|s| Arg::Positional(Expr::Literal(Value::String(s.to_string()))))
+}
+
 /// Argument parser for arguments before `--` (normal flag handling).
 fn arg_before_double_dash_parser<'tokens, I>(
 ) -> impl Parser<'tokens, I, Arg, extra::Err<Rich<'tokens, Token, Span>>> + Clone
@@ -1844,6 +1876,11 @@ where
     // Positional argument
     let positional = primary_expr_parser().map(Arg::Positional);
 
+    // The `test`/`[` operators (`=` `==` `!=` `!`) as literal positionals.
+    // After the flag/`named` productions (so glued `name=value` stays a
+    // WordAssign), before `positional` (which can't parse these tokens).
+    let test_operator = test_operator_arg_parser();
+
     // Order matters: try more specific patterns first
     // Note: DoubleDash is NOT included here - it's handled by args_list_parser
     choice((
@@ -1851,6 +1888,7 @@ where
         long_flag,
         short_flag,
         named,
+        test_operator,
         positional,
     ))
     .boxed()

--- a/crates/kaish-kernel/src/tools/builtin/mod.rs
+++ b/crates/kaish-kernel/src/tools/builtin/mod.rs
@@ -84,6 +84,7 @@ mod stat;
 mod tac;
 mod tail;
 mod tee;
+mod test;
 mod timeout;
 mod tojson;
 mod tojsonl;
@@ -214,6 +215,7 @@ pub fn register_builtins(registry: &mut ToolRegistry) {
     registry.register(tac::Tac);
     registry.register(tail::Tail);
     registry.register(tee::Tee);
+    registry.register(test::Test);
     registry.register(timeout::Timeout);
     #[cfg(feature = "tokens")]
     registry.register(tokens::Tokens);

--- a/crates/kaish-kernel/src/tools/builtin/test.rs
+++ b/crates/kaish-kernel/src/tools/builtin/test.rs
@@ -1,0 +1,247 @@
+//! `test` — POSIX condition evaluation, following kaish's `[[` semantics.
+//!
+//! `test EXPR` exits 0 if EXPR is true, 1 if false, and 2 on a usage or type
+//! error. Unlike POSIX `test` it is a *command* over kaish's own value model:
+//!
+//! - **VFS-aware** file tests (`-e -f -d -r -w -x`) stat through the kernel
+//!   backend, not the host filesystem.
+//! - **Numeric** comparison (`-eq -ne -gt -lt -ge -le`) is kaish's number
+//!   semantics — floats compare, identical to `[[`, not POSIX integer-only.
+//!   Non-numeric operands are a loud error, never silently zero.
+//! - **String equality** (`=` `==` `!=`) is literal (not glob), reusing `[[`'s
+//!   `values_equal`; a collection operand is a loud Shape error.
+//! - **No `-a`/`-o`/`( )`** — those XSI footguns are rejected loudly; chain with
+//!   shell `&&`/`||` or use `[[ ... ]]`. Negation is a single leading `!`.
+//! - **No POSIX arg-count magic**: an operator that is missing its operand
+//!   (`test -f`, `test -z`) is a loud error, not a surprise-true.
+//!
+//! It reads its argv in *source order with types preserved* via the schema's
+//! `raw_argv` opt-in, so an operand that looks like a flag (`test $x = -n`,
+//! `test 0 -gt -5`) is seen as a literal operand rather than a hoisted flag.
+
+use async_trait::async_trait;
+use clap::{CommandFactory, Parser};
+
+use kaish_types::Value;
+
+use crate::interpreter::{
+    is_collection, numeric_compare, scalar_test_operand_error, value_to_string, values_equal,
+    ExecResult,
+};
+use crate::tools::{schema_from_clap, ExecContext, GlobalFlags, Tool, ToolArgs, ToolCtx, ToolSchema};
+
+pub struct Test;
+
+/// clap-derived argv layer for `test`. The POSIX expression grammar is
+/// hand-rolled over the source-ordered `args.positional` (see the module docs
+/// on `raw_argv`); clap only owns the outer layer + `--json` (a no-op here,
+/// `test` has no output). `rest` is a hidden passthrough sink.
+#[derive(Parser, Debug)]
+#[command(name = "test", about = "Evaluate a conditional expression (exit 0 true / 1 false / 2 error)")]
+struct TestArgs {
+    #[command(flatten)]
+    global: GlobalFlags,
+
+    /// Sink — the expression is read from `args.positional`, not here.
+    #[arg(trailing_var_arg = true, allow_hyphen_values = true, hide = true)]
+    rest: Vec<String>,
+}
+
+#[async_trait]
+impl Tool for Test {
+    fn name(&self) -> &str {
+        "test"
+    }
+
+    fn schema(&self) -> ToolSchema {
+        schema_from_clap(
+            &TestArgs::command(),
+            "test",
+            "Evaluate a conditional expression: exit 0 if true, 1 if false, 2 on error",
+            [
+                ("File exists and is regular", "test -f config.toml"),
+                ("String equality", r#"test "$mode" = release"#),
+                ("Numeric comparison", "test $count -gt 0"),
+                ("Negation", "test ! -d build"),
+                ("Compound via shell", "test -f a && test -f b"),
+            ],
+        )
+        .with_raw_argv()
+    }
+
+    async fn execute(&self, args: ToolArgs, ctx: &mut dyn ToolCtx) -> ExecResult {
+        let Some(ctx) = ctx.as_any_mut().downcast_mut::<ExecContext>() else {
+            return ExecResult::failure(1, "internal error: kernel builtin requires ExecContext");
+        };
+        let parsed = match TestArgs::try_parse_from(
+            std::iter::once("test".to_string()).chain(args.to_argv()),
+        ) {
+            Ok(p) => p,
+            Err(e) => return ExecResult::failure(2, format!("test: {e}")),
+        };
+        parsed.global.apply(ctx);
+
+        // Read the expression from the source-ordered, typed argv.
+        match eval_test(ctx, &args.positional).await {
+            Ok(true) => ExecResult::success(""),
+            Ok(false) => ExecResult::failure(1, ""),
+            Err(msg) => ExecResult::failure(2, msg),
+        }
+    }
+}
+
+fn is_unary_op(s: &str) -> bool {
+    matches!(s, "-z" | "-n" | "-e" | "-f" | "-d" | "-r" | "-w" | "-x")
+}
+
+fn is_binary_op(s: &str) -> bool {
+    matches!(s, "=" | "==" | "!=" | "-eq" | "-ne" | "-gt" | "-lt" | "-ge" | "-le")
+}
+
+/// The XSI compound / grouping operators kaish deliberately does not implement.
+fn is_rejected_op(s: &str) -> bool {
+    matches!(s, "-a" | "-o" | "(" | ")")
+}
+
+fn is_any_op(s: &str) -> bool {
+    is_unary_op(s) || is_binary_op(s) || is_rejected_op(s) || s == "!"
+}
+
+const COMPOUND_HINT: &str =
+    "kaish `test` has no -a/-o/() compound — chain with shell `&&`/`||` or use `[[ ... ]]`";
+
+/// Evaluate a `test` expression. A single (or parity-collapsed) leading `!`
+/// negates; the rest is a primary. Returns Err (→ exit 2) on any usage/type
+/// error, so a malformed expression is loud, never a surprise true/false.
+async fn eval_test(ctx: &ExecContext, operands: &[Value]) -> Result<bool, String> {
+    // Strip leading `!` operators, but only while an expression remains after
+    // them — a bare trailing `!` is a missing-operand error, handled by the
+    // primary. `! !` collapses by parity (double negation is identity).
+    let mut negate = false;
+    let mut ops = operands;
+    while ops.len() >= 2 && value_to_string(&ops[0]) == "!" {
+        negate = !negate;
+        ops = &ops[1..];
+    }
+    let result = eval_primary(ctx, ops).await?;
+    Ok(negate ^ result)
+}
+
+async fn eval_primary(ctx: &ExecContext, operands: &[Value]) -> Result<bool, String> {
+    match operands.len() {
+        0 => Err("test: missing expression".to_string()),
+        1 => {
+            let operand = &operands[0];
+            let s = value_to_string(operand);
+            // A lone operator is a forgotten operand — loud, not surprise-true.
+            if is_any_op(&s) {
+                return Err(format!("test: '{s}' needs an operand"));
+            }
+            // A bare collection has no truth value here — loud Shape error.
+            if is_collection(operand) {
+                return Err(format!(
+                    "test: operand is a {}, not a string; a collection has no truth value",
+                    collection_kind(operand)
+                ));
+            }
+            Ok(!s.is_empty())
+        }
+        2 => {
+            let op = value_to_string(&operands[0]);
+            if is_rejected_op(&op) {
+                return Err(format!("test: '{op}' is not supported — {COMPOUND_HINT}"));
+            }
+            if is_unary_op(&op) {
+                return apply_unary(ctx, &op, &operands[1]).await;
+            }
+            Err(format!(
+                "test: expected a unary operator (-f, -z, …) before the operand, found '{op}'"
+            ))
+        }
+        3 => {
+            let op = value_to_string(&operands[1]);
+            if is_rejected_op(&op) {
+                return Err(format!("test: '{op}' is not supported — {COMPOUND_HINT}"));
+            }
+            if is_binary_op(&op) {
+                return apply_binary(&operands[0], &op, &operands[2]);
+            }
+            Err(format!(
+                "test: expected a binary operator (=, !=, -eq, …) between the operands, found '{op}'"
+            ))
+        }
+        _ => Err(format!("test: too many arguments — {COMPOUND_HINT}")),
+    }
+}
+
+async fn apply_unary(ctx: &ExecContext, op: &str, operand: &Value) -> Result<bool, String> {
+    // A collection operand to any unary test is a loud Shape error (Decision E).
+    if let Some(msg) = scalar_test_operand_error(op, operand) {
+        return Err(msg);
+    }
+    match op {
+        "-z" => Ok(value_to_string(operand).is_empty()),
+        "-n" => Ok(!value_to_string(operand).is_empty()),
+        "-e" | "-f" | "-d" | "-r" | "-w" | "-x" => {
+            Ok(file_test(ctx, op, &value_to_string(operand)).await)
+        }
+        _ => unreachable!("apply_unary called with non-unary op {op:?}"),
+    }
+}
+
+fn apply_binary(left: &Value, op: &str, right: &Value) -> Result<bool, String> {
+    match op {
+        // Literal string equality — reuses `[[`'s `values_equal`, which is loud
+        // on a collection-vs-scalar operand.
+        "=" | "==" => values_equal(left, right).map_err(|e| format!("test: {e}")),
+        "!=" => values_equal(left, right)
+            .map(|eq| !eq)
+            .map_err(|e| format!("test: {e}")),
+        "-eq" | "-ne" | "-gt" | "-lt" | "-ge" | "-le" => {
+            if let Some(msg) = scalar_test_operand_error(op, left) {
+                return Err(msg);
+            }
+            if let Some(msg) = scalar_test_operand_error(op, right) {
+                return Err(msg);
+            }
+            let ord = numeric_compare(left, right).map_err(|e| format!("test: {e}"))?;
+            Ok(match op {
+                "-eq" => ord.is_eq(),
+                "-ne" => !ord.is_eq(),
+                "-gt" => ord.is_gt(),
+                "-lt" => ord.is_lt(),
+                "-ge" => ord.is_ge(),
+                "-le" => ord.is_le(),
+                _ => unreachable!(),
+            })
+        }
+        _ => unreachable!("apply_binary called with non-binary op {op:?}"),
+    }
+}
+
+/// Stat `path` through the VFS backend and answer the file predicate — mirrors
+/// `[[`'s `FileTest` arm so the two stay consistent.
+async fn file_test(ctx: &ExecContext, op: &str, path: &str) -> bool {
+    let resolved = ctx.resolve_path(path);
+    let entry = ctx.backend.stat(&resolved).await.ok();
+    match op {
+        "-e" | "-r" => entry.is_some(),
+        "-f" => entry.as_ref().is_some_and(|e| e.is_file()),
+        "-d" => entry.as_ref().is_some_and(|e| e.is_dir()),
+        "-w" => entry
+            .as_ref()
+            .is_some_and(|e| e.permissions.is_none_or(|p| p & 0o222 != 0)),
+        "-x" => entry
+            .as_ref()
+            .is_some_and(|e| e.permissions.is_some_and(|p| p & 0o111 != 0)),
+        _ => unreachable!("file_test called with non-file op {op:?}"),
+    }
+}
+
+fn collection_kind(value: &Value) -> &'static str {
+    match value {
+        Value::Json(serde_json::Value::Array(_)) => "list",
+        Value::Json(serde_json::Value::Object(_)) => "record",
+        _ => "collection",
+    }
+}

--- a/crates/kaish-kernel/src/validator/walker.rs
+++ b/crates/kaish-kernel/src/validator/walker.rs
@@ -154,27 +154,13 @@ impl<'a> Validator<'a> {
         let is_special = is_special_command(&cmd.name);
 
         if !is_builtin && !is_user_tool && !is_special {
-            // `[ … ]` can't reach here — it's a parse error (`[` opens a `[[ ]]`
-            // test), so `test` is the only POSIX-conditional name that lands as a
-            // command. kaish has no `test` builtin; unguarded it resolves to an
-            // external binary that evaluates against the real host FS, bypassing
-            // the VFS/overlay — a silent wrong answer flowing into `if`/`&&`.
-            // Steer to `[[ … ]]`. Surfaced to the agent (see surfaces_to_agent).
-            if cmd.name == "test" {
-                self.issues.push(ValidationIssue::warning(
-                    IssueCode::PosixTestCommand,
-                    "'test' is not a kaish command".to_string(),
-                ).with_suggestion(
-                    "use [[ … ]] for conditionals — it is validated before running, \
-                     whereas `test` resolves to an external command that bypasses the VFS",
-                ));
-            } else {
-                // Warning only - command might be a script in PATH or external tool
-                self.issues.push(ValidationIssue::warning(
-                    IssueCode::UndefinedCommand,
-                    format!("command '{}' not found in builtin registry", cmd.name),
-                ).with_suggestion("this may be a script in PATH or external command"));
-            }
+            // Warning only - command might be a script in PATH or external tool.
+            // (`test` is now a first-class builtin — VFS-aware, validated — so it
+            // takes the `is_builtin` path above and never lands here.)
+            self.issues.push(ValidationIssue::warning(
+                IssueCode::UndefinedCommand,
+                format!("command '{}' not found in builtin registry", cmd.name),
+            ).with_suggestion("this may be a script in PATH or external command"));
         }
 
         // Validate arguments expressions
@@ -688,8 +674,8 @@ pub(crate) fn classify_command_name(
 
 /// Check if a command is a special built-in that we don't validate.
 fn is_special_command(name: &str) -> bool {
-    // `test`/`[`/`[[` are intentionally absent: there is no `test` builtin
-    // (it gets the PosixTestCommand advisory above), and `[`/`[[` parse as
+    // `test`/`[`/`[[` are intentionally absent: `test` is a real builtin now
+    // (it validates via the registry like any other), and `[`/`[[` parse as
     // `[[ … ]]` test expressions, never reaching here as a command name.
     matches!(name, "true" | "false" | ":" | "readonly" | "local")
 }
@@ -964,8 +950,11 @@ mod tests {
         assert!(issues.iter().any(|i| i.code == IssueCode::UndefinedCommand));
     }
 
+    /// `test` is a first-class builtin now, so it validates through the
+    /// registry like any other command — no POSIX-conditional advisory, and no
+    /// spurious undefined-command warning.
     #[test]
-    fn test_command_steers_to_double_bracket() {
+    fn test_command_is_a_known_builtin() {
         let (registry, user_tools) = make_validator();
         let validator = Validator::new(&registry, &user_tools);
 
@@ -981,40 +970,10 @@ mod tests {
         };
 
         let issues = validator.validate(&program);
-        let issue = issues
-            .iter()
-            .find(|i| i.code == IssueCode::PosixTestCommand)
-            .expect("`test` should emit a PosixTestCommand advisory");
-        assert_eq!(issue.severity, crate::validator::Severity::Warning);
-        assert!(issue.code.surfaces_to_agent(), "the advisory must surface to the agent");
-        assert!(issue.suggestion.as_deref().unwrap_or_default().contains("[["));
-        // It must NOT also fire the generic undefined-command warning.
-        assert!(!issues.iter().any(|i| i.code == IssueCode::UndefinedCommand));
-    }
-
-    #[test]
-    fn path_qualified_test_is_honored_not_steered() {
-        // A user who writes a path clearly wants that external binary — only the
-        // bare ident `test` is the POSIX-conditional footgun. The parser keeps
-        // the path in `cmd.name` (path_parser / DotSlashPath), so the advisory's
-        // `cmd.name == "test"` guard naturally excludes these.
-        let (registry, user_tools) = make_validator();
-
-        for name in ["./test", "/opt/custom/test"] {
-            let validator = Validator::new(&registry, &user_tools);
-            let program = Program {
-                statements: vec![Stmt::Command(Command {
-                    name: name.to_string(),
-                    args: vec![],
-                    redirects: vec![],
-                })],
-            };
-            let issues = validator.validate(&program);
-            assert!(
-                !issues.iter().any(|i| i.code == IssueCode::PosixTestCommand),
-                "path-qualified '{name}' must not get the test advisory"
-            );
-        }
+        assert!(
+            !issues.iter().any(|i| i.code == IssueCode::UndefinedCommand),
+            "`test` is a builtin — no undefined-command warning: {issues:?}"
+        );
     }
 
     #[test]

--- a/crates/kaish-kernel/tests/json_sweep_tests.rs
+++ b/crates/kaish-kernel/tests/json_sweep_tests.rs
@@ -71,6 +71,7 @@ const SKIPS: &[Skip] = &[
     Skip { name: "fg", reason: "requires a stopped job (PTY job control)" },
     Skip { name: "exec", reason: "replaces the calling process" },
     Skip { name: "kaish-trash", reason: "reads the user's real OS trash — non-hermetic" },
+    Skip { name: "test", reason: "exit-code only, no output surface; raw_argv makes --json a literal operand (like [[ ]], test takes no --json)" },
 ];
 
 const CASES: &[Case] = &[

--- a/crates/kaish-kernel/tests/parser_tests.rs
+++ b/crates/kaish-kernel/tests/parser_tests.rs
@@ -744,9 +744,18 @@ fn parser_named_arg_no_spaces() {
     parse_and_snapshot("named_arg_no_spaces", "cmd key=value");
 }
 
+/// Post-`test`-grammar-relief: a *spaced* `key = value` is no longer a
+/// "no spaces around =" parse error. `=` is now a literal argv operator (so
+/// POSIX `test a = b` can reach the `test` command), which makes
+/// `cmd key = value` parse as `cmd` with three positional args — exactly like
+/// bash. A *glued* `key=value` still binds as a WordAssign
+/// (see `parser_named_arg_no_spaces`), so the useful distinction survives.
 #[test]
-fn parser_named_arg_with_spaces_error() {
-    expect_parse_error("cmd key = value");
+fn parser_spaced_equals_is_literal_argv_operator() {
+    assert_eq!(
+        one_stmt_sexpr("cmd key = value"),
+        r#"(cmd cmd (pos (string "key")) (pos (string "=")) (pos (string "value")))"#
+    );
 }
 
 #[test]
@@ -941,4 +950,136 @@ fn parser_glob_in_named_arg() {
 #[test]
 fn parser_glob_in_test() {
     parse_and_snapshot("glob_in_test", "[[ *.txt == foo ]]");
+}
+
+// ---------------------------------------------------------------------------
+// Grammar relief for the `test` builtin (Phase 1). POSIX `test`/`[` is a
+// *command*, so its comparison and negation operators (`=`, `==`, `!=`, `!`)
+// must reach it as ordinary positional argv words. kaish's grammar treats
+// these as shell-significant tokens, so they used to parse-error before ever
+// reaching a command. This relief makes them literal positionals — but ONLY
+// these four: `<` `>` `<=` `>=` stay redirection (see the redirect-unaffected
+// test below) and remain `[[ ]]`-only. See signoff.md / project_test_builtin.
+// ---------------------------------------------------------------------------
+
+/// Parse `input`, require exactly one statement, and return its s-expr.
+/// A parse error (or a split into multiple statements) fails loudly here —
+/// that IS the pre-relief bug we're fixing.
+fn one_stmt_sexpr(input: &str) -> String {
+    let program = parse(input).unwrap_or_else(|errors| {
+        let msg = errors
+            .iter()
+            .map(|e| e.to_string())
+            .collect::<Vec<_>>()
+            .join("; ");
+        panic!("parse error for {input:?}: {msg}");
+    });
+    assert_eq!(
+        program.statements.len(),
+        1,
+        "{input:?} must be ONE statement, got {}: {}",
+        program.statements.len(),
+        format_program(&program),
+    );
+    format_program(&program)
+}
+
+#[rstest]
+// The canonical string-equality idiom — THE reason a flag-form-only `test`
+// was judged not-credible.
+#[case(
+    "test a = b",
+    r#"(cmd test (pos (string "a")) (pos (string "=")) (pos (string "b")))"#
+)]
+// bash-refugee `==` alias.
+#[case(
+    "test a == b",
+    r#"(cmd test (pos (string "a")) (pos (string "==")) (pos (string "b")))"#
+)]
+// Inequality.
+#[case(
+    "test a != b",
+    r#"(cmd test (pos (string "a")) (pos (string "!=")) (pos (string "b")))"#
+)]
+// Leading-`!` negation sugar (kaish has no `! cmd` pipeline negation, so this
+// is the only negation path for the builtin).
+#[case(
+    "test ! -f x",
+    r#"(cmd test (pos (string "!")) (shortflag f) (pos (string "x")))"#
+)]
+// Operators as ordinary argv on any command, not just `test` (the relief is
+// name-agnostic — no fragile special-casing of the `test` command name).
+#[case(
+    "echo a = b",
+    r#"(cmd echo (pos (string "a")) (pos (string "=")) (pos (string "b")))"#
+)]
+fn test_operators_reach_command_as_positionals(#[case] input: &str, #[case] expected: &str) {
+    assert_eq!(one_stmt_sexpr(input), expected);
+}
+
+/// The most common real-world form: quoted variable operands around `=`.
+/// We only assert the operator lands as a literal positional between them;
+/// the operand rendering is exercised elsewhere.
+#[test]
+fn test_quoted_var_equality_parses() {
+    let sexpr = one_stmt_sexpr(r#"test "$a" = "$b""#);
+    assert!(
+        sexpr.starts_with("(cmd test "),
+        "expected a `test` command, got: {sexpr}"
+    );
+    assert!(
+        sexpr.contains(r#"(pos (string "="))"#),
+        "`=` must land as a literal positional, got: {sexpr}"
+    );
+}
+
+// --- Regressions: the relief must not disturb assignment / argv-assign /
+// long-flag-value / redirection parsing. ---
+
+/// A glued `x=y` at statement level is still an ASSIGNMENT, not a command
+/// `x` with a bare `=` argument.
+#[test]
+fn glued_assignment_still_assignment_not_command() {
+    let sexpr = one_stmt_sexpr("x=y");
+    assert!(
+        !sexpr.starts_with("(cmd "),
+        "`x=y` must stay an assignment, not become a command: {sexpr}"
+    );
+}
+
+/// A glued `key=value` in argv position (`cat foo=bar`) stays the WordAssign
+/// production (bash: opens a file literally named `foo=bar`), NOT split into
+/// `foo` `=` `bar`.
+#[test]
+fn glued_argv_assign_stays_wordassign() {
+    let sexpr = one_stmt_sexpr("cat foo=bar");
+    assert!(
+        sexpr.contains("(wordassign foo"),
+        "glued `foo=bar` must stay a WordAssign, got: {sexpr}"
+    );
+    assert!(
+        !sexpr.contains(r#"(pos (string "="))"#),
+        "glued `foo=bar` must not fragment into a bare `=` positional: {sexpr}"
+    );
+}
+
+/// A glued `--name=value` long flag still binds its value.
+#[test]
+fn long_flag_with_value_still_binds() {
+    let sexpr = one_stmt_sexpr("grep --context=3 pat");
+    assert!(
+        sexpr.contains("(named context"),
+        "`--context=3` must stay a named flag, got: {sexpr}"
+    );
+}
+
+/// `<` / `>` stay REDIRECTION — the relief deliberately excludes the angle
+/// brackets so it can't shadow redirects.
+#[test]
+fn angle_brackets_stay_redirection() {
+    let sexpr = one_stmt_sexpr("echo x > f");
+    assert!(
+        sexpr.contains("redir") && !sexpr.contains(r#"(pos (string ">"))"#),
+        "`>` must remain a redirect, not become a positional: {sexpr}"
+    );
 }

--- a/crates/kaish-kernel/tests/test_builtin_tests.rs
+++ b/crates/kaish-kernel/tests/test_builtin_tests.rs
@@ -1,0 +1,204 @@
+//! Kernel-routed coverage for the `test` builtin.
+//!
+//! `test` follows kaish's `[[` semantics but as a *command*: it receives the
+//! true source-ordered argv (via the schema's `raw_argv` opt-in), so operands
+//! that look like flags (`test $x = -n`, `test 0 -gt -5`) survive the normal
+//! flag/positional split. Numeric comparison is kaish's own (JSON) number
+//! semantics — floats are fine, identical to `[[` — NOT POSIX integer-only.
+//!
+//! Every case runs a real command string through `kernel.execute()` so the
+//! full lex → parse → validate → dispatch → builtin path runs, and asserts the
+//! exit code (0 true / 1 false / 2 usage-or-type error).
+
+// Test-fixture code: unwrap/expect on known-good setup is the idiom here.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+#![cfg(feature = "localfs")]
+
+mod common;
+
+use std::fs;
+
+use common::{kernel_at, run};
+use tempfile::tempdir;
+
+/// Run `script` and return just the exit code.
+async fn code_of(script: &str) -> i64 {
+    let dir = tempdir().unwrap();
+    // Seed a known file + dir so file tests have something real to stat.
+    fs::write(dir.path().join("file.txt"), "hi\n").unwrap();
+    fs::create_dir(dir.path().join("sub")).unwrap();
+    let kernel = kernel_at(dir.path());
+    let (_out, code) = run(&kernel, script).await;
+    code
+}
+
+// --- string emptiness -------------------------------------------------------
+
+#[tokio::test]
+async fn string_emptiness() {
+    assert_eq!(code_of(r#"test -z """#).await, 0, "-z empty is true");
+    assert_eq!(code_of("test -z x").await, 1, "-z non-empty is false");
+    assert_eq!(code_of("test -n x").await, 0, "-n non-empty is true");
+    assert_eq!(code_of(r#"test -n """#).await, 1, "-n empty is false");
+}
+
+// --- one-argument truthiness (POSIX `test STRING`) --------------------------
+
+#[tokio::test]
+async fn one_arg_string_truthiness() {
+    assert_eq!(code_of("test x").await, 0, "non-empty single arg is true");
+    assert_eq!(code_of(r#"test """#).await, 1, "empty single arg is false");
+}
+
+// --- string equality (=, ==, !=) --------------------------------------------
+
+#[tokio::test]
+async fn string_equality() {
+    assert_eq!(code_of("test a = a").await, 0);
+    assert_eq!(code_of("test a = b").await, 1);
+    assert_eq!(code_of("test a == a").await, 0, "== is a literal-equality alias");
+    assert_eq!(code_of("test a != b").await, 0);
+    assert_eq!(code_of("test a != a").await, 1);
+}
+
+/// The killer case for the ordered-argv work: an operand that *looks* like a
+/// flag (`-n`, `-f`) must survive as a literal operand, not get hoisted into
+/// the flag set. A reconstruct-from-ToolArgs `test` would mis-handle these.
+#[tokio::test]
+async fn flag_shaped_operands_survive() {
+    assert_eq!(code_of("test -n = -n").await, 0, r#""-n" equals "-n""#);
+    assert_eq!(code_of("test x = -f").await, 1, r#""x" != "-f", -f is an operand"#);
+    assert_eq!(code_of("test -f = -f").await, 0, r#""-f" equals "-f""#);
+}
+
+// --- numeric comparison: kaish JSON-number semantics (floats OK) ------------
+
+#[tokio::test]
+async fn numeric_integer() {
+    assert_eq!(code_of("test 5 -eq 5").await, 0);
+    assert_eq!(code_of("test 5 -eq 3").await, 1);
+    assert_eq!(code_of("test 5 -ne 3").await, 0);
+    assert_eq!(code_of("test 5 -gt 3").await, 0);
+    assert_eq!(code_of("test 3 -gt 5").await, 1);
+    assert_eq!(code_of("test 3 -lt 5").await, 0);
+    assert_eq!(code_of("test 5 -ge 5").await, 0);
+    assert_eq!(code_of("test 4 -le 5").await, 0);
+    assert_eq!(code_of("test 08 -eq 8").await, 0, "leading zero is decimal, not octal");
+}
+
+/// Negative numbers as operands (second position is the killer spot — a `-5`
+/// there would be eaten as a flag without raw_argv).
+#[tokio::test]
+async fn numeric_negative_operands() {
+    assert_eq!(code_of("test 0 -gt -5").await, 0, "0 > -5, -5 survives as operand");
+    assert_eq!(code_of("test -5 -lt 0").await, 0, "-5 < 0");
+}
+
+/// Reversed panel decision (Amy): numeric is `[[`-consistent — floats work,
+/// because numbers are JSON numbers. POSIX `test` would error on `1.5`.
+#[tokio::test]
+async fn numeric_floats_allowed() {
+    assert_eq!(code_of("test 1.5 -gt 1").await, 0, "float operand compares, not errors");
+    assert_eq!(code_of("test 1.0 -eq 1").await, 0, "1.0 equals 1 numerically");
+    assert_eq!(code_of("test 2.5 -lt 2").await, 1, "2.5 is not < 2");
+}
+
+/// Non-numeric operands to a numeric op are LOUD (exit 2), never silently 0.
+#[tokio::test]
+async fn numeric_non_numeric_is_loud() {
+    assert_eq!(code_of("test abc -eq 5").await, 2, "non-numeric string is a usage error");
+}
+
+// --- file tests (VFS-aware) -------------------------------------------------
+
+#[tokio::test]
+async fn file_tests() {
+    assert_eq!(code_of("test -e file.txt").await, 0, "-e existing");
+    assert_eq!(code_of("test -e nope").await, 1, "-e missing");
+    assert_eq!(code_of("test -f file.txt").await, 0, "-f regular file");
+    assert_eq!(code_of("test -f sub").await, 1, "-f on a dir is false");
+    assert_eq!(code_of("test -d sub").await, 0, "-d directory");
+    assert_eq!(code_of("test -d file.txt").await, 1, "-d on a file is false");
+}
+
+/// Proves the *builtin* (not external `/usr/bin/test`) is in play and it stats
+/// through the kernel's VFS: floats work here where GNU test would exit 2.
+/// (Kept alongside file tests as a belt-and-suspenders "is the builtin live".)
+#[tokio::test]
+async fn builtin_shadows_external_test() {
+    // GNU /usr/bin/test 1.5 -gt 1 => exit 2 (integer syntax error).
+    // Our builtin => 0. If this is 2, we're accidentally shelling out.
+    assert_eq!(code_of("test 1.5 -gt 1").await, 0);
+}
+
+// --- negation (`test ! <primary>`) -----------------------------------------
+
+#[tokio::test]
+async fn negation() {
+    assert_eq!(code_of("test ! -f nope").await, 0, "! (nope is not a file) => true");
+    assert_eq!(code_of("test ! -f file.txt").await, 1, "! (file.txt is a file) => false");
+    assert_eq!(code_of("test ! a = a").await, 1, "! (a==a) => false");
+    assert_eq!(code_of("test ! a = b").await, 0, "! (a!=b as ==) => true");
+    assert_eq!(code_of("test ! -z x").await, 0, "! (-z x is false) => true");
+}
+
+// --- arity / usage errors (loud, per the 'require operands' decision) -------
+
+#[tokio::test]
+async fn arity_errors_are_loud() {
+    assert_eq!(code_of("test").await, 2, "0-arg test is a usage error");
+    assert_eq!(code_of("test -f").await, 2, "operator with missing operand is loud");
+    assert_eq!(code_of("test -z").await, 2, "operator with missing operand is loud");
+    assert_eq!(code_of("test !").await, 2, "bare ! has no expression");
+    assert_eq!(code_of("test a b").await, 2, "two barewords, no operator");
+}
+
+// --- compound (-a/-o) is rejected loudly, shell chaining is the path --------
+
+#[tokio::test]
+async fn compound_operators_rejected() {
+    assert_eq!(code_of("test -f file.txt -a -f sub").await, 2, "-a is not supported");
+    assert_eq!(code_of("test a = a -o b = b").await, 2, "-o is not supported");
+}
+
+#[tokio::test]
+async fn shell_chaining_is_the_compound_path() {
+    let dir = tempdir().unwrap();
+    fs::write(dir.path().join("file.txt"), "hi\n").unwrap();
+    fs::create_dir(dir.path().join("sub")).unwrap();
+    let kernel = kernel_at(dir.path());
+
+    let (out, code) = run(&kernel, "test -f file.txt && test -d sub && echo both").await;
+    assert_eq!(code, 0, "and-chain of two true tests succeeds: {out:?}");
+    assert_eq!(out, "both");
+
+    let (out, code) = run(&kernel, "test -f nope || echo fallback").await;
+    assert_eq!(code, 0);
+    assert_eq!(out, "fallback", "or-chain runs the fallback on a false test");
+}
+
+// --- collection operands are a loud Shape error (Decision E) ----------------
+
+#[tokio::test]
+async fn collection_operand_is_loud() {
+    let dir = tempdir().unwrap();
+    let kernel = kernel_at(dir.path());
+    let (_out, code) = run(&kernel, "xs=[1 2 3]; test $xs = foo").await;
+    assert_eq!(code, 2, "a list operand to = is a loud usage/shape error, not silent");
+}
+
+// --- test as an `if` condition (the primary use site) -----------------------
+
+#[tokio::test]
+async fn test_as_if_condition() {
+    let dir = tempdir().unwrap();
+    fs::write(dir.path().join("file.txt"), "hi\n").unwrap();
+    let kernel = kernel_at(dir.path());
+    let (out, code) = run(
+        &kernel,
+        r#"if test -f file.txt; then echo present; else echo absent; fi"#,
+    )
+    .await;
+    assert_eq!(code, 0);
+    assert_eq!(out, "present");
+}

--- a/crates/kaish-kernel/tests/test_builtin_tests.rs
+++ b/crates/kaish-kernel/tests/test_builtin_tests.rs
@@ -153,6 +153,24 @@ async fn arity_errors_are_loud() {
     assert_eq!(code_of("test a b").await, 2, "two barewords, no operator");
 }
 
+/// Subtle arity edges around the leading-`!` parity strip and operators that
+/// appear in operand position — each must resolve to a definite true/false or a
+/// loud exit 2, never a surprise. (Pinned after a kaibo review confirmed the
+/// behavior but found no coverage.)
+#[tokio::test]
+async fn arity_edge_cases() {
+    // Double negation collapses by parity: `! ! x` == `x` (non-empty → true).
+    assert_eq!(code_of("test ! ! x").await, 0, "! ! x is identity on non-empty");
+    // A bare `!` left after the strip has no expression → loud.
+    assert_eq!(code_of("test ! !").await, 2, "trailing bare ! is a usage error");
+    // `=` is a binary op, not unary — `! = x` has no valid primary → loud.
+    assert_eq!(code_of("test ! = x").await, 2, "= is not a unary operator");
+    // The operator token as a literal operand: `= = =` is string-eq of "=","=".
+    assert_eq!(code_of("test = = =").await, 0, r#""=" equals "=""#);
+    // An operator in operand position of a unary test: file named "-f".
+    assert_eq!(code_of("test -f -f").await, 1, r#"stats a file literally named "-f""#);
+}
+
 // --- compound (-a/-o) is rejected loudly, shell chaining is the path --------
 
 #[tokio::test]

--- a/crates/kaish-kernel/tests/validation_tests.rs
+++ b/crates/kaish-kernel/tests/validation_tests.rs
@@ -795,22 +795,25 @@ async fn validation_issue_in_heredoc_body_full_rendering_snapshot() {
 }
 
 // ============================================================================
-// Tests that verify selective warning SURFACING (W006 reaches the agent;
-// the generic undefined-command warning stays trace-only)
+// Tests that verify selective warning SURFACING. The one opted-in code (W006,
+// the old POSIX-`test` advisory) was retired when `test` became a builtin, so
+// surfacing is currently dormant; the generic undefined-command warning still
+// stays trace-only.
 // ============================================================================
 
 #[tokio::test]
-async fn posix_test_command_surfaces_advisory_but_still_runs() {
+async fn test_is_a_builtin_no_advisory() {
     let kernel = make_kernel().await;
-    // `test` is not a kaish command; the validator advisory (W006) must reach
-    // the agent on stderr, and the warning must NOT block execution.
+    // `test` is a first-class builtin now — it just runs. No W006 advisory and
+    // no undefined-command noise should reach the agent on stderr.
     let result = kernel
         .execute("test -n hi")
         .await
-        .expect("a warning must not turn into a validation error");
+        .expect("test runs as a builtin");
+    assert_eq!(result.code, 0, "`test -n hi` is true");
     assert!(
-        result.err.contains("W006") && result.err.contains("[["),
-        "the W006 `[[ … ]]` advisory should surface on stderr, got err: {:?}",
+        !result.err.contains("W006") && !result.err.contains("builtin registry"),
+        "no validator advisory should surface for the `test` builtin, got err: {:?}",
         result.err
     );
 }

--- a/crates/kaish-tool-api/src/issue.rs
+++ b/crates/kaish-tool-api/src/issue.rs
@@ -54,10 +54,6 @@ pub enum IssueCode {
     InvalidSedExpr,
     /// jq filter expression is syntactically invalid.
     InvalidJqFilter,
-    /// A POSIX `test` / `[ … ]` conditional was used. kaish has no such command
-    /// (it would resolve to an external binary that bypasses the VFS); use
-    /// `[[ … ]]`, which the validator checks before runtime.
-    PosixTestCommand,
     /// A subscripted assignment lvalue (`x[k]=v`) targets an undefined root
     /// variable. Unlike a plain read, a path-set never autovivifies the
     /// root — it must already exist as a collection.
@@ -73,7 +69,8 @@ impl IssueCode {
     /// Returns a short code string for the issue.
     ///
     /// Code numbers are stable identifiers, not contiguous. E010 and
-    /// W003/W004/W005 remain retired. E006 (InvalidSedExpr), E007
+    /// W003/W004/W005 remain retired, as does W006 (PosixTestCommand, retired
+    /// when `test` became a first-class builtin). E006 (InvalidSedExpr), E007
     /// (InvalidJqFilter), and E011 (DiffNeedsTwoFiles) were wired up with
     /// real emitters in 2026-06-14.
     pub fn code(&self) -> &'static str {
@@ -94,7 +91,6 @@ impl IssueCode {
             IssueCode::ForLoopScalarVar => "E012",
             IssueCode::ScatterWithoutGather => "E014",
             IssueCode::LastResultFieldAccess => "E015",
-            IssueCode::PosixTestCommand => "W006",
             IssueCode::LvalueUndefinedRoot => "E016",
             IssueCode::DottedAssignmentTarget => "E017",
         }
@@ -107,8 +103,13 @@ impl IssueCode {
     /// external command (`grep`, `cargo`), so surfacing them all would be
     /// noise. Opt a code in here only when its guidance is worth interrupting
     /// for. This is the surfacing seam for the "did-you-mean" guidance pass.
+    ///
+    /// Currently dormant: the one opted-in code (`PosixTestCommand`) was retired
+    /// when `test` became a builtin. The seam stays wired for the next code that
+    /// earns surfacing — add a `matches!(self, IssueCode::Foo | …)` arm here.
     pub fn surfaces_to_agent(&self) -> bool {
-        matches!(self, IssueCode::PosixTestCommand)
+        let _ = self;
+        false
     }
 
     /// Default severity for this issue code.
@@ -136,7 +137,6 @@ impl IssueCode {
             | IssueCode::InvalidArgType
             | IssueCode::UndefinedCommand
             | IssueCode::UnknownFlag
-            | IssueCode::PosixTestCommand
             | IssueCode::PossiblyUndefinedVariable => Severity::Warning,
         }
     }

--- a/crates/kaish-types/src/tool.rs
+++ b/crates/kaish-types/src/tool.rs
@@ -233,6 +233,19 @@ pub struct ToolSchema {
     /// themselves and emit final bytes. See [`ToolSchema::with_owned_output`].
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub owns_output: bool,
+    /// The tool wants its argv **in source order, with types preserved** — the
+    /// binder must NOT split flags into the unordered `flags` set. When true,
+    /// every argument is bound to `positional` in the order written (operators
+    /// like `-f`/`=`/`!` as strings, operands keeping their `Value` type), and
+    /// `named`/`flags` stay empty.
+    ///
+    /// Default false: normal tools get the clap-style order-independent split
+    /// (`-la` == `-al`). Set true for the rare *position-sensitive* command
+    /// whose operands may themselves look like flags — POSIX `test`, where
+    /// `test $x = -n` and `test 0 -gt -5` must see `-n`/`-5` as literal
+    /// operands. See [`ToolSchema::with_raw_argv`].
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub raw_argv: bool,
 }
 
 impl ToolSchema {
@@ -247,7 +260,15 @@ impl ToolSchema {
             subcommands: Vec::new(),
             aliases: Vec::new(),
             owns_output: false,
+            raw_argv: false,
         }
+    }
+
+    /// Declare that this tool wants its argv in source order with types
+    /// preserved (no flag/positional split). See [`ToolSchema::raw_argv`].
+    pub fn with_raw_argv(mut self) -> Self {
+        self.raw_argv = true;
+        self
     }
 
     /// Enable positional->named parameter mapping for MCP/external tools.

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -510,10 +510,39 @@ if [[ 443 in ${servers[web]} ]]; then echo "listening"; fi    # nested path as t
 [[ ! -f a || -d b && -e c ]]    # parsed as: (! -f a) || ((-d b) && (-e c))
 ```
 
-Note: `[ expr ]` (single brackets) is **not** kaish syntax and there is no `test`
-builtin — use `[[ ]]` for all conditionals (`[[ -f file ]] && echo yes`). This is
-deliberate: `[[ ]]` is real grammar the validator checks before runtime, whereas
-`test`/`[` would hide their operators as opaque runtime arguments.
+### The `test` command
+
+`test EXPR` is the command form of the same conditionals — exit `0` if true, `1`
+if false, `2` on a usage or type error. It is a real builtin (VFS-aware,
+validated), not a shell-out to the host `/usr/bin/test`:
+
+```sh
+test -f config.toml             # file tests: -e -f -d -r -w -x
+test -z "$out"                  # string tests: -z -n
+test "$mode" = release          # equality: = == != (literal, not glob)
+test "$count" -gt 0             # numeric: -eq -ne -gt -lt -ge -le
+test ! -d build                 # negation: a single leading !
+test -f a && test -f b          # compound: chain with shell && / ||
+if test -f "$path"; then …; fi  # the usual home, an `if`/`while` condition
+```
+
+`test` follows `[[`'s semantics, with a few deliberate, predictable differences:
+
+- **Numbers are kaish (JSON) numbers**, so `test 1.5 -gt 1` compares (it does not
+  error the way POSIX `test` would); a non-numeric operand is a loud error.
+- **No `-a` / `-o` / `\( \)`** — those ambiguous XSI operators are rejected
+  loudly. Compose with shell `&&` / `||`, or use `[[ ]]`.
+- **An operator missing its operand is a loud error** (`test -f` on its own),
+  never a surprise-true — kaish does no word splitting, so the classic
+  `test -n $empty` footgun can't arise.
+- **Richer tests stay `[[ ]]`-only**: membership (`in` / `not in`), regex
+  (`=~` / `!~`), and the shape guards (`-list` / `-record`).
+
+Prefer `[[ ]]` — it is real grammar the validator checks before runtime, carries
+the richer tests, and expresses compound logic (`&&` / `||` / `!`) in one
+construct. Reach for `test` for muscle memory or where a plain command is wanted
+(a condition builtin, a `&&` chain). `[ expr ]` (single brackets) remains **not**
+kaish syntax — `[` opens a list literal, so use `test` or `[[ ]]`.
 
 ## Control Flow
 

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -14,6 +14,57 @@ before it ships.
 
 ---
 
+## The `test` builtin — `[[` semantics as a command (2026-07-04)
+
+`test` had been quietly shelling out to the host `/usr/bin/test`: OS-dependent,
+not VFS-aware, and command-not-found in a no-subprocess build. Amy asked whether
+we could add a `test` that follows kaish's own `[[` semantics and whether that
+would be safe for muscle memory. A 4-model kaibo panel (deepseek/gemini/or-gpt/
+or-kimi, stateless) converged hard: yes — but a flag-form-only shim is
+*not credible*, because `test a = b` is the canonical idiom, and without it the
+thing would parse-error on the one form everyone reaches for. Full scope it was.
+
+**Two parts, and the second was the surprise.** Part one was grammar relief: kaish
+lexes `=`/`==`/`!=`/`!` as shell-significant tokens, so `test a = b` /
+`test ! -f x` parse-errored before reaching a command. The fix is a small,
+name-agnostic arg-parser production making those four operators literal positional
+words (angle brackets `< > <= >=` deliberately excluded — they stay redirection).
+A side effect, bash-consistent: spaced `cmd key = value` now parses as a three-arg
+command instead of an error (glued `key=value` stays an assignment).
+
+Part two — the builtin — turned out to be *not* about the predicate logic (that
+reuses `[[`'s engine verbatim), but about **argv shape**. POSIX `test` is
+position-sensitive (`test $x = -n`, `test 0 -gt -5`), while kaish's `ToolArgs`
+splits flags into an unordered set — so an operand that merely *looks* like a flag
+gets silently mis-routed (proof: `echo a -n b` prints `a b`). Amy pushed on
+whether the lexer could just preserve order always; the honest trace showed order
+dies in the *binder*, not the lexer, and that faithful source order is a distinct
+binding mode incompatible with the flag-value-consumption logic (`grep -A 3`
+consumes its `3`). So: a first-class opt-in `ToolSchema.raw_argv` — the binder
+binds every arg to `positional` in source order with `Value` types preserved.
+`test` opts in; nothing else pays. (A first-class field, not a reconstruct-and-
+shape-check — the same principle as the latch below.)
+
+**One decision reversed on the merits.** The panel wanted integer-strict numerics
+(POSIX errors on `1.5 -eq 1`). Amy pointed out that kaish numbers *are* JSON
+numbers and `[[` already compares floats via this exact `numeric_compare` —
+rejecting `1.5` in `test` but not `[[` would be the odd one out. She was right,
+and it *simplified* the code: `test` numeric == `[[` numeric, verbatim, no
+integer-strict wrapper. Still loud on non-numeric/collection/NaN.
+
+Predictable-by-design divergences from POSIX `test`, all deliberate: no word
+splitting; `-a`/`-o`/`( )` rejected loudly (chain with shell `&&`/`||` or use
+`[[ ]]`); no arg-count magic (an operator missing its operand is loud, not a
+surprise-true); negation is a single parity-collapsing leading `!`. Adding the
+builtin retired the `PosixTestCommand` validator advisory (W006) that used to
+steer `test` toward `[[` — it's a real command now.
+
+**Sequencing.** Built on a worktree parked while #94 (hardening) and #92/#97
+(latch) landed — the `raw_argv` work touches the same dispatch seam #92 reworks,
+so it went *after*, beside `current_invocation`, not in conflict. Then rebased
+across #99 (chumsky alpha.8 → 0.13); the parser change compiled clean on the new
+combinator surface.
+
 ## The confirmation latch becomes a first-class, fulfillable API (2026-07-04)
 
 Fell out of the redirect-in-`$()` work above. That change had to special-case


### PR DESCRIPTION
## What

Adds a **`test` builtin** that follows kaish's `[[` semantics as a *command* —
exit `0` true / `1` false / `2` usage-or-type error — replacing the previous
silent shell-out to the host `/usr/bin/test` (OS-dependent, not VFS-aware,
command-not-found in a no-subprocess build).

```sh
test -f config.toml             # VFS-aware file tests: -e -f -d -r -w -x
test "$mode" = release          # literal equality: = == !=
test "$count" -gt 0             # numeric: -eq -ne -gt -lt -ge -le
test ! -d build                 # negation: a single leading !
test -f a && test -f b          # compound: shell && / || (no -a/-o)
if test -f "$path"; then …; fi
```

## Why / decisions

A 4-model kaibo panel (deepseek/gemini/or-gpt/or-kimi) judged a flag-form-only
`test` **not credible** — `test a = b` is the canonical idiom, and without it the
builtin would parse-error on the one form everyone reaches for. So: full scope.

**Two parts.** (1) *Grammar relief*: kaish lexes `= == != !` as shell-significant
tokens, so `test a = b` / `test ! -f x` parse-errored before reaching a command.
A small, name-agnostic arg-parser production makes those four operators literal
positional words. Angle brackets `< > <= >=` are deliberately excluded — they stay
redirection. Side effect (bash-consistent): spaced `cmd key = value` now parses as
a three-arg command; glued `key=value` stays an assignment.

(2) *The builtin*. The hard part was **argv shape**, not the predicate logic.
POSIX `test` is position-sensitive (`test $x = -n`, `test 0 -gt -5`) but kaish's
`ToolArgs` splits flags into an unordered set — an operand that merely looks like
a flag gets silently mis-routed (`echo a -n b` → `a b`). Order dies in the
*binder*, not the lexer, and faithful source order is a distinct binding mode
(incompatible with flag-value consumption like `grep -A 3`). So this adds an
opt-in **`ToolSchema.raw_argv`**: the binder binds every arg to `positional` in
source order with `Value` types preserved. `test` opts in; nothing else pays. The
predicate layer then reuses `[[`'s engine verbatim (`values_equal`,
`numeric_compare`, the scalar guards).

**Numerics reversed on the merits (Amy's call):** NOT integer-strict. `test`
numeric == `[[` numeric — floats compare, because kaish numbers are JSON numbers;
rejecting `1.5` in `test` but not `[[`/arithmetic would be the odd one out. Still
loud on non-numeric / collection / NaN.

**Deliberate divergences from POSIX `test`, all toward predictability:** no word
splitting; `-a`/`-o`/`( )` rejected loudly (chain with shell `&&`/`||` or use
`[[ ]]`); no arg-count magic — an operator missing its operand is loud, not a
surprise-true; negation is a single parity-collapsing leading `!`. Membership,
regex, and shape guards stay `[[ ]]`-only.

Retires the `PosixTestCommand` validator advisory (**W006**) that steered `test`
toward `[[` — it's a first-class builtin now.

## Tests

`crates/kaish-kernel/tests/test_builtin_tests.rs` — kernel-routed, covering every
form and exit code, incl. the killer cases: flag-shaped operands (`test x = -f`),
negative operands (`test 0 -gt -5`), floats (`test 1.5 -gt 1`), collection-loud,
arity-loud, compound-rejected, and a guard that the builtin (not external `test`)
is in play. Full `cargo test --all` + `cargo clippy --all --all-targets` green;
rebased across #99 (chumsky 0.13) with no API breakage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
