### PR TITLE
fix([[ ]]): file tests honor `cd` — resolve relative paths against session cwd (#101)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -265,6 +265,10 @@ breaking entries are marked **BREAKING**.
   through the registry like any other command.
 
 ### Fixed
+- **`[[ ]]` file tests honor `cd`** (GH #101). A relative path in `[[ -f x ]]`
+  (and `-e -d -r -w -x`) used to stat against the process cwd, so after a `cd` an
+  existing file read as absent — a silent wrong `false` into `if`/`&&`. It now
+  resolves against the session cwd, agreeing with the VFS-aware `test` builtin.
 - **Binary data at text sinks is loud, not a silent placeholder** — a
   `Value::Bytes` value (e.g. `b=$(cat some-binary-file)`, since `cat` emits raw
   bytes for non-UTF-8 content) used to render the placeholder `[binary: N bytes]`

--- a/crates/kaish-kernel/src/kernel.rs
+++ b/crates/kaish-kernel/src/kernel.rs
@@ -4104,8 +4104,15 @@ impl Kernel {
                     let home = self.scope_home().await;
                     let path_value = apply_tilde_expansion(path_value, home.as_deref());
                     let path_str = value_to_string(&path_value);
-                    let backend = self.exec_ctx.read().await.backend.clone();
-                    let entry = backend.stat(std::path::Path::new(&path_str)).await.ok();
+                    // Resolve against the *session* cwd, not the process cwd, so a
+                    // relative `[[ -f rel ]]` honors `cd` and agrees with the
+                    // VFS-aware `test` builtin (GH #101). Backend stats a raw
+                    // relative path against the process cwd otherwise.
+                    let (resolved, backend) = {
+                        let ctx = self.exec_ctx.read().await;
+                        (ctx.resolve_path(&path_str), ctx.backend.clone())
+                    };
+                    let entry = backend.stat(&resolved).await.ok();
                     Ok(match op {
                         FileTestOp::Exists => entry.is_some(),
                         FileTestOp::IsFile => entry.as_ref().is_some_and(|e| e.is_file()),

--- a/crates/kaish-kernel/tests/file_test_tilde_tests.rs
+++ b/crates/kaish-kernel/tests/file_test_tilde_tests.rs
@@ -93,3 +93,64 @@ async fn file_test_tilde_resolves_against_home_not_cwd() {
         "`~` did not resolve against the session HOME"
     );
 }
+
+// --- relative paths resolve against the session cwd (GH #101) ---------------
+
+/// A bare relative path in a `[[ ]]` file test must stat against the session
+/// cwd, not the process cwd. `eval_test_async` used to hand the raw string to
+/// `backend.stat`, so `[[ -f rel ]]` silently missed a file that exists in the
+/// shell's cwd — a wrong `false` flowing into `if`/`&&`.
+#[tokio::test]
+async fn file_test_relative_path_resolves_against_session_cwd() {
+    let dir = tempdir();
+    std::fs::write(dir.path().join("here.txt"), b"hi").unwrap();
+    let kernel = kernel_at(dir.path());
+
+    let out = kernel
+        .execute("[[ -f here.txt ]] && echo 'yes' || echo 'no'")
+        .await
+        .unwrap();
+    assert_eq!(out.text_out().trim(), "yes", "relative -f ignored the session cwd");
+}
+
+/// The reported repro (GH #101): after `cd sub`, a relative `[[ -f f ]]` must
+/// honor the new cwd.
+#[tokio::test]
+async fn file_test_honors_cd() {
+    let dir = tempdir();
+    std::fs::create_dir(dir.path().join("sub")).unwrap();
+    std::fs::write(dir.path().join("sub").join("f.txt"), b"hi").unwrap();
+    let kernel = kernel_at(dir.path());
+
+    let out = kernel
+        .execute("cd sub; [[ -f f.txt ]] && echo 'yes' || echo 'no'")
+        .await
+        .unwrap();
+    assert_eq!(out.text_out().trim(), "yes", "[[ -f ]] did not honor cd");
+}
+
+/// Differential guard: `[[ -f rel ]]` and the VFS-aware `test -f rel` must
+/// agree on a relative path after `cd` (they disagreed before this fix —
+/// `test` resolved the cwd, `[[` did not).
+#[tokio::test]
+async fn double_bracket_and_test_agree_on_relative_path() {
+    let dir = tempdir();
+    std::fs::create_dir(dir.path().join("sub")).unwrap();
+    std::fs::write(dir.path().join("sub").join("f.txt"), b"hi").unwrap();
+    let kernel = kernel_at(dir.path());
+
+    let out = kernel
+        .execute(
+            "cd sub\n\
+             [[ -f f.txt ]]; b=$?\n\
+             test -f f.txt; t=$?\n\
+             [[ $b -eq $t ]] && echo agree || echo \"disagree b=$b t=$t\"",
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        out.text_out().trim(),
+        "agree",
+        "[[ -f ]] and test -f disagreed on a relative path"
+    );
+}


### PR DESCRIPTION
Closes #101.

## The bug

`[[ -f <relative> ]]` (and `-e -d -r -w -x`) stat'd the raw path string against the *process* cwd, so after a `cd` an existing file read as absent — a silent wrong `false` flowing into `if`/`&&`.

```sh
cd sub
test -f f.txt      # 0  (correct — resolves the session cwd)
[[ -f f.txt ]]     # 1  (WRONG — f.txt exists)   ← before this fix
```

## Fix

`eval_test_async`'s `FileTest` arm now routes the (already tilde-expanded) path through `ctx.resolve_path` — the same way the `test` builtin and `readlink` do — so relative paths resolve against the session cwd. One-liner in `kernel.rs`; the sync eval path doesn't stat files, so this is the only site.

## How it surfaced

A kaibo review of the `test` builtin (#100) noticed `test` resolved paths correctly while `[[` did not, and that the two would disagree. Verified: `test=0` / `bracket=1` after `cd sub`.

## Tests

Kernel-routed regressions in `file_test_tilde_tests.rs`: a bare relative test, a post-`cd` test, and a differential guard that `[[ -f rel ]]` and `test -f rel` agree. Full `cargo test --all` + `cargo clippy --all --all-targets` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)