### PR TITLE
chore: bump to v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ breaking entries are marked **BREAKING**.
 
 ## [Unreleased]
 
+## [0.11.0] - 2026-07-04
+
 ### Added
 - **`test` builtin** — POSIX condition evaluation as a command, following
   kaish's `[[` semantics (exit `0` true / `1` false / `2` usage-or-type error).
@@ -1043,7 +1045,8 @@ Initial public release of **kaish** (会sh) — a predictable Bourne-like shell 
 - **REPL** (`kaish-repl`) with multi-line input, completion, and history; **MCP server** (`kaish-mcp`) exposing `kaish_execute` with help resources and structured + plain-text content blocks.
 - **`KernelClient` trait** + `EmbeddedClient` for in-process embedding; topic-based help system; `kaish-wasi` `wasm32-wasip1` target.
 
-[Unreleased]: https://github.com/tobert/kaish/compare/v0.10.0...HEAD
+[Unreleased]: https://github.com/tobert/kaish/compare/v0.11.0...HEAD
+[0.11.0]: https://github.com/tobert/kaish/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/tobert/kaish/compare/v0.9.1...v0.10.0
 [0.9.1]: https://github.com/tobert/kaish/compare/v0.9.0...v0.9.1
 [0.9.0]: https://github.com/tobert/kaish/compare/v0.8.4...v0.9.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -965,7 +965,7 @@ dependencies = [
 
 [[package]]
 name = "kaish-client"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -979,7 +979,7 @@ dependencies = [
 
 [[package]]
 name = "kaish-glob"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "ignore",
@@ -991,14 +991,14 @@ dependencies = [
 
 [[package]]
 name = "kaish-help"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "kaish-types",
 ]
 
 [[package]]
 name = "kaish-kernel"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "ariadne",
@@ -1054,7 +1054,7 @@ dependencies = [
 
 [[package]]
 name = "kaish-repl"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1074,7 +1074,7 @@ dependencies = [
 
 [[package]]
 name = "kaish-tool-api"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "clap",
@@ -1084,7 +1084,7 @@ dependencies = [
 
 [[package]]
 name = "kaish-tools-host"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "clap",
@@ -1095,7 +1095,7 @@ dependencies = [
 
 [[package]]
 name = "kaish-types"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "base64",
  "schemars",
@@ -1107,7 +1107,7 @@ dependencies = [
 
 [[package]]
 name = "kaish-vfs"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "getrandom 0.3.4",
@@ -1118,7 +1118,7 @@ dependencies = [
 
 [[package]]
 name = "kaish-wasi"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "kaish-kernel",
  "kaish-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.10.0"
+version = "0.11.0"
 edition = "2024"
 rust-version = "1.85"
 authors = ["Amy Tobey <tobert@gmail.com>"]

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ everywhere, a `jq` that always uses the same filter syntax, an `awk` that never 
 | **JSON** | fromjson, fromjsonl, jq, keys, tojson, tojsonl, typeof, values |
 | **System** | alias, bg, date, echo, env, exec, export, fg, help, hostname, jobs, kill, printf, ps, push, read, seq, set, sleep, spawn, timeout, tokens, uname, unalias, unset, wait, which |
 | **Parallel** | scatter, gather |
-| **Meta** | assert, false, true |
+| **Meta** | assert, false, test, true |
 | **kaish-*** | kaish-ast, kaish-clear, kaish-ignore, kaish-last, kaish-mounts, kaish-output-limit, kaish-status, kaish-tools, kaish-trash, kaish-validate, kaish-vars, kaish-version, kaish-vfs |
 
 ---

--- a/crates/kaish-client/Cargo.toml
+++ b/crates/kaish-client/Cargo.toml
@@ -13,7 +13,7 @@ categories.workspace = true
 readme = "../../README.md"
 
 [dependencies]
-kaish-kernel = { path = "../kaish-kernel", version = "0.10.0" }
+kaish-kernel = { path = "../kaish-kernel", version = "0.11.0" }
 
 # Async runtime
 tokio = { workspace = true }

--- a/crates/kaish-help/Cargo.toml
+++ b/crates/kaish-help/Cargo.toml
@@ -13,7 +13,7 @@ categories.workspace = true
 readme = "../../README.md"
 
 [dependencies]
-kaish-types = { path = "../kaish-types", version = "0.10.0" }
+kaish-types = { path = "../kaish-types", version = "0.11.0" }
 
 [lints]
 workspace = true

--- a/crates/kaish-kernel/Cargo.toml
+++ b/crates/kaish-kernel/Cargo.toml
@@ -14,11 +14,11 @@ readme = "../../README.md"
 exclude = ["tests/snapshots/"]
 
 [dependencies]
-kaish-glob = { path = "../kaish-glob", version = "0.10.0" }
-kaish-types = { path = "../kaish-types", version = "0.10.0", features = [] }
-kaish-help = { path = "../kaish-help", version = "0.10.0" }
-kaish-tool-api = { path = "../kaish-tool-api", version = "0.10.0" }
-kaish-vfs = { path = "../kaish-vfs", version = "0.10.0", features = ["memory", "overlay"] }
+kaish-glob = { path = "../kaish-glob", version = "0.11.0" }
+kaish-types = { path = "../kaish-types", version = "0.11.0", features = [] }
+kaish-help = { path = "../kaish-help", version = "0.11.0" }
+kaish-tool-api = { path = "../kaish-tool-api", version = "0.11.0" }
+kaish-vfs = { path = "../kaish-vfs", version = "0.11.0", features = ["memory", "overlay"] }
 
 # Async runtime — minimal base; `localfs` adds tokio/fs, `subprocess` adds
 # tokio/process + tokio/rt-multi-thread (see [features]).
@@ -83,7 +83,7 @@ jaq-json = { workspace = true }
 # Optional deps, each pulled in by its capability feature:
 #   kaish-tools-host → host, trash/directories → os-integration,
 #   tiktoken-rs → tokens.
-kaish-tools-host = { path = "../kaish-tools-host", version = "0.10.0", optional = true }
+kaish-tools-host = { path = "../kaish-tools-host", version = "0.11.0", optional = true }
 trash = { workspace = true, optional = true }
 directories = { workspace = true, optional = true }
 tiktoken-rs = { workspace = true, optional = true }

--- a/crates/kaish-repl/Cargo.toml
+++ b/crates/kaish-repl/Cargo.toml
@@ -19,8 +19,8 @@ path = "src/main.rs"
 [dependencies]
 # The REPL is the full interactive human shell: it needs every capability
 # (external commands + job control, git, host introspection, tokens, trash).
-kaish-kernel = { path = "../kaish-kernel", version = "0.10.0", features = ["full"] }
-kaish-client = { path = "../kaish-client", version = "0.10.0" }
+kaish-kernel = { path = "../kaish-kernel", version = "0.11.0", features = ["full"] }
+kaish-client = { path = "../kaish-client", version = "0.11.0" }
 
 # Line editing
 rustyline = { workspace = true }

--- a/crates/kaish-tool-api/Cargo.toml
+++ b/crates/kaish-tool-api/Cargo.toml
@@ -12,7 +12,7 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-kaish-types = { path = "../kaish-types", version = "0.10.0", features = [] }
+kaish-types = { path = "../kaish-types", version = "0.11.0", features = [] }
 
 async-trait = { workspace = true }
 clap = { workspace = true }

--- a/crates/kaish-tools-host/Cargo.toml
+++ b/crates/kaish-tools-host/Cargo.toml
@@ -12,8 +12,8 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-kaish-types = { path = "../kaish-types", version = "0.10.0", features = [] }
-kaish-tool-api = { path = "../kaish-tool-api", version = "0.10.0" }
+kaish-types = { path = "../kaish-types", version = "0.11.0", features = [] }
+kaish-tool-api = { path = "../kaish-tool-api", version = "0.11.0" }
 
 async-trait = { workspace = true }
 clap = { workspace = true }

--- a/crates/kaish-vfs/Cargo.toml
+++ b/crates/kaish-vfs/Cargo.toml
@@ -12,7 +12,7 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-kaish-types = { path = "../kaish-types", version = "0.10.0", features = [] }
+kaish-types = { path = "../kaish-types", version = "0.11.0", features = [] }
 async-trait = { workspace = true }
 # DevFs's /dev/urandom pulls from the OS CSPRNG. Pure (no tokio); works on
 # Unix/macOS/WASI.


### PR DESCRIPTION
Version bump + changelog stamp for the **0.11.0** release.

## What's in 0.11.0

The headline of this cycle is the **arrays & hashes (native collections)** milestone, plus the data-bridge and ergonomics work around it:

- **Native collections** — list/record literals + spread, read access (`${xs[0]}`, `${r[key]}`, slices, nested paths), lvalue writes (bracket-path assignment, bareword `push`), `keys`/`values`, `typeof` + `[[ -list ]]`/`[[ -record ]]` shape guards, `[[ in ]]`/`[[ not in ]]` membership, path-aware `${#…}`/`${…:-default}`, arithmetic subscripts.
- **JSON/JSONL bridges** — new `fromjson`/`tojson`/`fromjsonl`/`tojsonl` builtins; real `jq -s` slurp.
- **`test` builtin** — VFS-aware `[[` semantics as a command (retires the `/usr/bin/test` shell-out and validator advisory W006).
- **BREAKING: typed scatter/gather** — one JSONL result record per worker, typed worker bindings, new exit-code contract; `--format`/`--first` removed, `--lines` added.
- **BREAKING: first-class confirmation latch** — `ExecResult.latch: Option<Box<LatchRequest>>` control-plane field + `Kernel::confirm()`; the `--json` nonce moves out of `.data`.
- **grep/sed/awk accept GNU BRE backslash-metas** as an ERE superset (BREAKING for `sed`).
- **chumsky** migrated off the dead `1.0.0-alpha` line to `0.13` (zero code changes).
- Plus a large batch of silent-corruption → loud-error hardening fixes (two AI-review rounds in #94) and the `redirects-inside-$()` / `.data`-clearing-on-redirect work.

Full detail in the stamped `## [0.11.0]` section of `CHANGELOG.md`.

## This PR (mechanical)

- Root workspace version `0.10.0` → `0.11.0`, all 14 inter-crate `path + version` pins moved together (`cargo check --all` green, `Cargo.lock` regenerated: 10 kaish-crate bumps, no dep changes).
- `CHANGELOG.md`: `Unreleased` → `[0.11.0] - 2026-07-04`, fresh empty `Unreleased` added, compare links updated.
- **Docs fix caught in preflight:** the `test` builtin (registered unconditionally, shipped this cycle) was missing from the README builtin table — added to the Meta row.

## Review

The substantive review of the release *contents* happened across the individual feature PRs on the way to `main` (every feature PR reviewed; #94 was explicitly two AI-review rounds). Pre-flight gate on this branch is clean: `cargo clippy --all --all-targets` (0 warnings), `cargo test --all`, `cargo insta test --check` (no pending snapshots). This bump diff itself is version strings + the changelog stamp + the one-line README fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)