### PR TITLE
docs(release): Phase 2 points at the real builtin source-of-truth

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -40,11 +40,25 @@ If any builtins were added, removed, or recategorized since the last tag,
 verify that documentation matches the actual tool registry. Launch a Task
 subagent (Explore type) to:
 
-1. List every builtin tool name from `crates/kaish-kernel/src/tools/builtin/`
-   (each file's `fn name(&self)` return value)
-2. Compare against the builtin table in `README.md` (the `| Category | Tools |` table)
-3. Compare against the category match arms in `crates/kaish-kernel/src/help.rs`
-   (`format_tool_list` function)
+1. List every registered builtin tool name. The authority is
+   `register_builtins()` in `crates/kaish-kernel/src/tools/builtin/mod.rs` — each
+   `registry.register(...)` maps to one `fn name()`. Note: multi-name builtins
+   register distinct structs (there is no `fn aliases()` mechanism), and
+   capability-gated builtins (subprocess/host/tokens) are absent from a default
+   build but are still real builtins.
+2. Compare against the builtin table in `README.md` (the `| Category | Tools |`
+   table). **This README table is the only *categorized* listing of builtins
+   anywhere**, so it's the only place a builtin can be hand-miscategorized or
+   omitted — check it carefully.
+3. There are **no code-side category groupings** to check against. The
+   `help builtins` output (`format_tool_list` in
+   `crates/kaish-help/src/topic.rs`) and the `kaish-tools` builtin
+   (`format_tool_list` in `crates/kaish-kernel/src/tools/builtin/introspect.rs`)
+   both emit a flat, alphabetical list built directly from the live registry
+   schemas, so they cannot omit or miscategorize a registered builtin
+   (feature-gated ones drop out naturally). `crates/kaish-kernel/src/help.rs` is
+   now just a re-export shim into the `kaish-help` crate — the old
+   `format_tool_list` category match arms it once held are gone.
 4. Check for hardcoded tool counts anywhere in docs (`README.md`, `docs/help/*.md`)
 
 Report any mismatches: ghost entries (listed but don't exist), missing entries


### PR DESCRIPTION
## Problem

The `/release` skill's Phase 2 (docs-consistency check) instructed the audit to
"compare against the category match arms in `crates/kaish-kernel/src/help.rs`
(`format_tool_list`)". That reference is stale — surfaced while running the
0.11.0 release.

## What's actually true (as of 0.11.0)

- `crates/kaish-kernel/src/help.rs` is now just a **re-export shim** into the
  `kaish-help` crate; the old category match arms are gone.
- `format_tool_list` lives in two places today —
  `crates/kaish-help/src/topic.rs` (the `help builtins` output) and
  `crates/kaish-kernel/src/tools/builtin/introspect.rs` (the `kaish-tools`
  builtin) — and **both emit a flat, alphabetical list built directly from the
  live registry schemas**. There is no code-side category grouping left to drift.
- The **only categorized listing of builtins anywhere is the README table**, so
  that's the sole place a builtin can be hand-miscategorized or omitted.

## The fix

Rewrite Phase 2 steps 1–3 to match reality:
- Step 1 names `register_builtins()` in `tools/builtin/mod.rs` as the
  registration authority, with the distinct-structs-per-alias and
  capability-gated nuances called out.
- Step 2 flags the README table as the single categorized listing worth
  hand-checking.
- Step 3 records that the code-side lists are registry-derived and can't
  miscategorize, and that `help.rs` is a shim now.

Caught while auditing the builtin table for 0.11.0 — the same audit found the
`test` builtin missing from the README table (fixed in the 0.11.0 bump PR #103).

Internal tooling doc only (no shell/embedder surface change), so no CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)