### PR TITLE
fix(grep): `-r` searches a file operand instead of silently missing (GH #105)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ breaking entries are marked **BREAKING**.
 
 ## [Unreleased]
 
+### Fixed
+- **`grep -r PATTERN FILE`** (a file operand, not a directory) now searches
+  that file instead of silently finding nothing (GH #105). `-r`/`-R` used to
+  treat every operand as a walk root; a file has nothing "under" it, so the
+  walk collected zero entries → 0 matches, exit 1, no error — a false negative
+  a model reads as "not found". `-r` now governs only how *directories* expand:
+  files are searched directly, directories walked, and a mixed `grep -r p file
+  dir` operand list does both.
+
 ## [0.11.0] - 2026-07-04
 
 ### Added

--- a/crates/kaish-kernel/src/tools/builtin/grep.rs
+++ b/crates/kaish-kernel/src/tools/builtin/grep.rs
@@ -379,59 +379,107 @@ impl Tool for Grep {
 
         // Handle recursive search
         if recursive {
-            let path = args
-                .get_string("path", 1)
-                .unwrap_or_else(|| ".".to_string());
-            let root = ctx.resolve_path(&path);
-
-            // Build include/exclude filter
-            let mut filter = IncludeExclude::new();
-            if let Some(Value::String(inc)) = args.get("include", usize::MAX) {
-                filter.include(inc);
-            }
-            if let Some(Value::String(exc)) = args.get("exclude", usize::MAX) {
-                filter.exclude(exc);
-            }
-
-            // Build glob pattern if include is specified
-            let glob = if let Some(Value::String(inc)) = args.get("include", usize::MAX) {
-                GlobPath::new(&format!("**/{}", inc)).ok()
+            // Partition the operands by kind. A *directory* is walked; a *file*
+            // is searched directly (#105 — a file has nothing "under" it, so
+            // treating it as a walk root collected zero entries and reported no
+            // matches *silently*, the worst failure mode for a model reading the
+            // empty result as "not found"). `-r` governs how *directories*
+            // expand, which is the only thing anyone means by it. A missing or
+            // otherwise-unstattable operand falls to the walker, preserving the
+            // pre-#105 behavior for a bad root.
+            let operands: Vec<String> = args
+                .positional
+                .iter()
+                .skip(1)
+                .map(crate::interpreter::value_to_string)
+                .collect();
+            let operands = if operands.is_empty() {
+                vec![".".to_string()]
             } else {
-                GlobPath::new("**/*").ok()
+                operands
             };
 
-            let options = WalkOptions {
-                max_depth: None,
-                entry_types: crate::walker::EntryTypes::files_only(),
-                respect_gitignore: ctx.ignore_config.auto_gitignore(),
-                include_hidden,
-                filter,
-                types: file_types.clone(),
-                ..WalkOptions::default()
-            };
-
-            let fs = BackendWalkerFs(ctx.backend.as_ref());
-            let mut walker = if let Some(g) = glob {
-                FileWalker::new(&fs, &root)
-                    .with_pattern(g)
-                    .with_options(options)
-            } else {
-                FileWalker::new(&fs, &root).with_options(options)
-            };
-
-            // Inject ignore filter from config
-            if let Some(ignore_filter) = ctx.build_ignore_filter(&root).await {
-                walker = walker.with_ignore(ignore_filter);
+            let mut dir_roots: Vec<PathBuf> = Vec::new();
+            let mut file_operands: Vec<PathBuf> = Vec::new();
+            for operand in &operands {
+                let resolved = ctx.resolve_path(operand);
+                match ctx.backend.stat(&resolved).await {
+                    Ok(entry) if entry.is_file() => file_operands.push(resolved),
+                    _ => dir_roots.push(resolved),
+                }
             }
 
-            let files = match walker.collect().await {
-                Ok(f) => f,
-                Err(e) => return ExecResult::failure(1, format!("grep: {}", e)),
-            };
+            // No directory to recurse into: every operand is a plain file. Fall
+            // through to the ordinary file-operand handling below (a lone file
+            // → no prefix like `grep -c`; several → prefixed) — exactly what
+            // grep *without* `-r` does with these files. This is the #105 fix.
+            if !dir_roots.is_empty() {
+                let fs = BackendWalkerFs(ctx.backend.as_ref());
+                let mut files: Vec<PathBuf> = Vec::new();
+                for root in &dir_roots {
+                    // include/exclude + glob are walk-only (see the validation
+                    // note above); rebuilt per root since `with_options` moves.
+                    let mut filter = IncludeExclude::new();
+                    if let Some(Value::String(inc)) = args.get("include", usize::MAX) {
+                        filter.include(inc);
+                    }
+                    if let Some(Value::String(exc)) = args.get("exclude", usize::MAX) {
+                        filter.exclude(exc);
+                    }
+                    let glob = if let Some(Value::String(inc)) = args.get("include", usize::MAX) {
+                        GlobPath::new(&format!("**/{}", inc)).ok()
+                    } else {
+                        GlobPath::new("**/*").ok()
+                    };
 
-            return self
-                .grep_multiple_files(ctx, &files, &root, &matcher, &grep_opts, quiet, files_only, count_only, false)
-                .await;
+                    let options = WalkOptions {
+                        max_depth: None,
+                        entry_types: crate::walker::EntryTypes::files_only(),
+                        respect_gitignore: ctx.ignore_config.auto_gitignore(),
+                        include_hidden,
+                        filter,
+                        types: file_types.clone(),
+                        ..WalkOptions::default()
+                    };
+
+                    let mut walker = if let Some(g) = glob {
+                        FileWalker::new(&fs, root)
+                            .with_pattern(g)
+                            .with_options(options)
+                    } else {
+                        FileWalker::new(&fs, root).with_options(options)
+                    };
+
+                    if let Some(ignore_filter) = ctx.build_ignore_filter(root).await {
+                        walker = walker.with_ignore(ignore_filter);
+                    }
+
+                    match walker.collect().await {
+                        Ok(f) => files.extend(f),
+                        Err(e) => return ExecResult::failure(1, format!("grep: {}", e)),
+                    }
+                }
+
+                // Directly-named file operands (the mixed `grep -r p file dir`
+                // case) join the walked set.
+                let has_file_operands = !file_operands.is_empty();
+                files.extend(file_operands);
+
+                // Display prefix: strip the sole walk root — preserving the
+                // historical `grep -r p dir` → `file` display byte-for-byte —
+                // whenever there's exactly one directory and no file operand
+                // mixed in. Otherwise strip cwd so each source shows under its
+                // own subpath (`top.txt`, `sub/inner.txt`).
+                let display_root = if dir_roots.len() == 1 && !has_file_operands {
+                    dir_roots[0].clone()
+                } else {
+                    ctx.resolve_path(".")
+                };
+
+                return self
+                    .grep_multiple_files(ctx, &files, &display_root, &matcher, &grep_opts, quiet, files_only, count_only, false)
+                    .await;
+            }
         }
 
         // Explicit multiple file operands: positional[1..]. The kernel

--- a/crates/kaish-kernel/tests/grep_search_features_tests.rs
+++ b/crates/kaish-kernel/tests/grep_search_features_tests.rs
@@ -202,3 +202,63 @@ async fn max_count_caps_streaming_stdin() {
     assert_eq!(code, 0, "out={out:?}");
     assert_eq!(out.lines().count(), 2, "stdin stream capped at 2: {out:?}");
 }
+
+// ─── #105: `grep -r PATTERN FILE` (a file operand, not a dir) ────────────────
+// `-r` used to unconditionally treat the operand as a walk root; a file has
+// nothing "under" it, so the walk collected zero entries → 0 matches, exit 1,
+// silently. A file operand under `-r` must be searched directly instead.
+
+/// The headline reflex: `grep -r PATTERN <file>` searches the file.
+#[tokio::test]
+async fn recursive_flag_searches_a_file_operand() {
+    let dir = tempdir().unwrap();
+    fs::write(dir.path().join("notes.txt"), "needle a\nhay\nneedle b\n").expect("write");
+    let kernel = kernel_at(dir.path());
+
+    let (out, code) = run(&kernel, "grep -r needle notes.txt").await;
+    assert_eq!(code, 0, "a file operand under -r must match, not silently miss: {out:?}");
+    assert!(out.contains("needle a"), "first match: {out:?}");
+    assert!(out.contains("needle b"), "second match: {out:?}");
+}
+
+/// `grep -rc PATTERN <file>` reports the real count (was 0), like plain `-c`
+/// on a single file — no filename prefix.
+#[tokio::test]
+async fn recursive_count_on_a_file_operand() {
+    let dir = tempdir().unwrap();
+    fs::write(dir.path().join("notes.txt"), "needle\nneedle\nhay\nneedle\n").expect("write");
+    let kernel = kernel_at(dir.path());
+
+    let (out, code) = run(&kernel, "grep -rc needle notes.txt").await;
+    assert_eq!(code, 0, "out={out:?}");
+    assert_eq!(out.trim(), "3", "count of a single file operand: {out:?}");
+}
+
+/// The uppercase `-R` alias behaves identically on a file operand.
+#[tokio::test]
+async fn recursive_upper_flag_searches_a_file_operand() {
+    let dir = tempdir().unwrap();
+    fs::write(dir.path().join("notes.txt"), "needle a\nhay\n").expect("write");
+    let kernel = kernel_at(dir.path());
+
+    let (out, code) = run(&kernel, "grep -R needle notes.txt").await;
+    assert_eq!(code, 0, "-R on a file operand must match: {out:?}");
+    assert!(out.contains("needle a"), "match: {out:?}");
+}
+
+/// A mixed operand list — a file *and* a directory — searches the file
+/// directly and walks the directory, prefixing both (multi-source display).
+#[tokio::test]
+async fn recursive_mixed_file_and_dir_operands() {
+    let dir = tempdir().unwrap();
+    fs::write(dir.path().join("top.txt"), "needle top\n").expect("write top");
+    fs::create_dir(dir.path().join("sub")).expect("mkdir sub");
+    fs::write(dir.path().join("sub/inner.txt"), "needle inner\n").expect("write inner");
+    let kernel = kernel_at(dir.path());
+
+    let (out, code) = run(&kernel, "grep -r needle top.txt sub").await;
+    assert_eq!(code, 0, "out={out:?}");
+    assert!(out.contains("top.txt"), "the file operand is searched: {out:?}");
+    assert!(out.contains("inner.txt"), "the dir operand is walked: {out:?}");
+    assert!(out.contains("needle top") && out.contains("needle inner"), "both matches: {out:?}");
+}

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -14,6 +14,31 @@ before it ships.
 
 ---
 
+## `grep -r` searches a file operand instead of silently missing (2026-07-05, GH #105)
+
+The reflex `grep -r PATTERN FILE` — `-r` is muscle memory, and everyone assumes
+handing a file to a recursive search searches *that file* — returned zero matches,
+exit 1, and **no error**. The recursive branch unconditionally treated the operand
+as a walk root and enumerated it with a files-only `**/*`; a directory yields its
+files, a plain file has nothing "under" it, so the walk collected nothing. The
+worst failure mode: silent. A model reads the empty result as "not found" and
+quietly corrupts whatever reasoning follows — bad enough that kaibo carries a note
+in its shell preamble steering models around it, spending instruction tokens every
+session.
+
+The fix reframes what `-r` *means*: it governs how **directories** expand, nothing
+more. The recursive branch now partitions its operands by `stat` — files are
+searched directly (falling through to the ordinary file-operand path, so a lone
+file prints unprefixed like plain `grep -c`), directories are walked, and a mixed
+`grep -r p file dir` does both. A stat-unresolvable operand still falls to the
+walker, preserving pre-fix behavior for a bad root. Display is conservative: the
+sole-directory walk strips its root exactly as before (byte-for-byte unchanged
+output for the overwhelmingly common `grep -r p dir`); only the genuinely-new
+mixed/multi-source shapes switch to cwd-relative prefixes so each source shows
+under its own subpath. TDD: four kernel-routed regression tests (single file, `-c`
+count, `-R` alias, mixed file+dir) red first, then green; 4370-test suite and
+clippy `--all-targets` clean. Once this ships, kaibo's preamble note can go.
+
 ## The `test` builtin — `[[` semantics as a command (2026-07-04)
 
 `test` had been quietly shelling out to the host `/usr/bin/test`: OS-dependent,


### PR DESCRIPTION
Closes #105.

## The bug

`grep -r PATTERN FILE`, where the operand is a **file** rather than a directory, returned **zero matches, exit 1, and no error** — even when the file plainly contained the pattern. Live on 0.11.0:

```
grep -rc 'kaish' AGENTS.md   # → 0    (exit 1, silent)
grep -c  'kaish' AGENTS.md   # → 15
grep -rc 'kaish' .           # → 662  (a directory works fine)
```

The recursive branch (`grep.rs`) unconditionally treated the path operand as a walk root and enumerated it with a files-only `**/*`. A directory yields its files; a plain file has nothing "under" it, so the walk collected zero entries → `grep_multiple_files` over an empty list → 0 matches.

The failure mode is the bad kind — **silent**. A caller, especially a model driving the shell, reads the empty result as "the pattern isn't there": a false negative that quietly corrupts whatever reasoning follows. kaibo carries a hand-rolled shell-preamble note *purely* to steer models around this; fixing it here lets that note (and its per-session instruction tokens) go away.

## The fix

Reframe what `-r` means: it governs how **directories** expand, nothing more — "recurse into directories, search files directly," which is the behavior everyone already assumes. The recursive branch now partitions its operands by `stat`:

- **file** → searched directly (falls through to the ordinary file-operand path below, so a lone file prints unprefixed like plain `grep -c`);
- **directory** → walked;
- **mixed** `grep -r p file dir` → does both (file operand joined to the walked set);
- **stat-unresolvable** operand → still falls to the walker, preserving pre-fix behavior for a bad root.

Display is deliberately conservative: the sole-directory walk strips its root **byte-for-byte as before** (zero change to the overwhelmingly common `grep -r p dir` output); only the genuinely-new mixed/multi-source shapes switch to cwd-relative prefixes so each source shows under its own subpath (`top.txt`, `sub/inner.txt`).

## Tests

Four kernel-routed regression tests in `grep_search_features_tests.rs`, written TDD-first (red → green): single file operand, `-rc` count (the exact `→ 0` repro), the `-R` alias, and a mixed `file dir` operand list. Also verified end-to-end against the built binary.

Full suite (4370 tests) + `cargo clippy --all --all-targets` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)