### PR TITLE
fix(redirects): run `$()` targets on a bare `Kernel::execute` — thread the dispatcher (GH #90)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ breaking entries are marked **BREAKING**.
 ## [Unreleased]
 
 ### Fixed
+- **`$(...)` in a redirect target now works on a bare `Kernel::execute`** (GH
+  #90). Command substitution in a redirect target or heredoc body (`echo x >
+  $(gen)`, `cat < $(gen)`, `cmd > $(gen)` in a pipeline stage) only ran when the
+  kernel was Arc-attached via `into_arc` — the REPL. A bare `Kernel::execute`
+  (every embedder holding a `Kernel` by value, and the whole test harness) left
+  `ctx.dispatcher` unset, so the target silently fell back to a sync evaluator
+  that can't run `$()` and failed with "could not evaluate redirect target".
+  The redirect evaluator now takes the dispatcher the runner already holds, so
+  the behavior no longer depends on how the kernel was constructed.
 - **`grep -r PATTERN FILE`** (a file operand, not a directory) now searches
   that file instead of silently finding nothing (GH #105). `-r`/`-R` used to
   treat every operand as a walk root; a file has nothing "under" it, so the

--- a/crates/kaish-kernel/src/scheduler/pipeline.rs
+++ b/crates/kaish-kernel/src/scheduler/pipeline.rs
@@ -30,6 +30,7 @@ pub(crate) async fn apply_redirects(
     mut result: ExecResult,
     redirects: &[Redirect],
     ctx: &ExecContext,
+    dispatcher: &dyn CommandDispatcher,
 ) -> ExecResult {
     // Defer materialization of OutputData → result.out to individual redirect
     // handlers. File redirects (Overwrite/Append) can stream OutputData directly
@@ -71,7 +72,7 @@ pub(crate) async fn apply_redirects(
                 result.clear_stdout();
             }
             RedirectKind::StdoutOverwrite => {
-                let path = match eval_redirect_target(&redir.target, ctx).await {
+                let path = match eval_redirect_target(&redir.target, ctx, dispatcher).await {
                     Ok(p) => p,
                     Err(e) => return ExecResult::failure(1, format!("redirect: {e}")),
                 };
@@ -96,7 +97,7 @@ pub(crate) async fn apply_redirects(
                 result.clear_stdout();
             }
             RedirectKind::StdoutAppend => {
-                let path = match eval_redirect_target(&redir.target, ctx).await {
+                let path = match eval_redirect_target(&redir.target, ctx, dispatcher).await {
                     Ok(p) => p,
                     Err(e) => return ExecResult::failure(1, format!("redirect: {e}")),
                 };
@@ -121,7 +122,7 @@ pub(crate) async fn apply_redirects(
                 result.clear_stdout();
             }
             RedirectKind::Stderr => {
-                let path = match eval_redirect_target(&redir.target, ctx).await {
+                let path = match eval_redirect_target(&redir.target, ctx, dispatcher).await {
                     Ok(p) => p,
                     Err(e) => return ExecResult::failure(1, format!("redirect: {e}")),
                 };
@@ -131,7 +132,7 @@ pub(crate) async fn apply_redirects(
                 result.err.clear();
             }
             RedirectKind::Both => {
-                let path = match eval_redirect_target(&redir.target, ctx).await {
+                let path = match eval_redirect_target(&redir.target, ctx, dispatcher).await {
                     Ok(p) => p,
                     Err(e) => return ExecResult::failure(1, format!("redirect: {e}")),
                 };
@@ -163,17 +164,24 @@ pub(crate) async fn apply_redirects(
 
 /// Evaluate a redirect target expression to get the file path (or heredoc body).
 ///
-/// Routes through `ctx.dispatcher` so command substitution (`$(...)`) in the
-/// target runs — e.g. `cat < $(echo f)`, `echo x > $(echo f)`, and `$(...)`
-/// inside a heredoc body. Falls back to the sync evaluator (which skips
-/// command substitution) only when no dispatcher is attached.
-async fn eval_redirect_target(expr: &Expr, ctx: &ExecContext) -> Result<String, String> {
-    let value = if let Some(dispatcher) = &ctx.dispatcher {
-        dispatcher.eval_expr(expr, ctx).await.map_err(|e| e.to_string())?
-    } else {
-        eval_simple_expr(expr, ctx)?
-            .ok_or_else(|| "could not evaluate redirect target".to_string())?
-    };
+/// Takes the `dispatcher` explicitly rather than reading `ctx.dispatcher`, so
+/// command substitution (`$(...)`) in the target runs on the *same* dispatcher
+/// the runner already uses — `cat < $(echo f)`, `echo x > $(echo f)`, and
+/// `$(...)` inside a heredoc body. `ctx.dispatcher` is only populated when the
+/// kernel is Arc-attached (`into_arc`); a bare `Kernel::execute` — every test,
+/// and any embedder holding a `Kernel` by value — left it `None`, so a `$()`
+/// target silently fell back to the sync evaluator that can't run it (GH #90).
+/// The runner always holds a real dispatcher; thread it through so the behavior
+/// no longer depends on how the kernel was constructed.
+async fn eval_redirect_target(
+    expr: &Expr,
+    ctx: &ExecContext,
+    dispatcher: &dyn CommandDispatcher,
+) -> Result<String, String> {
+    let value = dispatcher
+        .eval_expr(expr, ctx)
+        .await
+        .map_err(|e| e.to_string())?;
     // Decision D: a bare collection can't be a redirect target either — same
     // process-boundary guard as external argv (see `structured_boundary_error`).
     if let Some(msg) = crate::interpreter::structured_boundary_error("a redirect target", &value) {
@@ -209,12 +217,16 @@ async fn redirect_append(ctx: &ExecContext, path: &str, data: &[u8]) -> Result<(
 /// target resolved against `ctx.cwd`, mirroring how `cat` and the output
 /// redirects resolve their operands. A missing/unreadable file or non-UTF-8
 /// content is a hard error — we never silently feed the command empty stdin.
-async fn setup_stdin_redirects(cmd: &Command, ctx: &mut ExecContext) -> Result<(), String> {
+async fn setup_stdin_redirects(
+    cmd: &Command,
+    ctx: &mut ExecContext,
+    dispatcher: &dyn CommandDispatcher,
+) -> Result<(), String> {
     use std::path::Path;
     for redir in &cmd.redirects {
         match &redir.kind {
             RedirectKind::Stdin => {
-                let path = eval_redirect_target(&redir.target, ctx).await?;
+                let path = eval_redirect_target(&redir.target, ctx, dispatcher).await?;
                 let resolved = ctx.resolve_path(&path);
                 let data = ctx
                     .backend
@@ -233,7 +245,7 @@ async fn setup_stdin_redirects(cmd: &Command, ctx: &mut ExecContext) -> Result<(
                     // Heredoc bodies may contain `$(...)`; route through the
                     // dispatcher so command substitution runs.
                     expr => {
-                        let body = eval_redirect_target(expr, ctx).await?;
+                        let body = eval_redirect_target(expr, ctx, dispatcher).await?;
                         ctx.set_stdin(body);
                     }
                 }
@@ -241,7 +253,7 @@ async fn setup_stdin_redirects(cmd: &Command, ctx: &mut ExecContext) -> Result<(
             RedirectKind::HereString => {
                 // Per bash, here-strings append a trailing newline to the
                 // expanded word so the command receives a terminated line.
-                let mut s = eval_redirect_target(&redir.target, ctx).await?;
+                let mut s = eval_redirect_target(&redir.target, ctx, dispatcher).await?;
                 s.push('\n');
                 ctx.set_stdin(s);
             }
@@ -389,7 +401,7 @@ impl PipelineRunner {
         dispatcher: &dyn CommandDispatcher,
     ) -> ExecResult {
         // Set up stdin from redirects (< file, <<heredoc)
-        if let Err(e) = setup_stdin_redirects(cmd, ctx).await {
+        if let Err(e) = setup_stdin_redirects(cmd, ctx, dispatcher).await {
             return ExecResult::failure(1, e);
         }
 
@@ -408,7 +420,7 @@ impl PipelineRunner {
         };
 
         // Apply post-execution redirects
-        apply_redirects(result, &cmd.redirects, ctx).await
+        apply_redirects(result, &cmd.redirects, ctx, dispatcher).await
     }
 
     /// Run a multi-command pipeline concurrently.
@@ -465,7 +477,7 @@ impl PipelineRunner {
             // Set up stdin from redirects on the child context. A failure here
             // (e.g. `cmd < missing`) fails this stage; surface it from inside
             // the spawned task so the normal join/collection path reports it.
-            let stdin_setup = setup_stdin_redirects(&cmd, &mut stage_ctx).await;
+            let stdin_setup = setup_stdin_redirects(&cmd, &mut stage_ctx, dispatcher).await;
 
             // Wire pipe_stdin: stage 0 gets parent stdin (if no redirect), others get pipe reader
             if i == 0 {
@@ -528,8 +540,11 @@ impl PipelineRunner {
                     Err(e) => ExecResult::failure(1, e.to_string()),
                 };
 
-                // Apply post-execution redirects
-                result = apply_redirects(result, &cmd.redirects, &stage_ctx).await;
+                // Apply post-execution redirects. Use the stage's own
+                // (forked) dispatcher — the borrowed `dispatcher` can't cross
+                // the spawn boundary, and `stage_ctx.dispatcher` is `None` on a
+                // bare kernel, which is exactly the GH #90 gap.
+                result = apply_redirects(result, &cmd.redirects, &stage_ctx, &*task_dispatcher).await;
 
                 // Flush buffered stderr to the kernel's stderr stream.
                 // This delivers error output from intermediate pipeline stages
@@ -1728,6 +1743,13 @@ mod tests {
         ExecContext::new(Arc::new(vfs))
     }
 
+    /// A throwaway dispatcher for `apply_redirects` in tests that exercise
+    /// merge redirects (`2>&1`) only — they never evaluate a `$()` target, so
+    /// an empty-registry backend dispatcher suffices to satisfy the signature.
+    fn test_dispatcher() -> BackendDispatcher {
+        BackendDispatcher::new(Arc::new(ToolRegistry::new()))
+    }
+
     #[test]
     fn test_schema_aware_string_arg() {
         // --query "test" should become named: {"query": "test"}
@@ -2217,7 +2239,7 @@ mod tests {
         }];
 
         let ctx = make_minimal_ctx();
-        let result = apply_redirects(result, &redirects, &ctx).await;
+        let result = apply_redirects(result, &redirects, &ctx, &test_dispatcher()).await;
 
         assert_eq!(&*result.text_out(), "stdout contentstderr content");
         assert!(result.err.is_empty());
@@ -2234,7 +2256,7 @@ mod tests {
         }];
 
         let ctx = make_minimal_ctx();
-        let result = apply_redirects(result, &redirects, &ctx).await;
+        let result = apply_redirects(result, &redirects, &ctx, &test_dispatcher()).await;
 
         assert_eq!(&*result.text_out(), "stdout only");
         assert!(result.err.is_empty());
@@ -2255,7 +2277,7 @@ mod tests {
         }];
 
         let ctx = make_minimal_ctx();
-        let result = apply_redirects(result, &redirects, &ctx).await;
+        let result = apply_redirects(result, &redirects, &ctx, &test_dispatcher()).await;
 
         assert_eq!(&*result.text_out(), "stdout\nstderr\n");
         assert!(result.err.is_empty());

--- a/crates/kaish-kernel/src/scheduler/scatter.rs
+++ b/crates/kaish-kernel/src/scheduler/scatter.rs
@@ -210,7 +210,7 @@ impl ScatterGatherRunner {
         // when gather was the pipeline's last command, so a trailing
         // `gather > file | jq` silently skipped the file and let the
         // unredirected rows flow to `jq` instead.
-        let gathered = apply_redirects(gathered, gather_redirects, ctx).await;
+        let gathered = apply_redirects(gathered, gather_redirects, ctx, &*self.sequential_dispatcher).await;
 
         // Run post-gather commands if any. A failed gather short-circuits —
         // feeding partial/failed output onward would propagate corruption.

--- a/crates/kaish-kernel/tests/redirect_in_cmdsubst_tests.rs
+++ b/crates/kaish-kernel/tests/redirect_in_cmdsubst_tests.rs
@@ -130,11 +130,90 @@ async fn merge_stdout_to_stderr_inside_cmdsubst_does_not_leak_data() {
     );
 }
 
-// The sharpest test of the parser cycle-break — a `$(...)` in the redirect
-// *target*, itself inside a `$(...)` — lives as a parser unit test
-// (`parser::tests::parse_cmd_subst_redirect_target_with_nested_subst`): the
-// hazard it guards is parser *construction* (infinite recursion / stack
-// overflow), which is a parse-layer concern. End-to-end execution of a
-// `$()`-valued redirect target on a *bare* single command is blocked by a
-// separate, pre-existing bug (the dispatcher isn't attached, so the target
-// `$()` can't run) — GH #90, orthogonal to redirect-in-`$()`.
+// ─── GH #90: `$()` in a redirect target on a *bare* single command ──────────
+//
+// The parser cycle-break for a `$(...)` in the redirect *target* itself nested
+// inside a `$(...)` is pinned by a parser unit test
+// (`parser::tests::parse_cmd_subst_redirect_target_with_nested_subst`) — that
+// hazard is parser *construction* (infinite recursion). The *execution* half is
+// pinned here.
+//
+// #90 reported that a `$()`-valued redirect target on a bare single command
+// (not part of a pipeline or `&&`/`||` chain) failed with "could not evaluate
+// redirect target" — the dispatcher wasn't attached, so `eval_redirect_target`
+// fell back to the sync evaluator, which can't run `$()`. It's resolved: bare
+// commands no longer take a reduced sync fast path — every statement runs
+// through `execute_pipeline`, which attaches `ctx.dispatcher` (kernel.rs, "This
+// is the single execution path — no fast path for single commands"), so the
+// target `$()` runs regardless of surrounding syntax. These pin that.
+
+/// The exact #90 repro: a `$()` redirect *target* on a bare single command
+/// (`echo x > $(echo f)`) evaluates the substitution and writes the file.
+#[tokio::test]
+async fn bare_command_cmdsubst_redirect_target_writes_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let kernel = kernel_at(dir.path());
+
+    let r = kernel
+        .execute("echo hi > $(echo out.txt)")
+        .await
+        .expect("execute");
+    assert_eq!(r.code, 0, "bare-command redirect target must run $(): {r:?}");
+
+    let f = kernel.execute("cat out.txt").await.expect("cat");
+    assert_eq!(f.text_out().trim(), "hi", "the file received the output: {f:?}");
+}
+
+/// A `$()` *stdin* redirect target (`cat < $(echo f)`) on a bare command runs
+/// too — the same dispatcher path serves input redirects.
+#[tokio::test]
+async fn bare_command_cmdsubst_stdin_redirect_target() {
+    let dir = tempfile::tempdir().unwrap();
+    let kernel = kernel_at(dir.path());
+
+    kernel.execute("echo payload > src.txt").await.expect("seed");
+    let r = kernel
+        .execute("cat < $(echo src.txt)")
+        .await
+        .expect("execute");
+    assert_eq!(r.code, 0, "{r:?}");
+    assert_eq!(r.text_out().trim(), "payload", "stdin target $() must resolve: {r:?}");
+}
+
+/// The nested form #90 called out: a redirect inside `$()` whose target is
+/// itself a `$()` — `$(cmd > $(subst))`. The parser handles the nesting; the
+/// target-eval step used to fail. Now it executes: capture is empty (stdout
+/// went to the file) and the file has the bytes.
+#[tokio::test]
+async fn nested_cmdsubst_redirect_target_executes() {
+    let dir = tempfile::tempdir().unwrap();
+    let kernel = kernel_at(dir.path());
+
+    let r = kernel
+        .execute(r#"x=$(echo hi > $(echo inner.txt)); echo "[$x]""#)
+        .await
+        .expect("execute");
+    assert_eq!(r.code, 0, "{r:?}");
+    assert_eq!(r.text_out().trim(), "[]", "stdout went to the file, capture empty: {r:?}");
+
+    let f = kernel.execute("cat inner.txt").await.expect("cat");
+    assert_eq!(f.text_out().trim(), "hi", "the nested-target file received the output: {f:?}");
+}
+
+/// A `$()` redirect target on a *pipeline stage* (`echo x | cat > $(echo g)`).
+/// On a bare kernel the stage context copies `dispatcher: None` too, so this
+/// path had the same GH #90 gap — the fix threads the stage's own dispatcher.
+#[tokio::test]
+async fn pipeline_stage_cmdsubst_redirect_target_writes_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let kernel = kernel_at(dir.path());
+
+    let r = kernel
+        .execute("echo piped | cat > $(echo g.txt)")
+        .await
+        .expect("execute");
+    assert_eq!(r.code, 0, "{r:?}");
+
+    let f = kernel.execute("cat g.txt").await.expect("cat");
+    assert_eq!(f.text_out().trim(), "piped", "the pipeline redirect target resolved: {f:?}");
+}

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -14,6 +14,43 @@ before it ships.
 
 ---
 
+## `$()` in a redirect target — the bug that only bit embedders (2026-07-05, GH #90)
+
+Picked this up expecting a quick "attach the dispatcher for bare commands" fix.
+The first surprise: the exact repro (`echo x > $(echo f.txt)`) **worked** through
+the REPL. The `Stmt::Command` fast path was removed months ago ("This is the
+single execution path — no fast path for single commands"), so bare commands run
+through `execute_pipeline`, which attaches `ctx.dispatcher`. The GH #90 comment
+in `redirect_in_cmdsubst_tests.rs` describing it as blocked was stale — or so it
+looked. I nearly closed it as already-fixed with a pinning test.
+
+The pinning test is what saved it. Written through `kernel.execute()` (the
+embedder API, not the REPL), all three cases went **red**: `eval_redirect_target`
+fell back to the sync evaluator and failed with "could not evaluate redirect
+target". The REPL worked; `kernel.execute()` didn't. The tell: `ctx.dispatcher`
+is only populated by `self.dispatcher()`, which upgrades a `self_weak` that's set
+**only in `into_arc`**. The REPL Arc-attaches its kernel; a bare `Kernel` from
+`Kernel::new()` — every embedder holding a `Kernel` by value, and the entire
+4000-test harness — never sets `self_weak`, so `dispatcher()` returns `None` and
+a `$()` redirect target silently degrades. #90 was real, and it bit *exactly the
+surface that matters* (kaibo/kaijutsu drive `kernel.execute`), while hiding from
+the interactive shell we test by hand.
+
+The fix follows the constraint: without an `Arc<Kernel>` there is no
+`Arc<dyn CommandDispatcher>` to put in `ctx.dispatcher`, so the owned-handle
+approach can't work for a bare kernel. But the *runner* always holds a real
+`&dyn CommandDispatcher` (the kernel itself, Arc'd or not). So thread it: through
+`apply_redirects` and `setup_stdin_redirects` into `eval_redirect_target`, which
+now calls `dispatcher.eval_expr` directly and no longer reads `ctx.dispatcher` or
+falls back to the sync evaluator. The silent fallback — the thing that turned a
+missing dispatcher into a wrong answer instead of a loud error — is deleted
+outright. Bonus coverage: a pipeline-stage target (`echo x | cat > $(echo g)`)
+had the same gap (the stage context copies `dispatcher: None` too) and is now
+fixed and pinned. Four kernel-routed tests, red→green; 4374 suite + clippy clean.
+
+Lesson banked: **test the embedder path, not the REPL.** A convenience wrapper
+that Arc-attaches can paper over a defect on the API every real consumer uses.
+
 ## `grep -r` searches a file operand instead of silently missing (2026-07-05, GH #105)
 
 The reflex `grep -r PATTERN FILE` — `-r` is muscle memory, and everyone assumes


### PR DESCRIPTION
Closes #90.

## The bug — and why it hid

`$(...)` in a redirect **target** or heredoc body failed with `redirect: could not evaluate redirect target`:

```
echo x > $(echo f.txt)     # exit 1, f.txt NOT created
cat  < $(echo f.txt)       # same
echo x | cat > $(echo g)   # pipeline stage: same
```

…but **only through `kernel.execute()` on a `Kernel` held by value** — the path every embedder (kaibo/kaijutsu) and the entire test harness use. Through the REPL it worked, which is exactly why it looked already-fixed and the GH #90 comment in `redirect_in_cmdsubst_tests.rs` had gone stale.

`eval_redirect_target` read `ctx.dispatcher` to run the `$()`, and **silently fell back** to the sync evaluator (which can't run command substitution) when it was `None`. `ctx.dispatcher` is populated from `self.dispatcher()`, which upgrades a `self_weak` that is set **only in `into_arc`**. The REPL Arc-attaches its kernel → dispatcher present. A bare `Kernel::execute` never sets `self_weak` → dispatcher `None` → the target silently degraded to a wrong answer.

The pinning test written through `kernel.execute()` is what caught it — red on all three cases.

## The fix

Without an `Arc<Kernel>` there is no `Arc<dyn CommandDispatcher>` to put in `ctx.dispatcher`, so the owned-handle route fundamentally can't serve a bare kernel. But the **runner always holds a real `&dyn CommandDispatcher`** (the kernel itself, Arc'd or not). So thread it: through `apply_redirects` and `setup_stdin_redirects` into `eval_redirect_target`, which now calls `dispatcher.eval_expr` directly.

- The `ctx.dispatcher`-or-sync-fallback branch is **deleted** — no silent fallback (a missing dispatcher can no longer become a wrong answer; there's always a real one).
- A **pipeline-stage** target had the same gap (the stage ctx copies `dispatcher: None`); fixed by passing the stage's own forked dispatcher.
- `ctx.dispatcher` the field stays (the `timeout` builtin's re-dispatch still uses it); only the redirect evaluator stops depending on it.

Behavior no longer depends on how the kernel was constructed.

## Tests

Four kernel-routed regression tests in `redirect_in_cmdsubst_tests.rs`, TDD-first (red → green): bare-command target, `<` stdin target, the nested `$(cmd > $(subst))` form #90 called out, and a pipeline-stage target. The stale "GH #90 blocked" comment is replaced with the real pins.

Full suite (**4374**) + `cargo clippy --all --all-targets` clean. REPL smoke-tested unregressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)