### PR TITLE
feat(#96): surface the backgrounded confirmation latch to its consumers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ breaking entries are marked **BREAKING**.
 
 ## [Unreleased]
 
+### Added
+- **A backgrounded confirmation latch is now surfaced and fulfillable** (GH
+  #96). A destructive op gated under `set -o latch` and run in the background
+  (`rm x &`) stored its `LatchRequest` but no consumer exposed it, so the nonce
+  was unreachable and the gate could never be confirmed. Now: `wait` surfaces
+  the request on the result's `.latch` field (exit 2, like a foreground gate);
+  `jobs` and `/v/jobs/{id}/status` report `Latched` distinctly from a plain
+  failure; and a new `/v/jobs/{id}/latch` node renders the request as JSON
+  (nonce, command, paths, hint) — empty when the job isn't gated. An embedder
+  fulfills it with `Kernel::confirm(&latch)`. **BREAKING (embedders):**
+  `JobStatus` gains a `Latched` variant (exhaustive matches must handle it) and
+  `JobInfo` gains a `latch: Option<LatchRequest>` field.
+
 ### Fixed
 - **`$(...)` in a redirect target now works on a bare `Kernel::execute`** (GH
   #90). Command substitution in a redirect target or heredoc body (`echo x >

--- a/crates/kaish-help/content/en/vfs.md
+++ b/crates/kaish-help/content/en/vfs.md
@@ -33,9 +33,15 @@ Each background job gets a directory:
 ```
 /v/jobs/{id}/stdout    live output (ring buffer, 10MB max)
 /v/jobs/{id}/stderr    live error stream
-/v/jobs/{id}/status    "running" | "done:0" | "failed:N"
+/v/jobs/{id}/status    "running" | "done:0" | "latched" | "failed:N"
 /v/jobs/{id}/command   original command string
+/v/jobs/{id}/latch     confirmation-latch request (JSON) if gated, else empty
 ```
+
+A destructive op backgrounded under `set -o latch` (`rm x &`) gates in the
+background: status is `latched`, and `/v/jobs/{id}/latch` carries the JSON
+request (nonce, command, paths) so the gate can be fulfilled — read the nonce
+and re-run with `--confirm=<nonce>`, or, from an embedder, `Kernel::confirm`.
 
 ```sh
 cargo build &

--- a/crates/kaish-kernel/src/scheduler/job.rs
+++ b/crates/kaish-kernel/src/scheduler/job.rs
@@ -185,6 +185,10 @@ impl Job {
         self.try_poll();
         match &self.result {
             Some(r) if r.ok() => JobStatus::Done,
+            // A gated destructive op (exit 2 with a stored latch) is *held*,
+            // not failed — surface it distinctly so `Kernel::confirm` can
+            // still fulfill it (GH #96).
+            Some(r) if r.latch_request().is_some() => JobStatus::Latched,
             Some(_) => JobStatus::Failed,
             None => JobStatus::Running,
         }
@@ -195,14 +199,24 @@ impl Job {
     /// Returns:
     /// - `"running"` if the job is still running
     /// - `"done:0"` if the job completed successfully
+    /// - `"latched"` if the job is blocked on an unfulfilled confirmation latch
     /// - `"failed:{code}"` if the job failed with an exit code
     pub fn status_string(&mut self) -> String {
         self.try_poll();
         match &self.result {
             Some(r) if r.ok() => "done:0".to_string(),
+            Some(r) if r.latch_request().is_some() => "latched".to_string(),
             Some(r) => format!("failed:{}", r.code),
             None => "running".to_string(),
         }
+    }
+
+    /// The job's pending confirmation-latch request, if it is gated
+    /// (`JobStatus::Latched`). `None` otherwise. Backs `JobInfo.latch` and the
+    /// `/v/jobs/{id}/latch` node so a backgrounded gate is fulfillable (#96).
+    pub fn latch(&mut self) -> Option<kaish_types::result::LatchRequest> {
+        self.try_poll();
+        self.result.as_ref().and_then(|r| r.latch_request())
     }
 
     /// Get the stdout stream (if attached).
@@ -600,12 +614,17 @@ impl JobManager {
     pub async fn list(&self) -> Vec<JobInfo> {
         let mut jobs = self.jobs.lock().await;
         jobs.values_mut()
-            .map(|job| JobInfo {
-                id: job.id,
-                command: job.command.clone(),
-                status: job.status(),
-                output_file: job.output_file.clone(),
-                pid: job.pid,
+            .map(|job| {
+                let status = job.status();
+                let latch = job.latch();
+                JobInfo {
+                    id: job.id,
+                    command: job.command.clone(),
+                    status,
+                    output_file: job.output_file.clone(),
+                    pid: job.pid,
+                    latch,
+                }
             })
             .collect()
     }
@@ -644,12 +663,17 @@ impl JobManager {
     /// Get info for a specific job.
     pub async fn get(&self, id: JobId) -> Option<JobInfo> {
         let mut jobs = self.jobs.lock().await;
-        jobs.get_mut(&id).map(|job| JobInfo {
-            id: job.id,
-            command: job.command.clone(),
-            status: job.status(),
-            output_file: job.output_file.clone(),
-            pid: job.pid,
+        jobs.get_mut(&id).map(|job| {
+            let status = job.status();
+            let latch = job.latch();
+            JobInfo {
+                id: job.id,
+                command: job.command.clone(),
+                status,
+                output_file: job.output_file.clone(),
+                pid: job.pid,
+                latch,
+            }
         })
     }
 
@@ -663,6 +687,15 @@ impl JobManager {
     pub async fn get_status_string(&self, id: JobId) -> Option<String> {
         let mut jobs = self.jobs.lock().await;
         jobs.get_mut(&id).map(|job| job.status_string())
+    }
+
+    /// Get a gated job's pending confirmation-latch request (for
+    /// `/v/jobs/{id}/latch` and any embedder reaching a backgrounded gate).
+    /// `Some(None)` vs `None` distinguishes "job exists, not latched" from
+    /// "no such job"; jobfs flattens both to an empty node body. GH #96.
+    pub async fn get_latch(&self, id: JobId) -> Option<kaish_types::result::LatchRequest> {
+        let mut jobs = self.jobs.lock().await;
+        jobs.get_mut(&id).and_then(|job| job.latch())
     }
 
     /// Read stdout stream content for a job.

--- a/crates/kaish-kernel/src/tools/builtin/wait.rs
+++ b/crates/kaish-kernel/src/tools/builtin/wait.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use clap::{CommandFactory, Parser};
 
 use crate::ast::Value;
-use crate::interpreter::{ExecResult, OutputData};
+use crate::interpreter::{ExecResult, LatchRequest, OutputData};
 use crate::scheduler::JobId;
 use crate::tools::{schema_from_clap, ExecContext, ToolCtx, GlobalFlags, Tool, ToolArgs, ToolSchema};
 
@@ -61,6 +61,7 @@ impl Tool for Wait {
         if !args.positional.is_empty() {
             let mut output = String::new();
             let mut any_failed = false;
+            let mut latch: Option<LatchRequest> = None;
 
             for spec in &args.positional {
                 let id = match spec {
@@ -79,25 +80,14 @@ impl Tool for Wait {
 
                 match manager.wait(id).await {
                     Some(result) => {
-                        let status = if result.ok() {
-                            "Done"
-                        } else {
-                            any_failed = true;
-                            "Failed"
-                        };
+                        let status = classify(&result, &mut any_failed, &mut latch);
                         output.push_str(&format!("[{}] {}\n", id, status));
                     }
                     None => return ExecResult::failure(1, format!("wait: job {} not found", id)),
                 }
             }
 
-            if any_failed {
-                let mut result = ExecResult::from_output(1, output.clone(), "");
-                result.set_output(Some(OutputData::text(output)));
-                result
-            } else {
-                ExecResult::with_output(OutputData::text(output))
-            }
+            finish(output, any_failed, latch)
         } else {
             // Wait for all jobs
             let results = manager.wait_all().await;
@@ -108,25 +98,56 @@ impl Tool for Wait {
 
             let mut output = String::new();
             let mut any_failed = false;
+            let mut latch: Option<LatchRequest> = None;
 
             for (id, result) in results {
-                let status = if result.ok() {
-                    "Done"
-                } else {
-                    any_failed = true;
-                    "Failed"
-                };
+                let status = classify(&result, &mut any_failed, &mut latch);
                 output.push_str(&format!("[{}] {}\n", id, status));
             }
 
-            if any_failed {
-                let mut result = ExecResult::from_output(1, output.clone(), "");
-                result.set_output(Some(OutputData::text(output)));
-                result
-            } else {
-                ExecResult::with_output(OutputData::text(output))
-            }
+            finish(output, any_failed, latch)
         }
+    }
+}
+
+/// Classify one waited job's result into a display word, threading the
+/// aggregate `any_failed` flag and the first-seen backgrounded latch. A gated
+/// job (`set -o latch`, exit 2 with a stored request) is `Latched`, *not*
+/// `Failed` — the op is held, and the request must reach the caller so a
+/// backgrounded gate is fulfillable (GH #96).
+fn classify(
+    result: &ExecResult,
+    any_failed: &mut bool,
+    latch: &mut Option<LatchRequest>,
+) -> &'static str {
+    if result.ok() {
+        "Done"
+    } else if let Some(lr) = result.latch_request() {
+        // First latch wins if several jobs are gated — `.latch` holds one, and
+        // an embedder waiting on multiple gated jobs is an unusual pattern.
+        latch.get_or_insert(lr);
+        "Latched"
+    } else {
+        *any_failed = true;
+        "Failed"
+    }
+}
+
+/// Assemble `wait`'s result: a surfaced backgrounded latch wins (exit 2 with
+/// the request on the control-plane `.latch` field, mirroring a foreground
+/// gate); otherwise any failure is exit 1; otherwise success.
+fn finish(output: String, any_failed: bool, latch: Option<LatchRequest>) -> ExecResult {
+    if let Some(lr) = latch {
+        let mut result = ExecResult::from_output(2, output.clone(), "");
+        result.set_output(Some(OutputData::text(output)));
+        result.latch = Some(Box::new(lr));
+        result
+    } else if any_failed {
+        let mut result = ExecResult::from_output(1, output.clone(), "");
+        result.set_output(Some(OutputData::text(output)));
+        result
+    } else {
+        ExecResult::with_output(OutputData::text(output))
     }
 }
 

--- a/crates/kaish-kernel/src/vfs/jobfs.rs
+++ b/crates/kaish-kernel/src/vfs/jobfs.rs
@@ -127,6 +127,20 @@ impl Filesystem for JobFs {
                     .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "job not found"))?;
                 Ok(format!("{}\n", command).into_bytes())
             }
+            "latch" => {
+                // A gated job's pending confirmation-latch request as JSON, so
+                // a VFS consumer can read the nonce and fulfill a backgrounded
+                // gate (GH #96). Empty body when the job isn't latched — a
+                // consumer reads, then parses only if non-empty.
+                match self.jobs.get_latch(job_id).await {
+                    Some(latch) => {
+                        let json = serde_json::to_string_pretty(&latch)
+                            .map_err(|e| io::Error::other(format!("latch serialize: {e}")))?;
+                        Ok(format!("{json}\n").into_bytes())
+                    }
+                    None => Ok(Vec::new()),
+                }
+            }
             _ => Err(io::Error::new(
                 io::ErrorKind::NotFound,
                 format!("unknown file: {}", file),
@@ -213,6 +227,14 @@ impl Filesystem for JobFs {
                         size: 0,
                         symlink_target: None,
                     },
+                    DirEntry {
+                        name: "latch".to_string(),
+                        kind: DirEntryKind::File,
+                        modified: None,
+                        permissions: None,
+                        size: 0, // JSON when gated, empty otherwise
+                        symlink_target: None,
+                    },
                 ])
             }
         }
@@ -253,7 +275,7 @@ impl Filesystem for JobFs {
                 }
 
                 // Validate file name
-                if !["stdout", "stderr", "status", "command"].contains(&file) {
+                if !["stdout", "stderr", "status", "command", "latch"].contains(&file) {
                     return Err(io::Error::new(
                         io::ErrorKind::NotFound,
                         format!("unknown file: {}", file),

--- a/crates/kaish-kernel/tests/latch_trash_tests.rs
+++ b/crates/kaish-kernel/tests/latch_trash_tests.rs
@@ -1099,3 +1099,78 @@ async fn dd_of_overwrite_under_trash_snapshots_prior_bytes() {
     assert_eq!(snaps[0].1, b"old");
     assert_eq!(std::fs::read_to_string(dir.path().join("out.bin")).unwrap(), "fresh");
 }
+
+// ─── GH #96: a *backgrounded* confirmation latch reaches its consumers ───────
+// `rm x &` under `set -o latch` gates in the background — exit 2 + a stored
+// LatchRequest — but the latch was invisible to every job consumer: `wait`
+// reported "Failed", `jobs`/`JobInfo` had no latch, `/v/jobs/{id}` had no latch
+// node, and `JobStatus` mapped exit 2 to `Failed`. So a backgrounded gate could
+// never be *fulfilled* — the nonce was unreachable. These pin the surfaces.
+
+/// The capstone: background a gated `rm`, surface the latch via `wait`, and
+/// fulfill it with `Kernel::confirm` — the whole point of #96.
+#[tokio::test]
+async fn backgrounded_latch_is_reachable_and_confirmable() {
+    let dir = tempdir();
+    let kernel = kernel_at(dir.path());
+    let precious = dir.path().join("precious.txt");
+    std::fs::write(&precious, "keep me").expect("write");
+
+    run(&kernel, "set -o latch").await;
+    let bg = run(&kernel, "rm precious.txt &").await;
+    assert_eq!(bg.code, 0, "backgrounding itself succeeds: {}", bg.err);
+
+    // `wait` surfaces the stored latch on the control-plane field, exit 2.
+    let waited = run(&kernel, "wait 1").await;
+    assert_eq!(waited.code, 2, "a latched job waits to exit 2, not 1: {waited:?}");
+    let latch = waited
+        .latch_request()
+        .expect("wait must surface the backgrounded job's LatchRequest");
+    assert!(precious.exists(), "the gate held — file still present pre-confirm");
+
+    // and the embedder can fulfill the backgrounded gate.
+    let confirmed = kernel.confirm(&latch).await.expect("confirm");
+    assert_eq!(confirmed.code, 0, "confirm deletes: {}", confirmed.err);
+    assert!(!precious.exists(), "file removed after confirm");
+}
+
+/// `jobs` and `/v/jobs/{id}/status` name the latched state distinctly, not
+/// the generic "Failed".
+#[tokio::test]
+async fn backgrounded_latch_shows_distinct_status() {
+    let dir = tempdir();
+    let kernel = kernel_at(dir.path());
+    std::fs::write(dir.path().join("p.txt"), "x").expect("write");
+
+    run(&kernel, "set -o latch").await;
+    run(&kernel, "rm p.txt &").await;
+    run(&kernel, "wait 1").await; // let the background job reach the gate
+
+    let jobs = run(&kernel, "jobs").await;
+    assert!(jobs.text_out().contains("Latched"), "jobs shows Latched: {}", jobs.text_out());
+    assert!(!jobs.text_out().contains("Failed"), "not a plain failure: {}", jobs.text_out());
+
+    let status = run(&kernel, "cat /v/jobs/1/status").await;
+    assert_eq!(status.text_out().trim(), "latched", "status node: {}", status.text_out());
+}
+
+/// `/v/jobs/{id}/latch` renders the stored LatchRequest as JSON carrying the
+/// nonce, so a VFS consumer can read (and then confirm) it.
+#[tokio::test]
+async fn backgrounded_latch_vfs_node_renders_json() {
+    let dir = tempdir();
+    let kernel = kernel_at(dir.path());
+    std::fs::write(dir.path().join("p.txt"), "x").expect("write");
+
+    run(&kernel, "set -o latch").await;
+    run(&kernel, "rm p.txt &").await;
+    let waited = run(&kernel, "wait 1").await;
+    let nonce = waited.latch_request().expect("latch").nonce;
+
+    let node = run(&kernel, "cat /v/jobs/1/latch").await;
+    assert_eq!(node.code, 0, "latch node readable: {}", node.err);
+    assert!(node.text_out().contains(&nonce), "latch JSON carries the nonce: {}", node.text_out());
+    // round-trips through kaish's own JSON door.
+    let parsed = run(&kernel, "cat /v/jobs/1/latch | fromjson").await;
+    assert_eq!(parsed.code, 0, "latch node is valid JSON: {}", parsed.err);
+}

--- a/crates/kaish-types/src/job.rs
+++ b/crates/kaish-types/src/job.rs
@@ -2,6 +2,8 @@
 
 use std::path::PathBuf;
 
+use crate::result::LatchRequest;
+
 /// Unique identifier for a background job.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct JobId(pub u64);
@@ -21,6 +23,11 @@ pub enum JobStatus {
     Stopped,
     /// Job completed successfully.
     Done,
+    /// Job is blocked on an unfulfilled confirmation latch (exit 2 with a
+    /// stored `LatchRequest` — `rm x &` under `set -o latch`). Distinct from
+    /// `Failed`: the op is *held*, not errored, and can still be fulfilled via
+    /// `Kernel::confirm` with the request surfaced on `JobInfo.latch`.
+    Latched,
     /// Job failed with an error.
     Failed,
 }
@@ -31,6 +38,7 @@ impl std::fmt::Display for JobStatus {
             JobStatus::Running => write!(f, "Running"),
             JobStatus::Stopped => write!(f, "Stopped"),
             JobStatus::Done => write!(f, "Done"),
+            JobStatus::Latched => write!(f, "Latched"),
             JobStatus::Failed => write!(f, "Failed"),
         }
     }
@@ -49,4 +57,9 @@ pub struct JobInfo {
     pub output_file: Option<PathBuf>,
     /// OS process ID (if this is a stopped/foreground process).
     pub pid: Option<u32>,
+    /// The pending confirmation-latch request when the job is gated
+    /// (`JobStatus::Latched`) — the control-plane surface an embedder reads to
+    /// fulfill a *backgrounded* destructive op via `Kernel::confirm`. `None`
+    /// for any non-latched job. GH #96.
+    pub latch: Option<LatchRequest>,
 }

--- a/docs/EMBEDDING.md
+++ b/docs/EMBEDDING.md
@@ -643,8 +643,9 @@ job state:
 ├── 1/
 │   ├── stdout    # Captured stdout (bounded)
 │   ├── stderr    # Captured stderr (bounded)
-│   ├── status    # "running", "done:0", or "failed:N"
-│   └── command   # Original command string
+│   ├── status    # "running", "done:0", "latched", or "failed:N"
+│   ├── command   # Original command string
+│   └── latch     # Confirmation-latch request (JSON) if gated, else empty
 ├── 2/
 │   └── ...
 ```
@@ -659,6 +660,13 @@ cat /v/jobs/1/status    # "running"
 cat /v/jobs/1/stdout    # Job's stdout
 cat /v/jobs/1/status    # "done:0" on success, "failed:N" otherwise
 ```
+
+A destructive op backgrounded under `set -o latch` (`rm x &`) gates in the
+background rather than running: `status` is `latched`, `JobInfo.latch` (from
+`JobManager::list`/`get`) and `/v/jobs/{id}/latch` (JSON) carry the pending
+`LatchRequest`, and `wait` surfaces it on the result's `.latch` field (exit 2).
+An embedder fulfills the backgrounded gate with `Kernel::confirm(&latch)` — the
+same API as a foreground gate.
 
 The status strings are exactly `running`, `done:0`, and `failed:{code}` —
 match on those, not on `completed`.

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -1093,7 +1093,7 @@ VFS mounts provide unified resource access:
 /v/                → in-memory scratch storage
 /v/bin/            → read-only builtin listing (invocable: /v/bin/echo hi)
 /v/blobs/          → in-memory blob storage
-/v/jobs/<id>/      → live background job state (stdout, stderr, status, command)
+/v/jobs/<id>/      → live background job state (stdout, stderr, status, command, latch)
 /dev/              → synthetic devices: /dev/null, /dev/zero, /dev/urandom, /dev/random
 ```
 

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -14,6 +14,36 @@ before it ships.
 
 ---
 
+## Surfacing the backgrounded confirmation latch (2026-07-05, GH #96)
+
+The confirmation latch (`set -o latch`) went first-class in #92, but a gap
+survived: background a gated op — `rm precious.txt &` — and the latch is stored
+in the job's result, but *every* consumer was blind to it. `wait` reported
+`Failed`; `jobs`, `JobInfo`, and `/v/jobs/{id}` had no latch anywhere;
+`Job::status()` folded the exit-2-latch into `Failed`, indistinguishable from a
+real error. The op stayed safely *blocked* (no data loss), but the nonce was
+unreachable, so a backgrounded gate could never be *fulfilled*. Low-stakes, but
+a real dead-end in the safety story.
+
+The fix threads the stored `LatchRequest` out to all four surfaces named in the
+issue, each with one job: `JobStatus::Latched` (the state is *held*, not
+errored, so `jobs` and `/v/jobs/{id}/status` say so distinctly);
+`JobInfo.latch: Option<LatchRequest>` (the programmatic surface an embedder
+reads from `JobManager::list`/`get`); `wait` surfacing the request on its
+result's control-plane `.latch` field with exit 2, mirroring a foreground gate
+so `latch_request()`/`Kernel::confirm` work identically; and a new
+`/v/jobs/{id}/latch` VFS node rendering the request as JSON (nonce, command,
+paths, hint) — empty body when the job isn't gated, so a reader reads-then-parses.
+
+TDD, and the capstone test earns its keep: background a gated `rm`, `wait 1` to
+surface the latch, `Kernel::confirm(&latch)`, assert the file is gone — the
+whole loop, from backgrounded gate to fulfillment, in one test. Two design
+touches worth noting: `wait` on several gated jobs keeps the *first* latch
+(`.latch` holds one; waiting on multiple gated jobs is an odd pattern), and the
+VFS node stays plain-text-empty rather than error when not latched, matching how
+`status`/`command` always read. Three kernel-routed tests red→green, 4377 suite
++ clippy `--all-targets` clean, verified end-to-end through the REPL.
+
 ## `$()` in a redirect target — the bug that only bit embedders (2026-07-05, GH #90)
 
 Picked this up expecting a quick "attach the dispatcher for bare commands" fix.


### PR DESCRIPTION
Closes #96.

## The gap

The confirmation latch went first-class in #92, but a backgrounded gate was a dead end. `rm precious.txt &` under `set -o latch` gates in the background and **stores** its `LatchRequest` in the job's result — but every consumer was blind to it:

- **`wait`** reported `Failed` (read only the exit code).
- **`jobs` / `JobInfo`** had no latch field.
- **`/v/jobs/{id}/`** had no latch node.
- **`Job::status()`** folded exit-2-latch into `Failed`, indistinguishable from a real error.

The op stayed safely **blocked** (no data loss), but the nonce was unreachable, so a backgrounded gate could never be **fulfilled** (`Kernel::confirm`).

## The fix — thread the stored latch to all four surfaces

| Surface | Change |
|---|---|
| `JobStatus` | new `Latched` variant — the state is *held*, not errored |
| `jobs` / `/v/jobs/{id}/status` | report `Latched` / `"latched"` distinctly |
| `JobInfo` | new `latch: Option<LatchRequest>` — the programmatic surface (`JobManager::list`/`get`) |
| `wait` | surfaces the request on the result's control-plane `.latch` field, exit 2 — mirrors a foreground gate so `latch_request()` / `Kernel::confirm` work identically |
| `/v/jobs/{id}/latch` | **new** VFS node: the request as JSON (nonce, command, paths, hint); empty body when not gated |

Design touches: `wait` on several gated jobs keeps the *first* latch (`.latch` holds one; waiting on multiple gated jobs is an odd pattern); the VFS node reads empty (not error) when not latched, matching how `status`/`command` always read.

## The capstone test

Drives the whole loop end to end: background a gated `rm`, `wait 1` to surface the latch, `Kernel::confirm(&latch)`, assert the file is gone — from backgrounded gate to fulfillment in one test. Plus surface tests for `jobs`/status/the JSON node.

Docs updated (help `vfs.md`, `EMBEDDING.md`, `LANGUAGE.md`). 4377 suite + `cargo clippy --all --all-targets` clean; verified end-to-end through the REPL (`wait`→Latched, status→"latched", latch node → full JSON).

**BREAKING (embedders):** `JobStatus` gains a `Latched` variant (exhaustive matches must handle it) and `JobInfo` gains a `latch` field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)