### PR TITLE
feat(#46/#47): depth-guard the statement engine + size execution threads for it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,9 @@ breaking entries are marked **BREAKING**.
   `JobStatus` gains a `Latched` variant (exhaustive matches must handle it) and
   `JobInfo` gains a `latch: Option<LatchRequest>` field.
 - **Recursion is depth-guarded (`MAX_RECURSION_DEPTH` = 32)** (GH #46/#47).
-  Command substitution, shell-function calls, and `.kai` script sourcing all
-  re-enter the statement engine on the native stack; a runaway or mutually
+  Command substitution, shell-function calls, `.kai` script execution, and
+  `source`/`.` all re-enter the statement engine on the native stack; a runaway
+  or mutually
   recursive script now returns a loud `maximum recursion depth exceeded` error
   instead of overflowing the stack (a `SIGSEGV`/abort with no diagnostic). Two
   new `pub const`s let embedders size their runtime: `MAX_RECURSION_DEPTH` and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,21 @@ breaking entries are marked **BREAKING**.
   fulfills it with `Kernel::confirm(&latch)`. **BREAKING (embedders):**
   `JobStatus` gains a `Latched` variant (exhaustive matches must handle it) and
   `JobInfo` gains a `latch: Option<LatchRequest>` field.
+- **Recursion is depth-guarded (`MAX_RECURSION_DEPTH` = 32)** (GH #46/#47).
+  Command substitution, shell-function calls, and `.kai` script sourcing all
+  re-enter the statement engine on the native stack; a runaway or mutually
+  recursive script now returns a loud `maximum recursion depth exceeded` error
+  instead of overflowing the stack (a `SIGSEGV`/abort with no diagnostic). Two
+  new `pub const`s let embedders size their runtime: `MAX_RECURSION_DEPTH` and
+  `RECOMMENDED_STACK_SIZE` (16 MiB). The guard only fires *before* an overflow
+  on a thread that meets that floor — the reference REPL now sizes its tokio
+  worker threads (`thread_stack_size`) and its `block_on` driver thread to it;
+  embedders should too (see `docs/EMBEDDING.md`).
 
 ### Fixed
+- **Deep recursion no longer crashes the process** (GH #46). `f() { f; }; f`,
+  mutual recursion, and deeply nested `$(...)` aborted with a bare stack
+  overflow; they now hit the depth guard above and fail loudly.
 - **`$(...)` in a redirect target now works on a bare `Kernel::execute`** (GH
   #90). Command substitution in a redirect target or heredoc body (`echo x >
   $(gen)`, `cat < $(gen)`, `cmd > $(gen)` in a pipeline stage) only ran when the

--- a/crates/kaish-help/content/en/limits.md
+++ b/crates/kaish-help/content/en/limits.md
@@ -48,6 +48,7 @@ plain command is wanted — `test -f x && echo yes`, `if test "$a" = "$b"; then`
 - **Pipeline stages run concurrently** with isolated scopes (like bash subshells). Variable assignments in one stage aren't visible in others. Last stage syncs back to parent.
 - **Scatter results in completion order**, not input order.
 - **Command substitution runs in redirect targets and here-doc bodies** — `cmd > $(gen-path)`, `cat < $(find-cfg)`, and `$(...)` inside a here-doc body all work. The target is a single word, so quote it when it mixes text with an expansion: `> "/tmp/$(id -u).log"`, not `> /tmp/$(id -u).log`.
+- **Recursion is depth-capped at 32** — nested `$(...)`, recursive shell functions, and `.kai` scripts sourcing each other are bounded so a runaway (or a missing base case) returns a loud `maximum recursion depth exceeded` error instead of overflowing the stack. Real recursion nests far shallower; this only stops runaways.
 - **Preprocessor is context-unaware** — `$(( ))` and heredoc markers replaced before parsing.
 
 ## External Commands

--- a/crates/kaish-kernel/src/kernel.rs
+++ b/crates/kaish-kernel/src/kernel.rs
@@ -4635,6 +4635,13 @@ impl Kernel {
     /// Unlike regular tool execution, `source` executes in the CURRENT scope,
     /// allowing the sourced script to set variables and modify shell state.
     async fn execute_source(&self, args: &[Arg]) -> Result<ExecResult> {
+        // `source`/`.` is the fourth dynamic re-entry point: it runs the
+        // sourced file's statements inline via `execute_stmt_flow`, so a file
+        // that sources itself recurses unbounded just like a runaway function
+        // (GH #46). It's intercepted as a special form *before* the other
+        // guarded paths, so it needs its own guard.
+        let _depth = self.enter_recursion("source")?;
+
         // Get the file path from the first positional argument
         let tool_args = self.build_args_async(args, None).await?;
         let path = match tool_args.positional.first() {

--- a/crates/kaish-kernel/src/kernel.rs
+++ b/crates/kaish-kernel/src/kernel.rs
@@ -25,7 +25,7 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::time::Duration;
 
 use anyhow::{Context, Result};
@@ -43,6 +43,38 @@ use tokio::sync::RwLock;
 /// `~/.claude/projects/-home-atobey-src-kaish/memory/lang_dollar_dollar_identifier.md`
 /// for the design rationale.
 static KERNEL_COUNTER: AtomicU64 = AtomicU64::new(1);
+
+/// Maximum depth of dynamic statement-engine re-entry — command substitution
+/// (`$(…)`), shell-function calls, and `.kai` script sourcing — before a
+/// **loud** error is returned instead of letting the native call stack
+/// overflow (a `SIGSEGV`/abort with no diagnostic). Mirrors the intent of the
+/// alias re-entry cap (10) and the lexer's `MAX_PAREN_DEPTH` (256): a runaway
+/// or mutually recursive script hits a catchable ceiling, not a signal.
+///
+/// Each level stacks the dispatch chain between re-entries, which we measured
+/// at ~80 KB (release) / ~380 KB (debug) of native stack per level. `32` sits
+/// well inside [`RECOMMENDED_STACK_SIZE`] in **both** profiles (16 MB / 380 KB
+/// ≈ 42 debug levels) while allowing far deeper nesting than any real script.
+/// **The guard only fires *before* the stack overflows on a thread that meets
+/// that floor** — this is why the REPL sizes its threads to it and embedders
+/// must too (see `docs/EMBEDDING.md`). Forks (background jobs, scatter workers,
+/// pipeline stages) run on fresh stacks and get a fresh counter, bounding each
+/// chain independently. GH #46 / #47.
+pub const MAX_RECURSION_DEPTH: usize = 32;
+
+/// Recommended native stack size (16 MiB) for any thread that drives kaish
+/// execution — the REPL sizes its `block_on` thread and tokio worker threads
+/// to this, and embedders that call `Kernel::execute` (directly or via a tokio
+/// runtime) should do the same (`runtime::Builder::thread_stack_size`, and a
+/// `std::thread` stack for a non-worker driver).
+///
+/// The kernel recurses on the native stack (command substitution, shell
+/// functions, `.kai` scripts). [`MAX_RECURSION_DEPTH`] converts a runaway into
+/// a loud error, but only *if the stack is at least this large* — on the
+/// default ~2 MB tokio worker stack the recursion overflows (SIGSEGV) before
+/// reaching the cap. kaish can't set this itself (it doesn't own the runtime),
+/// so it exposes the floor for owners to apply. See GH #47.
+pub const RECOMMENDED_STACK_SIZE: usize = 16 * 1024 * 1024;
 
 use async_trait::async_trait;
 
@@ -738,6 +770,29 @@ pub struct Kernel {
     /// stages do NOT take this lock — they run against a *forked* Kernel
     /// (see [`Kernel::fork`]) so they never contend with the foreground.
     execute_lock: tokio::sync::Mutex<()>,
+    /// Current dynamic statement-engine re-entry depth — incremented on entry
+    /// to command substitution, a shell-function call, or a `.kai` source, and
+    /// decremented (via an RAII guard, so cancellation stays balanced) on exit.
+    /// Checked against [`MAX_RECURSION_DEPTH`] to turn a stack overflow into a
+    /// loud error (GH #46). Per-Kernel: a fork starts fresh at 0 because it
+    /// runs on its own stack. Atomic only for `Send`/`Sync`; within one Kernel
+    /// the recursion chain is single-threaded (top-level `execute` is
+    /// serialized by `execute_lock`; concurrency happens on forks).
+    recursion_depth: AtomicUsize,
+}
+
+/// RAII balance for [`Kernel::recursion_depth`]: increments on construction
+/// (in `enter_recursion`) and decrements on drop, so a cancelled or
+/// error-unwound re-entry can never leave the counter inflated (which would
+/// spuriously trip later, unrelated recursions).
+struct RecursionGuard<'a> {
+    counter: &'a AtomicUsize,
+}
+
+impl Drop for RecursionGuard<'_> {
+    fn drop(&mut self) {
+        self.counter.fetch_sub(1, Ordering::Relaxed);
+    }
 }
 
 /// Internal result of [`Kernel::setup_vfs`].
@@ -1148,6 +1203,7 @@ impl Kernel {
             terminal_state: None,
             self_weak: std::sync::OnceLock::new(),
             execute_lock: tokio::sync::Mutex::new(()),
+            recursion_depth: AtomicUsize::new(0),
             bg_job_id: None,
             // Overlay handle is set by Kernel::new after assemble returns;
             // assemble itself doesn't know the handle (it's constructed in setup_vfs).
@@ -1290,6 +1346,9 @@ impl Kernel {
             terminal_state: None,
             self_weak: std::sync::OnceLock::new(),
             execute_lock: tokio::sync::Mutex::new(()),
+            // A fork runs on a fresh stack (spawned task) — its recursion
+            // budget is independent of the parent's current depth (GH #46).
+            recursion_depth: AtomicUsize::new(0),
             bg_job_id,
             // Arc-clone the overlay handle so forks (background jobs, scatter
             // workers, pipeline stages) can reach the same overlay transaction
@@ -4373,6 +4432,8 @@ impl Kernel {
     /// with `local` are scoped to the function; other assignments modify outer
     /// scopes (or create in root if new).
     async fn execute_user_tool(&self, def: ToolDef, args: &[Arg]) -> Result<ExecResult> {
+        let _depth = self.enter_recursion("a shell function")?;
+
         // 1. Build function args from AST args (async to support command substitution)
         let tool_args = self.build_args_async(args, None).await?;
 
@@ -4487,7 +4548,30 @@ impl Kernel {
     /// so `for x in $(seq 3)` still iterates the array and `$(printf a; printf b)`
     /// captures `ab`. Scope/cwd snapshotting (so `$(cd / && pwd)` cannot leak the
     /// cwd) is the caller's responsibility.
+    /// Enter one level of dynamic statement-engine re-entry (command
+    /// substitution / function call / script source), returning an RAII guard
+    /// that releases the level on drop. Past [`MAX_RECURSION_DEPTH`] it returns
+    /// a loud, catchable error instead of letting the native stack overflow
+    /// (GH #46). `what` names the re-entry kind for the message.
+    ///
+    /// The guard is constructed *before* the ceiling check so the error path
+    /// unwinds it too — the counter is always balanced, even when we reject.
+    fn enter_recursion(&self, what: &str) -> Result<RecursionGuard<'_>> {
+        let depth = self.recursion_depth.fetch_add(1, Ordering::Relaxed) + 1;
+        let guard = RecursionGuard { counter: &self.recursion_depth };
+        if depth > MAX_RECURSION_DEPTH {
+            return Err(anyhow::anyhow!(
+                "maximum recursion depth ({MAX_RECURSION_DEPTH}) exceeded in {what} — \
+                 a runaway or mutually recursive script (deeply nested $(…), or \
+                 functions/scripts that call each other without a base case) was \
+                 stopped before it could overflow the stack"
+            ));
+        }
+        Ok(guard)
+    }
+
     async fn execute_block_capturing(&self, stmts: &[Stmt]) -> Result<ExecResult> {
+        let _depth = self.enter_recursion("command substitution")?;
         // Accumulate stdout as raw bytes so a binary-producing statement
         // (`$(dd …)`, `$(base64 -d …)`) isn't lossy-decoded here before the
         // caller can preserve it. The final result is text iff valid UTF-8.
@@ -4681,6 +4765,12 @@ impl Kernel {
     /// Searches PATH for `{name}.kai` files and executes them in isolated scope
     /// (like user-defined tools). Returns None if no script is found.
     async fn try_execute_script(&self, name: &str, args: &[Arg]) -> Result<Option<ExecResult>> {
+        // Held across the PATH probe *and* body execution: a `.kai` sourcing a
+        // `.kai` re-enters here, and that nesting is what must be bounded (#46).
+        // A non-script command pays only a transient, balanced increment during
+        // the probe before falling through to the external path.
+        let _depth = self.enter_recursion("a .kai script")?;
+
         // Get PATH from scope (default to "/bin")
         let path_value = {
             let scope = self.scope.read().await;

--- a/crates/kaish-kernel/src/lib.rs
+++ b/crates/kaish-kernel/src/lib.rs
@@ -64,7 +64,10 @@ pub use backend::{
 };
 pub use dispatch::{CommandDispatcher, PipelinePosition};
 pub use ignore_config::{IgnoreConfig, IgnoreScope};
-pub use kernel::{CommandKind, ExecuteOptions, Kernel, KernelConfig, VfsMountMode};
+pub use kernel::{
+    CommandKind, ExecuteOptions, Kernel, KernelConfig, VfsMountMode, MAX_RECURSION_DEPTH,
+    RECOMMENDED_STACK_SIZE,
+};
 pub use output_limit::OutputLimitConfig;
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/crates/kaish-kernel/tests/recursion_guard_tests.rs
+++ b/crates/kaish-kernel/tests/recursion_guard_tests.rs
@@ -76,6 +76,40 @@ fn bounded_recursion_within_cap_succeeds() {
     assert!(result.text_out().contains("done"), "must reach the base case: {result:?}");
 }
 
+/// `source`/`.` is the fourth re-entry point — a `.kai` file that sources
+/// itself runs its statements inline via the statement engine and recurses
+/// unbounded. It's intercepted as a special form before the other guarded
+/// paths, so it carries its own guard. Uses an in-memory `/v` file the kernel
+/// can source (no host FS).
+#[test]
+fn self_sourcing_script_is_a_loud_error() {
+    let after = std::thread::Builder::new()
+        .stack_size(RECOMMENDED_STACK_SIZE)
+        .spawn(|| {
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("runtime");
+            rt.block_on(async {
+                let kernel = Kernel::new(KernelConfig::isolated()).expect("kernel");
+                // Write a self-sourcing script into the in-memory VFS, then run it.
+                kernel
+                    .execute("echo 'source /v/self.kai' > /v/self.kai")
+                    .await
+                    .expect("seed");
+                kernel.execute("source /v/self.kai").await.expect("execute")
+            })
+        })
+        .expect("spawn")
+        .join()
+        .expect("join");
+    assert_ne!(after.code, 0, "self-sourcing must fail loudly: {after:?}");
+    assert!(
+        after.err.contains("maximum recursion depth"),
+        "expected a recursion-depth error, got: {after:?}"
+    );
+}
+
 /// The RAII guard balances the counter on unwind: after a tripped recursion, a
 /// later command on the same kernel is unaffected — no leaked depth that would
 /// spuriously trip an unrelated, shallow call.

--- a/crates/kaish-kernel/tests/recursion_guard_tests.rs
+++ b/crates/kaish-kernel/tests/recursion_guard_tests.rs
@@ -1,0 +1,104 @@
+//! GH #46/#47: the statement engine's dynamic re-entry — command substitution,
+//! shell-function calls, and `.kai` script sourcing — is depth-bounded, so a
+//! runaway or mutually recursive script returns a LOUD error instead of
+//! overflowing the native stack (a SIGSEGV/abort with no diagnostic).
+//!
+//! These MUST run the recursion on a stack sized to `RECOMMENDED_STACK_SIZE`:
+//! a default `#[tokio::test]` thread (~2 MB) overflows a deep recursion long
+//! before the cap trips — and that overflow is the very bug under test (it
+//! would abort the whole test binary). So each case drives a fresh
+//! current-thread runtime on a `std::thread` with the recommended stack,
+//! exactly as the REPL and embedders are told to size their execution threads.
+
+// Test-fixture code: unwrap/expect on known-good setup is the idiom here.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use kaish_kernel::interpreter::ExecResult;
+use kaish_kernel::{Kernel, KernelConfig, MAX_RECURSION_DEPTH, RECOMMENDED_STACK_SIZE};
+
+/// Execute `script` through a fresh in-memory kernel on a recommended-size
+/// stack (so the recursion can reach the cap before it could overflow).
+fn run_on_recommended_stack(script: String) -> ExecResult {
+    std::thread::Builder::new()
+        .name("recursion-test".to_string())
+        .stack_size(RECOMMENDED_STACK_SIZE)
+        .spawn(move || {
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("current-thread runtime");
+            rt.block_on(async move {
+                let kernel = Kernel::new(KernelConfig::isolated()).expect("kernel");
+                kernel.execute(&script).await.expect("execute returns a result")
+            })
+        })
+        .expect("spawn recommended-stack thread")
+        .join()
+        .expect("recommended-stack thread joined")
+}
+
+/// A self-recursive function with no base case returns a loud "maximum
+/// recursion depth" error — not a stack overflow. Without the guard this
+/// aborts the process (`f() { f; }; f` was a debug/release SIGSEGV).
+#[test]
+fn runaway_function_recursion_is_a_loud_error() {
+    let result = run_on_recommended_stack("f() { f; }; f".to_string());
+    assert_ne!(result.code, 0, "runaway recursion must fail loudly: {result:?}");
+    assert!(
+        result.err.contains("maximum recursion depth"),
+        "expected a recursion-depth error, got: {result:?}"
+    );
+}
+
+/// Mutual recursion (`a → b → a`) trips the same guard — the bound is on the
+/// dynamic re-entry chain, not on any one function name.
+#[test]
+fn mutual_recursion_is_a_loud_error() {
+    let result = run_on_recommended_stack("a() { b; }; b() { a; }; a".to_string());
+    assert_ne!(result.code, 0, "mutual recursion must fail loudly: {result:?}");
+    assert!(
+        result.err.contains("maximum recursion depth"),
+        "expected a recursion-depth error, got: {result:?}"
+    );
+}
+
+/// Legitimate bounded recursion well within the cap succeeds — the guard is a
+/// ceiling on runaways, not a tax on real recursion. `$(( ))` is arithmetic
+/// (not a command-substitution re-entry), so this is pure function-call depth.
+#[test]
+fn bounded_recursion_within_cap_succeeds() {
+    let depth = MAX_RECURSION_DEPTH / 2;
+    let script = format!(
+        "down() {{ if [[ $1 -le 0 ]]; then echo done; else down $(($1 - 1)); fi; }}; down {depth}"
+    );
+    let result = run_on_recommended_stack(script);
+    assert_eq!(result.code, 0, "bounded recursion must succeed: {result:?}");
+    assert!(result.text_out().contains("done"), "must reach the base case: {result:?}");
+}
+
+/// The RAII guard balances the counter on unwind: after a tripped recursion, a
+/// later command on the same kernel is unaffected — no leaked depth that would
+/// spuriously trip an unrelated, shallow call.
+#[test]
+fn counter_is_balanced_after_a_tripped_recursion() {
+    let after = std::thread::Builder::new()
+        .stack_size(RECOMMENDED_STACK_SIZE)
+        .spawn(|| {
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("runtime");
+            rt.block_on(async {
+                let kernel = Kernel::new(KernelConfig::isolated()).expect("kernel");
+                let tripped = kernel.execute("f() { f; }; f").await.expect("first execute");
+                assert_ne!(tripped.code, 0, "the first execute must trip the guard: {tripped:?}");
+                // Same kernel, a trivial command: it starts at depth 0 again.
+                kernel.execute("echo alive").await.expect("second execute")
+            })
+        })
+        .expect("spawn")
+        .join()
+        .expect("join");
+    assert_eq!(after.code, 0, "a command after a tripped recursion must succeed: {after:?}");
+    assert_eq!(after.text_out().trim(), "alive", "recursion counter leaked across executes: {after:?}");
+}

--- a/crates/kaish-repl/src/lib.rs
+++ b/crates/kaish-repl/src/lib.rs
@@ -504,6 +504,20 @@ pub struct Repl {
     runtime: Runtime,
 }
 
+/// Build the tokio runtime kaish execution runs on, with worker threads sized
+/// to [`kaish_kernel::RECOMMENDED_STACK_SIZE`] so deeply nested command
+/// substitution / shell functions / `.kai` scripts reach the interpreter's
+/// recursion guard (a loud error) instead of overflowing the default ~2 MB
+/// worker stack (GH #46/#47). The `block_on` *driver* thread is sized
+/// separately in `main.rs` — tokio doesn't own it.
+pub fn build_runtime() -> Result<tokio::runtime::Runtime> {
+    tokio::runtime::Builder::new_multi_thread()
+        .thread_stack_size(kaish_kernel::RECOMMENDED_STACK_SIZE)
+        .enable_all()
+        .build()
+        .context("Failed to create tokio runtime")
+}
+
 impl Repl {
     /// Create a new REPL instance with passthrough filesystem access.
     pub fn new() -> Result<Self> {
@@ -511,7 +525,7 @@ impl Repl {
             .with_interactive(true)
             .with_initial_vars(os_env_vars());
         let mut kernel = Kernel::new(config).context("Failed to create kernel")?;
-        let runtime = Runtime::new().context("Failed to create tokio runtime")?;
+        let runtime = build_runtime()?;
 
         // Initialize terminal job control if stdin is a TTY. See `new()`.
         #[cfg(unix)]
@@ -528,7 +542,7 @@ impl Repl {
     /// Create a new REPL with a custom kernel configuration.
     pub fn with_config(config: KernelConfig) -> Result<Self> {
         let mut kernel = Kernel::new(config).context("Failed to create kernel")?;
-        let runtime = Runtime::new().context("Failed to create tokio runtime")?;
+        let runtime = build_runtime()?;
 
         // Initialize terminal job control if stdin is a TTY. This needs the
         // owned kernel (&mut, local-TTY setup), so it stays as pre-wrap

--- a/crates/kaish-repl/src/main.rs
+++ b/crates/kaish-repl/src/main.rs
@@ -108,16 +108,39 @@ fn execute_noninteractive(
 }
 
 fn main() -> ExitCode {
-    // Initialize tracing (respects RUST_LOG env var)
+    // Initialize tracing (respects RUST_LOG env var) on the process's original
+    // thread, before we hand off to the sized driver thread below.
     tracing_subscriber::registry()
         .with(fmt::layer())
         .with(EnvFilter::from_default_env())
         .init();
 
-    match run() {
-        Ok(code) => code,
+    // Drive the whole REPL on a thread sized to `RECOMMENDED_STACK_SIZE`. The
+    // interpreter recurses on the native stack (command substitution, shell
+    // functions, `.kai` scripts) and its foreground work runs on the
+    // `block_on` thread — the OS-default main-thread stack (~8 MB) overflows a
+    // deep recursion in debug *before* the depth guard's cap trips, defeating
+    // it. Worker threads are sized via `build_runtime`; this covers the driver
+    // (GH #46/#47).
+    let spawned = std::thread::Builder::new()
+        .name("kaish".to_string())
+        .stack_size(kaish_kernel::RECOMMENDED_STACK_SIZE)
+        .spawn(run);
+    let joined = match spawned {
+        Ok(handle) => handle.join(),
         Err(e) => {
+            eprintln!("Error: could not spawn kaish driver thread: {e}");
+            return ExitCode::FAILURE;
+        }
+    };
+    match joined {
+        Ok(Ok(code)) => code,
+        Ok(Err(e)) => {
             eprintln!("Error: {e:?}");
+            ExitCode::FAILURE
+        }
+        Err(_) => {
+            eprintln!("Error: kaish driver thread panicked");
             ExitCode::FAILURE
         }
     }
@@ -224,7 +247,7 @@ fn run_script(path: &str, overlay: bool) -> Result<ExitCode> {
 
     let client = EmbeddedClient::new(kernel);
 
-    let rt = tokio::runtime::Runtime::new()?;
+    let rt = kaish_repl::build_runtime()?;
     // Set $0 to the script path
     rt.block_on(client.kernel().set_positional(path, vec![]));
     // Forward any upstream W3C trace context (TRACEPARENT/TRACESTATE/BAGGAGE)
@@ -254,7 +277,7 @@ fn run_command(cmd: &str, overlay: bool) -> Result<ExitCode> {
 
     let client = EmbeddedClient::new(kernel);
 
-    let rt = tokio::runtime::Runtime::new()?;
+    let rt = kaish_repl::build_runtime()?;
     // Forward any upstream W3C trace context (TRACEPARENT/TRACESTATE/BAGGAGE)
     // so e.g. `otel-cli exec -- kaish -c '…'` traces across the boundary.
     let opts = kaish_repl::trace_options_from_env();

--- a/docs/EMBEDDING.md
+++ b/docs/EMBEDDING.md
@@ -42,6 +42,42 @@ async fn main() -> anyhow::Result<()> {
 structured output when a builtin returned a table or tree); `code`, `err`,
 and `data` are public fields.
 
+## Stack size — size your execution threads
+
+The interpreter recurses on the **native stack**: command substitution
+(`$(…)`), shell-function calls, and `.kai` script sourcing all re-enter the
+statement engine. A runaway or mutually recursive script is caught by a depth
+guard ([`MAX_RECURSION_DEPTH`], 32) that returns a loud
+`"maximum recursion depth exceeded"` error instead of overflowing the stack —
+**but the guard only fires *before* the overflow if the thread has enough
+stack.** On the default ~2 MB tokio worker stack, a deep recursion SIGSEGVs
+before reaching the cap.
+
+kaish can't set this itself (it doesn't own your runtime), so it exposes the
+floor: **[`RECOMMENDED_STACK_SIZE`] (16 MiB)**. Size every thread that drives
+kaish execution to at least this:
+
+```rust
+// Worker threads (pipeline stages, background jobs, scatter workers run here):
+let runtime = tokio::runtime::Builder::new_multi_thread()
+    .thread_stack_size(kaish_kernel::RECOMMENDED_STACK_SIZE)
+    .enable_all()
+    .build()?;
+
+// The block_on / driver thread also runs foreground recursion — tokio doesn't
+// own it, so if it's the OS main thread (~8 MB) give it a sized std::thread:
+std::thread::Builder::new()
+    .stack_size(kaish_kernel::RECOMMENDED_STACK_SIZE)
+    .spawn(move || runtime.block_on(async { /* … kernel.execute … */ }))?
+    .join().unwrap();
+```
+
+Below the floor the guard still bounds *most* recursion, but a deep foreground
+recursion on an undersized driver thread can still overflow — the reference
+REPL (`kaish-repl`) sizes both its runtime workers and its driver thread to
+`RECOMMENDED_STACK_SIZE`, and is the working example. (Reducing the per-level
+stack cost so the floor can drop is tracked as an optimization pass.)
+
 ## Architecture
 
 kaish separates concerns into layers:

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -44,6 +44,54 @@ VFS node stays plain-text-empty rather than error when not latched, matching how
 `status`/`command` always read. Three kernel-routed tests red→green, 4377 suite
 + clippy `--all-targets` clean, verified end-to-end through the REPL.
 
+## The recursion guard, and why #46 and #47 are one PR (2026-07-05, GH #46/#47)
+
+The plan was a tidy correctness fix: thread a depth counter through the three
+dynamic re-entry points (command substitution, shell functions, `.kai`
+scripts), return a loud error past a cap, done. The counter + RAII guard part
+*was* tidy (an `AtomicUsize` on the Kernel, fresh per fork, decremented on drop
+so cancellation stays balanced). Picking the **cap** is where physics showed up.
+
+We measured the native stack cost per recursion level by disabling the cap and
+probing depth-at-overflow: **~380 KB/level in debug, ~80 KB/level in release**
+(the fat boxed async futures #48 is about). That means:
+
+| thread | debug | release |
+|---|---|---|
+| 8 MB main | ~21 levels | ~100 |
+| 2 MB tokio worker | ~5 | ~25 |
+
+The plan had been "defer #47 (stack size) to a doc note, ship #46 alone." The
+measurement killed it: with the default stacks, **no single cap works** — one
+safe on a 2 MB worker (~4) is uselessly shallow, and a useful cap (~16) doesn't
+protect workers *or the test itself* (a `#[tokio::test]` thread is ~2 MB, so a
+recursion test would SIGSEGV at ~5 before it could assert the loud error). #46
+needs #47's controlled stack to be effective *and* testable. Amy called it:
+ship them together.
+
+So the guard is tuned for a **documented floor**: `RECOMMENDED_STACK_SIZE`
+(16 MiB) and `MAX_RECURSION_DEPTH` (32), both `pub` so embedders can size their
+runtime against them. kaish can't set the stack itself (it doesn't own the
+runtime), so the REPL walks the talk — `thread_stack_size` on its tokio workers,
+and a `std::thread` with the recommended stack driving `block_on` (the OS main
+thread's ~8 MB overflows a deep debug recursion before the cap). The tests run
+each recursion on a `RECOMMENDED_STACK_SIZE` thread with a fresh current-thread
+runtime — the only honest way to reach the cap without the overflow-under-test
+taking down the binary. Verified end-to-end: `f(){f;};f`, mutual recursion, and
+`$()`-nested recursion all go loud (debug and release), foreground and inside a
+pipeline stage; `countdown 20` still runs.
+
+One consistency note banked: a recursion error *inside* `$(...)` follows kaish's
+existing command-substitution semantics — a failed `$()` yields an empty
+expansion and doesn't fail the enclosing command (same as `echo $(false)`), so
+that path is *bounded* (no crash) but not exit-code-loud. Direct recursion
+(functions, scripts) is exit-1-loud. Not a new silent path — it matches how
+`$()` already behaves; making `$()` failures louder is a separate concern.
+
+Meanwhile fired gemini-pro + fable batches at the kernel/types source to hunt
+per-level stack reductions (#48 territory) — shrink the ~380 KB and the floor
+can drop. That's a follow-up; this PR ships the guard + the floor it needs.
+
 ## `$()` in a redirect target — the bug that only bit embedders (2026-07-05, GH #90)
 
 Picked this up expecting a quick "attach the dispatcher for bare commands" fix.


### PR DESCRIPTION
Closes #46. Closes #47.

## #46 — the bug

The async statement engine recursed with **no bound**. Deeply nested `$(...)`, recursive shell functions, and `.kai` scripts sourcing each other re-enter the interpreter on the native stack and overflow it — a bare `SIGSEGV`/abort with no diagnostic:

```
$ kaish -c 'f() { f; }; f'
thread 'main' has overflowed its stack
fatal runtime error: stack overflow, aborting   # exit 134
```

We guard the analogous cases elsewhere (alias re-entry caps at 10, the lexer caps `$((…))` nesting at 256); the statement engine had nothing.

## The guard (#46)

Small and mechanical: an `AtomicUsize` on the Kernel (fresh per fork, so each chain is bounded independently), an RAII decrement so a cancelled/errored re-entry stays balanced, and an `enter_recursion()` check at the three re-entry points — `execute_block_capturing` (`$()`), `execute_user_tool` (functions), `try_execute_script` (`.kai`). Past the cap it returns a **loud, catchable** error:

```
$ kaish -c 'f() { f; }; f'
maximum recursion depth (32) exceeded in a shell function — …   # exit 1
```

## Why #47 is in the same PR

Picking the cap forced it. We measured native stack cost per level (disable the cap, probe depth-at-overflow):

| thread | debug (~380 KB/level) | release (~80 KB/level) |
|---|---|---|
| 8 MB main | ~21 levels | ~100 |
| 2 MB tokio worker | ~5 | ~25 |

On the default stacks, **no single cap both protects a 2 MB worker and allows useful depth** — and a `#[tokio::test]` thread (~2 MB) would SIGSEGV before a recursion test could even assert the guard. The guard needs a controlled stack to be effective **and** testable.

## The floor (#47)

The cap (`MAX_RECURSION_DEPTH` = 32) is tuned for a documented floor (`RECOMMENDED_STACK_SIZE` = 16 MiB), both now `pub` for embedders. kaish can't set stack size itself (it doesn't own the runtime), so the reference REPL does:
- `thread_stack_size(RECOMMENDED_STACK_SIZE)` on its tokio worker threads (pipeline/scatter/bg recursion);
- a `std::thread` with the recommended stack driving `block_on` (the OS main thread's ~8 MB overflows a deep debug recursion before the cap).

`docs/EMBEDDING.md` tells embedders to size their execution threads the same way (with a code sketch); `limits.md` documents the cap.

## Tests

Each recursion runs on a `RECOMMENDED_STACK_SIZE` `std::thread` with a fresh current-thread runtime — the only way to reach the cap without the overflow-under-test aborting the binary. Runaway self-recursion and mutual recursion go loud; depth-16 bounded recursion succeeds; the counter is balanced across executes (no leak). Verified end-to-end in **debug and release**, foreground and inside a pipeline stage. 4378 suite + `cargo clippy --all --all-targets` clean.

## Consistency note

A recursion error *inside* `$(...)` follows kaish's existing command-substitution semantics — a failed `$()` yields an empty expansion and doesn't fail the enclosing command (same as `echo $(false)`), so that path is **bounded** (no crash) but not exit-code-loud; direct recursion (functions/scripts) is exit-1-loud. Not a new silent path.

## Follow-up

Reduce per-level stack cost (#48) so the floor can drop — a gemini-pro + fable batch review of the recursion path is in flight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)