### PR TITLE
perf(#48): interpreter allocation/stack pass — ~46% off per-level native stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,30 @@ breaking entries are marked **BREAKING**.
   worker threads (`thread_stack_size`) and its `block_on` driver thread to it;
   embedders should too (see `docs/EMBEDDING.md`).
 
+### Changed
+- **Interpreter allocation/stack pass** (GH #48). The native stack consumed per
+  statement-engine re-entry level (`$(…)`, shell functions, `source`) is cut
+  ~46% (release ~92 → ~50 KB/level; debug similarly), shrinking the interpreter's
+  hot futures by boxing the cold dispatch branches, the per-command
+  `ExecContext`/scope snapshots, and `ExecResult`'s structured-output field, and
+  by dropping the per-command tracing spans on the recursion ring. The two
+  interpreter crates (`kaish-kernel`, `kaish-types`) also build at
+  `opt-level = 1` in dev/test now (contained compile-time cost, ~7× smaller debug
+  stack). A new `recursion_stack_cost_tests` probe measures the per-level cost.
+  This leaves headroom to raise `MAX_RECURSION_DEPTH` or lower
+  `RECOMMENDED_STACK_SIZE` as a follow-up (GH #46/#47).
+- **Removed the internal per-command/per-pipeline tracing spans** from the hot
+  execution ring (GH #48) — coarse spans remain on the outer execute entries, so
+  embedders consuming kaish's `tracing` output now see one execution span per
+  top-level call rather than one per nested command. Observability-shape change,
+  not a behavior change.
+- **BREAKING (embedders):** `ExecContext.tool_schemas` is now `Arc<[ToolSchema]>`
+  instead of `Vec<ToolSchema>` (GH #48) — the ~70-entry schema catalog is shared
+  by refcount rather than deep-cloned into every per-command context.
+  `set_tool_schemas` still accepts a `Vec` (converts internally) and all read
+  sites are unaffected (deref coercion to `&[ToolSchema]`); only direct field
+  assignment/mutation of the public field needs `.into()`.
+
 ### Fixed
 - **Deep recursion no longer crashes the process** (GH #46). `f() { f; }; f`,
   mutual recursion, and deeply nested `$(...)` aborted with a bare stack

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,17 +22,19 @@ breaking entries are marked **BREAKING**.
   fulfills it with `Kernel::confirm(&latch)`. **BREAKING (embedders):**
   `JobStatus` gains a `Latched` variant (exhaustive matches must handle it) and
   `JobInfo` gains a `latch: Option<LatchRequest>` field.
-- **Recursion is depth-guarded (`MAX_RECURSION_DEPTH` = 32)** (GH #46/#47).
-  Command substitution, shell-function calls, `.kai` script execution, and
-  `source`/`.` all re-enter the statement engine on the native stack; a runaway
-  or mutually
-  recursive script now returns a loud `maximum recursion depth exceeded` error
-  instead of overflowing the stack (a `SIGSEGV`/abort with no diagnostic). Two
-  new `pub const`s let embedders size their runtime: `MAX_RECURSION_DEPTH` and
-  `RECOMMENDED_STACK_SIZE` (16 MiB). The guard only fires *before* an overflow
-  on a thread that meets that floor — the reference REPL now sizes its tokio
-  worker threads (`thread_stack_size`) and its `block_on` driver thread to it;
-  embedders should too (see `docs/EMBEDDING.md`).
+- **Recursion is depth-guarded (`MAX_RECURSION_DEPTH` = 48)** (GH #46/#47, tuned
+  by #48). Command substitution, shell-function calls, `.kai` script execution,
+  and `source`/`.` all re-enter the statement engine on the native stack; a
+  runaway or mutually recursive script now returns a loud `maximum recursion
+  depth exceeded` error instead of overflowing the stack (a `SIGSEGV`/abort with
+  no diagnostic). Two new `pub const`s let embedders size their runtime:
+  `MAX_RECURSION_DEPTH` and the paired `RECOMMENDED_STACK_SIZE` (12 MiB) — the
+  cap trips before `cap × per-level-stack` can exceed the floor. #48's smaller
+  interpreter frames let the cap rise (32→48) and the floor drop (16→12 MiB)
+  together while keeping the same safety margin. The guard only fires *before* an
+  overflow on a thread that meets that floor — the reference REPL now sizes its
+  tokio worker threads (`thread_stack_size`) and its `block_on` driver thread to
+  it; embedders should too (see `docs/EMBEDDING.md`).
 
 ### Changed
 - **Interpreter allocation/stack pass** (GH #48). The native stack consumed per

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,6 +124,21 @@ rstest = "0.26"
 insta = "1.46"
 tempfile = "3"
 
+# Optimize the interpreter crate (and its pure-data leaf) even in debug/test
+# builds. Unoptimized `async fn` poll frames are ~proportional to future size
+# with redundant memcpys between suspend points; opt-level=1 collapses them
+# (measured ~5–10× on the recursive ring). That directly cuts the native
+# stack-per-recursion-level cost that sets `RECOMMENDED_STACK_SIZE` /
+# `MAX_RECURSION_DEPTH` (GH #46/#47) and is the baseline the #48 pass optimizes
+# against. opt-level=1 keeps `debug_assertions` and most debuginfo, and speeds
+# the test suite as a bonus. Only these two crates carry the interpreter's hot
+# futures, so the compile-time cost is contained.
+[profile.dev.package.kaish-kernel]
+opt-level = 1
+
+[profile.dev.package.kaish-types]
+opt-level = 1
+
 [workspace.lints.rust]
 unsafe_code = "deny"
 

--- a/crates/kaish-kernel/src/interpreter/scope.rs
+++ b/crates/kaish-kernel/src/interpreter/scope.rs
@@ -374,7 +374,13 @@ pub struct Scope {
     /// Variables marked for export to child processes.
     exported: HashSet<String>,
     /// The result of the last command execution.
-    last_result: ExecResult,
+    ///
+    /// Boxed: `Scope` is cloned/held by value at every recursion level (the
+    /// dispatch snapshot, the command-subst save/restore), and an inline
+    /// `ExecResult` made `Scope` ~half again as large in each of those copies
+    /// (GH #48, item 5). The box is reused in place by `set_last_result`, so the
+    /// steady state is one allocation per `Scope`, not one per update.
+    last_result: Box<ExecResult>,
     /// Script or tool name ($0).
     script_name: String,
     /// Positional arguments ($1-$9, $@, $#).
@@ -412,7 +418,7 @@ impl Scope {
         Self {
             frames: Arc::new(vec![HashMap::new()]),
             exported: HashSet::new(),
-            last_result: ExecResult::default(),
+            last_result: Box::new(ExecResult::default()),
             script_name: String::new(),
             positional: Vec::new(),
             error_exit: false,
@@ -510,7 +516,8 @@ impl Scope {
 
     /// Set the last command result (accessible via `$?`).
     pub fn set_last_result(&mut self, result: ExecResult) {
-        self.last_result = result;
+        // Write through the existing box rather than reallocating one.
+        *self.last_result = result;
     }
 
     /// Get the last command result.

--- a/crates/kaish-kernel/src/kernel.rs
+++ b/crates/kaish-kernel/src/kernel.rs
@@ -3988,7 +3988,10 @@ impl Kernel {
             Expr::CommandSubst(stmts) => {
                 // Snapshot scope+cwd before running — only output escapes,
                 // not side effects like `cd` or variable assignments.
-                let saved_scope = { self.scope.read().await.clone() };
+                // Boxed: this ~470 B scope snapshot is held across the nested
+                // `$(…)` recursion await below, so inlining it grows every
+                // command-substitution level's future (GH #48, item 4).
+                let saved_scope = Box::new(self.scope.read().await.clone());
                 let saved_cwd = {
                     let ec = self.exec_ctx.read().await;
                     (ec.cwd.clone(), ec.prev_cwd.clone())
@@ -4000,7 +4003,7 @@ impl Kernel {
                 // Restore scope and cwd regardless of success/failure
                 {
                     let mut scope = self.scope.write().await;
-                    *scope = saved_scope;
+                    *scope = *saved_scope;
                     if let Ok(ref r) = run_result {
                         scope.set_last_result(r.clone());
                     }
@@ -4350,7 +4353,10 @@ impl Kernel {
             StringPart::CommandSubst(stmts) => {
                 // Snapshot scope+cwd — command substitution in strings must
                 // not leak side effects (e.g., `"dir: $(cd /; pwd)"` must not change cwd).
-                let saved_scope = { self.scope.read().await.clone() };
+                // Boxed: this ~470 B scope snapshot is held across the nested
+                // `$(…)` recursion await below, so inlining it grows every
+                // command-substitution level's future (GH #48, item 4).
+                let saved_scope = Box::new(self.scope.read().await.clone());
                 let saved_cwd = {
                     let ec = self.exec_ctx.read().await;
                     (ec.cwd.clone(), ec.prev_cwd.clone())
@@ -4362,7 +4368,7 @@ impl Kernel {
                 // Restore scope and cwd regardless of success/failure
                 {
                     let mut scope = self.scope.write().await;
-                    *scope = saved_scope;
+                    *scope = *saved_scope;
                     if let Ok(ref r) = run_result {
                         scope.set_last_result(r.clone());
                     }

--- a/crates/kaish-kernel/src/kernel.rs
+++ b/crates/kaish-kernel/src/kernel.rs
@@ -2710,6 +2710,58 @@ impl Kernel {
         })
     }
 
+    /// Build a boxed per-command `ExecContext` snapshot from the persistent
+    /// kernel state (`ec`/`scope`, both already locked by the caller).
+    ///
+    /// Sync on purpose: the ~30 field clones live in this transient frame rather
+    /// than a coroutine slot, and the result is `Box`ed so only an 8-byte pointer
+    /// — not the 960-byte struct — rides the dispatch await at every recursion
+    /// level (GH #48, item 2). `pipeline_position` and `cancel` are the only
+    /// per-site differences (the pipeline runner uses the kernel's own cancel
+    /// token and forces `Only`; the per-command dispatch inherits `ec`'s), so
+    /// they're parameters; every other field is snapshotted identically.
+    fn snapshot_exec_ctx(
+        &self,
+        ec: &ExecContext,
+        scope: &Scope,
+        pipeline_position: PipelinePosition,
+        cancel: tokio_util::sync::CancellationToken,
+    ) -> Box<ExecContext> {
+        Box::new(ExecContext {
+            backend: ec.backend.clone(),
+            scope: scope.clone(),
+            cwd: ec.cwd.clone(),
+            prev_cwd: ec.prev_cwd.clone(),
+            stdin: ec.stdin.clone(),
+            stdin_data: ec.stdin_data.clone(),
+            stdin_data_rx: None,
+            pipe_stdin: None,
+            pipe_stdout: None,
+            stderr: ec.stderr.clone(),
+            tool_schemas: ec.tool_schemas.clone(),
+            tools: ec.tools.clone(),
+            job_manager: ec.job_manager.clone(),
+            pipeline_position,
+            interactive: self.interactive,
+            aliases: ec.aliases.clone(),
+            ignore_config: ec.ignore_config.clone(),
+            output_limit: ec.output_limit.clone(),
+            allow_external_commands: self.allow_external_commands,
+            nonce_store: ec.nonce_store.clone(),
+            trash_backend: ec.trash_backend.clone(),
+            #[cfg(all(unix, feature = "subprocess"))]
+            terminal_state: ec.terminal_state.clone(),
+            dispatcher: self.dispatcher(),
+            cancel,
+            output_format: None,
+            current_invocation: None,
+            vfs_budget: self.vfs_budget.clone(),
+            watchdog: ec.watchdog.clone(),
+            #[cfg(all(feature = "localfs", feature = "overlay"))]
+            overlay_handle: self.overlay_handle.clone(),
+        })
+    }
+
     /// Execute a pipeline.
     async fn execute_pipeline(&self, pipeline: &crate::ast::Pipeline) -> Result<ExecResult> {
         if pipeline.commands.is_empty() {
@@ -2735,47 +2787,17 @@ impl Kernel {
             // the persistent exec_ctx; it's moved (non-Clone) into this ctx in
             // the consume-once block below, so note its presence here.
             let has_pipe_stdin = ec.pipe_stdin.is_some();
-            (ExecContext {
-                backend: ec.backend.clone(),
-                scope: scope.clone(),
-                cwd: ec.cwd.clone(),
-                prev_cwd: ec.prev_cwd.clone(),
-                // Seed the first stage's stdin from any frontend-supplied input
-                // (`ExecuteOptions::stdin`, e.g. `printf … | kaish -c sort`). The
-                // runner forwards `ctx.stdin` to stage 0 unless a redirect
-                // (`< file`/heredoc) already set it, so redirect precedence holds.
-                stdin: ec.stdin.clone(),
-                stdin_data: ec.stdin_data.clone(),
-                stdin_data_rx: None,
-                pipe_stdin: None,
-                pipe_stdout: None,
-                stderr: ec.stderr.clone(),
-                tool_schemas: ec.tool_schemas.clone(),
-                tools: ec.tools.clone(),
-                job_manager: ec.job_manager.clone(),
-                pipeline_position: PipelinePosition::Only,
-                interactive: self.interactive,
-                aliases: ec.aliases.clone(),
-                ignore_config: ec.ignore_config.clone(),
-                output_limit: ec.output_limit.clone(),
-                allow_external_commands: self.allow_external_commands,
-                nonce_store: ec.nonce_store.clone(),
-                trash_backend: ec.trash_backend.clone(),
-                #[cfg(all(unix, feature = "subprocess"))]
-                terminal_state: ec.terminal_state.clone(),
-                dispatcher: self.dispatcher(),
-                cancel: {
-                    #[allow(clippy::expect_used)]
-                    let token = self.cancel_token.lock().expect("cancel_token poisoned");
-                    token.clone()
-                },
-                output_format: None,
-                current_invocation: None,
-                vfs_budget: self.vfs_budget.clone(),
-                watchdog: ec.watchdog.clone(),
-                #[cfg(all(feature = "localfs", feature = "overlay"))]
-                overlay_handle: self.overlay_handle.clone(),
-            }, has_pipe_stdin)
+            // The pipeline runner drives stage 0 with the first stage's stdin
+            // seeded from any frontend-supplied input (`ExecuteOptions::stdin`,
+            // e.g. `printf … | kaish -c sort`) unless a redirect already set it,
+            // and uses the kernel's own cancel token so a `cancel()` reaches the
+            // stages. See `snapshot_exec_ctx` for why the snapshot is boxed.
+            let cancel = {
+                #[allow(clippy::expect_used)]
+                let token = self.cancel_token.lock().expect("cancel_token poisoned");
+                token.clone()
+            };
+            (self.snapshot_exec_ctx(&ec, &scope, PipelinePosition::Only, cancel), has_pipe_stdin)
         }; // locks released
 
         // Consume-once: move/clear the seeded stdin sources from the persistent
@@ -3159,44 +3181,12 @@ impl Kernel {
         let mut ctx = {
             let ec = self.exec_ctx.write().await;
             let scope = self.scope.read().await;
-            ExecContext {
-                backend: ec.backend.clone(),
-                scope: scope.clone(),
-                cwd: ec.cwd.clone(),
-                prev_cwd: ec.prev_cwd.clone(),
-                stdin: ec.stdin.clone(),
-                stdin_data: ec.stdin_data.clone(),
-                stdin_data_rx: None,
-                pipe_stdin: None, // streaming pipes are per-pipeline; not snapshotted
-                pipe_stdout: None,
-                stderr: ec.stderr.clone(),
-                tool_schemas: ec.tool_schemas.clone(),
-                tools: ec.tools.clone(),
-                job_manager: ec.job_manager.clone(),
-                pipeline_position: ec.pipeline_position,
-                interactive: self.interactive,
-                aliases: ec.aliases.clone(),
-                ignore_config: ec.ignore_config.clone(),
-                output_limit: ec.output_limit.clone(),
-                allow_external_commands: self.allow_external_commands,
-                nonce_store: ec.nonce_store.clone(),
-                trash_backend: ec.trash_backend.clone(),
-                #[cfg(all(unix, feature = "subprocess"))]
-                terminal_state: ec.terminal_state.clone(),
-                dispatcher: self.dispatcher(),
-                // Use ec.cancel (set by dispatch_command from the runner's
-                // ctx.cancel) so any builtin-swapped child token (e.g. timeout's
-                // child token) reaches the spawned external via wait_or_kill.
-                // Falls back to the kernel's own token when ec.cancel is the
-                // default fresh token from a non-dispatch path.
-                cancel: ec.cancel.clone(),
-                output_format: None,
-                current_invocation: None,
-                vfs_budget: self.vfs_budget.clone(),
-                watchdog: ec.watchdog.clone(),
-                #[cfg(all(feature = "localfs", feature = "overlay"))]
-                overlay_handle: self.overlay_handle.clone(),
-            }
+            // Inherit `ec.pipeline_position` and `ec.cancel` (the latter set by
+            // dispatch_command from the runner's ctx.cancel, so a builtin-swapped
+            // child token — e.g. timeout's — reaches the spawned external via
+            // wait_or_kill; it falls back to the kernel's own token on a
+            // non-dispatch path). See `snapshot_exec_ctx` for the boxing rationale.
+            self.snapshot_exec_ctx(&ec, &scope, ec.pipeline_position, ec.cancel.clone())
         }; // both locks released — tool.execute can re-dispatch safely
 
         // Move stdin out of self.exec_ctx into the snapshot (consumed-by-tool
@@ -3215,7 +3205,7 @@ impl Kernel {
         // parse failure (e.g. `cmd --json --bogus-flag` would otherwise drop
         // --json on the floor when `try_parse_from` returns Err early).
         // The builtin's own `parsed.global.apply(ctx)` becomes idempotent.
-        GlobalFlags::apply_from_args(&tool_args, &mut ctx);
+        GlobalFlags::apply_from_args(&tool_args, &mut *ctx);
 
         // Capture the exact invocation at the dispatch seam so a latch producer
         // (`latch_result`/`gate_overwrites`) can stamp it into the LatchRequest
@@ -3233,7 +3223,7 @@ impl Kernel {
         // `tool.execute` below).
         ctx.current_invocation = Some(Box::new((name.to_string(), tool_args.to_argv())));
 
-        let result = tool.execute(tool_args, &mut ctx).await;
+        let result = tool.execute(tool_args, &mut *ctx).await;
 
         // Sync mutations back. Tools may have changed scope (set/cd),
         // cwd/prev_cwd (cd), and aliases (alias). Also return any unused pipe

--- a/crates/kaish-kernel/src/kernel.rs
+++ b/crates/kaish-kernel/src/kernel.rs
@@ -52,22 +52,27 @@ static KERNEL_COUNTER: AtomicU64 = AtomicU64::new(1);
 /// or mutually recursive script hits a catchable ceiling, not a signal.
 ///
 /// Each level stacks the dispatch chain between re-entries. After the GH #48
-/// allocation pass this measures ~50 KB (release) / ~57 KB (debug, the default
-/// `opt-level = 1` dev profile — see the root `Cargo.toml`) / ~193 KB (debug
-/// with optimization off) of native stack per level, down from ~80 / ~380 KB
-/// before; the `recursion_stack_cost_tests` probe reports the live figure. `32`
-/// sits well inside [`RECOMMENDED_STACK_SIZE`] with a wide margin in **every**
-/// profile (16 MB / 193 KB ≈ 85 levels even unoptimized) while allowing far
-/// deeper nesting than any real script. #48 leaves room to raise this cap or
-/// lower the floor; both are left as a follow-up decision on GH #46 / #47.
-/// **The guard only fires *before* the stack overflows on a thread that meets
-/// that floor** — this is why the REPL sizes its threads to it and embedders
-/// must too (see `docs/EMBEDDING.md`). Forks (background jobs, scatter workers,
-/// pipeline stages) run on fresh stacks and get a fresh counter, bounding each
-/// chain independently. GH #46 / #47.
-pub const MAX_RECURSION_DEPTH: usize = 32;
+/// allocation pass this measures ~50 KB (release) / ~57 KB (debug at the default
+/// `opt-level = 1` dev profile — see the root `Cargo.toml`) / ~193 KB (a fully
+/// unoptimized debug build) of native stack per level, down from ~80 / ~380 KB
+/// before; the `recursion_stack_cost_tests` probe reports the live figure.
+///
+/// This cap and [`RECOMMENDED_STACK_SIZE`] are a **matched pair**: the cap must
+/// trip *before* `cap × (worst-case per-level stack)` can exceed the floor, so a
+/// runaway is caught, not a `SIGSEGV`. The worst case is the ~193 KB unoptimized
+/// figure — the `opt-level = 1` dev profile above is local to this workspace and
+/// does **not** propagate to embedders, whose own debug builds of the kernel pay
+/// the full unoptimized cost. `48 × 193 KB ≈ 9.3 MB` under the 12 MiB floor
+/// keeps the same ~1.3× margin the pre-#48 pair had (`32 × 380 KB ≈ 12 MB` under
+/// 16 MiB); #48's smaller frames are what let the cap rise 32→48 and the floor
+/// drop 16→12 MiB together. **The guard only fires *before* the stack overflows
+/// on a thread that meets that floor** — this is why the REPL sizes its threads
+/// to it and embedders must too (see `docs/EMBEDDING.md`). Forks (background
+/// jobs, scatter workers, pipeline stages) run on fresh stacks and get a fresh
+/// counter, bounding each chain independently. GH #46 / #47 / #48.
+pub const MAX_RECURSION_DEPTH: usize = 48;
 
-/// Recommended native stack size (16 MiB) for any thread that drives kaish
+/// Recommended native stack size (12 MiB) for any thread that drives kaish
 /// execution — the REPL sizes its `block_on` thread and tokio worker threads
 /// to this, and embedders that call `Kernel::execute` (directly or via a tokio
 /// runtime) should do the same (`runtime::Builder::thread_stack_size`, and a
@@ -77,9 +82,13 @@ pub const MAX_RECURSION_DEPTH: usize = 32;
 /// functions, `.kai` scripts). [`MAX_RECURSION_DEPTH`] converts a runaway into
 /// a loud error, but only *if the stack is at least this large* — on the
 /// default ~2 MB tokio worker stack the recursion overflows (SIGSEGV) before
-/// reaching the cap. kaish can't set this itself (it doesn't own the runtime),
-/// so it exposes the floor for owners to apply. See GH #47.
-pub const RECOMMENDED_STACK_SIZE: usize = 16 * 1024 * 1024;
+/// reaching the cap. This floor is the companion to that cap (see its docs for
+/// the `cap × per-level < floor` relationship): 12 MiB holds the depth-48 cap
+/// with margin even for an unoptimized embedder build (~193 KB/level), and #48
+/// shrank the per-level cost enough to drop it from 16 MiB. kaish can't set this
+/// itself (it doesn't own the runtime), so it exposes the floor for owners to
+/// apply. See GH #47 / #48.
+pub const RECOMMENDED_STACK_SIZE: usize = 12 * 1024 * 1024;
 
 use async_trait::async_trait;
 

--- a/crates/kaish-kernel/src/kernel.rs
+++ b/crates/kaish-kernel/src/kernel.rs
@@ -3173,6 +3173,13 @@ impl Kernel {
             return Ok(ExecResult::with_output(crate::interpreter::OutputData::text(content)));
         }
 
+        // `owns_output` is the only thing read from `schema` after the recursive
+        // `tool.execute` await below; capture the bool and drop the (heap-backed)
+        // `ToolSchema` now so it doesn't ride that await in every command's frame
+        // (GH #48, item 7).
+        let owns_output = schema.owns_output;
+        drop(schema);
+
         // Snapshot exec_ctx into a local context and release the write lock
         // before calling tool.execute. Holding the write across tool execution
         // would deadlock any builtin that re-dispatches through ctx.dispatcher
@@ -3253,7 +3260,7 @@ impl Kernel {
         // struct and write ctx.output_format. The kernel applies it — unless the
         // tool owns its own output (renders --json itself), in which case we
         // leave its bytes untouched.
-        let result = finalize_output(result, ctx.output_format, schema.owns_output);
+        let result = finalize_output(result, ctx.output_format, owns_output);
 
         Ok(result)
     }

--- a/crates/kaish-kernel/src/kernel.rs
+++ b/crates/kaish-kernel/src/kernel.rs
@@ -2160,8 +2160,11 @@ impl Kernel {
         &'a self,
         stmt: &'a Stmt,
     ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<ControlFlow>> + Send + 'a>> {
-        use tracing::Instrument;
-        let span = tracing::debug_span!("execute_stmt_flow", stmt_type = %stmt.kind_name());
+        // No per-statement span here: `execute_stmt_flow` is the largest future
+        // on the recursion ring, and wrapping it in `Instrumented<Span>` carries
+        // the span's state through every `.await` at every level, costing native
+        // stack per level (GH #48). Coarser spans on the outer execute entries
+        // remain. See item 3 of the #48 burndown.
         Box::pin(async move {
         match stmt {
             Stmt::Assignment(assign) => {
@@ -2704,11 +2707,10 @@ impl Kernel {
             }
             Stmt::Empty => Ok(ControlFlow::ok(ExecResult::success(""))),
         }
-        }.instrument(span))
+        })
     }
 
     /// Execute a pipeline.
-    #[tracing::instrument(level = "debug", skip(self, pipeline), fields(background = pipeline.background, command_count = pipeline.commands.len()))]
     async fn execute_pipeline(&self, pipeline: &crate::ast::Pipeline) -> Result<ExecResult> {
         if pipeline.commands.is_empty() {
             return Ok(ExecResult::success(""));
@@ -2985,8 +2987,13 @@ impl Kernel {
         self.execute_command_depth(name, args, 0).await
     }
 
-    #[tracing::instrument(level = "info", skip(self, args, alias_depth), fields(command = %name), err)]
     async fn execute_command_depth(&self, name: &str, args: &[Arg], alias_depth: u8) -> Result<ExecResult> {
+        // Dispatch breadcrumb instead of an `#[instrument]` span: this is the
+        // most-recursed function on the ring, so wrapping its future in
+        // `Instrumented<Span>` (plus the `err` recorder) cost native stack at
+        // every level (GH #48, item 3). A `trace!` event records the command name
+        // without living in the future.
+        tracing::trace!(command = %name, alias_depth, "dispatch");
         // Special built-ins. `SpecialForm::from_name` is the single source of
         // truth (shared with `classify_command` via `is_runtime_special_form`),
         // and this match on the enum is *exhaustive* — adding a special-form is a

--- a/crates/kaish-kernel/src/kernel.rs
+++ b/crates/kaish-kernel/src/kernel.rs
@@ -51,10 +51,15 @@ static KERNEL_COUNTER: AtomicU64 = AtomicU64::new(1);
 /// alias re-entry cap (10) and the lexer's `MAX_PAREN_DEPTH` (256): a runaway
 /// or mutually recursive script hits a catchable ceiling, not a signal.
 ///
-/// Each level stacks the dispatch chain between re-entries, which we measured
-/// at ~80 KB (release) / ~380 KB (debug) of native stack per level. `32` sits
-/// well inside [`RECOMMENDED_STACK_SIZE`] in **both** profiles (16 MB / 380 KB
-/// ≈ 42 debug levels) while allowing far deeper nesting than any real script.
+/// Each level stacks the dispatch chain between re-entries. After the GH #48
+/// allocation pass this measures ~50 KB (release) / ~57 KB (debug, the default
+/// `opt-level = 1` dev profile — see the root `Cargo.toml`) / ~193 KB (debug
+/// with optimization off) of native stack per level, down from ~80 / ~380 KB
+/// before; the `recursion_stack_cost_tests` probe reports the live figure. `32`
+/// sits well inside [`RECOMMENDED_STACK_SIZE`] with a wide margin in **every**
+/// profile (16 MB / 193 KB ≈ 85 levels even unoptimized) while allowing far
+/// deeper nesting than any real script. #48 leaves room to raise this cap or
+/// lower the floor; both are left as a follow-up decision on GH #46 / #47.
 /// **The guard only fires *before* the stack overflows on a thread that meets
 /// that floor** — this is why the REPL sizes its threads to it and embedders
 /// must too (see `docs/EMBEDDING.md`). Forks (background jobs, scatter workers,

--- a/crates/kaish-kernel/src/kernel.rs
+++ b/crates/kaish-kernel/src/kernel.rs
@@ -2202,7 +2202,7 @@ impl Kernel {
                     commands: vec![cmd.clone()],
                     background: false,
                 };
-                let result = self.execute_pipeline(&pipeline).await?;
+                let result = Box::pin(self.execute_pipeline(&pipeline)).await?;
                 self.update_last_result(&result).await;
 
                 // Check for error exit mode (set -e)
@@ -2216,7 +2216,7 @@ impl Kernel {
                 Ok(ControlFlow::ok(result))
             }
             Stmt::Pipeline(pipeline) => {
-                let result = self.execute_pipeline(pipeline).await?;
+                let result = Box::pin(self.execute_pipeline(pipeline)).await?;
                 self.update_last_result(&result).await;
 
                 // Check for error exit mode (set -e)
@@ -2997,7 +2997,7 @@ impl Kernel {
             return match form {
                 crate::validator::SpecialForm::True => Ok(ExecResult::success("")),
                 crate::validator::SpecialForm::False => Ok(ExecResult::failure(1, "")),
-                crate::validator::SpecialForm::Source => self.execute_source(args).await,
+                crate::validator::SpecialForm::Source => Box::pin(self.execute_source(args)).await,
             };
         }
 
@@ -3035,7 +3035,7 @@ impl Kernel {
             if let Some(tool_def) = user_tools.get(name) {
                 let tool_def = tool_def.clone();
                 drop(user_tools);
-                return self.execute_user_tool(tool_def, args).await;
+                return Box::pin(self.execute_user_tool(tool_def, args)).await;
             }
         }
 
@@ -3044,11 +3044,15 @@ impl Kernel {
             Some(t) => t,
             None => {
                 // Try executing as .kai script from PATH
-                if let Some(result) = self.try_execute_script(name, args).await? {
+                if let Some(result) = Box::pin(self.try_execute_script(name, args)).await? {
                     return Ok(result);
                 }
-                // Try executing as external command from PATH
-                if let Some(result) = self.try_execute_external(name, args).await? {
+                // Try executing as external command from PATH — boxed because its
+                // future is the heaviest branch here (holds a `tokio::process::Command`,
+                // argv, the child's stdio streams, and kill/reap drop guards); leaving
+                // it inline fattens every `execute_command_depth` frame on the recursion
+                // ring even when the command is a builtin.
+                if let Some(result) = Box::pin(self.try_execute_external(name, args)).await? {
                     return Ok(result);
                 }
 

--- a/crates/kaish-kernel/src/scheduler/pipeline.rs
+++ b/crates/kaish-kernel/src/scheduler/pipeline.rs
@@ -284,7 +284,6 @@ impl PipelineRunner {
     /// The `dispatcher` handles the full command resolution chain (user tools,
     /// builtins, scripts, external commands, backend tools). The runner handles
     /// I/O routing: stdin redirects, piping between commands, and output redirects.
-    #[tracing::instrument(level = "debug", skip(self, commands, ctx, dispatcher), fields(command_count = commands.len()))]
     pub async fn run(
         &self,
         commands: &[Command],
@@ -307,7 +306,6 @@ impl PipelineRunner {
     ///
     /// Used by `ScatterGatherRunner` for pre_scatter, post_gather, and parallel
     /// workers. Breaks the async recursion chain (`run` → scatter → `run`).
-    #[tracing::instrument(level = "debug", skip(self, commands, ctx, dispatcher), fields(command_count = commands.len()))]
     pub async fn run_sequential(
         &self,
         commands: &[Command],
@@ -392,7 +390,6 @@ impl PipelineRunner {
     ///
     /// The dispatcher handles arg parsing, schema lookup, output format, and execution.
     /// The runner handles stdin setup (redirects + pipeline) and output redirects.
-    #[tracing::instrument(level = "debug", skip(self, cmd, ctx, stdin, dispatcher), fields(command = %cmd.name))]
     async fn run_single(
         &self,
         cmd: &Command,
@@ -432,7 +429,6 @@ impl PipelineRunner {
     /// - Early termination (e.g., `seq 1 1000000 | head -n 5`)
     ///
     /// Structured data (`stdin_data`) is passed via oneshot channels alongside pipes.
-    #[tracing::instrument(level = "debug", skip(self, commands, ctx, dispatcher), fields(stage_count = commands.len()))]
     async fn run_pipeline(
         &self,
         commands: &[Command],

--- a/crates/kaish-kernel/src/tools/builtin/help.rs
+++ b/crates/kaish-kernel/src/tools/builtin/help.rs
@@ -73,7 +73,7 @@ mod tests {
         let mut ctx = ExecContext::new(Arc::new(vfs));
 
         // Add some test schemas
-        ctx.tool_schemas = vec![
+        ctx.set_tool_schemas(vec![
             ToolSchema::new("echo", "Print arguments to stdout").param(ParamSchema::optional(
                 "args",
                 "any",
@@ -83,7 +83,7 @@ mod tests {
             ToolSchema::new("cat", "Read and output file contents")
                 .param(ParamSchema::required("path", "string", "File path to read")),
             ToolSchema::new("ls", "List directory contents"),
-        ];
+        ]);
 
         ctx
     }

--- a/crates/kaish-kernel/src/tools/context.rs
+++ b/crates/kaish-kernel/src/tools/context.rs
@@ -75,7 +75,14 @@ pub struct ExecContext {
     /// Streaming pipe output (set when this command is in a concurrent pipeline).
     pub pipe_stdout: Option<PipeWriter>,
     /// Tool schemas for help command.
-    pub tool_schemas: Vec<ToolSchema>,
+    ///
+    /// `Arc<[…]>` rather than `Vec`: the full builtin schema catalog (~70
+    /// entries, each with its own `Vec`s and `String`s) is snapshotted into a
+    /// fresh `ExecContext` at every command dispatch and pipeline/fork child. As
+    /// a `Vec` that was a deep clone of the whole catalog per command; as an
+    /// `Arc<[…]>` it's a refcount bump (GH #48, item 8). Immutable after the
+    /// kernel seeds it, so a shared slice is the right shape.
+    pub tool_schemas: Arc<[ToolSchema]>,
     /// Tool registry reference (for tools that need to inspect available tools).
     pub tools: Option<Arc<ToolRegistry>>,
     /// Job manager for background jobs (optional).
@@ -294,7 +301,7 @@ impl ExecContext {
             pipe_stdin: None,
             pipe_stdout: None,
             stderr: None,
-            tool_schemas: Vec::new(),
+            tool_schemas: Vec::new().into(),
             tools: None,
             job_manager: None,
             pipeline_position: PipelinePosition::Only,
@@ -334,7 +341,7 @@ impl ExecContext {
             pipe_stdin: None,
             pipe_stdout: None,
             stderr: None,
-            tool_schemas: Vec::new(),
+            tool_schemas: Vec::new().into(),
             tools: Some(tools),
             job_manager: None,
             pipeline_position: PipelinePosition::Only,
@@ -371,7 +378,7 @@ impl ExecContext {
             pipe_stdin: None,
             pipe_stdout: None,
             stderr: None,
-            tool_schemas: Vec::new(),
+            tool_schemas: Vec::new().into(),
             tools: None,
             job_manager: None,
             pipeline_position: PipelinePosition::Only,
@@ -408,7 +415,7 @@ impl ExecContext {
             pipe_stdin: None,
             pipe_stdout: None,
             stderr: None,
-            tool_schemas: Vec::new(),
+            tool_schemas: Vec::new().into(),
             tools: Some(tools),
             job_manager: None,
             pipeline_position: PipelinePosition::Only,
@@ -448,7 +455,7 @@ impl ExecContext {
             pipe_stdin: None,
             pipe_stdout: None,
             stderr: None,
-            tool_schemas: Vec::new(),
+            tool_schemas: Vec::new().into(),
             tools: None,
             job_manager: None,
             pipeline_position: PipelinePosition::Only,
@@ -485,7 +492,7 @@ impl ExecContext {
             pipe_stdin: None,
             pipe_stdout: None,
             stderr: None,
-            tool_schemas: Vec::new(),
+            tool_schemas: Vec::new().into(),
             tools: None,
             job_manager: None,
             pipeline_position: PipelinePosition::Only,
@@ -510,8 +517,11 @@ impl ExecContext {
     }
 
     /// Set the available tool schemas (for help command).
+    ///
+    /// Takes a `Vec` for caller convenience and converts to the shared
+    /// `Arc<[…]>` the field stores (see the field docs; GH #48).
     pub fn set_tool_schemas(&mut self, schemas: Vec<ToolSchema>) {
-        self.tool_schemas = schemas;
+        self.tool_schemas = schemas.into();
     }
 
     /// Set the tool registry reference.

--- a/crates/kaish-kernel/tests/recursion_stack_cost_tests.rs
+++ b/crates/kaish-kernel/tests/recursion_stack_cost_tests.rs
@@ -1,0 +1,151 @@
+//! Ground-truth measurement of native stack consumed per statement-engine
+//! re-entry level (`$(…)` command substitution) — the quantity that sets
+//! [`kaish_kernel::RECOMMENDED_STACK_SIZE`] / [`kaish_kernel::MAX_RECURSION_DEPTH`]
+//! (GH #46/#47) and that GH #48's allocation pass is trying to shrink.
+//!
+//! Why a runtime probe and not `-Zprint-type-sizes`: the coroutine *layout*
+//! (future struct size) is computed at MIR level and is invariant to
+//! optimization, so the type-size tool cannot see the native-stack win from
+//! `opt-level` or from removing per-poll temporaries. Only running the real
+//! recursion and reading the stack pointer at each depth measures it.
+//!
+//! How it works: a trivial `stackprobe` builtin calls a `#[inline(never)]` sync
+//! helper that returns the address of a stack local — a genuine native stack
+//! pointer at the current poll depth (the tool's own `async` body is heap-boxed
+//! by `async_trait`, so we must step into a sync frame to read the real SP).
+//! A script of `stackprobe $(stackprobe $(…))` nests N command substitutions;
+//! because pure builtins never yield, the whole nest runs in one synchronous
+//! poll, so every outer level's frames are live when the innermost probe fires.
+//! Consecutive probe addresses therefore differ by exactly one re-entry level's
+//! native stack. We report the median interior delta (robust to the shallow
+//! entry/exit levels, which differ from steady state).
+
+// Test-fixture code: unwrap/expect on known-good setup is the idiom here.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use kaish_kernel::tools::{ToolArgs, ToolCtx, ToolSchema};
+use kaish_kernel::vfs::{MemoryFs, VfsRouter};
+use kaish_kernel::{Kernel, KernelBackend, KernelConfig, LocalBackend, Tool};
+use kaish_types::ExecResult;
+
+/// Return the address of a stack local. `#[inline(never)]` + `black_box` keep
+/// the frame real so the pointer reflects the current native stack depth rather
+/// than being optimized away or folded into the caller.
+#[inline(never)]
+fn stack_marker() -> usize {
+    let x = 0u8;
+    std::hint::black_box(&x as *const u8 as usize)
+}
+
+/// A leaf builtin that records the native stack pointer each time it runs.
+struct StackProbe {
+    marks: Arc<Mutex<Vec<usize>>>,
+}
+
+#[async_trait]
+impl Tool for StackProbe {
+    fn name(&self) -> &str {
+        "stackprobe"
+    }
+
+    fn schema(&self) -> ToolSchema {
+        ToolSchema::new("stackprobe", "test tool: record the native stack pointer")
+    }
+
+    async fn execute(&self, _args: ToolArgs, _ctx: &mut dyn ToolCtx) -> ExecResult {
+        self.marks.lock().unwrap().push(stack_marker());
+        // Empty stdout so the wrapping `$(…)` substitutes to nothing.
+        ExecResult::success("")
+    }
+}
+
+/// `stackprobe $(stackprobe $(… $(stackprobe)))` — `depth` nested command
+/// substitutions wrapping `depth + 1` probes.
+fn nested_script(depth: usize) -> String {
+    let mut s = String::from("stackprobe");
+    for _ in 0..depth {
+        s = format!("stackprobe $({s})");
+    }
+    s
+}
+
+/// Median of a slice (sorted copy). Robust central tendency for the per-level
+/// deltas, ignoring the atypical outermost/innermost frames.
+fn median(v: &[usize]) -> usize {
+    let mut s = v.to_vec();
+    s.sort_unstable();
+    s[s.len() / 2]
+}
+
+#[test]
+fn per_level_native_stack_cost() {
+    // Drive on a generously sized thread so the measurement itself never
+    // overflows regardless of profile (debug is ~hundreds of KB/level).
+    let marks: Arc<Mutex<Vec<usize>>> = Arc::new(Mutex::new(Vec::new()));
+    let marks_for_thread = marks.clone();
+
+    let handle = std::thread::Builder::new()
+        .stack_size(128 * 1024 * 1024)
+        .spawn(move || {
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .unwrap();
+            rt.block_on(async {
+                let mut vfs = VfsRouter::new();
+                vfs.mount("/", MemoryFs::new());
+                let backend: Arc<dyn KernelBackend> = Arc::new(LocalBackend::new(Arc::new(vfs)));
+                let probe_marks = marks_for_thread.clone();
+                let kernel = Kernel::with_backend(backend, KernelConfig::isolated(), |_| {}, move |tools| {
+                    tools.register(StackProbe { marks: probe_marks.clone() });
+                })
+                .expect("build kernel")
+                .into_arc();
+
+                // Stay well under MAX_RECURSION_DEPTH (32); each `$()` is one level.
+                let depth = 24;
+                let result = kernel.execute(&nested_script(depth)).await.expect("execute");
+                assert_eq!(result.code, 0, "probe script failed: {}", result.err);
+            });
+        })
+        .unwrap();
+    handle.join().unwrap();
+
+    let addrs = marks.lock().unwrap().clone();
+    assert!(addrs.len() >= 10, "expected many probe samples, got {}", addrs.len());
+
+    // Adjacent probes differ by one re-entry level; the stack grows one way, so
+    // take absolute differences. Drop the first and last (entry/exit frames are
+    // not steady state) and report the median interior delta.
+    let mut deltas: Vec<usize> = addrs
+        .windows(2)
+        .map(|w| w[0].abs_diff(w[1]))
+        .collect();
+    deltas.sort_unstable();
+    let interior = &deltas[1..deltas.len().saturating_sub(1)];
+    let med = median(interior);
+    let min = interior.first().copied().unwrap_or(0);
+    let max = interior.last().copied().unwrap_or(0);
+
+    eprintln!(
+        "\n=== per-$()-level native stack ===\n  samples: {}\n  median : {} bytes ({} KiB)\n  min    : {} bytes\n  max    : {} bytes\n",
+        addrs.len(),
+        med,
+        med / 1024,
+        min,
+        max,
+    );
+
+    // Catastrophic-regression guard only — the real number is the eprintln
+    // above. Generous enough to hold in unoptimized debug (~hundreds of KB),
+    // tight enough to catch a runaway (e.g. an un-boxed multi-MB frame). If this
+    // trips, a hot future grew a large by-value field across an await.
+    assert!(
+        med < 1024 * 1024,
+        "per-level native stack {med} bytes exceeds 1 MiB — a hot recursive future \
+         likely grew a large by-value field; investigate before relaxing this bound"
+    );
+}

--- a/crates/kaish-types/src/result.rs
+++ b/crates/kaish-types/src/result.rs
@@ -146,7 +146,15 @@ pub struct ExecResult {
     /// Stdout is *never* sniffed; this stays `None` for external commands.
     pub data: Option<Value>,
     /// Structured output data for rendering.
-    output: Option<OutputData>,
+    ///
+    /// Boxed like [`Self::latch`]: `OutputData` is ~120 B and `ExecResult` (and
+    /// the `ControlFlow` that wraps it) is returned up every level of deep
+    /// `$()`/pipeline recursion, so an inline `Option<OutputData>` fattened every
+    /// frame. The box is allocated only when a builtin sets structured output,
+    /// and it serializes identically (Box is transparent to serde). Private —
+    /// the public accessors below hand back plain `OutputData`/`&OutputData`, so
+    /// the boxing never leaks (GH #48, item 5).
+    output: Option<Box<OutputData>>,
     /// True if the output limiter capped this result. Either the overflow was
     /// written to a disk spill file (the `out` message carries the path) or it
     /// was truncated in memory (Memory spill mode — head+tail only, no
@@ -213,7 +221,7 @@ impl ExecResult {
                 out: OutputPayload::Text(String::new()),
                 err: String::new(),
                 data: None,
-                output: Some(output),
+                output: Some(Box::new(output)),
                 did_spill: false,
                 original_code: None,
                 content_type: None,
@@ -328,7 +336,7 @@ impl ExecResult {
             out: OutputPayload::Text(text.into()),
             err: String::new(),
             data: None,
-            output: Some(output),
+            output: Some(Box::new(output)),
             did_spill: false,
             original_code: None,
             content_type: None,
@@ -421,7 +429,7 @@ impl ExecResult {
 
     /// Get a reference to structured output data.
     pub fn output(&self) -> Option<&OutputData> {
-        self.output.as_ref()
+        self.output.as_deref()
     }
 
     /// True if structured output data is present.
@@ -475,12 +483,12 @@ impl ExecResult {
 
     /// Replace `.output`.
     pub fn set_output(&mut self, o: Option<OutputData>) {
-        self.output = o;
+        self.output = o.map(Box::new);
     }
 
     /// Take `.output`, leaving None.
     pub fn take_output(&mut self) -> Option<OutputData> {
-        self.output.take()
+        self.output.take().map(|o| *o)
     }
 
     /// Materialize: if `.out` is empty and `.output` is present,
@@ -498,7 +506,7 @@ impl ExecResult {
     /// so caller can stream directly without materializing.
     pub fn take_output_for_stream(&mut self) -> Option<OutputData> {
         if matches!(&self.out, OutputPayload::Text(s) if s.is_empty()) {
-            self.output.take()
+            self.output.take().map(|o| *o)
         } else {
             None
         }

--- a/docs/EMBEDDING.md
+++ b/docs/EMBEDDING.md
@@ -47,15 +47,17 @@ and `data` are public fields.
 The interpreter recurses on the **native stack**: command substitution
 (`$(…)`), shell-function calls, and `.kai` script sourcing all re-enter the
 statement engine. A runaway or mutually recursive script is caught by a depth
-guard ([`MAX_RECURSION_DEPTH`], 32) that returns a loud
+guard ([`MAX_RECURSION_DEPTH`], 48) that returns a loud
 `"maximum recursion depth exceeded"` error instead of overflowing the stack —
 **but the guard only fires *before* the overflow if the thread has enough
 stack.** On the default ~2 MB tokio worker stack, a deep recursion SIGSEGVs
 before reaching the cap.
 
 kaish can't set this itself (it doesn't own your runtime), so it exposes the
-floor: **[`RECOMMENDED_STACK_SIZE`] (16 MiB)**. Size every thread that drives
-kaish execution to at least this:
+floor: **[`RECOMMENDED_STACK_SIZE`] (12 MiB)**. The cap and the floor are a
+matched pair — the floor is sized so the guard trips before `cap × per-level
+stack` can overflow it. Size every thread that drives kaish execution to at
+least this:
 
 ```rust
 // Worker threads (pipeline stages, background jobs, scatter workers run here):
@@ -75,8 +77,17 @@ std::thread::Builder::new()
 Below the floor the guard still bounds *most* recursion, but a deep foreground
 recursion on an undersized driver thread can still overflow — the reference
 REPL (`kaish-repl`) sizes both its runtime workers and its driver thread to
-`RECOMMENDED_STACK_SIZE`, and is the working example. (Reducing the per-level
-stack cost so the floor can drop is tracked as an optimization pass.)
+`RECOMMENDED_STACK_SIZE`, and is the working example.
+
+> **Debug builds pay more per level.** The GH #48 allocation pass cut the
+> per-level stack to ~50 KB (release) / ~57 KB (this workspace's debug, which
+> builds the interpreter crates at `opt-level = 1`). That profile setting lives
+> in kaish's own `Cargo.toml` and does **not** propagate to your build — your
+> *debug* build of the kernel pays the full unoptimized ~193 KB/level. The
+> 12 MiB floor is deliberately sized against that worst case (48 × 193 KB ≈
+> 9.3 MB), so you're covered either way; if you want the smaller debug frames
+> too, add `[profile.dev.package.kaish-kernel] opt-level = 1` to your own
+> workspace.
 
 ## Architecture
 

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -14,6 +14,77 @@ before it ships.
 
 ---
 
+## Interpreter allocation/stack pass (2026-07-05, GH #48)
+
+#46/#47 landed a recursion depth guard sized against a measured ~380 KB of
+native stack *per statement-engine re-entry level* — the figure that forced
+`RECOMMENDED_STACK_SIZE` to 16 MiB. #48 is the pass to make that cheaper. A
+model panel (gemini-pro + fable, whole hot files, no diff) had converged on a
+ranked burndown, posted on the issue: profile fix first, then a batch of
+mechanical boxing, then two wider items to measure-and-decide.
+
+**The measurement had a trap.** The obvious tool, `-Zprint-type-sizes`, reports
+the *coroutine layout* (future struct size), which is computed at MIR level and
+is invariant to optimization. So it's a fine proxy for the boxing items (they
+shrink the struct) but completely blind to the profile change and to
+codegen-level native-stack cost — the thing #46/#47 actually cares about. Proof:
+the debug and `opt-level=1` type-size logs were byte-identical. So the first real
+deliverable was a *runtime* probe: a `stackprobe` builtin that steps into a
+`#[inline(never)]` sync frame (the async body is heap-boxed by `async_trait`, so
+a local there isn't the native stack) to read the true stack pointer at each
+`$(…)` nesting level. Pure builtins never yield, so a nest runs in one
+synchronous poll and adjacent probes differ by exactly one re-entry level. It
+reads dead-consistent (min=max=median across 25 samples) — the recursion is
+perfectly self-similar — and it became the metric every item was measured
+against, plus a durable regression guard.
+
+**The batch, each step measured (median per-`$()`-level, `opt-level=1`):**
+- *Item 0* — `opt-level = 1` on the two interpreter crates: 414 → 106 KB debug
+  (**3.9×**), nearly closing the debug↔release gap. fable's lead insight —
+  unoptimized async poll frames are ~proportional to future size with redundant
+  memcpys — landed exactly.
+- *Item 1* (box the cold dispatch branches + the two `execute_pipeline` calls):
+  106 → 96.
+- *Item 3* (drop the per-command tracing spans off the ring): 96 → 76 — the
+  `Instrumented<Span>` wrapper was heavy on the big ring futures.
+- *Item 4* (box the command-subst scope snapshot): 78.7 → 77.8 KB.
+- *Item 2* (box the two per-command `ExecContext` snapshots via a sync helper,
+  collapsing two near-duplicate 30-field blocks into one): 77.8 → 74.6.
+- *Item 7* (drop the `ToolSchema` before the execute await): no-op under
+  optimization (the compiler already narrows it), kept for debug + clarity — and
+  reported honestly as such.
+- *Item 8* (`tool_schemas: Vec → Arc<[…]>`): an *allocation* win (the ~70-schema
+  catalog was deep-cloned per dispatch → refcount bump), invisible to the stack
+  probe, so validated by construction.
+- *Item 5* (box `ExecResult.output` and `Scope.last_result`) — **the headline:**
+  74.6 → 56.8. `ExecResult` is the most-replicated type in the recursion frame
+  (every `ControlFlow`, every return, the accumulator), so boxing its 120-byte
+  `output` cascaded ~10× per level for a single 14 KB/level drop.
+
+**Result: ~46% off the per-level native stack** — release 92 → 50 KB, debug
+opt=1 106 → 57 KB, debug no-opt 414 → 193 KB.
+
+**Two decisions were Amy's.** The wider items 6 (box `Value::Json`) and 9
+(Arc-split `ExecContext`) turned out poor value once re-measured: `Value` is only
+72 B and no longer dominant, and item 9's benefit largely evaporated — item 2
+already boxed `ExecContext` off the stack and item 8 already Arc'd its expensive
+clone, leaving a large invasive refactor for a small allocation gain. Deferred
+both (measure-first follow-ups on #48). And with the frames this much smaller,
+the #46/#47 pair was relaxed: `MAX_RECURSION_DEPTH` 32 → 48 and
+`RECOMMENDED_STACK_SIZE` 16 → 12 MiB, adjusted *together* with a comment making
+the relationship explicit — the cap must trip before `cap × (worst-case
+per-level) < floor`, and the worst case is deliberately the ~193 KB *unoptimized*
+figure because the new `opt-level=1` dev profile is local to this workspace and
+does **not** propagate to embedders, whose own debug builds pay the full cost.
+`48 × 193 KB ≈ 9.3 MB` under 12 MiB keeps the same ~1.3× margin the old pair had.
+
+kaibo (deepseek, holistic, pointed at the worktree) reviewed all six change
+classes clean — no drop-order/lock-lifetime issue from the `Box::pin`s, faithful
+field parity in the snapshot helper, correct accessor boxing, identical serde
+wire format, sound `Arc` sharing, and adequate margin math. One flagged
+"output_limit sync" was pre-existing code it noticed while reading, not part of
+the change.
+
 ## Surfacing the backgrounded confirmation latch (2026-07-05, GH #96)
 
 The confirmation latch (`set -o latch`) went first-class in #92, but a gap


### PR DESCRIPTION
Closes the mechanical batch of the GH #48 interpreter allocation/stack pass and relaxes the #46/#47 recursion caps it enables. Median native stack **per statement-engine re-entry level** (`$(…)`, shell functions, `source`) drops **~46%**: release **92 → 50 KB**, debug (opt=1) **106 → 57 KB**, debug no-opt **414 → 193 KB**.

### The measurement (item 0, and why it mattered)
`-Zprint-type-sizes` reports the coroutine *layout*, computed at MIR level and **invariant to optimization** — so it's blind to the native-stack cost the guard actually cares about (the debug and opt=1 type-size logs were byte-identical). The first real deliverable was therefore a runtime probe, `recursion_stack_cost_tests`: a `stackprobe` builtin steps into a `#[inline(never)]` sync frame (the async body is heap-boxed by `async_trait`) to read the true stack pointer at each `$(…)` level; pure builtins never yield, so adjacent probes differ by exactly one re-entry level. It reads dead-consistent (min=max=median) and is now a durable regression guard. Every item below was measured against it.

`opt-level = 1` on the two interpreter crates alone took debug 414 → 106 KB (3.9×) — unoptimized async poll frames are ~proportional to future size with redundant memcpys.

### The batch (each its own commit, each measured)
| Item | Change | median/level (opt=1) |
|---|---|---|
| 0 | `opt-level = 1` on `kaish-kernel`/`kaish-types` + the probe | 414→106 KB (debug) |
| 1 | `Box::pin` the cold dispatch branches + `execute_pipeline` calls | 106→96 |
| 3 | drop per-command tracing spans off the ring | 96→76 |
| 4 | box the command-subst scope snapshot | 78.7→77.8 |
| 2 | box both per-command `ExecContext` snapshots via a sync helper | 77.8→74.6 |
| 7 | free the `ToolSchema` before the execute await | no-op under opt (kept for debug/clarity) |
| 8 | `tool_schemas: Vec → Arc<[…]>` (allocation win; catalog was deep-cloned per dispatch) | — |
| 5 | **box `ExecResult.output` + `Scope.last_result`** | **74.6→56.8** |

Item 5 is the headline: `ExecResult` is the most-replicated type in the recursion frame (every `ControlFlow`, every return, the accumulator), so boxing its 120-byte `output` cascaded ~10× for a single 14 KB/level drop.

### Decisions (Amy's calls)
- **Items 6 & 9 deferred** (measure-first follow-ups on #48). Re-measuring showed they're now poor value: `Value` is only 72 B and no longer dominant (item 6 would be a **breaking** public-enum change for a modest cascade); and item 9's benefit largely evaporated once item 2 boxed `ExecContext` off the stack and item 8 Arc'd its expensive clone — a large invasive refactor for a small allocation gain.
- **#46/#47 relaxed together:** `MAX_RECURSION_DEPTH` 32 → 48, `RECOMMENDED_STACK_SIZE` 16 → 12 MiB. They're a matched pair, made explicit in the const docs: the cap must trip before `cap × (worst-case per-level) < floor`. The worst case is deliberately the ~193 KB **unoptimized** figure, because `opt-level=1` is local to this workspace and does **not** propagate to embedders — their debug builds pay full cost. `48 × 193 KB ≈ 9.3 MB` under 12 MiB keeps the same ~1.3× margin the old pair had.

### Review
kaibo (deepseek, holistic, no diff, pointed at the worktree) reviewed all six change classes **clean** — no drop-order/lock-lifetime issue from the `Box::pin`s, faithful field parity in the snapshot helper, correct accessor boxing, identical serde wire format (`Option<Box<T>>` ≡ `Option<T>`), sound `Arc` sharing, adequate margin math. Its one flag (an `output_limit` sync) is pre-existing code it noticed while reading, not part of this change (verified against the diff).

### Breaking
- `ExecContext.tool_schemas`: `Vec<ToolSchema>` → `Arc<[ToolSchema]>` (public field). `set_tool_schemas` still takes a `Vec`; reads are unaffected (deref coercion); only direct field assignment needs `.into()`.
- The recursion constant *values* change (48 / 12 MiB) — same API.

### Gates
`cargo test --all` (111 test binaries, 0 failures) and `cargo clippy --all --all-targets` both green. One pre-existing flaky subprocess test (`non_interactive_stdin_is_dev_null`, `#[ignore]`'d sibling notes the same stdin-harness sensitivity) failed once under peak build+test load, then passed deterministically in isolation, full-binary, and 4× re-run incl. on `main` — environmental, not from this change. Worth a separate flake-hardening issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)