### PR TITLE
fix(#93): jq -s wraps array-of-one on the .data path, matching real jq

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,14 @@ breaking entries are marked **BREAKING**.
   assignment/mutation of the public field needs `.into()`.
 
 ### Fixed
+- **`jq -s`/`--slurp` now wraps the `.data` pipeline path in an array-of-one,
+  matching real jq** (GH #93 item 2). Real `jq -s` always wraps its input in
+  an array, even a single document. On kaish's structured `.data` shortcut
+  (a scalar or record handed over by an upstream stage like `fromjson`),
+  `-s` was a no-op, so `<produces scalar .data> | jq -s length` diverged from
+  real jq. It now wraps the incoming value in a one-element array before
+  applying the filter, same as the text path; plain `jq` (no `-s`) on the
+  `.data` path is unchanged.
 - **Deep recursion no longer crashes the process** (GH #46). `f() { f; }; f`,
   mutual recursion, and deeply nested `$(...)` aborted with a bare stack
   overflow; they now hit the depth guard above and fail loudly.

--- a/crates/kaish-kernel/src/tools/builtin/jq_native.rs
+++ b/crates/kaish-kernel/src/tools/builtin/jq_native.rs
@@ -57,7 +57,9 @@ struct JqArgs {
     /// Slurp mode (-s): read the whole input as a document stream and wrap
     /// it in one array — always, even for a single document (real jq
     /// semantics; see module docs "jq — stays one-document, gets louder").
-    /// A no-op on the `.data` path, where the pipeline is already slurped.
+    /// On the `.data` path the upstream stage already handed over one
+    /// structured value, so there's exactly one "document" to wrap —
+    /// `-s` still wraps it in a one-element array, matching real jq.
     #[arg(short = 's', long = "slurp")]
     slurp: bool,
 
@@ -756,9 +758,18 @@ fn jsonl_hint_for_trailing_error(text: &str, err: &serde_json::Error) -> Option<
 async fn resolve_stdin_json(ctx: &mut ExecContext, slurp: bool) -> Result<serde_json::Value, (i64, String)> {
     let (data, text) = ctx.resolve_stdin().await.map_err(|e| (2, format!("jq: {e}")))?;
     if let Some(data) = data {
-        // `.data` path: `-s` is a no-op — the upstream stage (scatter/gather,
-        // fromjson, …) already handed over one structured value.
-        return Ok(ast_value_to_json(&data));
+        // `.data` path: the upstream stage (scatter/gather, fromjson, …)
+        // already handed over one structured value — that's the single
+        // "document" real jq would have read. `-s`/`--slurp` still wraps it
+        // in a one-element array, exactly like `jq -s` always wraps its
+        // input regardless of document count (see GH #93 item 2 — a bare
+        // pass-through here was a kaish-only divergence from real jq).
+        let json = ast_value_to_json(&data);
+        return Ok(if slurp {
+            serde_json::Value::Array(vec![json])
+        } else {
+            json
+        });
     }
     if text.is_empty() {
         return if slurp {

--- a/crates/kaish-kernel/tests/jsonl_doors_tests.rs
+++ b/crates/kaish-kernel/tests/jsonl_doors_tests.rs
@@ -274,16 +274,51 @@ async fn jq_slurp_handles_pretty_printed_multi_doc_stream() {
 }
 
 #[tokio::test]
-async fn jq_slurp_is_a_noop_on_the_data_path() {
-    // `.data` from an upstream builtin is already one structured value —
-    // `-s` must not double-wrap it.
+async fn jq_slurp_wraps_the_data_path_value_in_an_array_of_one() {
+    // GH #93 item 2: `.data` from an upstream builtin is already one
+    // structured value (the single "document" real jq would have read from
+    // stdin) — `-s` must still wrap *that* value in a one-element array,
+    // exactly like the text path always wraps, rather than passing it
+    // through untouched. A bare array happens to make `length` ambiguous
+    // between "no-op" and "wrap" (both a 3-element array and a 1-element
+    // array-of-that-array give different answers), so use a scalar `.data`
+    // where the two behaviors are unmistakably different.
     let k = setup().await;
     // fromjson's own ExecResult carries `.data` through the pipe sideband
     // (unlike `echo $var`, which only renders text) — the same mechanism
     // scatter/gather's rows ride.
+    let (out, code, err) = run(&k, r#"fromjson '42' | jq -s 'length'"#).await;
+    assert_eq!(code, 0, "err: {err}");
+    assert_eq!(out, "1", "a no-op would error (scalar has no length); wrap gives array length 1");
+
+    let (out, code, err) = run(&k, r#"fromjson '42' | jq -sc '.[0]'"#).await;
+    assert_eq!(code, 0, "err: {err}");
+    assert_eq!(out, "42", ".[0] unwraps back to the original scalar");
+}
+
+#[tokio::test]
+async fn jq_slurp_still_wraps_an_array_shaped_data_value() {
+    // Same law, but the `.data` value is itself an array: `-s` wraps it one
+    // more level (`[1,2,3]` → `[[1,2,3]]`), it does not pass the array
+    // through as if already slurped.
+    let k = setup().await;
     let (out, code, err) = run(&k, r#"fromjson '[1,2,3]' | jq -sc 'length'"#).await;
     assert_eq!(code, 0, "err: {err}");
-    assert_eq!(out, "3", "-s is a no-op on .data: length is the array's, not [array]'s (1)");
+    assert_eq!(out, "1", "wrapped: outer array has one element (the inner array)");
+
+    let (out, code, err) = run(&k, r#"fromjson '[1,2,3]' | jq -sc '.[0]'"#).await;
+    assert_eq!(code, 0, "err: {err}");
+    assert_eq!(out, "[1,2,3]", ".[0] unwraps back to the original array");
+}
+
+#[tokio::test]
+async fn jq_slurp_on_the_data_path_does_not_affect_plain_jq() {
+    // Guard: bare `jq` (no `-s`) on the `.data` path is untouched by this
+    // fix — only the `-s`/`--slurp` branch changed.
+    let k = setup().await;
+    let (out, code, err) = run(&k, r#"fromjson '[1,2,3]' | jq 'length'"#).await;
+    assert_eq!(code, 0, "err: {err}");
+    assert_eq!(out, "3", "plain jq still sees the array directly, unwrapped");
 }
 
 #[tokio::test]

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -446,10 +446,13 @@ scalar is one document, so that's `tojson`'s job instead.
 `jq -s` / `--slurp` also reads a document stream, with real jq framing (so
 pretty multi-line documents are fine) and *always* wraps the result in an
 array — even a single document (`printf '{"a":1}' | jq -s length` → `1`, the
-array length). On the `.data` pipeline path `-s` is a no-op — the upstream
-stage already handed over one structured value. If plain `jq` (no `-s`) sees
-JSONL-shaped input, the error names the document count and points at
-`fromjsonl` or `jq -s` instead of a bare parse failure.
+array length). On the `.data` pipeline path the upstream stage has already
+handed over one structured value — that's the single "document" — so `-s`
+wraps *that* value in a one-element array, same as the text path
+(`fromjson '{"a":1}' | jq -s length` → `1`; `... | jq -s '.[0]'` → the
+original value). If plain `jq` (no `-s`) sees JSONL-shaped input, the error
+names the document count and points at `fromjsonl` or `jq -s` instead of a
+bare parse failure.
 
 ## Statement Chaining
 

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -14,6 +14,34 @@ before it ships.
 
 ---
 
+## `jq -s` stops being a no-op on the `.data` path (2026-07-06, GH #93 item 2)
+
+Real `jq -s`/`--slurp` has one law: wrap the inputs in an array, always —
+even a single document (`printf '{"a":1}' | jq -s length` is `1`, the array
+length, not the object's key count). kaish's `jq` already got that right on
+the text path (GH #80 landed real slurp framing there). But the structured
+`.data` shortcut — the fast path used when an upstream stage like `fromjson`
+or scatter/gather already handed over a parsed value instead of raw stdin
+text — treated `-s` as a no-op, reasoning that "the pipeline is already
+slurped." That reasoning doesn't hold: `.data` carries exactly *one*
+document, the same as reading one document off stdin, and real jq wraps a
+single document too. The divergence was silent and easy to miss because it
+only shows up on scalar/record `.data` (an array `.data` piped through
+`-s length` gives a plausible-looking wrong answer instead of an error).
+
+The fix is a three-line change in `resolve_stdin_json`: wrap the `.data`
+value in a one-element JSON array when `slurp` is set, same as the text path
+already does. `docs/LANGUAGE.md`'s slurp section and the `JqArgs::slurp` doc
+comment both asserted the old no-op behavior as intentional — both corrected
+to describe the wrap. TDD: the existing `jq_slurp_is_a_noop_on_the_data_path`
+test encoded the old (wrong) behavior as a passing assertion; it now fails
+red against the fix and was rewritten in place as
+`jq_slurp_wraps_the_data_path_value_in_an_array_of_one` plus two new
+guard tests — one confirming an array-shaped `.data` value still gets one
+more layer of wrapping (not passed through as "already an array"), and one
+confirming plain `jq` (no `-s`) on the `.data` path is untouched. Full suite
+and `clippy --all-targets` both clean.
+
 ## Interpreter allocation/stack pass (2026-07-05, GH #48)
 
 #46/#47 landed a recursion depth guard sized against a measured ~380 KB of


### PR DESCRIPTION
## Summary

Part of #93 (item 2).

Real jq's `-s`/`--slurp` always wraps its input in an array, even a single
document (`printf '{"a":1}' | jq -s length` → `1`, the array length). kaish's
jq already got this right on the text-stdin path (GH #80), but the
structured `.data` pipeline shortcut — the fast path used when an upstream
stage like `fromjson` or scatter/gather already handed over a parsed value
instead of raw stdin text — treated `-s` as a no-op, on the reasoning that
"the pipeline is already slurped." That reasoning doesn't hold: `.data`
carries exactly one document, the same as a single document read from
stdin, and real jq wraps a single document too. The divergence was easy to
miss because it only surfaces on a scalar/record `.data` value — an array
`.data` piped through `-s length` gave a plausible-looking wrong answer
instead of an obviously-wrong one.

**Decision (owner):** fix it to match real jq. `resolve_stdin_json` now
wraps the `.data` value in a one-element JSON array when `slurp` is set,
mirroring the text path. Updated the doc comments on `JqArgs::slurp` and
`resolve_stdin_json`, and `docs/LANGUAGE.md`'s slurp section, all of which
asserted the old no-op as intentional.

Plain `jq` (no `-s`) on the `.data` path is untouched — only the slurp
branch changed.

## Discovered during review, filed separately

A `kaibo` (deepseek) review of the diff confirmed the fix and traced every
input combination (empty stdin, `--path` file reads, `--arg`/`--argjson`
bindings) as unaffected or already correct. It surfaced one separate,
pre-existing gap: `jq -n -s` doesn't wrap its synthetic `null` input in an
array, because `-n` short-circuits before the slurp branch is ever
consulted. That bug predates this change and isn't part of the `.data`-path
divergence this PR fixes, so it's filed as its own issue: #111.

## Test plan

- [x] TDD: the existing `jq_slurp_is_a_noop_on_the_data_path` test encoded
      the old (wrong) behavior as a passing assertion. Confirmed it goes red
      against the fix, then rewrote it in place as three tests:
      `jq_slurp_wraps_the_data_path_value_in_an_array_of_one` (scalar `.data`
      → length 1, `.[0]` unwraps back), `jq_slurp_still_wraps_an_array_shaped_data_value`
      (array `.data` gets exactly one more layer of wrapping, not passed
      through), and `jq_slurp_on_the_data_path_does_not_affect_plain_jq`
      (guard: no `-s` is unchanged). All routed through `kernel.execute(...)`.
- [x] `cargo test --all` — full suite green, no failures.
- [x] `cargo clippy --all --all-targets` — zero warnings, zero errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)