### PR TITLE
fix(#93): honor escaped quotes in ${VAR:-default} default words

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,13 @@ breaking entries are marked **BREAKING**.
   a model reads as "not found". `-r` now governs only how *directories* expand:
   files are searched directly, directories walked, and a mixed `grep -r p file
   dir` operand list does both.
+- **A backslash-escaped quote in a `${VAR:-default}` default word no longer
+  corrupts the value** (GH #93 item 5). `${UNSET:-"hello \"world\""}` used to
+  toggle quote-tracking state on the escaped inner `"` (any `"`/`'` flipped
+  state regardless of a preceding `\`), mangling the default to `hello
+  \world\`. Escaped quotes now unescape to a literal quote character without
+  toggling state, matching bash's double-quote escape rule; kaish extends the
+  same rule to single-quoted default words for symmetry.
 
 ## [0.11.0] - 2026-07-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,9 +84,11 @@ breaking entries are marked **BREAKING**.
   corrupts the value** (GH #93 item 5). `${UNSET:-"hello \"world\""}` used to
   toggle quote-tracking state on the escaped inner `"` (any `"`/`'` flipped
   state regardless of a preceding `\`), mangling the default to `hello
-  \world\`. Escaped quotes now unescape to a literal quote character without
-  toggling state, matching bash's double-quote escape rule; kaish extends the
-  same rule to single-quoted default words for symmetry.
+  \world\`. Outside single quotes, an escaped quote now unescapes to a literal
+  quote character without toggling state — matching bash's double-quote escape
+  rule and the `'it'\''s'` → `it's` embedding idiom. Single-quoted default
+  words remain a fully literal region (zero escape processing, zero
+  interpolation), per shell rules.
 
 ## [0.11.0] - 2026-07-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,11 +100,12 @@ breaking entries are marked **BREAKING**.
   corrupts the value** (GH #93 item 5). `${UNSET:-"hello \"world\""}` used to
   toggle quote-tracking state on the escaped inner `"` (any `"`/`'` flipped
   state regardless of a preceding `\`), mangling the default to `hello
-  \world\`. Outside single quotes, an escaped quote now unescapes to a literal
-  quote character without toggling state — matching bash's double-quote escape
-  rule and the `'it'\''s'` → `it's` embedding idiom. Single-quoted default
-  words remain a fully literal region (zero escape processing, zero
-  interpolation), per shell rules.
+  \world\`. Escape handling now tracks context, matching bash: outside any
+  quotes both `\"` and `\'` unescape (so the `'it'\''s'` → `it's` embedding
+  idiom resolves); inside double quotes only `\"` unescapes while `\'` stays
+  literal (`"a\'b"` → `a\'b`, since `'` is an ordinary character there); and
+  single-quoted default words remain a fully literal region (zero escape
+  processing, zero interpolation).
 - **`ToolResult` no longer drops `did_spill`/`original_code` crossing the
   backend seam** (GH #93 item 3). `ExecResult` already tracked whether the
   output limiter capped a result and its pre-spill exit code; `ToolResult` had

--- a/crates/kaish-kernel/src/parser.rs
+++ b/crates/kaish-kernel/src/parser.rs
@@ -62,16 +62,18 @@ fn parse_var_expr(raw: &str) -> Expr {
 /// `__KAISH_ESCAPED_DOLLAR__` marker that `parse_interpolated_string` turns
 /// back into a bare `$`). Unquoted text passes through unchanged.
 ///
-/// A backslash-escaped quote (`\"` or `\'`) OUTSIDE a single-quoted region is
-/// literal data: it does not toggle the quote-tracking state and unescapes to
-/// a bare quote character — matching bash's double-quote escape rule and the
-/// unquoted `'it'\''s'` → `it's` embedding idiom (GH #93 item 5). A run of
-/// backslashes immediately before a quote is judged by parity (bash pairs them
-/// left-to-right): an odd run escapes the quote, an even run doesn't, and
-/// either way the run collapses to half as many literal backslashes.
-/// Backslashes not immediately followed by a quote are untouched — general
-/// backslash-escape processing (`\\`, `\n`, ...) outside quote-adjacency is
-/// out of scope for this function.
+/// A backslash-escaped quote unescapes to a bare quote character without
+/// toggling the quote-tracking state, but *which* quote is escapable depends on
+/// context, matching bash (GH #93 item 5): OUTSIDE any quotes both `\"` and
+/// `\'` escape (this is what makes the `'it'\''s'` → `it's` embedding idiom
+/// resolve); INSIDE double quotes only `\"` escapes, since `'` is an ordinary
+/// character there — a backslash before it stays literal (`"a\'b"` → `a\'b`). A
+/// run of backslashes immediately before an escapable quote is judged by parity
+/// (bash pairs them left-to-right): an odd run escapes the quote, an even run
+/// doesn't, and either way the run collapses to half as many literal
+/// backslashes. Backslashes not immediately followed by an escapable quote are
+/// untouched — general backslash-escape processing (`\\`, `\n`, ...) outside
+/// quote-adjacency is out of scope for this function.
 ///
 /// Inside a single-quoted region shell rules apply verbatim: it is a LITERAL
 /// span with zero escape processing and zero interpolation. A backslash is a
@@ -96,7 +98,10 @@ fn unquote_default_word(word: &str) -> String {
                 i += 1;
             }
             let run_len = i - run_start;
-            let next_is_quote = chars.get(i).is_some_and(|c| *c == '"' || *c == '\'');
+            // Inside double quotes only `\"` escapes; `'` is an ordinary
+            // character there, so a preceding backslash stays literal.
+            let next_is_quote =
+                chars.get(i).is_some_and(|c| *c == '"' || (*c == '\'' && !in_double));
             if next_is_quote {
                 if run_len / 2 > 0 {
                     out.push_str(&"\\".repeat(run_len / 2));

--- a/crates/kaish-kernel/src/parser.rs
+++ b/crates/kaish-kernel/src/parser.rs
@@ -62,18 +62,23 @@ fn parse_var_expr(raw: &str) -> Expr {
 /// `__KAISH_ESCAPED_DOLLAR__` marker that `parse_interpolated_string` turns
 /// back into a bare `$`). Unquoted text passes through unchanged.
 ///
-/// A backslash-escaped quote (`\"` or `\'`) is literal data: it must not
-/// toggle the quote-tracking state, and unescapes to a bare quote character
-/// in the output — matching bash's double-quote escape rule (GH #93 item 5).
-/// kaish extends the same rule to single-quoted words for symmetry, which is
-/// a deliberate divergence: bash has no escape mechanism inside single quotes
-/// at all. A run of backslashes immediately before a quote is judged by
-/// parity (bash pairs them left-to-right): an odd run escapes the quote,
-/// an even run doesn't, and either way the run collapses to half as many
-/// literal backslashes. Backslashes not immediately followed by a quote are
-/// untouched — general backslash-escape processing (`\\`, `\n`, ...) outside
-/// quote-adjacency stays out of scope for this function, unchanged from
-/// before this fix.
+/// A backslash-escaped quote (`\"` or `\'`) OUTSIDE a single-quoted region is
+/// literal data: it does not toggle the quote-tracking state and unescapes to
+/// a bare quote character — matching bash's double-quote escape rule and the
+/// unquoted `'it'\''s'` → `it's` embedding idiom (GH #93 item 5). A run of
+/// backslashes immediately before a quote is judged by parity (bash pairs them
+/// left-to-right): an odd run escapes the quote, an even run doesn't, and
+/// either way the run collapses to half as many literal backslashes.
+/// Backslashes not immediately followed by a quote are untouched — general
+/// backslash-escape processing (`\\`, `\n`, ...) outside quote-adjacency is
+/// out of scope for this function.
+///
+/// Inside a single-quoted region shell rules apply verbatim: it is a LITERAL
+/// span with zero escape processing and zero interpolation. A backslash is a
+/// literal character and a `'` always closes the region (it is never escaped);
+/// only `$` is marked (`__KAISH_ESCAPED_DOLLAR__`) so it can't interpolate
+/// downstream. Only the delimiter quotes themselves are stripped — they are
+/// syntax, not data.
 fn unquote_default_word(word: &str) -> String {
     let mut out = String::with_capacity(word.len());
     let mut in_single = false;
@@ -82,7 +87,10 @@ fn unquote_default_word(word: &str) -> String {
     let mut i = 0;
     while i < chars.len() {
         let ch = chars[i];
-        if ch == '\\' {
+        // Backslash-escape processing applies only OUTSIDE single quotes. In a
+        // single-quoted region a backslash is a literal character (handled by
+        // the `_` arm below) and a `'` always closes the span, per shell rules.
+        if ch == '\\' && !in_single {
             let run_start = i;
             while i < chars.len() && chars[i] == '\\' {
                 i += 1;

--- a/crates/kaish-kernel/src/parser.rs
+++ b/crates/kaish-kernel/src/parser.rs
@@ -61,11 +61,53 @@ fn parse_var_expr(raw: &str) -> Expr {
 /// suppress interpolation (their `$` becomes a literal, via the lexer's
 /// `__KAISH_ESCAPED_DOLLAR__` marker that `parse_interpolated_string` turns
 /// back into a bare `$`). Unquoted text passes through unchanged.
+///
+/// A backslash-escaped quote (`\"` or `\'`) is literal data: it must not
+/// toggle the quote-tracking state, and unescapes to a bare quote character
+/// in the output — matching bash's double-quote escape rule (GH #93 item 5).
+/// kaish extends the same rule to single-quoted words for symmetry, which is
+/// a deliberate divergence: bash has no escape mechanism inside single quotes
+/// at all. A run of backslashes immediately before a quote is judged by
+/// parity (bash pairs them left-to-right): an odd run escapes the quote,
+/// an even run doesn't, and either way the run collapses to half as many
+/// literal backslashes. Backslashes not immediately followed by a quote are
+/// untouched — general backslash-escape processing (`\\`, `\n`, ...) outside
+/// quote-adjacency stays out of scope for this function, unchanged from
+/// before this fix.
 fn unquote_default_word(word: &str) -> String {
     let mut out = String::with_capacity(word.len());
     let mut in_single = false;
     let mut in_double = false;
-    for ch in word.chars() {
+    let chars: Vec<char> = word.chars().collect();
+    let mut i = 0;
+    while i < chars.len() {
+        let ch = chars[i];
+        if ch == '\\' {
+            let run_start = i;
+            while i < chars.len() && chars[i] == '\\' {
+                i += 1;
+            }
+            let run_len = i - run_start;
+            let next_is_quote = chars.get(i).is_some_and(|c| *c == '"' || *c == '\'');
+            if next_is_quote {
+                if run_len / 2 > 0 {
+                    out.push_str(&"\\".repeat(run_len / 2));
+                }
+                if run_len % 2 == 1 {
+                    // Odd run: the quote is escaped — literal quote, no
+                    // toggle. Consume it here; the main loop below never
+                    // sees it.
+                    out.push(chars[i]);
+                    i += 1;
+                }
+                // Even run: the quote at chars[i] is unescaped and falls
+                // through to the normal toggle logic on the next iteration.
+            } else {
+                out.push_str(&"\\".repeat(run_len));
+            }
+            continue;
+        }
+        i += 1;
         match ch {
             // A quote delimiter toggles its mode and is itself dropped; the
             // other quote kind is literal data while inside one.

--- a/crates/kaish-kernel/tests/shell_compat_tests.rs
+++ b/crates/kaish-kernel/tests/shell_compat_tests.rs
@@ -665,6 +665,16 @@ shell_compat! {
     eq: "it's \"quoted\"",
 }
 
+// Inside DOUBLE quotes, `'` is not special, so a backslash before it is
+// literal — only `\"`, `\$`, `\\`, `` \` `` are escapes in a double-quoted
+// region. `${VAR:-"a\'b"}` therefore keeps the backslash (`a\'b`), matching
+// bash (kaibo-caught divergence: the escape used to also fire on `\'` here).
+shell_compat! {
+    name: default_word_double_quoted_backslash_before_squote_literal,
+    script: r#"echo ${NAME:-"a\'b"}"#,
+    eq: "a\\'b",
+}
+
 // Single-quoted default words are a LITERAL region, per shell rules: zero
 // interpolation AND zero escape processing. Only the delimiter quotes are
 // stripped (syntax, not data); a backslash stays literal and a `'` always

--- a/crates/kaish-kernel/tests/shell_compat_tests.rs
+++ b/crates/kaish-kernel/tests/shell_compat_tests.rs
@@ -642,6 +642,41 @@ shell_compat! {
     eq: "actual",
 }
 
+// `${VAR:-default}` default-word ESCAPED quotes (GH #93 item 5). A
+// backslash-escaped quote inside the default word must not toggle the
+// quote-tracking state — it's literal data, unescaping to a bare quote
+// character, exactly like bash's double-quote escape rule.
+
+shell_compat! {
+    name: default_word_double_quoted_escaped_quotes_literal,
+    script: r#"echo ${NAME:-"hello \"world\""}"#,
+    eq: "hello \"world\"",
+}
+
+// kaish divergence (documented): kaish deliberately extends the same
+// backslash-escape rule to single-quoted default words for symmetry with the
+// double-quoted case above. Real bash has no escape mechanism inside single
+// quotes at all — a `\'` there ends the quoted string, so the equivalent
+// bash script is a syntax error (unterminated quote), never reaching stdout.
+shell_compat! {
+    name: default_word_single_quoted_escaped_quotes_literal,
+    script: r#"echo ${NAME:-'hello \'world\''}"#,
+    kaish_eq: "hello 'world'",
+    bash_eq: "",
+}
+
+shell_compat! {
+    name: default_word_escaped_backslash_before_quote,
+    script: r#"echo ${NAME:-"a\\"}"#,
+    eq: "a\\",
+}
+
+shell_compat! {
+    name: default_word_mixed_single_and_escaped_double_quotes,
+    script: r#"echo ${NAME:-"it's \"quoted\""}"#,
+    eq: "it's \"quoted\"",
+}
+
 // =============================================================================
 // `break N` / `continue N` must not discard output printed before the signal.
 // The signal used to replace the loop's accumulated result on its way up, so

--- a/crates/kaish-kernel/tests/shell_compat_tests.rs
+++ b/crates/kaish-kernel/tests/shell_compat_tests.rs
@@ -642,27 +642,15 @@ shell_compat! {
     eq: "actual",
 }
 
-// `${VAR:-default}` default-word ESCAPED quotes (GH #93 item 5). A
-// backslash-escaped quote inside the default word must not toggle the
-// quote-tracking state — it's literal data, unescaping to a bare quote
-// character, exactly like bash's double-quote escape rule.
+// `${VAR:-default}` default-word ESCAPED quotes inside DOUBLE quotes (GH #93
+// item 5). A backslash-escaped quote inside a double-quoted default word must
+// not toggle the quote-tracking state — it's literal data, unescaping to a
+// bare quote character, exactly like bash's double-quote escape rule.
 
 shell_compat! {
     name: default_word_double_quoted_escaped_quotes_literal,
     script: r#"echo ${NAME:-"hello \"world\""}"#,
     eq: "hello \"world\"",
-}
-
-// kaish divergence (documented): kaish deliberately extends the same
-// backslash-escape rule to single-quoted default words for symmetry with the
-// double-quoted case above. Real bash has no escape mechanism inside single
-// quotes at all — a `\'` there ends the quoted string, so the equivalent
-// bash script is a syntax error (unterminated quote), never reaching stdout.
-shell_compat! {
-    name: default_word_single_quoted_escaped_quotes_literal,
-    script: r#"echo ${NAME:-'hello \'world\''}"#,
-    kaish_eq: "hello 'world'",
-    bash_eq: "",
 }
 
 shell_compat! {
@@ -675,6 +663,38 @@ shell_compat! {
     name: default_word_mixed_single_and_escaped_double_quotes,
     script: r#"echo ${NAME:-"it's \"quoted\""}"#,
     eq: "it's \"quoted\"",
+}
+
+// Single-quoted default words are a LITERAL region, per shell rules: zero
+// interpolation AND zero escape processing. Only the delimiter quotes are
+// stripped (syntax, not data); a backslash stays literal and a `'` always
+// closes the region — it is never escaped.
+
+shell_compat! {
+    name: default_word_single_quoted_strips_delimiters,
+    script: "echo ${NAME:-'x'}",
+    eq: "x",
+}
+
+shell_compat! {
+    name: default_word_single_quoted_no_interpolation,
+    script: "echo ${NAME:-'$HOME'}",
+    eq: "$HOME",
+}
+
+shell_compat! {
+    name: default_word_single_quoted_backslash_literal,
+    script: r#"echo ${NAME:-'a\b'}"#,
+    eq: "a\\b",
+}
+
+// The shell-correct way to embed a single quote is the `'…'\''…'` idiom:
+// close the single-quoted span, emit an UNQUOTED escaped `\'`, reopen. The
+// escape fires only outside single quotes — which this fix keeps working.
+shell_compat! {
+    name: default_word_single_quote_embed_idiom,
+    script: r#"echo ${NAME:-'it'\''s'}"#,
+    eq: "it's",
 }
 
 // =============================================================================

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -72,18 +72,30 @@ The delimiter-stripping itself (`${X:-'x'}` → `x`) was double-checked and is
 correct — that's the function's whole purpose, the quotes are syntax not data.
 Only the escape-processing-inside-single-quotes overreach was the bug.
 
+A third round, from a kaibo review of the revision, caught a subtler
+context bug: the escape predicate treated `'` and `"` identically, gated only
+on `!in_single`. So inside a *double*-quoted region a `\'` still escaped —
+`${X:-"a\'b"}` came out `a'b`. Bash disagrees: inside `"…"` a `'` is an
+ordinary character, and only `\"`, `\$`, `\\`, `` \` `` are escapes, so the
+backslash before `'` is literal and bash yields `a\'b` (verified against real
+bash). The fix is a one-line narrowing of the predicate — a `'` only counts as
+escapable when *not* `in_double` — so unquoted `\'` still powers the
+`'it'\''s'` idiom, double-quoted `\'` stays literal, and single-quoted regions
+(already fully literal) are untouched.
+
 Tests in `shell_compat_tests.rs`: the double-quote fix is pinned by
 `default_word_double_quoted_escaped_quotes_literal`,
 `default_word_escaped_backslash_before_quote` (the `"a\\"` → `a\` parity
-case), and `default_word_mixed_single_and_escaped_double_quotes`. The
+case), `default_word_mixed_single_and_escaped_double_quotes`, and
+`default_word_double_quoted_backslash_before_squote_literal` (the kaibo-caught
+`"a\'b"` → `a\'b` case, confirmed red as `a'b` before the predicate fix). The
 shell-literal single-quote contract is pinned by four cases:
 `…_strips_delimiters` (`'x'` → `x`), `…_no_interpolation` (`'$HOME'` →
 `$HOME`), `…_backslash_literal` (`'a\b'` → `a\b`, backslash NOT collapsed),
-and `…_embed_idiom` (`'it'\''s'` → `it's`). All double-quote cases were
+and `…_embed_idiom` (`'it'\''s'` → `it's`). All the newly-fixed cases were
 confirmed failing against the pre-fix code; every case — single- and
 double-quoted alike — now passes under `KAISH_BASH_COMPAT=1` against real
-bash, with no recorded divergence, because the shell-literal rule *is* bash's
-rule.
+bash, with no recorded divergence, because the shell rule *is* bash's rule.
 
 ## `jq -s` stops being a no-op on the `.data` path (2026-07-06, GH #93 item 2)
 

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -46,21 +46,44 @@ the reported quote-toggle bug, not a full escape-processing rewrite. Recorded
 as a known gap in the PR body rather than filed as a separate issue — it's a
 narrow, pre-existing limitation, not a regression.
 
-The single-quote case forced a judgment call. Real bash has *no* escape
-mechanism inside single quotes at all — `${NAME:-'hello \'world\''}` is a
-syntax error in bash (verified: unterminated quote), not a way to embed an
-apostrophe. kaish extends the same escape rule to single-quoted default words
-anyway, symmetric with the double-quoted fix, since the alternative (bash's
-actual behavior) isn't a coherent target to match. Recorded as an explicit,
-documented `shell_compat!` divergence (`kaish_eq`/`bash_eq` pair) rather than
-silently diverging.
+The single-quote case forced a judgment call, and the *first* answer was
+wrong. The initial pass extended the same backslash-escape rule *into*
+single-quoted default words "for symmetry," reasoning that real bash's
+behavior there (`'hello \'world\''` is a syntax error — unterminated quote —
+not an embedded apostrophe) wasn't a coherent target to match. Amy overruled
+it on review, and correctly: single quotes are a *literal* region in shell,
+full stop. A model relying on shell muscle memory must get **zero** surprises
+inside `'…'` — zero interpolation, zero escape processing. A backslash there
+is a literal byte and a `'` always closes the span; it is never escaped. The
+"symmetry" argument was inventing a dialect where the whole point is fidelity
+to shell's literal-region contract.
 
-Four new `shell_compat!` cases in `shell_compat_tests.rs` (double-quoted
-escaped quotes, the single-quote divergence, an escaped-backslash-before-quote
-parity case, and a mixed single/double case), all confirmed failing against
-the pre-fix code before the fix landed, and passing after — including under
-`KAISH_BASH_COMPAT=1` against real bash for the three cases where bash and
-kaish agree.
+So the escape logic is gated to fire only *outside* single quotes (`if ch ==
+'\\' && !in_single`). Nothing is actually lost: the shell-correct way to embed
+a single quote is the `'…'\''…'` idiom — close the span, emit an **unquoted**
+escaped `\'`, reopen — and that unquoted escape still works (it's the same
+code path as the double-quote fix, just outside any quote). `${X:-'it'\''s'}`
+→ `it's`, matching bash exactly. The one behavior that stays inside single
+quotes is the pre-existing `$` → `__KAISH_ESCAPED_DOLLAR__` marking, which is
+what *implements* "zero interpolation" — it isn't escape processing, it's
+suppression.
+
+The delimiter-stripping itself (`${X:-'x'}` → `x`) was double-checked and is
+correct — that's the function's whole purpose, the quotes are syntax not data.
+Only the escape-processing-inside-single-quotes overreach was the bug.
+
+Tests in `shell_compat_tests.rs`: the double-quote fix is pinned by
+`default_word_double_quoted_escaped_quotes_literal`,
+`default_word_escaped_backslash_before_quote` (the `"a\\"` → `a\` parity
+case), and `default_word_mixed_single_and_escaped_double_quotes`. The
+shell-literal single-quote contract is pinned by four cases:
+`…_strips_delimiters` (`'x'` → `x`), `…_no_interpolation` (`'$HOME'` →
+`$HOME`), `…_backslash_literal` (`'a\b'` → `a\b`, backslash NOT collapsed),
+and `…_embed_idiom` (`'it'\''s'` → `it's`). All double-quote cases were
+confirmed failing against the pre-fix code; every case — single- and
+double-quoted alike — now passes under `KAISH_BASH_COMPAT=1` against real
+bash, with no recorded divergence, because the shell-literal rule *is* bash's
+rule.
 
 ## Interpreter allocation/stack pass (2026-07-05, GH #48)
 

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -14,6 +14,54 @@ before it ships.
 
 ---
 
+## Escaped quotes in `${VAR:-default}` (2026-07-06, GH #93 item 5)
+
+Item 5 of #93's punch list: `unquote_default_word` (the function that strips
+the syntactic quotes off a `${VAR:-"default"}` word before it's parsed for
+interpolation) toggled its `in_single`/`in_double` state on *every* `"`/`'` it
+saw, with no notion of a preceding backslash. So `${UNSET:-"hello
+\"world\""}` — a double-quoted default containing an escaped inner quote —
+had its second `"` prematurely close the quoted region, and the value came
+out as `hello \world\` instead of `hello "world"`.
+
+The fix needed to answer a harder question than "skip escaped quotes": what
+does a *run* of backslashes immediately before a quote mean? Bash's actual
+rule (verified empirically against real bash, not from memory) pairs
+backslashes left-to-right — an even run collapses to half as many literal
+backslashes and leaves the quote as a real, state-toggling delimiter; an odd
+run does the same collapse and additionally escapes the quote (literal
+character, no toggle). A naive one-token lookahead gets this wrong on 2+
+backslash runs (`"a\\"` → `a\` in real bash; a lookahead that treats each
+backslash independently would misjudge the second backslash as escaping the
+closing quote instead of pairing with the first). The fix buffers the
+contiguous backslash run and decides once it hits the terminating character.
+
+Backslashes *not* adjacent to a quote were left untouched on purpose — real
+bash also collapses `\\` inside double quotes when it's followed by an
+ordinary character (verified: `"foo\\bar"` → `foo\bar` in bash), but
+`unquote_default_word` never did general backslash-escape processing before
+this fix (confirmed by reading `parse_interpolated_string`, its downstream
+consumer, which has no backslash handling at all), and this PR is scoped to
+the reported quote-toggle bug, not a full escape-processing rewrite. Recorded
+as a known gap in the PR body rather than filed as a separate issue — it's a
+narrow, pre-existing limitation, not a regression.
+
+The single-quote case forced a judgment call. Real bash has *no* escape
+mechanism inside single quotes at all — `${NAME:-'hello \'world\''}` is a
+syntax error in bash (verified: unterminated quote), not a way to embed an
+apostrophe. kaish extends the same escape rule to single-quoted default words
+anyway, symmetric with the double-quoted fix, since the alternative (bash's
+actual behavior) isn't a coherent target to match. Recorded as an explicit,
+documented `shell_compat!` divergence (`kaish_eq`/`bash_eq` pair) rather than
+silently diverging.
+
+Four new `shell_compat!` cases in `shell_compat_tests.rs` (double-quoted
+escaped quotes, the single-quote divergence, an escaped-backslash-before-quote
+parity case, and a mixed single/double case), all confirmed failing against
+the pre-fix code before the fix landed, and passing after — including under
+`KAISH_BASH_COMPAT=1` against real bash for the three cases where bash and
+kaish agree.
+
 ## Interpreter allocation/stack pass (2026-07-05, GH #48)
 
 #46/#47 landed a recursion depth guard sized against a measured ~380 KB of


### PR DESCRIPTION
## Summary

Part of #93 (item 5). `unquote_default_word` (crates/kaish-kernel/src/parser.rs) strips the syntactic quotes off a `${VAR:-"default"}` word before it's parsed for interpolation. It toggled `in_single`/`in_double` state on *every* `"`/`'` it saw, with no notion of a preceding backslash — so `${UNSET:-"hello \"world\""}` had its escaped inner quote prematurely close the double-quoted region, corrupting the default to `hello \world\` instead of `hello "world"`.

## What changed

- **Double-quoted default words:** `unquote_default_word` now buffers a contiguous backslash run when it hits one. If the run is immediately followed by a quote, escape parity is judged bash-style (backslashes pair off left-to-right): an **odd** run escapes the quote (literal quote char in the output, no state toggle) and an **even** run leaves the quote as a real delimiter — either way the run collapses to half as many literal backslashes. Verified empirically against real `bash -c`, not from memory (e.g. `"a\\"` → `a\`: the two backslashes pair off, and the closing quote is a genuine terminator).
- **Single-quoted default words stay a fully literal region, per shell rules — zero interpolation AND zero escape processing.** The backslash-escape logic is gated to fire only *outside* single quotes (`if ch == '\\' && !in_single`). Inside `'…'` a backslash is a literal byte and a `'` always closes the span (it is never escaped). The pre-existing `$` → `__KAISH_ESCAPED_DOLLAR__` marking stays — that's what implements "zero interpolation", not escape processing.
  - *(An earlier revision of this PR extended escape-awareness into single quotes "for symmetry"; the maintainer reversed that on review — single quotes must give zero surprises to shell muscle memory. That extension is reverted; see the second commit.)*
- **Nothing is lost by keeping single quotes literal:** the shell-correct way to embed a single quote is the `'…'\''…'` idiom — close the span, emit an **unquoted** escaped `\'`, reopen. That unquoted escape uses the same code path as the double-quote fix, so `${X:-'it'\''s'}` → `it's`, matching bash exactly.
- Delimiter-stripping (`${X:-'x'}` → `x`) was double-checked and is correct — that's the function's whole purpose (quotes are syntax, not data). Only the escape-processing-inside-single-quotes overreach was the bug.
- Backslash runs **not** immediately followed by a quote are emitted unchanged. `unquote_default_word` never did general backslash-escape processing before this fix (its downstream consumer, `parse_interpolated_string`, has none either), and this PR is scoped to the reported quote-toggle bug, not a full escape-processing rewrite.

## Rationale

Single quotes are a literal region in shell; a model relying on shell muscle memory must get zero surprises inside `'…'`. The `'…'\''…'` idiom (which we keep) is the shell-correct way to embed a quote, so nothing is lost by making single quotes fully literal.

## Tests

All routed through `kernel.execute(...)`, in `crates/kaish-kernel/tests/shell_compat_tests.rs`:

Double-quote fix (the reported bug):
- `default_word_double_quoted_escaped_quotes_literal` — `"hello \"world\""` → `hello "world"`
- `default_word_escaped_backslash_before_quote` — `"a\\"` → `a\` (backslash-run parity)
- `default_word_mixed_single_and_escaped_double_quotes` — `"it's \"quoted\""` → `it's "quoted"`

Single-quote shell-literal contract:
- `default_word_single_quoted_strips_delimiters` — `'x'` → `x`
- `default_word_single_quoted_no_interpolation` — `'$HOME'` → `$HOME`
- `default_word_single_quoted_backslash_literal` — `'a\b'` → `a\b` (backslash literal, NOT collapsed)
- `default_word_single_quote_embed_idiom` — `'it'\''s'` → `it's` (the unquoted `\'` idiom)

Every single- and double-quote case agrees with real bash under `KAISH_BASH_COMPAT=1` — no recorded divergence, because the shell-literal rule *is* bash's rule.

## Test plan

- [x] `cargo test --all` — green (222 passing in `shell_compat_tests`, 0 failed anywhere)
- [x] `cargo clippy --all --all-targets` — zero warnings
- [x] Double-quote tests confirmed failing pre-fix, passing post-fix
- [x] All new tests re-verified passing under `KAISH_BASH_COMPAT=1` (real bash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)