### PR TITLE
harden(#93): non_exhaustive the job/tool-result seam + close ToolResult metadata gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,9 @@ breaking entries are marked **BREAKING**.
   `jobs` and `/v/jobs/{id}/status` report `Latched` distinctly from a plain
   failure; and a new `/v/jobs/{id}/latch` node renders the request as JSON
   (nonce, command, paths, hint) — empty when the job isn't gated. An embedder
-  fulfills it with `Kernel::confirm(&latch)`. **BREAKING (embedders):**
-  `JobStatus` gains a `Latched` variant (exhaustive matches must handle it) and
-  `JobInfo` gains a `latch: Option<LatchRequest>` field.
+  fulfills it with `Kernel::confirm(&latch)`. **Embedders:** `JobStatus` gains
+  a `Latched` variant (exhaustive matches must handle it) and `JobInfo` gains
+  a `latch: Option<LatchRequest>` field.
 - **Recursion is depth-guarded (`MAX_RECURSION_DEPTH` = 48)** (GH #46/#47, tuned
   by #48). Command substitution, shell-function calls, `.kai` script execution,
   and `source`/`.` all re-enter the statement engine on the native stack; a
@@ -59,6 +59,14 @@ breaking entries are marked **BREAKING**.
   `set_tool_schemas` still accepts a `Vec` (converts internally) and all read
   sites are unaffected (deref coercion to `&[ToolSchema]`); only direct field
   assignment/mutation of the public field needs `.into()`.
+- **Embedders:** `JobStatus`, `JobInfo`, and `ToolResult` are now
+  `#[non_exhaustive]` (GH #93, part of item 3/4 plus a hygiene pass) —
+  construct them via their constructors (`JobInfo::new()` +
+  `.with_output_file()`/`.with_pid()`/`.with_latch()`; `ToolResult::success()`/
+  `.failure()`/`.with_data()` plus the new `.with_output()`/
+  `.with_content_type()`/`.with_baggage()`/`.with_latch()`/`.with_did_spill()`/
+  `.with_original_code()`) and add a `_` arm to any exhaustive match — future
+  variants/fields won't break you.
 
 ### Fixed
 - **`jq -s`/`--slurp` now wraps the `.data` pipeline path in an array-of-one,
@@ -88,6 +96,12 @@ breaking entries are marked **BREAKING**.
   a model reads as "not found". `-r` now governs only how *directories* expand:
   files are searched directly, directories walked, and a mixed `grep -r p file
   dir` operand list does both.
+- **`ToolResult` no longer drops `did_spill`/`original_code` crossing the
+  backend seam** (GH #93 item 3). `ExecResult` already tracked whether the
+  output limiter capped a result and its pre-spill exit code; `ToolResult` had
+  neither field, so a backend-registered tool's (kaijutsu, an MCP engine)
+  capped result silently looked uncapped by the time it reached the kernel, in
+  both `ExecResult`↔`ToolResult` directions. Both fields now round-trip intact.
 
 ## [0.11.0] - 2026-07-04
 

--- a/crates/kaish-kernel/src/dispatch.rs
+++ b/crates/kaish-kernel/src/dispatch.rs
@@ -455,22 +455,15 @@ impl CommandDispatcher for BackendDispatcher {
         // Execute via backend
         let backend = ctx.backend.clone();
         let result = match backend.call_tool(&cmd.name, tool_args, ctx).await {
-            Ok(tool_result) => {
-                let mut exec = ExecResult::from_output(
-                    tool_result.code as i64,
-                    tool_result.stdout,
-                    tool_result.stderr,
-                );
-                exec.set_output(tool_result.output);
-                exec.content_type = tool_result.content_type;
-                exec.baggage = tool_result.baggage;
-                exec.latch = tool_result.latch;
-                // Restore structured data from ToolResult (preserved through backend roundtrip)
-                if let Some(json_data) = tool_result.data {
-                    exec.data = Some(Value::Json(json_data));
-                }
-                exec
-            }
+            // Route through the same `From<ToolResult> for ExecResult` the
+            // production dispatch path uses (kernel.rs) rather than
+            // hand-rolling the field-by-field copy: the old inline version
+            // wrapped `data` unconditionally as `Value::Json`, which skipped
+            // `json_to_value_no_envelope`'s scalar-unwrap (`Value::Int`/
+            // `Value::String`/…) and silently dropped `did_spill`/
+            // `original_code` — a divergence this test-only dispatcher must
+            // not have from the real path (GH #93 item 4).
+            Ok(tool_result) => ExecResult::from(tool_result),
             Err(BackendError::ToolNotFound(_)) => {
                 // Fall back to external command execution
                 match self.try_external(&cmd.name, &cmd.args, ctx).await {

--- a/crates/kaish-kernel/src/kernel.rs
+++ b/crates/kaish-kernel/src/kernel.rs
@@ -6482,16 +6482,11 @@ mod tests {
         let backend = mock.with_tool_result(|_name| {
             let mut baggage = std::collections::BTreeMap::new();
             baggage.insert("trace_id".to_string(), "abc123".to_string());
-            Ok(ToolResult {
-                code: 0,
-                stdout: String::new(),
-                stderr: String::new(),
-                data: Some(serde_json::json!({"key": "value"})),
-                output: None,
-                content_type: Some("application/json".to_string()),
-                baggage,
-                latch: None,
-            })
+            // ToolResult is #[non_exhaustive] (GH #93 item 3/hygiene pass) —
+            // construct via with_data + the with_* setters, not a struct literal.
+            Ok(ToolResult::with_data("", serde_json::json!({"key": "value"}))
+                .with_content_type("application/json")
+                .with_baggage(baggage))
         });
         let backend: Arc<dyn crate::backend::KernelBackend> = Arc::new(backend);
         let kernel = Kernel::with_backend(backend, KernelConfig::isolated(), |_| {}, |_| {})

--- a/crates/kaish-kernel/src/scheduler/job.rs
+++ b/crates/kaish-kernel/src/scheduler/job.rs
@@ -617,14 +617,10 @@ impl JobManager {
             .map(|job| {
                 let status = job.status();
                 let latch = job.latch();
-                JobInfo {
-                    id: job.id,
-                    command: job.command.clone(),
-                    status,
-                    output_file: job.output_file.clone(),
-                    pid: job.pid,
-                    latch,
-                }
+                JobInfo::new(job.id, job.command.clone(), status)
+                    .with_output_file(job.output_file.clone())
+                    .with_pid(job.pid)
+                    .with_latch(latch)
             })
             .collect()
     }
@@ -666,14 +662,10 @@ impl JobManager {
         jobs.get_mut(&id).map(|job| {
             let status = job.status();
             let latch = job.latch();
-            JobInfo {
-                id: job.id,
-                command: job.command.clone(),
-                status,
-                output_file: job.output_file.clone(),
-                pid: job.pid,
-                latch,
-            }
+            JobInfo::new(job.id, job.command.clone(), status)
+                .with_output_file(job.output_file.clone())
+                .with_pid(job.pid)
+                .with_latch(latch)
         })
     }
 

--- a/crates/kaish-kernel/src/scheduler/pipeline.rs
+++ b/crates/kaish-kernel/src/scheduler/pipeline.rs
@@ -1720,6 +1720,88 @@ mod tests {
         assert_eq!(call_count.load(Ordering::SeqCst), 3, "call_tool should be invoked for each command");
     }
 
+    /// GH #93 item 4: the test-only `BackendDispatcher` used to hand-roll the
+    /// `ToolResult` -> `ExecResult` conversion (wrapping `data` unconditionally
+    /// as `Value::Json`), diverging from the production path in kernel.rs,
+    /// which goes through `ExecResult::from(tool_result)` and unwraps JSON
+    /// scalars into native `Value` variants via `json_to_value_no_envelope`.
+    /// A scalar `data` payload is where the two paths visibly disagreed.
+    #[tokio::test]
+    async fn backend_dispatcher_scalar_data_matches_production_unwrap() {
+        use crate::backend::testing::MockBackend;
+        use crate::backend::ToolResult;
+
+        let (mock, _calls) = MockBackend::new();
+        let backend = mock.with_tool_result(|_name| Ok(ToolResult::with_data("", serde_json::json!(42))));
+        let backend: Arc<dyn crate::backend::KernelBackend> = Arc::new(backend);
+        let mut ctx = ExecContext::with_backend(backend);
+
+        let dispatcher = BackendDispatcher::new(Arc::new(ToolRegistry::new()));
+        let cmd = make_cmd("embedder_tool", vec![]);
+
+        let result = dispatcher.dispatch(&cmd, &mut ctx).await.expect("dispatch");
+        assert_eq!(
+            result.data,
+            Some(Value::Int(42)),
+            "a scalar ToolResult.data must unwrap to a native Value, matching \
+             the production From<ToolResult> path — not stay Value::Json(42)"
+        );
+    }
+
+    /// Companion to the scalar test above: an object shaped like the binary
+    /// byte-envelope must stay a plain structured record (`Value::Json`), not
+    /// get auto-decoded into `Value::Bytes`. Pins the same guarantee
+    /// `json_to_value_no_envelope` gives the production path, now that the
+    /// test dispatcher shares that exact conversion.
+    #[tokio::test]
+    async fn backend_dispatcher_envelope_shaped_data_stays_structured() {
+        use crate::backend::testing::MockBackend;
+        use crate::backend::ToolResult;
+
+        let envelope = kaish_types::bytes_to_envelope(&[1u8, 2, 3]);
+        let (mock, _calls) = MockBackend::new();
+        let backend = mock.with_tool_result(move |_name| Ok(ToolResult::with_data("", envelope.clone())));
+        let backend: Arc<dyn crate::backend::KernelBackend> = Arc::new(backend);
+        let mut ctx = ExecContext::with_backend(backend);
+
+        let dispatcher = BackendDispatcher::new(Arc::new(ToolRegistry::new()));
+        let cmd = make_cmd("embedder_tool", vec![]);
+
+        let result = dispatcher.dispatch(&cmd, &mut ctx).await.expect("dispatch");
+        assert!(
+            matches!(result.data, Some(Value::Json(_))),
+            "envelope-shaped external data must stay structured, not silently \
+             decode to Value::Bytes: got {:?}",
+            result.data
+        );
+    }
+
+    /// GH #93 item 3: `did_spill`/`original_code` must survive the
+    /// ToolResult <-> ExecResult seam. The old hand-rolled conversion in the
+    /// test dispatcher never touched either field, so a capped backend-tool
+    /// result silently looked uncapped by the time it reached the kernel.
+    #[tokio::test]
+    async fn backend_dispatcher_preserves_did_spill_and_original_code() {
+        use crate::backend::testing::MockBackend;
+        use crate::backend::ToolResult;
+
+        let (mock, _calls) = MockBackend::new();
+        let backend = mock.with_tool_result(|_name| {
+            Ok(ToolResult::success("truncated...")
+                .with_did_spill(true)
+                .with_original_code(Some(0)))
+        });
+        let backend: Arc<dyn crate::backend::KernelBackend> = Arc::new(backend);
+        let mut ctx = ExecContext::with_backend(backend);
+
+        let dispatcher = BackendDispatcher::new(Arc::new(ToolRegistry::new()));
+        let cmd = make_cmd("embedder_tool", vec![]);
+
+        let result = dispatcher.dispatch(&cmd, &mut ctx).await.expect("dispatch");
+        assert!(result.did_spill, "did_spill must survive the backend seam");
+        assert_eq!(result.original_code, Some(0), "original_code must survive the backend seam");
+    }
+
     // === Schema-Aware Argument Parsing Tests ===
 
     use crate::tools::{ParamSchema, ToolSchema};

--- a/crates/kaish-types/src/backend.rs
+++ b/crates/kaish-types/src/backend.rs
@@ -230,6 +230,7 @@ pub enum WriteMode {
 }
 
 /// Result from tool execution via backend.
+#[non_exhaustive]
 #[derive(Debug, Clone)]
 pub struct ToolResult {
     /// Exit code (0 = success).
@@ -242,6 +243,14 @@ pub struct ToolResult {
     pub data: Option<JsonValue>,
     /// Structured output data for rendering (preserved from ExecResult).
     pub output: Option<OutputData>,
+    /// True if the output limiter capped this result (propagated from
+    /// `ExecResult`). See `ExecResult.did_spill` for the full semantics (disk
+    /// spill vs. in-memory truncation, exit code remap to 3).
+    pub did_spill: bool,
+    /// The command's original exit code before spill logic overwrote it
+    /// (propagated from `ExecResult`). Present only when `did_spill` is true
+    /// and `code` was changed. See `ExecResult.original_code`.
+    pub original_code: Option<i64>,
     /// MIME content type hint (propagated from ExecResult).
     pub content_type: Option<String>,
     /// Opaque key-value context (propagated from ExecResult).
@@ -262,6 +271,8 @@ impl ToolResult {
             stderr: String::new(),
             data: None,
             output: None,
+            did_spill: false,
+            original_code: None,
             content_type: None,
             baggage: BTreeMap::new(),
             latch: None,
@@ -276,6 +287,8 @@ impl ToolResult {
             stderr: stderr.into(),
             data: None,
             output: None,
+            did_spill: false,
+            original_code: None,
             content_type: None,
             baggage: BTreeMap::new(),
             latch: None,
@@ -290,6 +303,8 @@ impl ToolResult {
             stderr: String::new(),
             data: Some(data),
             output: None,
+            did_spill: false,
+            original_code: None,
             content_type: None,
             baggage: BTreeMap::new(),
             latch: None,
@@ -299,6 +314,42 @@ impl ToolResult {
     /// Check if the tool execution succeeded.
     pub fn ok(&self) -> bool {
         self.code == 0
+    }
+
+    /// Set the structured output-data payload, returning self for chaining.
+    pub fn with_output(mut self, output: Option<OutputData>) -> Self {
+        self.output = output;
+        self
+    }
+
+    /// Set the content-type hint, returning self for chaining.
+    pub fn with_content_type(mut self, ct: impl Into<String>) -> Self {
+        self.content_type = Some(ct.into());
+        self
+    }
+
+    /// Replace the baggage map, returning self for chaining.
+    pub fn with_baggage(mut self, baggage: BTreeMap<String, String>) -> Self {
+        self.baggage = baggage;
+        self
+    }
+
+    /// Set the pending confirmation-latch request, returning self for chaining.
+    pub fn with_latch(mut self, latch: Option<LatchRequest>) -> Self {
+        self.latch = latch.map(Box::new);
+        self
+    }
+
+    /// Set the spill flag, returning self for chaining.
+    pub fn with_did_spill(mut self, did_spill: bool) -> Self {
+        self.did_spill = did_spill;
+        self
+    }
+
+    /// Set the pre-spill original exit code, returning self for chaining.
+    pub fn with_original_code(mut self, original_code: Option<i64>) -> Self {
+        self.original_code = original_code;
+        self
     }
 }
 
@@ -332,6 +383,8 @@ impl From<ExecResult> for ToolResult {
             stderr: exec.err,
             data,
             output,
+            did_spill: exec.did_spill,
+            original_code: exec.original_code,
             content_type: exec.content_type,
             baggage: exec.baggage,
             latch: exec.latch,
@@ -355,6 +408,8 @@ impl From<ToolResult> for ExecResult {
         let mut exec = ExecResult::from_output(result.code as i64, result.stdout, result.stderr);
         exec.set_output(result.output);
         exec.data = result.data.map(json_to_value_no_envelope);
+        exec.did_spill = result.did_spill;
+        exec.original_code = result.original_code;
         exec.content_type = result.content_type;
         exec.baggage = result.baggage;
         exec.latch = result.latch;
@@ -400,5 +455,77 @@ mod tests {
         let failure = ToolResult::failure(1, "err");
         assert!(failure.baggage.is_empty());
         assert!(failure.content_type.is_none());
+    }
+
+    #[test]
+    fn tool_result_constructors_default_did_spill_and_original_code() {
+        // GH #93 item 3 baseline: the new fields must not silently drift the
+        // existing constructors' defaults.
+        assert!(!ToolResult::success("ok").did_spill);
+        assert!(ToolResult::success("ok").original_code.is_none());
+        assert!(!ToolResult::failure(1, "err").did_spill);
+        assert!(!ToolResult::with_data("ok", serde_json::json!(1)).did_spill);
+    }
+
+    #[test]
+    fn tool_result_from_exec_result_preserves_did_spill_and_original_code() {
+        // GH #93 item 3: ExecResult -> ToolResult must not drop the spill
+        // metadata — an embedder reading a ToolResult off this seam needs to
+        // know the output was capped and what the code was before the remap.
+        let mut exec = ExecResult::success("hello");
+        exec.did_spill = true;
+        exec.original_code = Some(0);
+
+        let tool_result = ToolResult::from(exec);
+        assert!(tool_result.did_spill);
+        assert_eq!(tool_result.original_code, Some(0));
+    }
+
+    #[test]
+    fn exec_result_from_tool_result_preserves_did_spill_and_original_code() {
+        // The reverse direction: a backend tool that reports a capped result
+        // (e.g. an embedder fronting its own output limiter) must have that
+        // survive back into the kernel's ExecResult.
+        let tool_result = ToolResult::success("hello")
+            .with_did_spill(true)
+            .with_original_code(Some(5));
+
+        let exec = ExecResult::from(tool_result);
+        assert!(exec.did_spill);
+        assert_eq!(exec.original_code, Some(5));
+    }
+
+    #[test]
+    fn tool_result_builder_setters_chain() {
+        // Exercises the ergonomic construction surface added for
+        // `#[non_exhaustive]`: every field not covered by success/failure/
+        // with_data gets a with_* setter, matching the ExecResult style.
+        let mut baggage = BTreeMap::new();
+        baggage.insert("k".to_string(), "v".to_string());
+
+        let latch = LatchRequest {
+            nonce: "n".to_string(),
+            command: "rm".to_string(),
+            paths: vec!["f".to_string()],
+            hint: "rm --confirm=n f".to_string(),
+            tool: "rm".to_string(),
+            argv: vec!["f".to_string()],
+            ttl: 60,
+        };
+
+        let result = ToolResult::success("hi")
+            .with_output(Some(OutputData::text("hi")))
+            .with_content_type("text/plain")
+            .with_baggage(baggage.clone())
+            .with_latch(Some(latch.clone()))
+            .with_did_spill(true)
+            .with_original_code(Some(2));
+
+        assert!(result.output.is_some());
+        assert_eq!(result.content_type.as_deref(), Some("text/plain"));
+        assert_eq!(result.baggage, baggage);
+        assert_eq!(result.latch.as_deref(), Some(&latch));
+        assert!(result.did_spill);
+        assert_eq!(result.original_code, Some(2));
     }
 }

--- a/crates/kaish-types/src/job.rs
+++ b/crates/kaish-types/src/job.rs
@@ -15,6 +15,7 @@ impl std::fmt::Display for JobId {
 }
 
 /// Status of a background job.
+#[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum JobStatus {
     /// Job is currently running.
@@ -45,6 +46,7 @@ impl std::fmt::Display for JobStatus {
 }
 
 /// Information about a job for listing.
+#[non_exhaustive]
 #[derive(Debug, Clone)]
 pub struct JobInfo {
     /// Job ID.
@@ -62,4 +64,67 @@ pub struct JobInfo {
     /// fulfill a *backgrounded* destructive op via `Kernel::confirm`. `None`
     /// for any non-latched job. GH #96.
     pub latch: Option<LatchRequest>,
+}
+
+impl JobInfo {
+    /// Create a `JobInfo` with the required fields; `output_file`/`pid`/`latch`
+    /// default to `None`. Chain the `with_*` setters to fill them in.
+    ///
+    /// `#[non_exhaustive]` blocks struct-literal construction from outside this
+    /// crate — this constructor plus the setters below are the replacement.
+    pub fn new(id: JobId, command: impl Into<String>, status: JobStatus) -> Self {
+        Self {
+            id,
+            command: command.into(),
+            status,
+            output_file: None,
+            pid: None,
+            latch: None,
+        }
+    }
+
+    /// Set the output file path.
+    pub fn with_output_file(mut self, output_file: Option<PathBuf>) -> Self {
+        self.output_file = output_file;
+        self
+    }
+
+    /// Set the OS process ID.
+    pub fn with_pid(mut self, pid: Option<u32>) -> Self {
+        self.pid = pid;
+        self
+    }
+
+    /// Set the pending confirmation-latch request (see [`Self::latch`]).
+    pub fn with_latch(mut self, latch: Option<LatchRequest>) -> Self {
+        self.latch = latch;
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_defaults_optional_fields_to_none() {
+        let info = JobInfo::new(JobId(1), "echo hi", JobStatus::Running);
+        assert_eq!(info.id, JobId(1));
+        assert_eq!(info.command, "echo hi");
+        assert_eq!(info.status, JobStatus::Running);
+        assert!(info.output_file.is_none());
+        assert!(info.pid.is_none());
+        assert!(info.latch.is_none());
+    }
+
+    #[test]
+    fn with_setters_chain_and_override_defaults() {
+        let info = JobInfo::new(JobId(2), "sleep 1", JobStatus::Done)
+            .with_output_file(Some(PathBuf::from("job-output.txt")))
+            .with_pid(Some(1234))
+            .with_latch(None);
+        assert_eq!(info.output_file, Some(PathBuf::from("job-output.txt")));
+        assert_eq!(info.pid, Some(1234));
+        assert!(info.latch.is_none());
+    }
 }

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -42,6 +42,66 @@ more layer of wrapping (not passed through as "already an array"), and one
 confirming plain `jq` (no `-s`) on the `.data` path is untouched. Full suite
 and `clippy --all-targets` both clean.
 
+## Hardening the job/tool-result seam (2026-07-06, GH #93 items 3, 4)
+
+`kaish-types` had adopted `#[non_exhaustive]` broadly — `ExecResult`,
+`OutputData`, `ToolSchema`, `ToolArgs`, `WriteMode`, `BackendError`,
+`CommandKind`, `DirEntryKind` — but `job.rs` was missed. That gap had just bitten
+an embedder for real: #96 added `JobStatus::Latched` and `JobInfo.latch` and had
+to call it out as **BREAKING (embedders)** in the changelog, because a bare
+`JobStatus`/`JobInfo` gave downstream `match`es and struct literals no forward
+compatibility. Closing the gap now (`JobStatus`, `JobInfo`, `ToolResult`) means
+the *next* variant/field addition is additive, not breaking — and softens that
+existing #96 bullet from `**BREAKING (embedders):**` to a plain `Embedders:`
+heads-up, matching the calmer framing Amy asked for (bug-fix-shaped changes
+toward correct behavior, first-party/coordinated dependents, don't cry wolf).
+
+`JobInfo` got a `new(id, command, status)` constructor plus
+`.with_output_file()`/`.with_pid()`/`.with_latch()`, mirroring the existing
+kaish-types builder idiom. `ToolResult` already had `success`/`failure`/
+`with_data`; it picked up `.with_output()`/`.with_content_type()`/
+`.with_baggage()`/`.with_latch()`/`.with_did_spill()`/`.with_original_code()` so
+every field has a construction path across the crate boundary. `JobStatus`
+needed no call-site changes at all — its variants are all unit variants, so
+external construction was never blocked by `#[non_exhaustive]`; only its
+(nonexistent, it turns out) external exhaustive matches would have needed a `_`
+arm. Letting the compiler drive turned up exactly three struct-literal sites to
+fix: two `JobInfo { .. }` in `scheduler/job.rs` and one test-only
+`ToolResult { .. }` in `kernel.rs` — `cargo build --all-targets` was clean
+immediately after, which is as much confirmation as this kind of attribute
+change gets.
+
+**Item 3** was a quieter bug found by reading `ExecResult` and `ToolResult`
+side by side: `ExecResult.did_spill`/`.original_code` (the output-limiter's
+"this got capped, and here's the code before the remap" signal) had no
+`ToolResult` counterpart, so a backend-registered tool's (kaijutsu, an MCP
+engine) capped result silently looked uncapped by the time it crossed back into
+the kernel — in *both* `From` directions. Added both fields, propagated them
+in both impls, and pinned it with round-trip tests in each direction.
+
+**Item 4** turned out bigger than "align a test double." The test-only
+`BackendDispatcher::dispatch` (used by `scheduler/pipeline.rs`'s unit tests, not
+by any real embedder path) hand-rolled the `ToolResult → ExecResult` conversion
+instead of calling `From<ToolResult> for ExecResult` — the exact function the
+production dispatch path in `kernel.rs` uses. The hand-rolled version wrapped
+`data` unconditionally as `Value::Json(json_data)`, which happens to coincide
+with the real conversion for object/array-shaped data (both stay `Value::Json`)
+but silently diverges for *scalar* `data` — the production path unwraps a plain
+JSON number/bool/string into the matching native `Value` variant via
+`json_to_value_no_envelope`; the old test-dispatcher path never did. It also
+never touched `did_spill`/`original_code` at all, so item 3's new fields would
+have been silently dropped on this path even after being added to `ToolResult`.
+TDD caught both: wrote a scalar-unwrap test and a did_spill/original_code test,
+confirmed each genuinely failed by temporarily reverting the dispatch.rs fix
+and rerunning (red), then swapped the hand-rolled block for
+`ExecResult::from(tool_result)` (green). A third test pins that envelope-shaped
+`data` stays structured (`Value::Json`, never auto-decoded to `Value::Bytes`) —
+it passes either way today, since neither path decoded envelopes, but it's
+worth keeping now that both paths share one conversion function: any future
+regression that adds envelope-decoding to the shared `From` impl trips it on
+both the production and test-dispatcher side at once. No `CHANGELOG.md` entry
+for item 4 — it's test-only internal churn with no embedder-visible effect.
+
 ## Interpreter allocation/stack pass (2026-07-05, GH #48)
 
 #46/#47 landed a recursion depth guard sized against a measured ~380 KB of


### PR DESCRIPTION
## Summary

`kaish-types` had adopted `#[non_exhaustive]` broadly (`ExecResult`, `OutputData`, `ToolSchema`, `ToolArgs`, `WriteMode`, `BackendError`, `CommandKind`, `DirEntryKind`, …) but `job.rs` was missed. That gap had just bitten an embedder for real: #96 added `JobStatus::Latched` and `JobInfo.latch` and had to call it out as `**BREAKING (embedders):**` in the changelog, because a bare enum/struct gave downstream `match`es and struct literals no forward compatibility. This PR closes the gap (`JobStatus`, `JobInfo`, `ToolResult`) so the next variant/field addition is additive, and softens that existing #96 changelog bullet from `**BREAKING (embedders):**` to a calmer `Embedders:` note — matching the sparing-with-BREAKING framing for bug-fix-shaped changes toward correct behavior with first-party, coordinated dependents.

Alongside the hygiene pass, this closes two real gaps in the `ToolResult` ↔ `ExecResult` seam (GH #93 items 3 & 4):

- **Item 3 — dropped spill metadata.** `ExecResult.did_spill`/`.original_code` (the output-limiter's "this got capped, and here's the code before the remap" signal) had no `ToolResult` counterpart, so a backend-registered tool's (kaijutsu, an MCP engine) capped result silently looked uncapped by the time it crossed back into the kernel — in *both* `From` directions. Added both fields, propagated them both ways, pinned with round-trip tests.

- **Item 4 — test dispatcher divergence.** The test-only `BackendDispatcher::dispatch` (used by `scheduler/pipeline.rs`'s unit tests) hand-rolled the `ToolResult → ExecResult` conversion instead of calling `From<ToolResult> for ExecResult` — the exact function the production dispatch path in `kernel.rs` uses. The hand-rolled version wrapped `data` unconditionally as `Value::Json(json_data)`, which coincides with the real conversion for object/array-shaped data but silently diverges for *scalar* `data` (production unwraps via `json_to_value_no_envelope`; the old path never did), and it never touched `did_spill`/`original_code` at all — so item 3's new fields would have been silently dropped on this path too. Swapped the hand-rolled block for `ExecResult::from(tool_result)`.

## Changes

- `crates/kaish-types/src/job.rs`: `#[non_exhaustive]` on `JobStatus`/`JobInfo`; `JobInfo::new(id, command, status)` + `.with_output_file()`/`.with_pid()`/`.with_latch()`.
- `crates/kaish-types/src/backend.rs`: `#[non_exhaustive]` on `ToolResult`; new `did_spill`/`original_code` fields propagated in both `From` directions; new `.with_output()`/`.with_content_type()`/`.with_baggage()`/`.with_latch()`/`.with_did_spill()`/`.with_original_code()` setters.
- `crates/kaish-kernel/src/scheduler/job.rs`: two `JobInfo { .. }` struct literals → `JobInfo::new(...)` builder chain.
- `crates/kaish-kernel/src/kernel.rs`: one test-only `ToolResult { .. }` struct literal → builder chain.
- `crates/kaish-kernel/src/dispatch.rs`: `BackendDispatcher::dispatch`'s hand-rolled `ToolResult → ExecResult` conversion → `ExecResult::from(tool_result)`.
- `crates/kaish-kernel/src/scheduler/pipeline.rs`: three new tests exercising the fixed dispatcher (scalar-data unwrap parity, envelope-shaped-data stays structured, did_spill/original_code propagation).
- `crates/kaish-types/src/{job,backend}.rs`: new unit tests for the constructors/setters and the did_spill/original_code round trip (both directions).
- `CHANGELOG.md`, `docs/devlog.md`: softened the #96 bullet, added Changed/Fixed bullets for this PR (item 4 gets no changelog bullet — test-only internal churn, no embedder-visible effect).

## Method

TDD throughout: the item-3/4 tests were written to fail against pre-fix code first (verified by temporarily reverting the `dispatch.rs` fix and confirming two of the three new pipeline tests went red), then the fix made them green. The `#[non_exhaustive]` attrs were validated by letting the compiler find every call site — `cargo build --all-targets` was clean immediately after fixing the three struct literals it flagged.

Reviewed by kaibo (deepseek cast, pointed at this worktree) — came back clean: hygiene pass confirmed complete across the whole workspace, propagation confirmed correct in both directions, and the `dispatch.rs` swap confirmed to be a strict superset of the old behavior with no lost semantics.

## Test plan

- [x] `cargo test --all` — all green (0 failures)
- [x] `cargo clippy --all --all-targets` — zero warnings
- [x] `cargo check -p kaish-kernel --no-default-features` — clean
- [x] New tests confirmed red pre-fix, green post-fix (manual revert-and-rerun)
- [x] kaibo review (deepseek) — LGTM

Part of #93 (items 3, 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)