### PR TITLE
docs: rewrite README for the first-time visitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,12 @@ breaking entries are marked **BREAKING**.
   assignment/mutation of the public field needs `.into()`.
 
 ### Fixed
+- **README install instructions pointed at a crate that doesn't exist.**
+  `cargo install kaish` fails — there is no `kaish` package on crates.io; the
+  binary named `kaish` ships in the `kaish-repl` crate. The README now says
+  `cargo install kaish-repl` (and was restructured for first-time visitors
+  alongside; the exit-code table and output contract moved to
+  `docs/EMBEDDING.md`, trash thresholds to `docs/LANGUAGE.md`).
 - **`jq -s`/`--slurp` now wraps the `.data` pipeline path in an array-of-one,
   matching real jq** (GH #93 item 2). Real `jq -s` always wraps its input in
   an array, even a single document. On kaish's structured `.data` shortcut

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ syntax checking, easy embedding, and a VFS abstraction to help with sandboxing.
 - **Bare glob expansion** — `ls *.txt` works; opt out with `set +o glob`
 - **Structured iteration** — `for i in $(seq 1 5)` works via structured data, not word splitting
 - **Line iteration in for-loops** — `for line in $(cat file)` splits on `\n` only; whitespace within a line is never split
-- **JSON data model** — kaish values *are* JSON values: strings, numbers, booleans, arrays, records. `fromjson`/`tojson` bridge text; `${xs[0]}`, `${r[key]}`, `keys`, `values` index natively
+- **JSON data model** — kaish's native values are JSON's: strings, numbers, booleans, arrays, records (plus raw bytes for binary data). `fromjson`/`tojson` bridge text; `${xs[0]}`, `${r[key]}`, `keys`, `values` index natively
 - **Explicit splitting** — use `split "$VAR"` for whitespace/delimiter/regex splitting
 - **No backticks** — only `$(cmd)` substitution
 - **Strict booleans** — `TRUE` and `yes` are errors, not truthy
@@ -250,7 +250,7 @@ an `awk` that never surprises.
 
 - Builtins go through the VFS and see only its mounts — the agent preset
   sandboxes to `$HOME` + `/tmp`, with `/v/` as in-memory scratch under a
-  64 MiB per-call budget.
+  64 MiB budget.
 - **External commands resolved via `PATH` run against the real filesystem** —
   the VFS sandbox does not apply to them. Block them at runtime with
   `allow_external_commands=false`, or build without the `subprocess` capability

--- a/README.md
+++ b/README.md
@@ -4,39 +4,69 @@
   <img src="docs/banner.svg" alt="Kai the hermit crab — kaish mascot — looking at kaish code" width="720">
 </p>
 
-Kaish is a predictable shell as a rust library. It includes builtin commands so it does
-not need `fork()` or `exec()` to perform most text processing tasks. Kaish has its
-own virtual filesystem layer that can be passed through to a regular filesystem, or
-work completely in-memory. This enables kaish to be sandboxed from its host while
-providing a complete shell scripting environment for agents without backflips to contain
-and parse the output of a traditional shell.
+**kaish** is a predictable shell for AI agents: an embeddable Rust library with a
+reference REPL. The language is a strict subset of the `sh` that's already in your
+muscle memory — and the models' — so skills transfer from bash. Footguns
+(hopefully) don't.
 
-## Install
+The builtins — grep, sed, awk, find, and ninety-odd more — run in-process, so most
+text processing never needs `fork()` or `exec()`. All file I/O goes through a
+virtual filesystem that can pass through to the real one, stay entirely in memory,
+or overlay copy-on-write between the two. That's the sandbox story: an embedded
+kaish gives an agent a complete scripting environment without the backflips it
+takes to contain a traditional shell and parse its output.
+
+**Status:** 0.11, pre-1.0. The language has settled; what remains before 1.0 is
+ergonomics and correctness polish. Everything ships through
+[CHANGELOG.md](CHANGELOG.md).
+
+## Why a shell for agents?
+
+Agents need to compose operations — filter output, transform data, iterate over
+results. One tool call per operation is atomic and chatty; a shell does it in one
+round trip:
 
 ```sh
-cargo install kaish
+# Filter and transform in one script
+ls src/ | grep "\.rs$" | head -n 5
+
+# Iterate over results
+for f in *.log; do
+    wc -l "$f"
+done
+
+# Parallel processing with bounded concurrency
+seq 1 10 | scatter --as N --limit 4 | echo "processing $N" | gather
 ```
 
-This is preferred for now while kaish is still experimental. Containers and binaries
-are in future plans when things stabilize a bit more and I have time (or PRs!).
+But handing an agent `bash -c` is a rough deal for everyone involved:
+word-splitting surprises, tools that vary by platform and version, and full host
+access by default. kaish keeps the language the models already know and swaps out
+the implementation: strict parsing with pre-execution validation, builtins that
+behave identically everywhere, and a filesystem boundary the embedder controls.
+
+Underneath, kaish's data model is JSON. A variable holds an array or a record as
+naturally as a string, `$(cmd)` substitution carries structured values — not
+text to re-split — and `--json` on any command emits the same typed data the
+language works with internally. Structured results flow through pipes,
+subscripts, and iteration without a serialization step at every seam.
 
 ## Why kaish?
 
-Kaish is sh-like but not a full Bourne shell or bash. The idea is to preserve the language
-that's in our muscle/model memory, while providing better pre-execution syntax checking,
-easy embedding, and a VFS abstraction to help with sandboxing.
+Kaish is sh-like but not a full Bourne shell or bash. The idea is to preserve the
+language that's in our muscle/model memory, while providing better pre-execution
+syntax checking, easy embedding, and a VFS abstraction to help with sandboxing.
 
 - **No implicit word splitting** — `$VAR` is always one value, never split on spaces
 - **Quote to join** — kaish doesn't paste adjacent unquoted tokens; quote interpolated words: `"$dir/file.txt"`, `"out-$(date +%s).log"`
 - **Bare glob expansion** — `ls *.txt` works; opt out with `set +o glob`
 - **Structured iteration** — `for i in $(seq 1 5)` works via structured data, not word splitting
 - **Line iteration in for-loops** — `for line in $(cat file)` splits on `\n` only; whitespace within a line is never split
+- **JSON data model** — kaish values *are* JSON values: strings, numbers, booleans, arrays, records. `fromjson`/`tojson` bridge text; `${xs[0]}`, `${r[key]}`, `keys`, `values` index natively
 - **Explicit splitting** — use `split "$VAR"` for whitespace/delimiter/regex splitting
 - **No backticks** — only `$(cmd)` substitution
 - **Strict booleans** — `TRUE` and `yes` are errors, not truthy
 - **Pre-validation** — catch errors before execution, not at runtime
-
-Skills transfer from bash. Footguns (hopefully) don't.
 
 ## Quick Tour
 
@@ -76,41 +106,122 @@ echo "$GREETING/world.txt"          # ✅  quote the whole word
 # Pipes and redirects
 cat urls.txt | grep "https" | head -n 10 > filtered.txt
 
-# Here-strings: feed a variable straight into stdin — jq is built-in, so
-# this replaces bash's `echo "$R" | jq` without spawning a subprocess
-RESULT='{"name":"amy"}'
-jq -r '.name' <<< "$RESULT"
+# The data model is JSON: parse text into typed collections, index directly
+CONFIG='{"name":"amy","langs":["rust","kaish"]}'
+C=$(fromjson <<< "$CONFIG")
+echo "${C[name]} writes ${C[langs][0]}"      # amy writes rust
 
-# jq also speaks --arg / --argjson / -n (matches real jq's CLI):
-jq -n --argjson r "$RESULT" -r '$r.name'
+SERVERS=$(fromjson <<< '{"web1":"10.0.0.1","web2":"10.0.0.2"}')
+for host in $(keys $SERVERS); do
+    echo "$host -> ${SERVERS[$host]}"
+done
 
 # Glob patterns expand inline, or use the glob builtin for options
 glob "**/*.rs" --exclude="*_test.rs"
 
-# Parallel execution with scatter/gather — --as N binds $N in each worker; --limit caps concurrency
+# Parallel execution with scatter/gather — --as N binds $N in each worker;
+# --limit caps concurrency; gather emits one JSONL record per worker
 seq 1 10 | scatter --as N --limit 4 | echo "processing $N" | gather
 ```
 
-## Language Features
+See [docs/LANGUAGE.md](docs/LANGUAGE.md) for the complete language reference, or
+ask kaish itself — help is in-band: `help builtins`, `help syntax`, `help <tool>`.
 
-| Feature | Description |
-|---------|-------------|
-| **Familiar syntax** | Variables, pipes, control flow, functions — Bourne-inspired, modern semantics |
-| **Builtins** | grep, jq, find, sed, awk, diff, patch, and more — all in-process |
-| **Structured data** | Commands return typed arrays — `for i in $(seq 1 5)` iterates 5 values, not word-split text |
-| **Strict validation** | Errors caught before execution with clear messages |
-| **Virtual filesystem** | Unified access: native `$HOME` paths (sandboxed), `/tmp`, and the in-memory `/v/` namespace (`/v/jobs` observability, scratch storage) |
-| **Scatter/gather** | Built-in parallelism with 散/集 |
+## Getting Started
 
-See [Language Reference](docs/LANGUAGE.md) for complete syntax. Use `help builtins` or `help <tool>` for per-tool docs.
+You'll need a Rust toolchain ([rustup](https://rustup.rs)). Containers and
+prebuilt binaries are in future plans when things stabilize a bit more and I have
+time (or PRs!).
 
----
+### The REPL
+
+```sh
+cargo install kaish-repl    # installs a binary named `kaish`
+```
+
+```
+$ kaish
+会sh> for f in *.rs; do wc -l "$f"; done
+  142 main.rs
+   87 lib.rs
+会sh>
+```
+
+The REPL loads an init file on startup — the first match of `$KAISH_INIT`,
+`~/.config/kaish/init.kai`, `~/.kaishrc` — for aliases, exports, and a custom
+prompt. Define `kaish_prompt` and it's called before each input line:
+
+```sh
+# ~/.config/kaish/init.kai
+alias ll='ls -la'
+alias gs='git status'
+export EDITOR=vim
+
+kaish_prompt() {
+    echo "$(pwd)> "
+}
+```
+
+### Embedding the kernel
+
+Construct a `Kernel`, point it at a sandbox root, call `execute()`:
+
+```toml
+[dependencies]
+kaish-kernel = "0.11"
+tokio = { version = "1", features = ["full"] }
+```
+
+```rust
+use kaish_kernel::{Kernel, KernelConfig, VfsMountMode};
+use std::path::PathBuf;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    // Sandboxed to one directory. The default build can't spawn processes
+    // at all — external commands are an opt-in cargo feature (`subprocess`).
+    let config = KernelConfig::named("my-agent")
+        .with_vfs_mode(VfsMountMode::Sandboxed {
+            root: Some(PathBuf::from("/path/to/workspace")),
+        })
+        .with_cwd(PathBuf::from("/path/to/workspace"));
+    let kernel = Kernel::new(config)?;
+
+    let result = kernel.execute(r#"ls | grep '\.rs$' | head -n 3"#).await?;
+    if result.code != 0 {
+        eprintln!("script failed: {}", result.err);
+    }
+    println!("{}", result.text_out());
+    Ok(())
+}
+```
+
+The kernel is hermetic by default — it never reads the OS environment (the
+frontend supplies vars), and the OS-touching capability features (`subprocess`,
+`host`, `os-integration`, `tokens`) are opt-in cargo features, so the dangerous
+surface is named, not inherited. Every `execute()` returns an `ExecResult` with
+clean text output, an optional typed `data` payload (`--json` on any command),
+and an exit code agents can branch on: `2` means a destructive op wants
+confirmation, `3` means output was truncated, `124` is a timeout.
+
+[docs/EMBEDDING.md](docs/EMBEDDING.md) is the full guide: kernel construction,
+capability features, `ExecuteOptions`, custom tools, the exit-code contract, and
+thread stack sizing.
+
+**Using kaish over MCP?** kaish core doesn't ship an MCP server — that surface
+lives in the embedders. [**kaibo**](https://github.com/tobert/kaibo) (解剖) is the
+showcase: a read-only codebase-analysis MCP that drives kaish to read and reason
+about a project and answers with cited `file:line` spans.
+[**kaijutsu**](https://github.com/tobert/kaijutsu) embeds kaish behind its own MCP
+interface too. Both show the pattern: embed the kernel, then expose it however
+your agent needs.
 
 ## Builtins
 
 kaish builtins run in-process — no subprocesses, no PATH lookups, no platform
-variance. They exist because agents need tools they can verify: a `grep` that behaves identically
-everywhere, a `jq` that always uses the same filter syntax, an `awk` that never surprises.
+variance. They exist because agents need tools they can verify: a `grep` that
+behaves identically everywhere, a `sed` whose dialect doesn't depend on the host,
+an `awk` that never surprises.
 
 **Design principles:**
 
@@ -135,164 +246,26 @@ everywhere, a `jq` that always uses the same filter syntax, an `awk` that never 
 | **Meta** | assert, false, test, true |
 | **kaish-*** | kaish-ast, kaish-clear, kaish-ignore, kaish-last, kaish-mounts, kaish-output-limit, kaish-status, kaish-tools, kaish-trash, kaish-validate, kaish-vars, kaish-version, kaish-vfs |
 
----
+## Safety rails
 
-## Configuration
+- Builtins go through the VFS and see only its mounts — the agent preset
+  sandboxes to `$HOME` + `/tmp`, with `/v/` as in-memory scratch under a
+  64 MiB per-call budget.
+- **External commands resolved via `PATH` run against the real filesystem** —
+  the VFS sandbox does not apply to them. Block them at runtime with
+  `allow_external_commands=false`, or build without the `subprocess` capability
+  feature and they don't exist at all.
+- `--overlay` makes a call copy-on-write: writes stay in memory unless the
+  script runs `kaish-vfs commit`.
+- `set -o latch` (or `KAISH_LATCH=1`) gates destructive commands behind
+  nonce confirmation — the command returns exit 2 and a re-run hint instead
+  of acting.
+- `set -o trash` (or `KAISH_TRASH=1`) diverts deletes to the freedesktop.org
+  Trash instead of removing them.
 
-The REPL loads an init file on startup (first match wins):
-
-1. `$KAISH_INIT` (env var)
-2. `~/.config/kaish/init.kai`
-3. `~/.kaishrc`
-
-Use it for aliases, exports, and a custom prompt:
-
-```sh
-# ~/.config/kaish/init.kai
-alias ll='ls -la'
-alias gs='git status'
-export EDITOR=vim
-
-kaish_prompt() {
-    echo "$(pwd)> "
-}
-```
-
-The `kaish_prompt` function is called before each input line. If not defined,
-the default `会sh> ` prompt is used.
-
-### Environment Variables
-
-| Variable | Effect |
-|----------|--------|
-| `KAISH_INIT` | Path to init script (overrides default locations) |
-| `KAISH_LATCH=1` | Enable confirmation latch — `rm` requires nonce confirmation |
-| `KAISH_TRASH=1` | Enable trash-on-delete — `rm` moves files to freedesktop.org Trash |
-
-Latch and trash can also be toggled at runtime with `set -o latch` / `set -o trash`.
-
-**Latch details:** Nonces are scoped to command + path — a nonce issued for `rm fileA`
-cannot confirm `rm fileB`. Confirmed paths must be a subset of authorized paths.
-Nonces persist within a session — in the REPL across commands, and across an
-embedder's `execute()` calls. Each new connection starts a fresh nonce store.
-Embedders control this via `KernelConfig::with_nonce_store()`.
-
-**Trash details:** Files under 10MB and all directories go to trash (configurable via
-`kaish-trash config max-size`). Excluded paths (`/tmp`, `/v/*`) bypass trash. If
-`trash::delete` fails, `rm` returns an error — it never silently falls through to
-permanent delete.
-
----
-
-## Components
-
-kaish is built as a set of crates that can be used independently:
-
-### kaish-kernel
-
-The core execution engine. Lexer, parser, interpreter, builtins, VFS.
-
-```rust
-use kaish_kernel::{Kernel, KernelConfig};
-
-let kernel = Kernel::new(KernelConfig::default())?;
-let result = kernel.execute("echo hello | tr a-z A-Z").await?;
-println!("{}", result.text_out());  // "HELLO"
-```
-
-The kernel is embeddable — no external dependencies, no subprocess spawning for builtins.
-
-### kaish-repl
-
-Interactive shell with readline support, history, and tab completion.
-
-```sh
-$ kaish
-kaish> for f in *.rs; do wc -l "$f"; done
-  142 main.rs
-   87 lib.rs
-kaish>
-```
-
-### Embedding
-
-kaish is built to be embedded: construct a `Kernel`, give it a backend, and call
-`execute()`. The kernel is hermetic (it never reads ambient OS env — the frontend
-supplies vars), the VFS can be bridged to the host or fully sandboxed, and the
-OS-touching capability features (`subprocess`, `host`, `os-integration`, `tokens`)
-are opt-in so the dangerous surface is named, not inherited. The default build is
-real-file I/O plus an in-memory overlay — nothing that spawns a process or reads the
-host. See [docs/EMBEDDING.md](docs/EMBEDDING.md) for the full guide.
-
-**Using kaish as an MCP server?** kaish core doesn't ship one — the showcase is
-[**kaibo**](https://github.com/tobert/kaibo) (解剖), a read-only codebase-analysis
-MCP that drives kaish to read and reason about a project and answers with cited
-`file:line` spans. [**kaijutsu**](https://github.com/tobert/kaijutsu) embeds kaish
-behind its own MCP interface too. Both show the pattern: embed the kernel, then
-expose it however your agent needs.
-
-Every `execute()` returns an `ExecResult`. Output is clean text by default — simple
-commands return plain text, structured builtins (`ls`, `kaish-mounts`, `kaish-vars`)
-render readable tab-separated values, and `--json` on any command emits JSON plus a
-parsed value (`data`) that builtins set explicitly — kaish never infers it by
-sniffing stdout. The exit code is something agents can branch on:
-
-| `code` | Meaning | Recovery |
-|--------|---------|----------|
-| 0 | Success | — |
-| 1 | Failure | Read `stderr` |
-| 2 | Confirmation required (`set -o latch`) | Re-run with `--confirm="<nonce>"` — embedders read the typed `ExecResult.latch` (or call `Kernel::confirm`); the `To confirm, run:` line shows it for humans |
-| 3 | Output truncated by the output limit | `original_code` holds the real exit code; the message names the spill file — `cat` it, or narrow the query |
-| 124 | Timeout (`timeout_ms`, default 30 s) | — |
-| 130 | Cancelled | — |
-
-Embedders typically run a fresh kernel per request (variables, functions, aliases,
-`set -o` options, and `cwd` reset each time) while trash and confirmation nonces
-(60 s TTL) persist — see [docs/EMBEDDING.md](docs/EMBEDDING.md) for the lifecycle and
-`ExecuteOptions`.
-
-#### Sandbox & safety
-
-- Builtins go through the VFS, sandboxed to `$HOME` + `/tmp`; `/v/` is
-  in-memory scratch with a 64 MiB per-call budget.
-- **External commands resolved via `PATH` run against the real filesystem**
-  — the VFS sandbox does not apply to them. Block them entirely with
-  `allow_external_commands=false`, or build without the `subprocess`
-  capability feature.
-- `--overlay` makes the sandbox copy-on-write for the call: writes stay in
-  memory unless the script runs `kaish-vfs commit` (same call — overlays
-  don't persist across calls).
-- `set -o latch` gates destructive commands behind exit-2 nonce
-  confirmation; `set -o trash` diverts deletes to the trash instead.
-
-#### Agent gotchas
-
-- **Quote to join.** Unlike bash, kaish never concatenates adjacent unquoted
-  tokens. `echo $dir/out.txt` is a **parse error** (the words would otherwise
-  splat into two arguments) — quote the whole word: `echo "$dir/out.txt"`.
-  Single-token words like `file.txt` or `v1.2.3` are fine unquoted.
-- `FOO=bar cmd` scopes `FOO` to that one command (its environment and arguments),
-  like bash — it does **not** persist afterward. A plain `FOO=bar` with no
-  command following still sets `FOO` persistently.
-- Help is in-band: `help builtins`, `help syntax`, `help <tool>`.
-
-#### Why a shell for agents?
-
-AI agents need to compose operations — filter outputs, transform data, iterate over results.
-A single tool call per operation is atomic and chatty; kaish lets agents combine them in one script:
-
-```sh
-# Filter and transform in one script
-ls src/ | grep "\.rs$" | head -n 5
-
-# Iterate over results
-for f in *.json; do
-    jq ".name" "$f"
-done
-
-# Parallel processing
-seq 1 10 | scatter --as N --limit 4 | echo "processing $N" | gather
-```
+Latch and trash semantics are covered in [docs/LANGUAGE.md](docs/LANGUAGE.md);
+the embedder-facing contract (`LatchRequest`, nonce stores, `Kernel::confirm`)
+in [docs/EMBEDDING.md](docs/EMBEDDING.md).
 
 ## Why 会sh (kaish)?
 
@@ -300,14 +273,13 @@ seq 1 10 | scatter --as N --limit 4 | echo "processing $N" | gather
 it made sense to split it out. Amy was also a fan of ksh and pdksh back in the 00s
 so k-ai-sh seems fun.
 
----
-
 ## Building from Source
 
 ```sh
 git clone https://github.com/tobert/kaish
 cd kaish
 cargo build --release
+cargo test --all
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -4,17 +4,15 @@
   <img src="docs/banner.svg" alt="Kai the hermit crab — kaish mascot — looking at kaish code" width="720">
 </p>
 
-**kaish** is a predictable shell for AI agents: an embeddable Rust library with a
-reference REPL. The language is a strict subset of the `sh` that's already in your
-muscle memory — and the models' — so skills transfer from bash. Footguns
-(hopefully) don't.
+**kaish** is a predictable shell for AI agents delivered as an embeddable Rust
+library with a reference REPL. The language is a strict subset of `sh`, so most
+muscle memory and model training will transfer.
 
 The builtins — grep, sed, awk, find, and ninety-odd more — run in-process, so most
 text processing never needs `fork()` or `exec()`. All file I/O goes through a
-virtual filesystem that can pass through to the real one, stay entirely in memory,
-or overlay copy-on-write between the two. That's the sandbox story: an embedded
-kaish gives an agent a complete scripting environment without the backflips it
-takes to contain a traditional shell and parse its output.
+virtual filesystem that can pass through, stay in memory, or overlay the two.
+An embedded kaish gives an agent a complete scripting environment that can be
+constrained naturally.
 
 **Status:** 0.11, pre-1.0. The language has settled; what remains before 1.0 is
 ergonomics and correctness polish. Everything ships through
@@ -22,9 +20,11 @@ ergonomics and correctness polish. Everything ships through
 
 ## Why a shell for agents?
 
-Agents need to compose operations — filter output, transform data, iterate over
-results. One tool call per operation is atomic and chatty; a shell does it in one
-round trip:
+Agents need to compose operations such as filtering output, transforming data,
+and iterating over results. They are already good at Bourne shell idioms, and
+shell is already an ideal language for text processing. kaish inherits all of
+that, so piping, redirecting, and composing commands works like it always has,
+with just a couple changes.
 
 ```sh
 # Filter and transform in one script
@@ -39,74 +39,62 @@ done
 seq 1 10 | scatter --as N --limit 4 | echo "processing $N" | gather
 ```
 
-But handing an agent `bash -c` is a rough deal for everyone involved:
+Handing an agent `bash -c` is dangerous on many levels. It comes with
 word-splitting surprises, tools that vary by platform and version, and full host
 access by default. kaish keeps the language the models already know and swaps out
 the implementation: strict parsing with pre-execution validation, builtins that
 behave identically everywhere, and a filesystem boundary the embedder controls.
 
 Underneath, kaish's data model is JSON. A variable holds an array or a record as
-naturally as a string, `$(cmd)` substitution carries structured values — not
-text to re-split — and `--json` on any command emits the same typed data the
+naturally as a string, `$(cmd)` substitution carries structured values, so you
+can choose between old-school text parsing and using JSON-typed data. Using the
+`--json` flag on any command will get it to emit the same typed data the
 language works with internally. Structured results flow through pipes,
-subscripts, and iteration without a serialization step at every seam.
+subscripts, and iteration without extra serialization / deserialization steps.
 
-## Why kaish?
+## What's Different About kaish?
 
 Kaish is sh-like but not a full Bourne shell or bash. The idea is to preserve the
-language that's in our muscle/model memory, while providing better pre-execution
+language that's comes naturally, while providing better pre-execution
 syntax checking, easy embedding, and a VFS abstraction to help with sandboxing.
 
+- **JSON data model** — kaish's native values are JSON types: strings, numbers, booleans, arrays, and records.
+- **Single brackets are JSON** - `[` is for json arrays and records, `[[` is for branching
 - **No implicit word splitting** — `$VAR` is always one value, never split on spaces
-- **Quote to join** — kaish doesn't paste adjacent unquoted tokens; quote interpolated words: `"$dir/file.txt"`, `"out-$(date +%s).log"`
-- **Bare glob expansion** — `ls *.txt` works; opt out with `set +o glob`
-- **Structured iteration** — `for i in $(seq 1 5)` works via structured data, not word splitting
 - **Line iteration in for-loops** — `for line in $(cat file)` splits on `\n` only; whitespace within a line is never split
-- **JSON data model** — kaish's native values are JSON's: strings, numbers, booleans, arrays, records (plus raw bytes for binary data). `fromjson`/`tojson` bridge text; `${xs[0]}`, `${r[key]}`, `keys`, `values` index natively
+- **Structured iteration** — `for i in $(seq 1 5)` works via structured data, not word splitting
 - **Explicit splitting** — use `split "$VAR"` for whitespace/delimiter/regex splitting
 - **No backticks** — only `$(cmd)` substitution
 - **Strict booleans** — `TRUE` and `yes` are errors, not truthy
-- **Pre-validation** — catch errors before execution, not at runtime
+- **Pre-validation** — validation stretches down into builtins, revealing errors before execution
 
 ## Quick Tour
 
 ```sh
 #!/usr/bin/env kaish
 
-# Familiar bash-style syntax
 GREETING="Hello"
 echo "$GREETING, world!"
 
-# Control flow
+# control flow with [[ works just like bash
 if [[ -f config.json ]]; then
     echo "Config found"
 fi
 
-# For loops - no implicit *word* splitting
-for item in one two three; do      # literal items
-    echo "Processing: $item"
+# regular *.log works but glob adds modern affordances and its
+# data passes to the for loop as a JSON array
+for file in $(glob **/*.log); do
+    echo "logfile: $file"
 done
 
-for i in $(seq 1 3); do            # structured data iteration
-    echo "Count: $i"
-done
-
-for line in $(cat hosts.txt); do   # multi-line stdout splits on \n
-    echo "host: $line"
-done
-
-for file in *.txt; do              # bare glob expansion
-    echo "Found: $file"
-done
-
-# Quote to join: adjacent unquoted tokens never paste together
+# quote to join: adjacent unquoted tokens never paste together
 echo "$GREETING/world.txt"          # ✅  quote the whole word
 # echo $GREETING/world.txt          # ❌  parse error — kaish won't paste $GREETING and /world.txt
 
-# Pipes and redirects
+# pipes and redirects
 cat urls.txt | grep "https" | head -n 10 > filtered.txt
 
-# The data model is JSON: parse text into typed collections, index directly
+# the data model is JSON: parse text into typed collections, index directly
 CONFIG='{"name":"amy","langs":["rust","kaish"]}'
 C=$(fromjson <<< "$CONFIG")
 echo "${C[name]} writes ${C[langs][0]}"      # amy writes rust
@@ -116,10 +104,10 @@ for host in $(keys $SERVERS); do
     echo "$host -> ${SERVERS[$host]}"
 done
 
-# Glob patterns expand inline, or use the glob builtin for options
+# glob patterns expand inline, or use the glob builtin for options
 glob "**/*.rs" --exclude="*_test.rs"
 
-# Parallel execution with scatter/gather — --as N binds $N in each worker;
+# parallel execution with scatter/gather — --as N binds $N in each worker;
 # --limit caps concurrency; gather emits one JSONL record per worker
 seq 1 10 | scatter --as N --limit 4 | echo "processing $N" | gather
 ```
@@ -129,9 +117,7 @@ ask kaish itself — help is in-band: `help builtins`, `help syntax`, `help <too
 
 ## Getting Started
 
-You'll need a Rust toolchain ([rustup](https://rustup.rs)). Containers and
-prebuilt binaries are in future plans when things stabilize a bit more and I have
-time (or PRs!).
+You'll need a Rust toolchain ([rustup](https://rustup.rs)). For
 
 ### The REPL
 
@@ -267,11 +253,12 @@ Latch and trash semantics are covered in [docs/LANGUAGE.md](docs/LANGUAGE.md);
 the embedder-facing contract (`LatchRequest`, nonce stores, `Kernel::confirm`)
 in [docs/EMBEDDING.md](docs/EMBEDDING.md).
 
-## Why 会sh (kaish)?
+## Why build 会sh?
 
-会sh was originally prototyped as part of 会術 Kaijutsu and was separate enough
+会sh (kaish) was originally prototyped as part of 会術 Kaijutsu and was separate enough
 it made sense to split it out. Amy was also a fan of ksh and pdksh back in the 00s
-so k-ai-sh seems fun.
+so k-ai-sh seemed fun. kaish is now also used by [kaibo](https://github.com/tobert/kaibo)
+to provide agents with a read-only shell.
 
 ## Building from Source
 
@@ -291,7 +278,9 @@ exception). That said, please have your agent (or another model) review the PR
 before submitting — a few tokens on review goes a long way. Same goes for issues:
 agent-filed is fine, just make sure it makes sense.
 
-If you're working with AI coding agents, you might also be interested in:
+If you're working with AI coding agents, you might also be interested in
+[kaibo](https://github.com/tobert/kaibo), an assistant for you assistant with a
+read-only kaish shell.
 
 - [**gpal**](https://github.com/tobert/gpal) — Gemini as an MCP server (pairs well with Claude Code)
 - [**cpal**](https://github.com/tobert/cpal) — Claude as an MCP server (pairs well with Gemini CLI)

--- a/docs/EMBEDDING.md
+++ b/docs/EMBEDDING.md
@@ -55,7 +55,7 @@ code is something agents can branch on:
 | 0 | Success | — |
 | 1 | Failure | Read `err` |
 | 2 | Confirmation required (`set -o latch`) | Re-run with `--confirm="<nonce>"` — embedders read the typed `ExecResult.latch` (or call `Kernel::confirm`); the `To confirm, run:` line shows it for humans |
-| 3 | Output truncated by the output limit | `original_code` holds the real exit code; the message names the spill file — `cat` it, or narrow the query |
+| 3 | Output truncated by the output limit | `original_code` holds the real exit code. With disk spill the message names the spill file — `cat` it, or narrow the query; memory-spill kernels (`with_backend`, `SpillMode::Memory`) truncate in place with no file |
 | 124 | Timeout (`timeout_ms`, default 30 s) | — |
 | 130 | Cancelled | — |
 

--- a/docs/EMBEDDING.md
+++ b/docs/EMBEDDING.md
@@ -6,7 +6,7 @@ and output capture.
 
 ## Stability
 
-kaish is pre-1.0 (currently 0.8.x, MSRV 1.85). The language has settled;
+kaish is pre-1.0 (currently 0.11.x, MSRV 1.85). The language has settled;
 the embedding API may still change between minor versions where it improves
 both kaish and its embedders — [kaijutsu](https://github.com/tobert/kaijutsu)
 is the reference embedder. Pin a minor version and read release notes when
@@ -41,6 +41,29 @@ async fn main() -> anyhow::Result<()> {
 `ExecResult` exposes stdout via the `text_out()` accessor (it materializes
 structured output when a builtin returned a table or tree); `code`, `err`,
 and `data` are public fields.
+
+## The result contract
+
+Output is clean text by default — simple commands return plain text, structured
+builtins (`ls`, `kaish-mounts`, `kaish-vars`) render readable tab-separated
+values, and `--json` on any command emits JSON plus a parsed value (`data`) that
+builtins set explicitly — kaish never infers it by sniffing stdout. The exit
+code is something agents can branch on:
+
+| `code` | Meaning | Recovery |
+|--------|---------|----------|
+| 0 | Success | — |
+| 1 | Failure | Read `err` |
+| 2 | Confirmation required (`set -o latch`) | Re-run with `--confirm="<nonce>"` — embedders read the typed `ExecResult.latch` (or call `Kernel::confirm`); the `To confirm, run:` line shows it for humans |
+| 3 | Output truncated by the output limit | `original_code` holds the real exit code; the message names the spill file — `cat` it, or narrow the query |
+| 124 | Timeout (`timeout_ms`, default 30 s) | — |
+| 130 | Cancelled | — |
+
+Embedders typically run a fresh kernel per request (variables, functions,
+aliases, `set -o` options, and `cwd` reset each time) while trash and
+confirmation nonces (60 s TTL) persist across calls — share the store with
+`KernelConfig::with_nonce_store()` (see
+[Destructive-op rails](#destructive-op-rails-inspecting-and-fulfilling-the-latch)).
 
 ## Stack size — size your execution threads
 

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -804,6 +804,11 @@ channel, request on `.latch` (under the `latch` key with `--json`). `dd` confirm
 *into* a directory (and recursive `cp -r`/`mv` of a tree) gates the named
 destination, not each child file.
 
+Files under 10MB and all directories go to trash (configurable via
+`kaish-trash config max-size`); larger files are deleted permanently. Excluded
+paths (`/tmp`, `/v/*`) bypass trash. If the trash operation fails, `rm` returns
+an error — it never silently falls through to permanent delete.
+
 The `kaish-trash` builtin manages trashed files: `list`, `restore`, `empty`, `config`.
 
 When output is truncated by the limit, the result exits **3** with `did_spill: true` and `original_code` set. The spill file path is in the output. To read it in full:

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -14,6 +14,39 @@ before it ships.
 
 ---
 
+## The README learns to face the front door (2026-07-06)
+
+Amy asked for a first-time-visitor evaluation of README.md ahead of a rewrite.
+Two stateless outside reads (deepseek and gemini-flash via kaibo `oneshot`,
+given only the README — exactly what a visitor sees) converged with our own
+read almost point-for-point: the project thesis ("Why a shell for agents?")
+was buried as an `####` heading inside Components → Embedding at 85% document
+depth; the doc oscillated between agent-runtime and daily-driver-shell
+identities section by section; and reference-grade material (exit-code table,
+latch/trash mechanics, embedder lifecycle) clogged the middle. The accuracy
+pass found worse: the very first instruction was broken — `cargo install
+kaish` names a crate that doesn't exist (the binary ships in `kaish-repl`) —
+and "still experimental" contradicted the settled-language stance.
+
+Decisions:
+
+- **Sequence, don't interleave.** The rewrite front-loads the universal pitch
+  (hero with the "skills transfer" line both reviewers independently named the
+  strongest sentence in the file, thesis, differences-from-bash), keeps the
+  Quick Tour, then branches Getting Started into the two real journeys: REPL
+  and embedding. Six crates ship this README as their crates.io page, so the
+  embedder content stays — sequenced, not braided.
+- **Reference material moved to its homes.** Exit-code table + output contract
+  + fresh-kernel-per-request lifecycle → EMBEDDING.md (new "result contract"
+  section; its stale "0.8.x" fixed too). Trash thresholds/exclusions →
+  LANGUAGE.md — they had no home outside the README.
+- **Everything shown is verified.** Every tour example ran against the current
+  binary (including the quote-to-join parse error); the embed example was
+  compiled and run from a scratch crate against the worktree kernel. The tour
+  now shows 0.11 typed collections (`fromjson` + `${r[k]}`) instead of jq —
+  Amy may spin jq out to its own crate, so the README stops showcasing it
+  (it stays in the builtin inventory table, which tracks code).
+
 ## `jq -s` stops being a no-op on the `.data` path (2026-07-06, GH #93 item 2)
 
 Real `jq -s`/`--slurp` has one law: wrap the inputs in an array, always —


### PR DESCRIPTION
## What

Full restructure of README.md for its primary audience — people (and models) discovering the repo — plus the doc migrations that restructure implies. Evaluated first with two outside cold reads (deepseek + gemini-flash via kaibo `oneshot`, given only the README, exactly what a visitor sees); both converged with our own read.

## Why

- **The first instruction was broken.** `cargo install kaish` fails: there is no `kaish` crate on crates.io — the binary named `kaish` ships in `kaish-repl`. Fixed, with a CHANGELOG entry.
- **The thesis was buried.** "Why a shell for agents?" — the reason the project exists — sat as an `####` heading inside Components → Embedding at 85% document depth. It's now the first section after the hero.
- **Identity oscillation.** The doc interleaved the agent-runtime and human-REPL stories section by section. The rewrite sequences instead: universal pitch → differences from bash → Quick Tour → Getting Started with two labeled paths (REPL / embed the kernel).
- **Reference material clogged the middle.** The exit-code table and output contract moved to `docs/EMBEDDING.md` as a new "result contract" section (its stale "0.8.x" is fixed too); trash thresholds/exclusions moved to `docs/LANGUAGE.md`, which previously had no home for them. Six crates ship this README to crates.io, so embedder content stays — sequenced, not braided.
- **Stale claims.** "still experimental" contradicted the settled pre-1.0 stance; the README now carries an explicit status line (0.11, pre-1.0, language settled).

## Direction calls (from the conversation)

- **jq is no longer showcased** — a spin-out to its own repo/crate is under consideration. The tour demonstrates native JSON with `fromjson` + typed collections instead. jq remains in the builtin inventory table because that table tracks `register_builtins()`.
- **The JSON data model is load-bearing now**: a thesis paragraph ("Underneath, kaish's data model is JSON…"), a differences bullet, and the tour segment showing `${C[name]}` / `keys` iteration.

## Verification

- All Quick Tour snippets ran against the current binary, including the quote-to-join parse error and both `fromjson` collection examples.
- The new embed example was compiled and executed from a scratch crate against this branch's kernel (sandboxed `ls | grep | head` returns the expected files).
- Builtin table checked against `register_builtins()`: 95/95, no drift.
- `cargo test --all` and `cargo clippy --all --all-targets` both clean, zero warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)