### PR TITLE
fix(#93): binary values go loud at the remaining text sinks; stream &>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,13 +75,16 @@ breaking entries are marked **BREAKING**.
   the behavior no longer depends on how the kernel was constructed.
 - **Binary (`Value::Bytes`) now goes loud at every remaining text sink** (GH
   #93 item 1), not just the primary ones 0.11.0 fixed. A path-coercing builtin
-  positional (`mkdir`/`cp`/`rm`/`ls`/`find`/`grep`/`sed -i`/etc.), a `[[ -f
-  $x ]]`/`test -f $x` file-test path, an exported env var reaching a spawned
-  process, a redirect target (`cmd > $x`), a `case $x in`/`==`/`in` operand,
-  and `exec`'s own argv all used to silently fall back to the `[binary: N
-  bytes]` placeholder — a wrong path, a wrong env var value, or a comparison
-  against the placeholder text instead of the real bytes. All now error
-  clearly instead.
+  positional (`mkdir`/`cp`/`rm`/`ls`/`find`/`grep`/`sed`/`uniq`/`jq`/`tree`/
+  `write`/`ln`/`patch`/`checksum`/`spawn`/`cd`/`awk`/etc.), a `[[ -f $x ]]`/
+  `test -f $x` file-test path, an exported env var reaching a spawned process,
+  a redirect target (`cmd > $x`), a `case $x in`/`==`/`in` operand, and
+  `exec`'s own argv all used to silently mishandle a binary operand instead of
+  erroring — most stringified it into the `[binary: N bytes]` placeholder (a
+  wrong path, a wrong env var value, a comparison against placeholder text
+  instead of the real bytes), and a few (`cat`/`head`/`tail`/`wc`/`sed`/
+  `uniq`/`jq`/`cd`/`awk`) instead silently dropped it and fell back to reading
+  stdin or `$HOME`. All now error clearly instead.
 - **`&>` (`RedirectKind::Both`) streams structured output like `>`/`>>`** (GH
   #93 item 6) instead of building the whole output as one `String` first —
   aligns it with the lazy `take_output_for_stream`/`write_canonical` path the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,19 @@ breaking entries are marked **BREAKING**.
   that can't run `$()` and failed with "could not evaluate redirect target".
   The redirect evaluator now takes the dispatcher the runner already holds, so
   the behavior no longer depends on how the kernel was constructed.
+- **Binary (`Value::Bytes`) now goes loud at every remaining text sink** (GH
+  #93 item 1), not just the primary ones 0.11.0 fixed. A path-coercing builtin
+  positional (`mkdir`/`cp`/`rm`/`ls`/`find`/`grep`/`sed -i`/etc.), a `[[ -f
+  $x ]]`/`test -f $x` file-test path, an exported env var reaching a spawned
+  process, a redirect target (`cmd > $x`), a `case $x in`/`==`/`in` operand,
+  and `exec`'s own argv all used to silently fall back to the `[binary: N
+  bytes]` placeholder — a wrong path, a wrong env var value, or a comparison
+  against the placeholder text instead of the real bytes. All now error
+  clearly instead.
+- **`&>` (`RedirectKind::Both`) streams structured output like `>`/`>>`** (GH
+  #93 item 6) instead of building the whole output as one `String` first —
+  aligns it with the lazy `take_output_for_stream`/`write_canonical` path the
+  plain stdout redirects already use.
 - **`grep -r PATTERN FILE`** (a file operand, not a directory) now searches
   that file instead of silently finding nothing (GH #105). `-r`/`-R` used to
   treat every operand as a walk root; a file has nothing "under" it, so the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,15 +76,15 @@ breaking entries are marked **BREAKING**.
 - **Binary (`Value::Bytes`) now goes loud at every remaining text sink** (GH
   #93 item 1), not just the primary ones 0.11.0 fixed. A path-coercing builtin
   positional (`mkdir`/`cp`/`rm`/`ls`/`find`/`grep`/`sed`/`uniq`/`jq`/`tree`/
-  `write`/`ln`/`patch`/`checksum`/`spawn`/`cd`/`awk`/etc.), a `[[ -f $x ]]`/
-  `test -f $x` file-test path, an exported env var reaching a spawned process,
-  a redirect target (`cmd > $x`), a `case $x in`/`==`/`in` operand, and
-  `exec`'s own argv all used to silently mishandle a binary operand instead of
-  erroring — most stringified it into the `[binary: N bytes]` placeholder (a
-  wrong path, a wrong env var value, a comparison against placeholder text
-  instead of the real bytes), and a few (`cat`/`head`/`tail`/`wc`/`sed`/
-  `uniq`/`jq`/`cd`/`awk`) instead silently dropped it and fell back to reading
-  stdin or `$HOME`. All now error clearly instead.
+  `write`/`ln`/`patch`/`checksum`/`cmp`/`spawn`/`cd`/`awk`/etc.), a
+  `[[ -f $x ]]`/`test -f $x` file-test path, an exported env var reaching a
+  spawned process, a redirect target (`cmd > $x`), a `case $x in`/`==`/`in`
+  operand, and `exec`'s own argv all used to silently mishandle a binary
+  operand instead of erroring — most stringified it into the `[binary: N
+  bytes]` placeholder (a wrong path, a wrong env var value, a comparison
+  against placeholder text instead of the real bytes), and a few (`cat`/
+  `head`/`tail`/`wc`/`sed`/`uniq`/`jq`/`cd`/`awk`) instead silently dropped it
+  and fell back to reading stdin or `$HOME`. All now error clearly instead.
 - **`&>` (`RedirectKind::Both`) streams structured output like `>`/`>>`** (GH
   #93 item 6) instead of building the whole output as one `String` first —
   aligns it with the lazy `take_output_for_stream`/`write_canonical` path the

--- a/crates/kaish-kernel/src/dispatch.rs
+++ b/crates/kaish-kernel/src/dispatch.rs
@@ -262,7 +262,18 @@ impl BackendDispatcher {
             return Some(ExecResult::failure(1, msg));
         }
         for (var_name, value) in exported {
-            cmd.env(var_name, crate::interpreter::value_to_string(&value));
+            // Binary can't cross the process boundary as an env var value
+            // either — loud, not the `[binary: N bytes]` placeholder (kept in
+            // sync with the production spawn site).
+            match crate::interpreter::value_to_text_sink_named(
+                &value,
+                "an exported environment variable value",
+            ) {
+                Ok(s) => {
+                    cmd.env(var_name, s);
+                }
+                Err(e) => return Some(ExecResult::failure(1, e.to_string())),
+            }
         }
 
         // Stdin: pipe_stdin or buffered string or inherit (interactive) or null

--- a/crates/kaish-kernel/src/interpreter.rs
+++ b/crates/kaish-kernel/src/interpreter.rs
@@ -39,7 +39,7 @@ mod result;
 mod scope;
 
 pub use control_flow::ControlFlow;
-pub use eval::{eval_expr, expand_tilde, is_collection, numeric_compare, resolve_default, resolve_length, scalar_test_operand_error, strip_leading_tabs, structured_boundary_error, structured_export_error, value_defaults_on_emptiness, values_equal, value_to_bool, value_to_exit_code, value_length, value_to_string, value_to_string_with_tilde, value_to_text_sink, EvalError, EvalResult, Evaluator, HeredocAssembler};
+pub use eval::{eval_expr, expand_tilde, is_collection, numeric_compare, resolve_default, resolve_length, scalar_test_operand_error, strip_leading_tabs, structured_boundary_error, structured_export_error, value_defaults_on_emptiness, values_equal, value_to_bool, value_to_exit_code, value_length, value_to_string, value_to_string_with_tilde, value_to_text_sink, value_to_text_sink_named, values_to_text_sink_named, EvalError, EvalResult, Evaluator, HeredocAssembler};
 pub use result::{apply_output_format, hex_dump, json_to_value, json_to_value_no_envelope, value_to_json, EntryType, ExecResult, LatchRequest, OutputData, OutputFormat, OutputNode, OutputPayload};
 pub use scope::{PathError, Scope};
 // Crate-internal: the reduced sync evaluator (scheduler/pipeline.rs) reuses the

--- a/crates/kaish-kernel/src/interpreter/eval.rs
+++ b/crates/kaish-kernel/src/interpreter/eval.rs
@@ -187,8 +187,14 @@ impl<'a> Evaluator<'a> {
                     match &sp.part {
                         StringPart::Literal(s) => asm.push_literal(s),
                         other => {
+                            // `eval_interpolated` already guards binary at
+                            // every `StringPart` arm internally (it always
+                            // returns `Value::String`), but reach for the
+                            // text-sink guard here too rather than leaning on
+                            // that non-local invariant — a heredoc body is a
+                            // text sink like any other.
                             let value = self.eval_interpolated(std::slice::from_ref(other))?;
-                            asm.push_interpolated(&value_to_string(&value));
+                            asm.push_interpolated(&value_to_text_sink(&value)?);
                         }
                     }
                 }
@@ -249,9 +255,12 @@ impl<'a> Evaluator<'a> {
                 RecordKey::Bare(s) | RecordKey::Quoted(s) => s.clone(),
                 // `{"$k": v}` — a double-quoted key resolves like any
                 // double-quoted string (issue found by the 2026-07-03 review:
-                // it used to silently create a literal "$k" key).
+                // it used to silently create a literal "$k" key). A record
+                // key is always textual, so route the assembled key through
+                // the text-sink guard rather than `value_to_string` — same
+                // reasoning as the heredoc-body push above.
                 RecordKey::Interpolated(parts) => {
-                    value_to_string(&self.eval_interpolated(parts)?)
+                    value_to_text_sink(&self.eval_interpolated(parts)?)?
                 }
             };
             let value = self.eval(&entry.value)?;
@@ -787,17 +796,36 @@ pub fn value_to_string(value: &Value) -> String {
 /// infallible form stays correct for semantic/internal uses where a stable
 /// placeholder is wanted and no data crosses a text boundary.
 pub fn value_to_text_sink(value: &Value) -> EvalResult<String> {
+    value_to_text_sink_named(value, "text")
+}
+
+/// Same as [`value_to_text_sink`], but `sink` names the specific boundary in
+/// the error message (e.g. "a path", "an exported environment variable
+/// value", "a redirect target") instead of the generic "text" — mirroring the
+/// `sink` parameter [`structured_boundary_error`] already uses for the
+/// collection-vs-process-boundary guard. Every remaining text sink that used
+/// to fall back to [`value_to_string`]'s `[binary: N bytes]` placeholder
+/// (path-coercing builtins, env export, redirect targets, …) routes through
+/// this so the error names what the binary data was actually being used as.
+pub fn value_to_text_sink_named(value: &Value, sink: &str) -> EvalResult<String> {
     match value {
         Value::Bytes(b) => match std::str::from_utf8(b) {
             Ok(s) => Ok(s.to_string()),
             Err(_) => Err(EvalError::Unsupported(format!(
-                "binary data ({} bytes) cannot be used as text — decode it \
+                "binary data ({} bytes) cannot be used as {sink} — decode it \
                  (base64/xxd) or redirect to a file",
                 b.len()
             ))),
         },
         other => Ok(value_to_string(other)),
     }
+}
+
+/// [`value_to_text_sink_named`] over a whole positional list — a builtin's
+/// path operands (`ls`/`find`/`grep`/`sed -i` file lists), going loud on the
+/// first binary element rather than collecting placeholders.
+pub fn values_to_text_sink_named(values: &[Value], sink: &str) -> EvalResult<Vec<String>> {
+    values.iter().map(|v| value_to_text_sink_named(v, sink)).collect()
 }
 
 /// Convert a Value to its boolean representation.
@@ -994,6 +1022,17 @@ pub fn values_equal(left: &Value, right: &Value) -> EvalResult<bool> {
                 other_kind = type_name(other),
             )))
         }
+        // Binary compared to a non-binary scalar: a loud type error, never the
+        // `value_to_string` fallback below — that would silently compare the
+        // OTHER side's text against the `[binary: N bytes]` placeholder rather
+        // than the value's real bytes (Decision E; the (Bytes, Bytes) arm above
+        // already took the real "compare the actual bytes" case).
+        (Value::Bytes(b), other) | (other, Value::Bytes(b)) => Err(EvalError::Unsupported(format!(
+            "binary data ({} bytes) cannot be used as an ==/!= operand against a {} — decode it \
+             first (base64/xxd), or compare two binary values directly",
+            b.len(),
+            type_name(other),
+        ))),
         // Mixed scalars (most commonly String vs Int/Float from a quoted variable
         // against a numeric literal): fall back to string equality.
         _ => Ok(value_to_string(left) == value_to_string(right)),
@@ -1012,8 +1051,12 @@ fn element_matches(needle: &Value, element: &Value) -> bool {
     match (needle, element) {
         (Value::Json(a), Value::Json(b)) => a == b,
         (Value::Json(_), _) | (_, Value::Json(_)) => false,
-        // Neither side is a collection here, so `values_equal` can't hit its
-        // collection-vs-scalar error arm — this can never actually error.
+        // Neither side is a collection here, so `values_equal`'s collection
+        // guard can't fire. Its binary-vs-scalar guard *can* (`$bin in
+        // $list` scanning past a non-binary element) — treated the same as a
+        // shape mismatch above: this element is simply "not a match," never
+        // an abort, so the whole scan doesn't die over one heterogeneous
+        // element.
         _ => values_equal(needle, element).unwrap_or(false),
     }
 }
@@ -1039,6 +1082,17 @@ fn eval_membership(needle: &Value, haystack: &Value) -> EvalResult<bool> {
             Ok(false)
         }
         Value::Json(serde_json::Value::Object(map)) => {
+            // Record keys are always strings; a binary needle has no sensible
+            // stringification into one, so it's a loud type error rather than
+            // silently looking up the `[binary: N bytes]` placeholder key
+            // (which would almost certainly — and silently — miss).
+            if let Value::Bytes(b) = needle {
+                return Err(EvalError::Unsupported(format!(
+                    "binary data ({} bytes) cannot be used as a record key for `in` — \
+                     decode it first (base64/xxd)",
+                    b.len()
+                )));
+            }
             Ok(map.contains_key(&value_to_string(needle)))
         }
         other => Err(EvalError::Unsupported(format!(
@@ -1291,6 +1345,102 @@ mod tests {
         assert_eq!(
             eval_expr(&expr, &mut scope),
             Ok(Value::String("Hello, World!".into()))
+        );
+    }
+
+    // `Expr::HereDocBody` and `Expr::RecordLiteral`'s `RecordKey::Interpolated`
+    // arm are unreachable from a real script through `kernel.execute()` — heredocs
+    // and record literals always resolve through the kernel's ASYNC evaluator in
+    // production (`kernel.rs::eval_expr_async`), which already composes through
+    // the guarded `eval_string_part[s]_async`. These two arms only fire when an
+    // embedder drives the sync `Evaluator` directly (or in these unit tests), so
+    // they're exercised here rather than through `kernel.execute()` per
+    // CLAUDE.md's "test through kernel.execute()" convention — that convention is
+    // about builtins reachable via the dispatch chain, and there is no such path
+    // to these two sync-only arms.
+
+    #[test]
+    fn eval_heredoc_body_binary_var_is_loud() {
+        let mut scope = Scope::new();
+        scope.set("B", Value::Bytes(vec![0xff, 0x00, 0xfe]));
+
+        let expr = Expr::HereDocBody {
+            parts: vec![
+                crate::ast::SpannedPart {
+                    part: StringPart::Literal("before ".into()),
+                    offset: 0,
+                    len: 0,
+                },
+                crate::ast::SpannedPart {
+                    part: StringPart::Var(VarPath::simple("B")),
+                    offset: 0,
+                    len: 0,
+                },
+            ],
+            strip_tabs: false,
+        };
+        let err = eval_expr(&expr, &mut scope).expect_err("binary in a heredoc body must be loud");
+        assert!(
+            matches!(err, EvalError::Unsupported(ref msg) if msg.contains("cannot be used as")),
+            "got {err:?}"
+        );
+    }
+
+    #[test]
+    fn eval_heredoc_body_text_var_is_unaffected() {
+        let mut scope = Scope::new();
+        scope.set("NAME", Value::String("World".into()));
+
+        let expr = Expr::HereDocBody {
+            parts: vec![
+                crate::ast::SpannedPart {
+                    part: StringPart::Literal("Hello, ".into()),
+                    offset: 0,
+                    len: 0,
+                },
+                crate::ast::SpannedPart {
+                    part: StringPart::Var(VarPath::simple("NAME")),
+                    offset: 0,
+                    len: 0,
+                },
+            ],
+            strip_tabs: false,
+        };
+        assert_eq!(
+            eval_expr(&expr, &mut scope),
+            Ok(Value::String("Hello, World".into()))
+        );
+    }
+
+    #[test]
+    fn eval_record_literal_interpolated_key_binary_var_is_loud() {
+        let mut scope = Scope::new();
+        scope.set("B", Value::Bytes(vec![0xff, 0x00, 0xfe]));
+
+        let expr = Expr::RecordLiteral(vec![RecordEntry {
+            key: RecordKey::Interpolated(vec![StringPart::Var(VarPath::simple("B"))]),
+            value: Expr::Literal(Value::Int(1)),
+        }]);
+        let err = eval_expr(&expr, &mut scope)
+            .expect_err("a binary record key must be loud, not a `[binary: N bytes]` key");
+        assert!(
+            matches!(err, EvalError::Unsupported(ref msg) if msg.contains("cannot be used as")),
+            "got {err:?}"
+        );
+    }
+
+    #[test]
+    fn eval_record_literal_interpolated_key_text_var_is_unaffected() {
+        let mut scope = Scope::new();
+        scope.set("K", Value::String("port".into()));
+
+        let expr = Expr::RecordLiteral(vec![RecordEntry {
+            key: RecordKey::Interpolated(vec![StringPart::Var(VarPath::simple("K"))]),
+            value: Expr::Literal(Value::Int(8080)),
+        }]);
+        assert_eq!(
+            eval_expr(&expr, &mut scope),
+            Ok(Value::Json(serde_json::json!({"port": 8080})))
         );
     }
 
@@ -1846,6 +1996,57 @@ mod tests {
         let a = Value::Json(serde_json::json!({"a": 1, "b": 2}));
         let b = Value::Json(serde_json::json!({"b": 2, "a": 1}));
         assert_eq!(values_equal(&a, &b), Ok(true));
+    }
+
+    // ── GH #93 item 1: binary at the remaining text sinks ──
+
+    #[test]
+    fn values_equal_bytes_vs_bytes_still_works() {
+        // The one case that legitimately compares binary: byte-for-byte.
+        assert_eq!(
+            values_equal(&Value::Bytes(vec![1, 2, 3]), &Value::Bytes(vec![1, 2, 3])),
+            Ok(true)
+        );
+        assert_eq!(
+            values_equal(&Value::Bytes(vec![1, 2, 3]), &Value::Bytes(vec![1, 2, 4])),
+            Ok(false)
+        );
+    }
+
+    #[test]
+    fn values_equal_bytes_vs_scalar_is_loud() {
+        // Binary compared to ANY non-binary scalar must be a loud type error,
+        // never a silent stringify-then-compare against the `[binary: N
+        // bytes]` placeholder — order-independent, like the collection guard.
+        let bin = Value::Bytes(vec![0xff, 0x00]);
+        assert!(matches!(
+            values_equal(&bin, &Value::String("x".into())),
+            Err(EvalError::Unsupported(_))
+        ));
+        assert!(matches!(
+            values_equal(&Value::Int(1), &bin),
+            Err(EvalError::Unsupported(_))
+        ));
+    }
+
+    #[test]
+    fn eval_membership_bytes_needle_against_record_key_is_loud() {
+        let record = Value::Json(serde_json::json!({"k": 1}));
+        let bin = Value::Bytes(vec![0xff, 0x00]);
+        assert!(matches!(
+            eval_membership(&bin, &record),
+            Err(EvalError::Unsupported(_))
+        ));
+    }
+
+    #[test]
+    fn eval_membership_bytes_needle_against_list_is_not_a_match_not_an_abort() {
+        // Same "shape mismatch is just not-a-match" treatment as a nested
+        // collection element (`element_matches`) — the scan doesn't abort just
+        // because one element isn't binary.
+        let list = Value::Json(serde_json::json!(["a", "b"]));
+        let bin = Value::Bytes(vec![0xff, 0x00]);
+        assert_eq!(eval_membership(&bin, &list), Ok(false));
     }
 
     #[test]

--- a/crates/kaish-kernel/src/kernel.rs
+++ b/crates/kaish-kernel/src/kernel.rs
@@ -2493,10 +2493,13 @@ impl Kernel {
                 Ok(ControlFlow::ok(result))
             }
             Stmt::Case(case_stmt) => {
-                // Evaluate the expression to match against
+                // Evaluate the expression to match against. Text sink: a
+                // `case $bin in ...)` pattern match on binary goes loud
+                // rather than glob-matching against the `[binary: N bytes]`
+                // placeholder (Decision E — same class as `==`/`in`).
                 let match_value = {
                     let value = self.eval_expr_async(&case_stmt.expr).await?;
-                    value_to_string(&value)
+                    value_to_text_sink(&value).map_err(|e| anyhow::anyhow!("{e}"))?
                 };
 
                 // Try each branch until we find a match
@@ -4187,7 +4190,12 @@ impl Kernel {
                     // stats the literal `~/x` and is always false.
                     let home = self.scope_home().await;
                     let path_value = apply_tilde_expansion(path_value, home.as_deref());
-                    let path_str = value_to_string(&path_value);
+                    // A binary `[[ -f $bin ]]` operand goes loud rather than
+                    // silently stat'ing a file literally named
+                    // `[binary: N bytes]` (the same path-positional guard
+                    // builtins like `stat`/`cp` use).
+                    let path_str = crate::interpreter::value_to_text_sink_named(&path_value, "a path")
+                        .map_err(|e| anyhow::anyhow!("{e}"))?;
                     // Resolve against the *session* cwd, not the process cwd, so a
                     // relative `[[ -f rel ]]` honors `cd` and agrees with the
                     // VFS-aware `test` builtin (GH #101). Backend stats a raw
@@ -5109,7 +5117,16 @@ impl Kernel {
                 return Err(anyhow::anyhow!(msg));
             }
             for (var_name, value) in exported {
-                cmd.env(var_name, value_to_string(&value));
+                // Binary can't cross the process boundary as an env var value
+                // either — loud, not the `[binary: N bytes]` placeholder
+                // silently exported in its place (kept in sync with
+                // dispatch.rs::try_external and env.rs::execute_with_env).
+                let value_str = crate::interpreter::value_to_text_sink_named(
+                    &value,
+                    "an exported environment variable value",
+                )
+                .map_err(|e| anyhow::anyhow!("{e}"))?;
+                cmd.env(var_name, value_str);
             }
         }
 

--- a/crates/kaish-kernel/src/scheduler/pipeline.rs
+++ b/crates/kaish-kernel/src/scheduler/pipeline.rs
@@ -136,11 +136,23 @@ pub(crate) async fn apply_redirects(
                     Ok(p) => p,
                     Err(e) => return ExecResult::failure(1, format!("redirect: {e}")),
                 };
-                // Build the combined bytes: raw binary stdout (no lossy decode)
-                // or text stdout, followed by stderr.
-                let mut combined: Vec<u8> = match result.out_bytes() {
-                    Some(b) => b.to_vec(),
-                    None => result.text_out().into_owned().into_bytes(),
+                // Build the combined bytes: raw binary stdout (no lossy decode),
+                // or structured output streamed straight to a byte buffer via
+                // `take_output_for_stream`/`write_canonical` — same lazy path
+                // `>`/`>>` use above — instead of forcing it through one
+                // `String` first (`text_out()`'s canonical-string fallback).
+                // Falls back to the text form only when neither applies.
+                // Followed by stderr.
+                let mut combined: Vec<u8> = if let Some(b) = result.out_bytes() {
+                    b.to_vec()
+                } else if let Some(output) = result.take_output_for_stream() {
+                    let mut buf = Vec::new();
+                    if let Err(e) = output.write_canonical(&mut buf, None) {
+                        return ExecResult::failure(1, format!("redirect: {e}"));
+                    }
+                    buf
+                } else {
+                    result.text_out().into_owned().into_bytes()
                 };
                 combined.extend_from_slice(result.err.as_bytes());
                 if let Err(e) = redirect_write(ctx, &path, &combined).await {
@@ -187,7 +199,9 @@ async fn eval_redirect_target(
     if let Some(msg) = crate::interpreter::structured_boundary_error("a redirect target", &value) {
         return Err(msg);
     }
-    Ok(value_to_string(&value))
+    // Text sink: binary goes loud rather than becoming a file literally named
+    // `[binary: N bytes]` — the same guard external argv and env export use.
+    crate::interpreter::value_to_text_sink_named(&value, "a redirect target").map_err(|e| e.to_string())
 }
 
 /// Write data to a file via the VFS backend.
@@ -566,12 +580,28 @@ impl PipelineRunner {
                 // Write output to pipe for next stage (if not last).
                 // Consumer is now unblocked and can drain concurrently.
                 if let Some(mut pipe_out) = stage_ctx.pipe_stdout.take() {
-                    // A binary result flows through the pipe as raw bytes; text
-                    // results as their UTF-8 bytes. Either way the next stage
-                    // gets exactly what was produced — no lossy round-trip.
-                    let bytes: Vec<u8> = match result.out_bytes() {
-                        Some(b) => b.to_vec(),
-                        None => result.text_out().into_owned().into_bytes(),
+                    // A binary result flows through the pipe as raw bytes;
+                    // structured output serializes straight to a byte buffer
+                    // (`write_canonical`) rather than building the full
+                    // canonical `String` first — same lazy path the `>`/`>>`
+                    // file redirects use via `take_output_for_stream`. Either
+                    // way the next stage gets exactly what was produced — no
+                    // lossy round-trip.
+                    let bytes: Vec<u8> = if let Some(b) = result.out_bytes() {
+                        b.to_vec()
+                    } else if let Some(output) = result.take_output_for_stream() {
+                        let mut buf = Vec::new();
+                        // `Vec<u8>`'s `Write` impl is infallible; a serialize
+                        // error here would only come from a future non-memory
+                        // writer, so fall back to the same lossy text form the
+                        // non-streaming branch already uses rather than
+                        // dropping the stage's output outright.
+                        if output.write_canonical(&mut buf, None).is_err() {
+                            buf = output.to_canonical_string().into_bytes();
+                        }
+                        buf
+                    } else {
+                        result.text_out().into_owned().into_bytes()
                     };
                     if !bytes.is_empty() {
                         // Write result to pipe; ignore broken pipe (reader dropped early)
@@ -1060,19 +1090,6 @@ pub(crate) fn eval_simple_expr(expr: &Expr, ctx: &ExecContext) -> Result<Option<
 /// Evaluate a literal value.
 fn eval_literal(value: &Value, _ctx: &ExecContext) -> Value {
     value.clone()
-}
-
-/// Convert a value to a string for interpolation.
-fn value_to_string(value: &Value) -> String {
-    match value {
-        Value::Null => "".to_string(),
-        Value::Bool(b) => b.to_string(),
-        Value::Int(i) => i.to_string(),
-        Value::Float(f) => f.to_string(),
-        Value::String(s) => s.clone(),
-        Value::Json(json) => json.to_string(),
-        Value::Bytes(b) => format!("[binary: {} bytes]", b.len()),
-    }
 }
 
 /// Evaluate string parts synchronously (for pipeline context).
@@ -2322,5 +2339,102 @@ mod tests {
         let result = runner.run(&[echo_cmd, grep_cmd], &mut ctx, &dispatcher).await;
         assert!(result.ok(), "result failed: code={}, err={}", result.code, result.err);
         assert!(result.text_out().contains("output"));
+    }
+
+    // === Item 6: `&>` (RedirectKind::Both) streams structured output ===
+    //
+    // `>`/`>>` already stream a command's structured `OutputData` straight to
+    // a byte buffer via `take_output_for_stream`/`write_canonical` instead of
+    // building the whole `to_canonical_string()` `String` first. `&>` used to
+    // skip that path entirely (`result.text_out().into_owned().into_bytes()`,
+    // which forces the full-string materialization). These tests lock in that
+    // `&>` now takes the same streaming path and — since the file bytes are
+    // the only thing observable from outside — that it produces byte-for-byte
+    // the same content the old materialize-first code did.
+
+    fn big_table_output(rows: usize) -> crate::interpreter::OutputData {
+        use crate::interpreter::OutputNode;
+        let headers = vec!["id".to_string(), "name".to_string()];
+        let nodes: Vec<OutputNode> = (0..rows)
+            .map(|i| OutputNode::new(i.to_string()).with_cells(vec![format!("row-{i}")]))
+            .collect();
+        crate::interpreter::OutputData::table(headers, nodes)
+    }
+
+    #[tokio::test]
+    async fn test_both_redirect_streams_structured_output_to_file() {
+        // A result with structured `.output` and empty `.out` — exactly the
+        // shape `take_output_for_stream` requires, and the shape a real
+        // builtin (e.g. `ls`, `find`) hands back before `--json`/materialize
+        // ever runs.
+        let output = big_table_output(50);
+        let expected_stdout = output.to_canonical_string();
+        let mut result = ExecResult::with_output(output);
+        result.err = "warning: heads up\n".to_string();
+
+        let redirects = vec![Redirect {
+            kind: RedirectKind::Both,
+            target: Expr::Literal(Value::String("/out.txt".to_string())),
+        }];
+        let ctx = make_minimal_ctx();
+        let result = apply_redirects(result, &redirects, &ctx, &test_dispatcher()).await;
+
+        // Both streams went to the file: stdout (incl. the sideband) and
+        // stderr are both dropped from the in-memory result.
+        assert!(result.ok());
+        assert_eq!(&*result.text_out(), "");
+        assert!(result.err.is_empty());
+        assert!(!result.has_output());
+
+        let written = ctx.backend.read(Path::new("/out.txt"), None).await.expect("file written");
+        let written = String::from_utf8(written).expect("valid utf8");
+        // Byte-for-byte the same as the pre-refactor path would have produced:
+        // the table's canonical string, followed by stderr, with nothing lost
+        // or reordered by streaming it through `write_canonical` instead.
+        assert_eq!(written, format!("{expected_stdout}warning: heads up\n"));
+    }
+
+    #[tokio::test]
+    async fn test_both_redirect_streams_large_structured_output_intact() {
+        // A much bigger table than any single test needs to *pass*, but large
+        // enough that a regression re-introducing a size-limited or
+        // truncating path (rather than genuinely streaming) would be caught:
+        // every row must survive the round-trip through `&>`.
+        let rows = 5_000;
+        let output = big_table_output(rows);
+        let expected_stdout = output.to_canonical_string();
+        let result = ExecResult::with_output(output);
+
+        let redirects = vec![Redirect {
+            kind: RedirectKind::Both,
+            target: Expr::Literal(Value::String("/big.txt".to_string())),
+        }];
+        let ctx = make_minimal_ctx();
+        let result = apply_redirects(result, &redirects, &ctx, &test_dispatcher()).await;
+        assert!(result.ok());
+
+        let written = ctx.backend.read(Path::new("/big.txt"), None).await.expect("file written");
+        let written = String::from_utf8(written).expect("valid utf8");
+        assert_eq!(written, expected_stdout);
+        assert!(written.contains("row-0"));
+        assert!(written.contains(&format!("row-{}", rows - 1)));
+    }
+
+    #[tokio::test]
+    async fn test_both_redirect_still_writes_binary_stdout_raw() {
+        // Unchanged branch (`out_bytes()`), covered here so the refactor
+        // can't accidentally regress the binary path while touching the
+        // structured-output branch next to it.
+        let result = ExecResult::success_text_or_bytes(vec![0xff, 0x00, 0xfe, b'x']);
+        let redirects = vec![Redirect {
+            kind: RedirectKind::Both,
+            target: Expr::Literal(Value::String("/bin.out".to_string())),
+        }];
+        let ctx = make_minimal_ctx();
+        let result = apply_redirects(result, &redirects, &ctx, &test_dispatcher()).await;
+        assert!(result.ok());
+
+        let written = ctx.backend.read(Path::new("/bin.out"), None).await.expect("file written");
+        assert_eq!(written, vec![0xff, 0x00, 0xfe, b'x']);
     }
 }

--- a/crates/kaish-kernel/src/tools/builtin/awk.rs
+++ b/crates/kaish-kernel/src/tools/builtin/awk.rs
@@ -14,6 +14,7 @@ use std::path::Path;
 #[cfg(test)]
 use crate::ast::Value;
 use crate::interpreter::{ExecResult, OutputData};
+use crate::tools::builtin::get_path_string;
 use crate::tools::builtin::regex_dialect::{append_dialect_hint, bre_metas_to_ere};
 use crate::tools::{schema_from_clap, ExecContext, ToolCtx, GlobalFlags, Tool, ToolArgs, ToolSchema};
 
@@ -111,10 +112,12 @@ impl Tool for Awk {
             .or_else(|| args.get_string("field_separator", usize::MAX))
             .or_else(|| args.get_string("F", usize::MAX));
 
-        // Get input
+        // Get input. A binary `path` operand goes loud rather than silently
+        // falling through to the "no operand" branch (which reads stdin instead
+        // of the file the user actually named).
         let file_pos = 1;
-        let input = match args.get_string("path", file_pos) {
-            Some(path) => {
+        let input = match get_path_string(&args, "path", file_pos) {
+            Ok(Some(path)) => {
                 let resolved = ctx.resolve_path(&path);
                 match ctx.backend.read(Path::new(&resolved), None).await {
                     Ok(data) => match String::from_utf8(data) {
@@ -126,10 +129,11 @@ impl Tool for Awk {
                     Err(e) => return ExecResult::failure(1, format!("awk: {}: {}", path, e)),
                 }
             }
-            None => match ctx.read_stdin_to_text().await {
+            Ok(None) => match ctx.read_stdin_to_text().await {
                 Ok(s) => s.unwrap_or_default(),
                 Err(e) => return ExecResult::failure(2, format!("awk: {e}")),
             },
+            Err(e) => return ExecResult::failure(1, format!("awk: {e}")),
         };
 
         // Build runtime with initial variables

--- a/crates/kaish-kernel/src/tools/builtin/basename.rs
+++ b/crates/kaish-kernel/src/tools/builtin/basename.rs
@@ -7,6 +7,7 @@ use std::path::Path;
 #[cfg(test)]
 use crate::ast::Value;
 use crate::interpreter::{ExecResult, OutputData};
+use crate::tools::builtin::get_path_string;
 use crate::tools::{schema_from_clap, ExecContext, ToolCtx, GlobalFlags, Tool, ToolArgs, ToolSchema};
 
 /// Basename tool: extract filename from path.
@@ -53,9 +54,10 @@ impl Tool for Basename {
         };
         parsed.global.apply(ctx);
 
-        let path_str = match args.get_string("path", 0) {
-            Some(p) => p,
-            None => return ExecResult::failure(1, "basename: missing path argument"),
+        let path_str = match get_path_string(&args, "path", 0) {
+            Ok(Some(p)) => p,
+            Ok(None) => return ExecResult::failure(1, "basename: missing path argument"),
+            Err(e) => return ExecResult::failure(1, format!("basename: {e}")),
         };
 
         let path = Path::new(&path_str);

--- a/crates/kaish-kernel/src/tools/builtin/cd.rs
+++ b/crates/kaish-kernel/src/tools/builtin/cd.rs
@@ -6,6 +6,7 @@ use std::path::{Path, PathBuf};
 
 use crate::ast::Value;
 use crate::interpreter::{ExecResult, OutputData};
+use crate::tools::builtin::get_path_string;
 use crate::tools::{schema_from_clap, ExecContext, ToolCtx, GlobalFlags, Tool, ToolArgs, ToolSchema};
 
 /// Cd tool: change current working directory.
@@ -54,18 +55,25 @@ impl Tool for Cd {
         };
         parsed.global.apply(ctx);
 
-        let path_arg = args.get_string("path", 0).unwrap_or_else(|| {
-            // Consult the session HOME from the kernel scope only — never the
-            // host env (the kernel is hermetic). With no HOME in scope, bare
-            // `cd` falls back to `/` rather than leaking the host home dir.
-            ctx.scope
-                .get("HOME")
-                .and_then(|v| match v {
-                    Value::String(s) => Some(s.clone()),
-                    _ => None,
-                })
-                .unwrap_or_else(|| "/".to_string())
-        });
+        // A binary `path` operand goes loud rather than silently falling
+        // through to the "no operand" branch below (which would silently `cd`
+        // to $HOME/`/` instead of erroring on the path the user actually gave).
+        let path_arg = match get_path_string(&args, "path", 0) {
+            Ok(Some(p)) => p,
+            Ok(None) => {
+                // Consult the session HOME from the kernel scope only — never the
+                // host env (the kernel is hermetic). With no HOME in scope, bare
+                // `cd` falls back to `/` rather than leaking the host home dir.
+                ctx.scope
+                    .get("HOME")
+                    .and_then(|v| match v {
+                        Value::String(s) => Some(s.clone()),
+                        _ => None,
+                    })
+                    .unwrap_or_else(|| "/".to_string())
+            }
+            Err(e) => return ExecResult::failure(1, format!("cd: {e}")),
+        };
 
         // Handle `cd -` for previous directory
         let resolved: PathBuf = if path_arg == "-" {

--- a/crates/kaish-kernel/src/tools/builtin/checksum.rs
+++ b/crates/kaish-kernel/src/tools/builtin/checksum.rs
@@ -7,6 +7,7 @@ use std::path::Path;
 use digest::Digest;
 
 use crate::interpreter::{ExecResult, OutputData, OutputNode};
+use crate::tools::builtin::get_path_string;
 use crate::tools::{schema_from_clap, ExecContext, ToolCtx, GlobalFlags, Tool, ToolArgs, ToolSchema};
 
 /// Checksum tool: compute or verify file hashes.
@@ -99,8 +100,21 @@ impl Tool for Checksum {
             );
         }
 
-        // Check mode: verify checksums from a file
-        if let Some(check_path) = parsed.check.clone().or_else(|| args.get_string("check", usize::MAX)) {
+        // Check mode: verify checksums from a file. Read the untouched typed
+        // value FIRST (not `parsed.check`) — clap's own field comes from
+        // `to_argv()`'s re-serialization, which is exactly the lossy
+        // stringify-to-`[binary: N bytes]` boundary this PR closes elsewhere,
+        // so checking it first would silently defeat the guard below. A
+        // binary `--check` value goes loud rather than silently falling
+        // through to ordinary hash mode (which would hash the files named as
+        // if `--check` was never passed at all — a silently wrong operation,
+        // not just a wrong path).
+        let check_path = match get_path_string(&args, "check", usize::MAX) {
+            Ok(Some(p)) => Some(p),
+            Ok(None) => parsed.check.clone(),
+            Err(e) => return ExecResult::failure(1, format!("checksum: {e}")),
+        };
+        if let Some(check_path) = check_path {
             return self.verify_checksums(ctx, &check_path, &algo).await;
         }
 

--- a/crates/kaish-kernel/src/tools/builtin/cmp.rs
+++ b/crates/kaish-kernel/src/tools/builtin/cmp.rs
@@ -67,7 +67,16 @@ impl Tool for Cmp {
         if parsed.paths.len() != 2 {
             return ExecResult::failure(2, "cmp: expected two file operands");
         }
-        let (name1, name2) = (parsed.paths[0].clone(), parsed.paths[1].clone());
+        // Read the operand VALUES off `args.positional`, not `parsed.paths` —
+        // `parsed.paths` came through `to_argv()`'s lossy re-serialization
+        // (a `Value::Bytes` operand would already be the `[binary: N bytes]`
+        // placeholder by the time clap saw it), so a binary path would
+        // otherwise silently name a nonexistent file instead of erroring.
+        let (name1, name2) = match crate::interpreter::values_to_text_sink_named(&args.positional, "a path") {
+            Ok(paths) if paths.len() == 2 => (paths[0].clone(), paths[1].clone()),
+            Ok(_) => return ExecResult::failure(2, "cmp: expected two file operands"),
+            Err(e) => return ExecResult::failure(2, format!("cmp: {e}")),
+        };
         if name1 == "-" && name2 == "-" {
             return ExecResult::failure(2, "cmp: only one operand may be '-' (stdin)");
         }

--- a/crates/kaish-kernel/src/tools/builtin/cp.rs
+++ b/crates/kaish-kernel/src/tools/builtin/cp.rs
@@ -76,7 +76,14 @@ impl Tool for Cp {
             Some((last, rest)) if !rest.is_empty() => (rest, last),
             _ => return ExecResult::failure(1, "cp: missing file operand (need source and destination)"),
         };
-        let dest = crate::interpreter::value_to_string(dest_value);
+        let dest = match crate::interpreter::value_to_text_sink_named(dest_value, "a path") {
+            Ok(d) => d,
+            Err(e) => return ExecResult::failure(1, format!("cp: {e}")),
+        };
+        let sources = match crate::interpreter::values_to_text_sink_named(sources, "a path") {
+            Ok(s) => s,
+            Err(e) => return ExecResult::failure(1, format!("cp: {e}")),
+        };
         let dst_path = ctx.resolve_path(&dest);
 
         // Multiple sources require destination to be an existing directory.
@@ -107,8 +114,8 @@ impl Tool for Cp {
                 .await
                 .map(|info| !info.is_dir())
                 .unwrap_or(false);
-            let src_display = crate::interpreter::value_to_string(&sources[0]);
-            let src_resolved = ctx.resolve_path(&src_display);
+            let src_display = &sources[0];
+            let src_resolved = ctx.resolve_path(src_display);
             let src_is_dir = ctx
                 .backend
                 .stat(Path::new(&src_resolved))
@@ -133,9 +140,8 @@ impl Tool for Cp {
         }
 
         let mut last_err: Option<String> = None;
-        for src_value in sources {
-            let source = crate::interpreter::value_to_string(src_value);
-            let src_path = ctx.resolve_path(&source);
+        for source in &sources {
+            let src_path = ctx.resolve_path(source);
             if let Err(e) = copy_path(
                 &*ctx.backend,
                 &src_path,

--- a/crates/kaish-kernel/src/tools/builtin/cut.rs
+++ b/crates/kaish-kernel/src/tools/builtin/cut.rs
@@ -81,7 +81,10 @@ impl Tool for Cut {
         } else {
             let mut acc = String::new();
             for value in &args.positional {
-                let path = crate::interpreter::value_to_string(value);
+                let path = match crate::interpreter::value_to_text_sink_named(value, "a path") {
+                    Ok(p) => p,
+                    Err(e) => return ExecResult::failure(1, format!("cut: {e}")),
+                };
                 let resolved = ctx.resolve_path(&path);
                 match ctx.backend.read(Path::new(&resolved), None).await {
                     Ok(data) => match String::from_utf8(data) {

--- a/crates/kaish-kernel/src/tools/builtin/diff.rs
+++ b/crates/kaish-kernel/src/tools/builtin/diff.rs
@@ -16,6 +16,7 @@ use std::path::Path;
 
 use crate::ast::Value;
 use crate::interpreter::{ExecResult, OutputData};
+use crate::tools::builtin::get_path_string;
 use crate::tools::{schema_from_clap, validate_against_schema, ExecContext, ToolCtx, GlobalFlags, Tool, ToolArgs, ToolSchema};
 use crate::validator::{IssueCode, ValidationIssue};
 
@@ -139,14 +140,16 @@ impl Tool for Diff {
         }
 
         // Get file paths
-        let file1 = match args.get_string("file1", 0) {
-            Some(f) => f,
-            None => return ExecResult::failure(2, "diff: missing first file"),
+        let file1 = match get_path_string(&args, "file1", 0) {
+            Ok(Some(f)) => f,
+            Ok(None) => return ExecResult::failure(2, "diff: missing first file"),
+            Err(e) => return ExecResult::failure(1, format!("diff: {e}")),
         };
 
-        let file2 = match args.get_string("file2", 1) {
-            Some(f) => f,
-            None => return ExecResult::failure(2, "diff: missing second file"),
+        let file2 = match get_path_string(&args, "file2", 1) {
+            Ok(Some(f)) => f,
+            Ok(None) => return ExecResult::failure(2, "diff: missing second file"),
+            Err(e) => return ExecResult::failure(1, format!("diff: {e}")),
         };
 
         let path1 = ctx.resolve_path(&file1);

--- a/crates/kaish-kernel/src/tools/builtin/dirname.rs
+++ b/crates/kaish-kernel/src/tools/builtin/dirname.rs
@@ -58,7 +58,10 @@ impl Tool for Dirname {
         // POSIX: `dirname a/b c/d` prints one parent per line.
         let mut output = String::new();
         for value in &args.positional {
-            let path_str = crate::interpreter::value_to_string(value);
+            let path_str = match crate::interpreter::value_to_text_sink_named(value, "a path") {
+                Ok(p) => p,
+                Err(e) => return ExecResult::failure(1, format!("dirname: {e}")),
+            };
             // POSIX: a path consisting entirely of slashes (e.g. `//`, `///`)
             // has itself as its own dirname — just like `/`. `Path::parent()`
             // returns `None` for such paths, so we special-case before using it.

--- a/crates/kaish-kernel/src/tools/builtin/env.rs
+++ b/crates/kaish-kernel/src/tools/builtin/env.rs
@@ -284,8 +284,19 @@ async fn execute_with_env(
         if let Some(msg) = crate::interpreter::structured_export_error(&exported) {
             return ExecResult::failure(1, msg);
         }
+        // Binary can't cross the process boundary as an env var value either
+        // — loud, not the `[binary: N bytes]` placeholder (kept in sync with
+        // kernel.rs::try_execute_external and dispatch.rs::try_external).
         for (name, value) in exported {
-            cmd.env(&name, value_to_string(&value));
+            match crate::interpreter::value_to_text_sink_named(
+                &value,
+                "an exported environment variable value",
+            ) {
+                Ok(s) => {
+                    cmd.env(&name, s);
+                }
+                Err(e) => return ExecResult::failure(1, format!("env: {e}")),
+            }
         }
     }
 

--- a/crates/kaish-kernel/src/tools/builtin/exec.rs
+++ b/crates/kaish-kernel/src/tools/builtin/exec.rs
@@ -107,13 +107,19 @@ impl Tool for Exec {
         // can't cross the process boundary as an argv element — refuse rather
         // than the previous silent JSON stringify (via `value_to_string`).
         // exec consumes typed Values directly (no `build_args_flat`), so the
-        // guard lives here at exec's own edge.
+        // guard lives here at exec's own edge. Binary gets the same treatment
+        // as `build_args_flat`'s argv (text sink, loud rather than the
+        // `[binary: N bytes]` placeholder) — exec's argv crosses the same
+        // process boundary as any other external command's.
         let mut argv: Vec<String> = Vec::with_capacity(args.positional.len().saturating_sub(1));
         for v in args.positional.iter().skip(1) {
             if let Some(msg) = crate::interpreter::structured_boundary_error("a command argument", v) {
                 return ExecResult::failure(1, format!("exec: {msg}"));
             }
-            argv.push(value_to_string(v));
+            match crate::interpreter::value_to_text_sink(v) {
+                Ok(s) => argv.push(s),
+                Err(e) => return ExecResult::failure(1, format!("exec: {e}")),
+            }
         }
 
         // Platform-specific: Unix replaces the process, others error

--- a/crates/kaish-kernel/src/tools/builtin/exec.rs
+++ b/crates/kaish-kernel/src/tools/builtin/exec.rs
@@ -19,6 +19,7 @@ use clap::{CommandFactory, Parser};
 
 use crate::ast::Value;
 use crate::interpreter::ExecResult;
+use crate::tools::builtin::get_path_string;
 use crate::tools::{schema_from_clap, ExecContext, ToolCtx, GlobalFlags, Tool, ToolArgs, ToolSchema};
 
 use super::spawn::resolve_in_path;
@@ -76,10 +77,14 @@ impl Tool for Exec {
                 "exec: external commands are disabled (allow_external_commands=false)");
         }
 
-        // First positional is the command, rest are argv
-        let command_name = match args.get_string("command", 0) {
-            Some(cmd) => cmd,
-            None => return ExecResult::failure(1, "exec: missing command"),
+        // First positional is the command, rest are argv. A binary command
+        // name goes loud rather than `get_string`'s silent `None` (which would
+        // misreport it as "exec: missing command"); exec's argv loop below is
+        // already guarded, but the command word itself slipped through.
+        let command_name = match get_path_string(&args, "command", 0) {
+            Ok(Some(cmd)) => cmd,
+            Ok(None) => return ExecResult::failure(1, "exec: missing command"),
+            Err(e) => return ExecResult::failure(1, format!("exec: {e}")),
         };
 
         // Resolve command path

--- a/crates/kaish-kernel/src/tools/builtin/find.rs
+++ b/crates/kaish-kernel/src/tools/builtin/find.rs
@@ -117,10 +117,10 @@ impl Tool for Find {
         let start_paths: Vec<String> = if args.positional.is_empty() {
             vec![".".to_string()]
         } else {
-            args.positional
-                .iter()
-                .map(crate::interpreter::value_to_string)
-                .collect()
+            match crate::interpreter::values_to_text_sink_named(&args.positional, "a path") {
+                Ok(p) => p,
+                Err(e) => return ExecResult::failure(1, format!("find: {e}")),
+            }
         };
 
         // Parse predicates from the parsed clap struct (kebab-case, authoritative).

--- a/crates/kaish-kernel/src/tools/builtin/grep.rs
+++ b/crates/kaish-kernel/src/tools/builtin/grep.rs
@@ -387,12 +387,11 @@ impl Tool for Grep {
             // expand, which is the only thing anyone means by it. A missing or
             // otherwise-unstattable operand falls to the walker, preserving the
             // pre-#105 behavior for a bad root.
-            let operands: Vec<String> = args
-                .positional
-                .iter()
-                .skip(1)
-                .map(crate::interpreter::value_to_string)
-                .collect();
+            let operands: Vec<String> =
+                match crate::interpreter::values_to_text_sink_named(&args.positional[1..], "a path") {
+                    Ok(p) => p,
+                    Err(e) => return ExecResult::failure(1, format!("grep: {e}")),
+                };
             let operands = if operands.is_empty() {
                 vec![".".to_string()]
             } else {
@@ -488,12 +487,11 @@ impl Tool for Grep {
         // Search ALL of them (the old single `get_string("path", 1)` searched
         // only the first and silently ignored the rest), reusing the
         // filename-prefixing multi-file renderer.
-        let file_operands: Vec<String> = args
-            .positional
-            .iter()
-            .skip(1)
-            .map(crate::interpreter::value_to_string)
-            .collect();
+        let file_operands: Vec<String> =
+            match crate::interpreter::values_to_text_sink_named(&args.positional[1..], "a path") {
+                Ok(p) => p,
+                Err(e) => return ExecResult::failure(1, format!("grep: {e}")),
+            };
         if file_operands.len() > 1 {
             let root = ctx.resolve_path(".");
             let resolved: Vec<PathBuf> = file_operands

--- a/crates/kaish-kernel/src/tools/builtin/jq_native.rs
+++ b/crates/kaish-kernel/src/tools/builtin/jq_native.rs
@@ -27,6 +27,7 @@ use jaq_std::ValT as _;
 
 use crate::ast::Value;
 use crate::interpreter::{ExecResult, OutputData};
+use crate::tools::builtin::get_path_string;
 use crate::tools::{schema_from_clap, validate_against_schema, ExecContext, ToolCtx, GlobalFlags, ParamSchema, Tool, ToolArgs, ToolSchema};
 use crate::validator::{IssueCode, ValidationIssue};
 
@@ -554,58 +555,57 @@ impl Tool for JqNative {
         // pre-parsed structured data, then file, then stdin text.
         let input_json: serde_json::Value = if null_input {
             serde_json::Value::Null
-        } else if let Some(path) = args.get_string("path", 1) {
-            if !path.is_empty() {
-                // Read from backend - path takes precedence over stdin
-                let resolved = ctx.resolve_path(&path);
-                match ctx.backend.read(Path::new(&resolved), None).await {
-                    Ok(bytes) => {
-                        // Decode strictly: a non-UTF-8 file is a loud error, not
-                        // a U+FFFD mangle that then fails JSON parsing confusingly.
-                        let text = match String::from_utf8(bytes) {
-                            Ok(t) => t,
-                            Err(_) => {
-                                return ExecResult::failure(
-                                    1,
-                                    format!("jq: {}: invalid UTF-8", path),
-                                )
-                            }
-                        };
-                        if slurp {
-                            match parse_document_stream(&text) {
-                                Ok(docs) => serde_json::Value::Array(docs),
-                                Err(e) => {
-                                    return ExecResult::failure(1, format!("jq: -s: {}: {}", path, e))
-                                }
-                            }
-                        } else {
-                            match serde_json::from_str(&text) {
-                                Ok(json) => json,
-                                Err(e) => {
-                                    let hint =
-                                        jsonl_hint_for_trailing_error(&text, &e).unwrap_or_default();
+        } else {
+            // A binary `path` operand goes loud rather than silently falling
+            // through to the stdin branches below.
+            match get_path_string(&args, "path", 1) {
+                Ok(Some(path)) if !path.is_empty() => {
+                    // Read from backend - path takes precedence over stdin
+                    let resolved = ctx.resolve_path(&path);
+                    match ctx.backend.read(Path::new(&resolved), None).await {
+                        Ok(bytes) => {
+                            // Decode strictly: a non-UTF-8 file is a loud error, not
+                            // a U+FFFD mangle that then fails JSON parsing confusingly.
+                            let text = match String::from_utf8(bytes) {
+                                Ok(t) => t,
+                                Err(_) => {
                                     return ExecResult::failure(
                                         1,
-                                        format!("jq: invalid JSON in {}: {}{}", path, e, hint),
-                                    );
+                                        format!("jq: {}: invalid UTF-8", path),
+                                    )
+                                }
+                            };
+                            if slurp {
+                                match parse_document_stream(&text) {
+                                    Ok(docs) => serde_json::Value::Array(docs),
+                                    Err(e) => {
+                                        return ExecResult::failure(1, format!("jq: -s: {}: {}", path, e))
+                                    }
+                                }
+                            } else {
+                                match serde_json::from_str(&text) {
+                                    Ok(json) => json,
+                                    Err(e) => {
+                                        let hint =
+                                            jsonl_hint_for_trailing_error(&text, &e).unwrap_or_default();
+                                        return ExecResult::failure(
+                                            1,
+                                            format!("jq: invalid JSON in {}: {}{}", path, e, hint),
+                                        );
+                                    }
                                 }
                             }
                         }
-                    }
-                    Err(e) => {
-                        return ExecResult::failure(1, format!("jq: failed to read {}: {}", path, e))
+                        Err(e) => {
+                            return ExecResult::failure(1, format!("jq: failed to read {}: {}", path, e))
+                        }
                     }
                 }
-            } else {
-                match resolve_stdin_json(ctx, slurp).await {
+                Ok(_) => match resolve_stdin_json(ctx, slurp).await {
                     Ok(json) => json,
                     Err((code, msg)) => return ExecResult::failure(code, msg),
-                }
-            }
-        } else {
-            match resolve_stdin_json(ctx, slurp).await {
-                Ok(json) => json,
-                Err((code, msg)) => return ExecResult::failure(code, msg),
+                },
+                Err(e) => return ExecResult::failure(1, format!("jq: {e}")),
             }
         };
 

--- a/crates/kaish-kernel/src/tools/builtin/ln.rs
+++ b/crates/kaish-kernel/src/tools/builtin/ln.rs
@@ -8,6 +8,7 @@ use clap::{CommandFactory, Parser};
 use std::path::Path;
 
 use crate::interpreter::ExecResult;
+use crate::tools::builtin::get_path_string;
 use crate::tools::{schema_from_clap, ExecContext, ToolCtx, GlobalFlags, Tool, ToolArgs, ToolSchema};
 
 /// Ln tool: create symbolic links.
@@ -62,14 +63,16 @@ impl Tool for Ln {
         };
         parsed.global.apply(ctx);
 
-        let target = match args.get_string("target", 0) {
-            Some(t) => t,
-            None => return ExecResult::failure(1, "ln: missing target argument"),
+        let target = match get_path_string(&args, "target", 0) {
+            Ok(Some(t)) => t,
+            Ok(None) => return ExecResult::failure(1, "ln: missing target argument"),
+            Err(e) => return ExecResult::failure(1, format!("ln: {e}")),
         };
 
-        let link_name = match args.get_string("link_name", 1) {
-            Some(l) => l,
-            None => return ExecResult::failure(1, "ln: missing link_name argument"),
+        let link_name = match get_path_string(&args, "link_name", 1) {
+            Ok(Some(l)) => l,
+            Ok(None) => return ExecResult::failure(1, "ln: missing link_name argument"),
+            Err(e) => return ExecResult::failure(1, format!("ln: {e}")),
         };
 
         let symbolic = parsed.symbolic;

--- a/crates/kaish-kernel/src/tools/builtin/ls.rs
+++ b/crates/kaish-kernel/src/tools/builtin/ls.rs
@@ -135,11 +135,11 @@ impl Tool for Ls {
         // into one positional per match, so a multi-element list is the norm
         // for `ls *.rs` / `ls a b c`. The old `get_string("path", 0)` read
         // only the first and silently dropped the rest.
-        let mut paths: Vec<String> = args
-            .positional
-            .iter()
-            .map(crate::interpreter::value_to_string)
-            .collect();
+        let mut paths: Vec<String> =
+            match crate::interpreter::values_to_text_sink_named(&args.positional, "a path") {
+                Ok(p) => p,
+                Err(e) => return ExecResult::failure(1, format!("ls: {e}")),
+            };
         if paths.is_empty() {
             paths.push(".".to_string());
         }

--- a/crates/kaish-kernel/src/tools/builtin/mkdir.rs
+++ b/crates/kaish-kernel/src/tools/builtin/mkdir.rs
@@ -64,7 +64,10 @@ impl Tool for Mkdir {
         // every failure rather than just the first; exit non-zero if any failed.
         let mut last_err: Option<String> = None;
         for value in &args.positional {
-            let path = crate::interpreter::value_to_string(value);
+            let path = match crate::interpreter::value_to_text_sink_named(value, "a path") {
+                Ok(p) => p,
+                Err(e) => return ExecResult::failure(1, format!("mkdir: {e}")),
+            };
             let resolved = ctx.resolve_path(&path);
             if let Err(e) = ctx.backend.mkdir(Path::new(&resolved)).await {
                 last_err = Some(format!("mkdir: {}: {}", path, e));

--- a/crates/kaish-kernel/src/tools/builtin/mod.rs
+++ b/crates/kaish-kernel/src/tools/builtin/mod.rs
@@ -134,6 +134,33 @@ pub(crate) fn read_repeatable_strings(args: &super::ToolArgs, key: &str) -> Vec<
     }
 }
 
+/// Read a path-typed positional/named arg as a string, going LOUD on a
+/// `Value::Bytes` operand rather than `ToolArgs::get_string`'s silent `None`
+/// (that method lives in the `kaish-types` leaf crate, which has no
+/// `EvalError`/rich-error machinery to report *why* it returned nothing, so it
+/// just treats any non-scalar-text value as absent).
+///
+/// A caller reading `get_string` for a *path* generally treats `None` as
+/// "operand missing" and either errors or falls back to some other input
+/// (stdin, `$HOME`, …) — exactly the silent-wrong-source shape GH #93 item 1
+/// is about, just reached through `get_string`'s catch-all instead of
+/// `value_to_string`'s placeholder. `Ok(None)` here means genuinely absent;
+/// `Err` means it was present and binary.
+pub(crate) fn get_path_string(
+    args: &super::ToolArgs,
+    name: &str,
+    positional_index: usize,
+) -> Result<Option<String>, String> {
+    use crate::ast::Value;
+    match args.get(name, positional_index) {
+        Some(v @ Value::Bytes(_)) => match crate::interpreter::value_to_text_sink_named(v, "a path") {
+            Ok(s) => Ok(Some(s)),
+            Err(e) => Err(e.to_string()),
+        },
+        _ => Ok(args.get_string(name, positional_index)),
+    }
+}
+
 /// Register all built-in tools with the registry.
 pub fn register_builtins(registry: &mut ToolRegistry) {
     registry.register(alias::Alias);

--- a/crates/kaish-kernel/src/tools/builtin/mv.rs
+++ b/crates/kaish-kernel/src/tools/builtin/mv.rs
@@ -68,7 +68,14 @@ impl Tool for Mv {
             Some((last, rest)) if !rest.is_empty() => (rest, last),
             _ => return ExecResult::failure(1, "mv: missing file operand (need source and destination)"),
         };
-        let dest = crate::interpreter::value_to_string(dest_value);
+        let dest = match crate::interpreter::value_to_text_sink_named(dest_value, "a path") {
+            Ok(d) => d,
+            Err(e) => return ExecResult::failure(1, format!("mv: {e}")),
+        };
+        let sources = match crate::interpreter::values_to_text_sink_named(sources, "a path") {
+            Ok(s) => s,
+            Err(e) => return ExecResult::failure(1, format!("mv: {e}")),
+        };
         let dst_path = ctx.resolve_path(&dest);
 
         // Multiple sources require destination to be an existing directory.
@@ -101,7 +108,7 @@ impl Tool for Mv {
                 .map(|info| !info.is_dir())
                 .unwrap_or(false);
             if dst_is_existing_file {
-                let src_display = crate::interpreter::value_to_string(&sources[0]);
+                let src_display = &sources[0];
                 if let Err(blocked) = ctx
                     .gate_overwrites("mv", &[(dest.clone(), false)], parsed.confirm.as_deref(), |nonce, joined| {
                         format!("mv --confirm=\"{nonce}\" {src_display} {joined}")
@@ -114,9 +121,8 @@ impl Tool for Mv {
         }
 
         let mut last_err: Option<String> = None;
-        for src_value in sources {
-            let source = crate::interpreter::value_to_string(src_value);
-            let src_path = ctx.resolve_path(&source);
+        for source in &sources {
+            let src_path = ctx.resolve_path(source);
             if let Err(e) = move_path(&*ctx.backend, &src_path, &dst_path, no_clobber).await {
                 last_err = Some(format!("mv: {}: {}", source, e));
             }

--- a/crates/kaish-kernel/src/tools/builtin/patch.rs
+++ b/crates/kaish-kernel/src/tools/builtin/patch.rs
@@ -17,6 +17,7 @@ use std::path::Path;
 use crate::ast::Value;
 use crate::backend::PatchOp;
 use crate::interpreter::{ExecResult, OutputData};
+use crate::tools::builtin::get_path_string;
 use crate::tools::{schema_from_clap, ExecContext, ToolCtx, GlobalFlags, Tool, ToolArgs, ToolSchema};
 
 /// Patch tool: applies unified diffs to files.
@@ -119,7 +120,17 @@ impl Tool for Patch {
 
         let reverse = parsed.reverse || args.has_flag("R");
         let dry_run = parsed.dry_run || args.has_flag("dry-run");
-        let explicit_file = parsed.file.clone().or_else(|| args.get_string("file", 0));
+        // Read the untouched typed value FIRST (not `parsed.file`) — clap's
+        // own field comes from `to_argv()`'s re-serialization, the same lossy
+        // stringify boundary this PR closes elsewhere, so checking it first
+        // would silently defeat the guard below. A binary `--file`/positional
+        // override goes loud rather than silently falling back to deriving
+        // target paths from the diff hunks.
+        let explicit_file = match get_path_string(&args, "file", 0) {
+            Ok(Some(f)) => Some(f),
+            Ok(None) => parsed.file.clone(),
+            Err(e) => return ExecResult::failure(1, format!("patch: {e}")),
+        };
 
         // Parse the unified diff
         let hunks = match parse_unified_diff(&patch_content) {

--- a/crates/kaish-kernel/src/tools/builtin/printf.rs
+++ b/crates/kaish-kernel/src/tools/builtin/printf.rs
@@ -95,9 +95,22 @@ impl Tool for Printf {
         };
         parsed.global.apply(ctx);
 
-        let format = match args.get_string("format", 0) {
-            Some(f) => f,
-            None => return ExecResult::failure(1, "printf: missing format argument"),
+        // The format is a text sink like the operands below: a binary
+        // (non-UTF-8) format string goes loud rather than `get_string`'s
+        // silent `None` (which would misreport it as "missing format
+        // argument"). Read the value first so a `Value::Bytes` is caught
+        // before it degrades to `None`.
+        let format = match args.get("format", 0) {
+            Some(v @ Value::Bytes(_)) => {
+                match crate::interpreter::value_to_text_sink_named(v, "a printf format string") {
+                    Ok(f) => f,
+                    Err(e) => return ExecResult::failure(1, format!("printf: {e}")),
+                }
+            }
+            _ => match args.get_string("format", 0) {
+                Some(f) => f,
+                None => return ExecResult::failure(1, "printf: missing format argument"),
+            },
         };
 
         let format_args: Vec<&Value> = args.positional.iter().skip(1).collect();

--- a/crates/kaish-kernel/src/tools/builtin/readlink.rs
+++ b/crates/kaish-kernel/src/tools/builtin/readlink.rs
@@ -71,7 +71,10 @@ impl Tool for Readlink {
         let mut exit_code = 0i64;
 
         for value in &args.positional {
-            let path_str = crate::interpreter::value_to_string(value);
+            let path_str = match crate::interpreter::value_to_text_sink_named(value, "a path") {
+                Ok(p) => p,
+                Err(e) => return ExecResult::failure(1, format!("readlink: {e}")),
+            };
             let resolved = ctx.resolve_path(&path_str);
 
             if canonicalize {

--- a/crates/kaish-kernel/src/tools/builtin/realpath.rs
+++ b/crates/kaish-kernel/src/tools/builtin/realpath.rs
@@ -65,7 +65,10 @@ impl Tool for Realpath {
         let mut last_err: Option<String> = None;
 
         for value in &args.positional {
-            let path_str = crate::interpreter::value_to_string(value);
+            let path_str = match crate::interpreter::value_to_text_sink_named(value, "a path") {
+                Ok(p) => p,
+                Err(e) => return ExecResult::failure(1, format!("realpath: {e}")),
+            };
             let resolved = ctx.resolve_path(&path_str);
 
             match canonicalize_path_full(ctx, &resolved).await {

--- a/crates/kaish-kernel/src/tools/builtin/rm.rs
+++ b/crates/kaish-kernel/src/tools/builtin/rm.rs
@@ -160,7 +160,10 @@ impl Tool for Rm {
         }
         let mut decisions: Vec<Decision> = Vec::with_capacity(args.positional.len());
         for value in &args.positional {
-            let path = crate::interpreter::value_to_string(value);
+            let path = match crate::interpreter::value_to_text_sink_named(value, "a path") {
+                Ok(p) => p,
+                Err(e) => return ExecResult::failure(1, format!("rm: {e}")),
+            };
             let resolved = ctx.resolve_path(&path);
             // lstat, never stat: classify the link itself, so a symlink-to-dir
             // is treated as a (non-dir) symlink rather than its target. This is

--- a/crates/kaish-kernel/src/tools/builtin/sed.rs
+++ b/crates/kaish-kernel/src/tools/builtin/sed.rs
@@ -13,6 +13,7 @@ use std::path::Path;
 
 use crate::ast::Value;
 use crate::backend::PatchOp;
+use crate::tools::builtin::get_path_string;
 use crate::tools::builtin::regex_dialect::{append_dialect_hint, bre_metas_to_ere};
 use crate::interpreter::{ExecResult, OutputData};
 use crate::tools::{schema_from_clap, validate_against_schema, ExecContext, ToolCtx, GlobalFlags, Tool, ToolArgs, ToolSchema};
@@ -275,9 +276,11 @@ impl Tool for Sed {
             };
         }
 
-        // Streaming mode: read one file (or stdin) and write to stdout.
-        let input = match args.get_string("path", file_pos) {
-            Some(path) => {
+        // Streaming mode: read one file (or stdin) and write to stdout. A
+        // binary `path` operand goes loud rather than silently falling
+        // through to the stdin branch below.
+        let input = match get_path_string(&args, "path", file_pos) {
+            Ok(Some(path)) => {
                 let resolved = ctx.resolve_path(&path);
                 match ctx.backend.read(Path::new(&resolved), None).await {
                     Ok(data) => match String::from_utf8(data) {
@@ -289,10 +292,11 @@ impl Tool for Sed {
                     Err(e) => return ExecResult::failure(1, format!("sed: {}: {}", path, e)),
                 }
             }
-            None => match ctx.read_stdin_to_text().await {
+            Ok(None) => match ctx.read_stdin_to_text().await {
                 Ok(s) => s.unwrap_or_default(),
                 Err(e) => return ExecResult::failure(2, format!("sed: {e}")),
             },
+            Err(e) => return ExecResult::failure(1, format!("sed: {e}")),
         };
 
         // Execute

--- a/crates/kaish-kernel/src/tools/builtin/sed.rs
+++ b/crates/kaish-kernel/src/tools/builtin/sed.rs
@@ -200,12 +200,11 @@ impl Tool for Sed {
         // it routes through the same latch+trash gate as tee/patch. Editing a
         // stream in place is meaningless, so no operands is a loud error.
         if in_place {
-            let files: Vec<String> = args
-                .positional
-                .iter()
-                .skip(file_pos)
-                .map(crate::interpreter::value_to_string)
-                .collect();
+            let operands = args.positional.get(file_pos..).unwrap_or(&[]);
+            let files: Vec<String> = match crate::interpreter::values_to_text_sink_named(operands, "a path") {
+                Ok(f) => f,
+                Err(e) => return ExecResult::failure(1, format!("sed: {e}")),
+            };
             if files.is_empty() {
                 return ExecResult::failure(
                     1,

--- a/crates/kaish-kernel/src/tools/builtin/sort.rs
+++ b/crates/kaish-kernel/src/tools/builtin/sort.rs
@@ -97,7 +97,10 @@ impl Tool for Sort {
         } else {
             let mut acc = String::new();
             for value in &args.positional {
-                let path = crate::interpreter::value_to_string(value);
+                let path = match crate::interpreter::value_to_text_sink_named(value, "a path") {
+                    Ok(p) => p,
+                    Err(e) => return ExecResult::failure(1, format!("sort: {e}")),
+                };
                 let resolved = ctx.resolve_path(&path);
                 match ctx.backend.read(Path::new(&resolved), None).await {
                     Ok(data) => match String::from_utf8(data) {

--- a/crates/kaish-kernel/src/tools/builtin/spawn.rs
+++ b/crates/kaish-kernel/src/tools/builtin/spawn.rs
@@ -22,6 +22,7 @@ use tokio::process::Command;
 
 use crate::ast::Value;
 use crate::interpreter::ExecResult;
+use crate::tools::builtin::get_path_string;
 use crate::tools::{schema_from_clap, ExecContext, ToolCtx, GlobalFlags, Tool, ToolArgs, ToolSchema};
 
 /// Spawn tool: runs an external command as a subprocess and captures output.
@@ -99,10 +100,12 @@ impl Tool for Spawn {
                 "spawn: external commands are disabled (allow_external_commands=false)");
         }
 
-        // Get command (required)
-        let command_name = match args.get_string("command", 0) {
-            Some(cmd) => cmd,
-            None => return ExecResult::failure(1, "spawn: command parameter required"),
+        // Get command (required). A binary value goes loud rather than
+        // silently being treated as "not given".
+        let command_name = match get_path_string(&args, "command", 0) {
+            Ok(Some(cmd)) => cmd,
+            Ok(None) => return ExecResult::failure(1, "spawn: command parameter required"),
+            Err(e) => return ExecResult::failure(1, format!("spawn: {e}")),
         };
 
         // Resolve command path (PATH lookup if not absolute)
@@ -140,8 +143,12 @@ impl Tool for Spawn {
             .map(extract_string_object)
             .unwrap_or_default();
 
-        // Get cwd (optional)
-        let cwd = args.get_string("cwd", usize::MAX);
+        // Get cwd (optional). A binary value goes loud rather than silently
+        // being treated as "no cwd override".
+        let cwd = match get_path_string(&args, "cwd", usize::MAX) {
+            Ok(c) => c,
+            Err(e) => return ExecResult::failure(1, format!("spawn: {e}")),
+        };
 
         // Get timeout (optional, in milliseconds)
         let timeout_ms: Option<u64> = args

--- a/crates/kaish-kernel/src/tools/builtin/stat.rs
+++ b/crates/kaish-kernel/src/tools/builtin/stat.rs
@@ -71,7 +71,10 @@ impl Tool for Stat {
         let mut last_err: Option<String> = None;
 
         for value in &args.positional {
-            let path_str = crate::interpreter::value_to_string(value);
+            let path_str = match crate::interpreter::value_to_text_sink_named(value, "a path") {
+                Ok(p) => p,
+                Err(e) => return ExecResult::failure(1, format!("stat: {e}")),
+            };
             let resolved = ctx.resolve_path(&path_str);
             match ctx.backend.stat(Path::new(&resolved)).await {
                 Ok(info) => {

--- a/crates/kaish-kernel/src/tools/builtin/tee.rs
+++ b/crates/kaish-kernel/src/tools/builtin/tee.rs
@@ -66,15 +66,18 @@ impl Tool for Tee {
 
         let append = args.has_flag("append") || args.has_flag("a");
 
+        // Resolve every operand to a path once, up front — binary goes loud
+        // rather than becoming a file literally named `[binary: N bytes]`.
+        let paths = match crate::interpreter::values_to_text_sink_named(&args.positional, "a path") {
+            Ok(p) => p,
+            Err(e) => return ExecResult::failure(1, format!("tee: {e}")),
+        };
+
         // Gate truncating overwrites through latch + trash (no-op when both are
         // off). Append never gates (it doesn't destroy prior content); a new
         // file just writes. On latch this returns an exit-2 nonce result; under
         // trash the prior content is snapshotted before we write below.
-        let targets: Vec<(String, bool)> = args
-            .positional
-            .iter()
-            .map(|v| (crate::interpreter::value_to_string(v), append))
-            .collect();
+        let targets: Vec<(String, bool)> = paths.iter().map(|p| (p.clone(), append)).collect();
         let snapshots = match ctx
             .gate_overwrites("tee", &targets, parsed.confirm.as_deref(), |nonce, joined| {
                 format!("tee --confirm=\"{nonce}\" {joined}")
@@ -93,9 +96,8 @@ impl Tool for Tee {
         // per-file errors (matches POSIX `tee` semantics) and report every
         // failure so the agent sees the full picture, not just the last one.
         let mut errors: Vec<String> = Vec::new();
-        for value in &args.positional {
-            let path_str = crate::interpreter::value_to_string(value);
-            let resolved = ctx.resolve_path(&path_str);
+        for path_str in &paths {
+            let resolved = ctx.resolve_path(path_str);
             let path = Path::new(&resolved);
 
             // Overwrite writes the borrowed input directly (no clone); append

--- a/crates/kaish-kernel/src/tools/builtin/test.rs
+++ b/crates/kaish-kernel/src/tools/builtin/test.rs
@@ -25,8 +25,8 @@ use clap::{CommandFactory, Parser};
 use kaish_types::Value;
 
 use crate::interpreter::{
-    is_collection, numeric_compare, scalar_test_operand_error, value_to_string, values_equal,
-    ExecResult,
+    is_collection, numeric_compare, scalar_test_operand_error, value_to_string,
+    value_to_text_sink_named, values_equal, ExecResult,
 };
 use crate::tools::{schema_from_clap, ExecContext, GlobalFlags, Tool, ToolArgs, ToolCtx, ToolSchema};
 
@@ -183,7 +183,11 @@ async fn apply_unary(ctx: &ExecContext, op: &str, operand: &Value) -> Result<boo
         "-z" => Ok(value_to_string(operand).is_empty()),
         "-n" => Ok(!value_to_string(operand).is_empty()),
         "-e" | "-f" | "-d" | "-r" | "-w" | "-x" => {
-            Ok(file_test(ctx, op, &value_to_string(operand)).await)
+            // A binary operand goes loud rather than silently stat'ing a file
+            // literally named `[binary: N bytes]` — mirrors `[[`'s `FileTest`
+            // arm (kernel.rs::eval_test_async) so the two evaluators agree.
+            let path = value_to_text_sink_named(operand, "a path").map_err(|e| format!("test: {e}"))?;
+            Ok(file_test(ctx, op, &path).await)
         }
         _ => unreachable!("apply_unary called with non-unary op {op:?}"),
     }

--- a/crates/kaish-kernel/src/tools/builtin/touch.rs
+++ b/crates/kaish-kernel/src/tools/builtin/touch.rs
@@ -61,7 +61,10 @@ impl Tool for Touch {
         // the last failure rather than bailing at the first.
         let mut last_err: Option<String> = None;
         for value in &args.positional {
-            let path_str = crate::interpreter::value_to_string(value);
+            let path_str = match crate::interpreter::value_to_text_sink_named(value, "a path") {
+                Ok(p) => p,
+                Err(e) => return ExecResult::failure(1, format!("touch: {e}")),
+            };
             let resolved = ctx.resolve_path(&path_str);
             let path = Path::new(&resolved);
 

--- a/crates/kaish-kernel/src/tools/builtin/tree.rs
+++ b/crates/kaish-kernel/src/tools/builtin/tree.rs
@@ -7,6 +7,7 @@ use std::path::Path;
 
 use crate::ast::Value;
 use crate::interpreter::{EntryType, ExecResult, OutputData, OutputNode};
+use crate::tools::builtin::get_path_string;
 use crate::tools::{schema_from_clap, ExecContext, ToolCtx, GlobalFlags, Tool, ToolArgs, ToolSchema};
 
 /// Tree tool: display directory structure.
@@ -176,9 +177,12 @@ impl Tool for Tree {
         };
         parsed.global.apply(ctx);
 
-        let path = args
-            .get_string("path", 0)
-            .unwrap_or_else(|| ".".to_string());
+        // A binary `path` operand goes loud rather than silently defaulting to
+        // "." (the "no operand given" case).
+        let path = match get_path_string(&args, "path", 0) {
+            Ok(p) => p.unwrap_or_else(|| ".".to_string()),
+            Err(e) => return ExecResult::failure(1, format!("tree: {e}")),
+        };
 
         let resolved = ctx.resolve_path(&path).to_string_lossy().to_string();
 

--- a/crates/kaish-kernel/src/tools/builtin/uniq.rs
+++ b/crates/kaish-kernel/src/tools/builtin/uniq.rs
@@ -5,6 +5,7 @@ use clap::{CommandFactory, Parser};
 use std::path::Path;
 
 use crate::interpreter::{ExecResult, OutputData};
+use crate::tools::builtin::get_path_string;
 use crate::tools::{schema_from_clap, ExecContext, ToolCtx, GlobalFlags, Tool, ToolArgs, ToolSchema};
 
 /// Uniq tool: report or filter out repeated adjacent lines.
@@ -67,9 +68,10 @@ impl Tool for Uniq {
         };
         parsed.global.apply(ctx);
 
-        // Get input: from file or stdin
-        let input = match args.get_string("path", 0) {
-            Some(path) => {
+        // Get input: from file or stdin. A binary `path` operand goes loud
+        // rather than silently falling through to the stdin branch below.
+        let input = match get_path_string(&args, "path", 0) {
+            Ok(Some(path)) => {
                 let resolved = ctx.resolve_path(&path);
                 match ctx.backend.read(Path::new(&resolved), None).await {
                     Ok(data) => match String::from_utf8(data) {
@@ -84,10 +86,11 @@ impl Tool for Uniq {
                     Err(e) => return ExecResult::failure(1, format!("uniq: {}: {}", path, e)),
                 }
             }
-            None => match ctx.read_stdin_to_text().await {
+            Ok(None) => match ctx.read_stdin_to_text().await {
                 Ok(s) => s.unwrap_or_default(),
                 Err(e) => return ExecResult::failure(2, format!("uniq: {e}")),
             },
+            Err(e) => return ExecResult::failure(1, format!("uniq: {e}")),
         };
 
         let show_count = parsed.count;

--- a/crates/kaish-kernel/src/tools/builtin/validate.rs
+++ b/crates/kaish-kernel/src/tools/builtin/validate.rs
@@ -15,6 +15,7 @@ use std::path::Path;
 use crate::ast::ToolDef;
 use crate::interpreter::{ExecResult, OutputData};
 use crate::parser::parse;
+use crate::tools::builtin::get_path_string;
 use crate::tools::{schema_from_clap, ExecContext, ToolCtx, GlobalFlags, Tool, ToolArgs, ToolSchema};
 use crate::validator::{Severity, Validator};
 
@@ -87,24 +88,31 @@ impl Tool for Validate {
         // parsed clap field, not the raw flag map.
         let show_warnings = parsed.warnings;
 
-        // Get input: from file, -e expression, or stdin
+        // Get input: from file, -e expression, or stdin. A binary `path`
+        // operand goes loud rather than silently falling through to stdin.
         let (source, label) = if let Some(expr) = args.get_string("expr", usize::MAX) {
             (expr, "<expr>".to_string())
-        } else if let Some(path) = args.get_string("path", 0) {
-            let resolved = ctx.resolve_path(&path);
-            match ctx.backend.read(Path::new(&resolved), None).await {
-                Ok(data) => match String::from_utf8(data) {
-                    Ok(content) => (content, path),
-                    Err(_) => return ExecResult::failure(1, format!("kaish-validate: {}: invalid UTF-8", path)),
-                },
-                Err(e) => return ExecResult::failure(1, format!("kaish-validate: {}: {}", path, e)),
-            }
         } else {
-            // stdin (pipe or buffered — `read_stdin_to_text` prefers the pipe).
-            match ctx.read_stdin_to_text().await {
-                Ok(Some(s)) => (s, "<stdin>".to_string()),
-                Ok(None) => return ExecResult::failure(1, "kaish-validate: no input provided (use path or -e)"),
-                Err(e) => return ExecResult::failure(2, format!("kaish-validate: {e}")),
+            match get_path_string(&args, "path", 0) {
+                Ok(Some(path)) => {
+                    let resolved = ctx.resolve_path(&path);
+                    match ctx.backend.read(Path::new(&resolved), None).await {
+                        Ok(data) => match String::from_utf8(data) {
+                            Ok(content) => (content, path),
+                            Err(_) => return ExecResult::failure(1, format!("kaish-validate: {}: invalid UTF-8", path)),
+                        },
+                        Err(e) => return ExecResult::failure(1, format!("kaish-validate: {}: {}", path, e)),
+                    }
+                }
+                Ok(None) => {
+                    // stdin (pipe or buffered — `read_stdin_to_text` prefers the pipe).
+                    match ctx.read_stdin_to_text().await {
+                        Ok(Some(s)) => (s, "<stdin>".to_string()),
+                        Ok(None) => return ExecResult::failure(1, "kaish-validate: no input provided (use path or -e)"),
+                        Err(e) => return ExecResult::failure(2, format!("kaish-validate: {e}")),
+                    }
+                }
+                Err(e) => return ExecResult::failure(1, format!("kaish-validate: {e}")),
             }
         };
 

--- a/crates/kaish-kernel/src/tools/builtin/write.rs
+++ b/crates/kaish-kernel/src/tools/builtin/write.rs
@@ -6,6 +6,7 @@ use std::path::Path;
 
 use crate::ast::Value;
 use crate::interpreter::{ExecResult, OutputData};
+use crate::tools::builtin::get_path_string;
 use crate::tools::{schema_from_clap, ExecContext, ToolCtx, GlobalFlags, Tool, ToolArgs, ToolSchema};
 
 /// Write tool: write content to a file.
@@ -64,9 +65,10 @@ impl Tool for Write {
         };
         parsed.global.apply(ctx);
 
-        let path = match args.get_string("path", 0) {
-            Some(p) => p,
-            None => return ExecResult::failure(1, "write: missing path argument"),
+        let path = match get_path_string(&args, "path", 0) {
+            Ok(Some(p)) => p,
+            Ok(None) => return ExecResult::failure(1, "write: missing path argument"),
+            Err(e) => return ExecResult::failure(1, format!("write: {e}")),
         };
 
         let resolved = ctx.resolve_path(&path);

--- a/crates/kaish-kernel/src/tools/context.rs
+++ b/crates/kaish-kernel/src/tools/context.rs
@@ -1001,6 +1001,12 @@ impl ExecContext {
     /// Used by file-processing builtins (cat, head, tail, wc) that accept
     /// glob patterns in their path arguments. Non-string values are converted
     /// to strings (matching shell conventions).
+    ///
+    /// A `Value::Bytes` operand goes LOUD (GH #93 item 1) rather than being
+    /// silently dropped from the list by the old catch-all — every caller here
+    /// falls back to reading stdin (or a generic "missing path" error) when the
+    /// path list comes back empty, so a binary path used to vanish into a wrong
+    /// data source instead of erroring.
     pub async fn expand_paths(&self, positional: &[Value]) -> Result<Vec<String>, String> {
         let mut paths = Vec::new();
         for arg in positional {
@@ -1008,6 +1014,9 @@ impl ExecContext {
                 Value::String(s) => s.clone(),
                 Value::Int(n) => n.to_string(),
                 Value::Float(f) => f.to_string(),
+                Value::Bytes(_) => {
+                    crate::interpreter::value_to_text_sink_named(arg, "a path").map_err(|e| e.to_string())?
+                }
                 _ => continue,
             };
             if crate::glob::contains_glob(&s) {

--- a/crates/kaish-kernel/tests/binary_text_sink_tests.rs
+++ b/crates/kaish-kernel/tests/binary_text_sink_tests.rs
@@ -216,6 +216,210 @@ async fn env_export_of_binary_value_is_loud() {
     assert_loud_binary("b=$(cat src.bin); export BIN=$b; /bin/true").await;
 }
 
+// ── `ExecContext::expand_paths` — a second, independent path-coercion sink
+// (found via kaibo review of this PR) ──
+//
+// `cat`/`head`/`tail`/`wc`/`checksum`/`file`/`base64_tool`/`tac`/`xxd` all
+// funnel their path positionals through this one shared helper. It used to
+// silently `continue` (skip) a `Value::Bytes` operand rather than reporting
+// it — worse than the placeholder-stringify bug, since the value just
+// vanished from the list, so most of these builtins fell back to reading
+// STDIN instead of erroring on the binary path the user actually gave.
+
+#[tokio::test]
+async fn cat_binary_path_positional_is_loud() {
+    assert_loud_binary("b=$(cat src.bin); cat $b").await;
+}
+
+#[tokio::test]
+async fn head_binary_path_does_not_silently_fall_back_to_stdin() {
+    // Prove it's not just "loud" but genuinely refuses to substitute stdin:
+    // feed distinguishable stdin content and confirm it never appears.
+    let dir = tempdir().unwrap();
+    fs::write(dir.path().join("src.bin"), BIN).unwrap();
+    let kernel = kernel_at(dir.path());
+    let result = kernel
+        .execute("b=$(cat src.bin); echo from-stdin | head $b")
+        .await
+        .unwrap();
+    assert_ne!(result.code, 0, "err={}", result.err);
+    assert!(result.err.contains("cannot be used as"), "err={:?}", result.err);
+    assert!(
+        !result.text_out().contains("from-stdin"),
+        "must not silently read stdin instead of erroring on the binary path: {:?}",
+        result.text_out()
+    );
+}
+
+#[tokio::test]
+async fn wc_binary_path_positional_is_loud() {
+    assert_loud_binary("b=$(cat src.bin); wc $b").await;
+}
+
+// ── `cd`/`awk`/`basename`/`diff` — `ToolArgs::get_string`-based path reads
+// (found via the same review) ──
+//
+// `get_string` (in the `kaish-types` leaf crate) already silently returns
+// `None` for a `Value::Bytes` operand — not a corruption in itself, but each
+// of these callers treats `None` as "operand absent" and does something
+// silently wrong with a *present* binary operand: `cd` falls back to $HOME,
+// `awk` falls back to reading stdin. `basename`/`diff` already errored loudly
+// (just with a generic "missing" message); fixed for a clearer message and
+// consistency with the rest of this sweep.
+
+#[tokio::test]
+async fn cd_binary_path_does_not_silently_go_to_home() {
+    assert_loud_binary("b=$(cat src.bin); cd $b").await;
+}
+
+#[tokio::test]
+async fn awk_binary_path_does_not_silently_fall_back_to_stdin() {
+    let dir = tempdir().unwrap();
+    fs::write(dir.path().join("src.bin"), BIN).unwrap();
+    let kernel = kernel_at(dir.path());
+    let result = kernel
+        .execute(r#"b=$(cat src.bin); echo from-stdin | awk '{print}' $b"#)
+        .await
+        .unwrap();
+    assert_ne!(result.code, 0, "err={}", result.err);
+    assert!(result.err.contains("cannot be used as"), "err={:?}", result.err);
+    assert!(
+        !result.text_out().contains("from-stdin"),
+        "must not silently read stdin instead of erroring on the binary path: {:?}",
+        result.text_out()
+    );
+}
+
+#[tokio::test]
+async fn basename_binary_path_is_loud() {
+    assert_loud_binary("b=$(cat src.bin); basename $b").await;
+}
+
+#[tokio::test]
+async fn diff_binary_first_file_is_loud() {
+    assert_loud_binary("b=$(cat src.bin); diff $b src.bin").await;
+}
+
+// ── The rest of the `ToolArgs::get_string`-based path readers (same review
+// pass as `cd`/`awk` above) — `get_path_string` threaded through each ──
+
+#[tokio::test]
+async fn sed_binary_path_does_not_silently_fall_back_to_stdin() {
+    let dir = tempdir().unwrap();
+    fs::write(dir.path().join("src.bin"), BIN).unwrap();
+    let kernel = kernel_at(dir.path());
+    let result = kernel
+        .execute("b=$(cat src.bin); echo from-stdin | sed 's/a/b/' $b")
+        .await
+        .unwrap();
+    assert_ne!(result.code, 0, "err={}", result.err);
+    assert!(result.err.contains("cannot be used as"), "err={:?}", result.err);
+    assert!(
+        !result.text_out().contains("from-stdin"),
+        "must not silently read stdin instead of erroring on the binary path: {:?}",
+        result.text_out()
+    );
+}
+
+#[tokio::test]
+async fn uniq_binary_path_does_not_silently_fall_back_to_stdin() {
+    let dir = tempdir().unwrap();
+    fs::write(dir.path().join("src.bin"), BIN).unwrap();
+    let kernel = kernel_at(dir.path());
+    let result = kernel
+        .execute("b=$(cat src.bin); echo from-stdin | uniq $b")
+        .await
+        .unwrap();
+    assert_ne!(result.code, 0, "err={}", result.err);
+    assert!(result.err.contains("cannot be used as"), "err={:?}", result.err);
+    assert!(
+        !result.text_out().contains("from-stdin"),
+        "must not silently read stdin instead of erroring on the binary path: {:?}",
+        result.text_out()
+    );
+}
+
+#[tokio::test]
+async fn jq_binary_path_does_not_silently_fall_back_to_stdin() {
+    let dir = tempdir().unwrap();
+    fs::write(dir.path().join("src.bin"), BIN).unwrap();
+    let kernel = kernel_at(dir.path());
+    let result = kernel
+        .execute(r#"b=$(cat src.bin); echo '{"from":"stdin"}' | jq '.' $b"#)
+        .await
+        .unwrap();
+    assert_ne!(result.code, 0, "err={}", result.err);
+    assert!(result.err.contains("cannot be used as"), "err={:?}", result.err);
+    assert!(
+        !result.text_out().contains("stdin"),
+        "must not silently read stdin instead of erroring on the binary path: {:?}",
+        result.text_out()
+    );
+}
+
+#[tokio::test]
+async fn tree_binary_path_is_loud() {
+    assert_loud_binary("b=$(cat src.bin); tree $b").await;
+}
+
+#[tokio::test]
+async fn write_binary_path_is_loud() {
+    assert_loud_binary(r#"b=$(cat src.bin); write $b "content""#).await;
+}
+
+#[tokio::test]
+async fn ln_binary_target_is_loud() {
+    assert_loud_binary("b=$(cat src.bin); ln -s $b link.txt").await;
+}
+
+#[tokio::test]
+async fn patch_binary_file_override_is_loud() {
+    let dir = tempdir().unwrap();
+    fs::write(dir.path().join("src.bin"), BIN).unwrap();
+    let kernel = kernel_at(dir.path());
+    let result = kernel
+        .execute(r#"b=$(cat src.bin); echo "diff" | patch --file=$b"#)
+        .await
+        .unwrap();
+    assert_ne!(result.code, 0, "err={}", result.err);
+    assert!(result.err.contains("cannot be used as"), "err={:?}", result.err);
+}
+
+#[tokio::test]
+async fn validate_binary_path_does_not_silently_fall_back_to_stdin() {
+    let dir = tempdir().unwrap();
+    fs::write(dir.path().join("src.bin"), BIN).unwrap();
+    let kernel = kernel_at(dir.path());
+    let result = kernel
+        .execute("b=$(cat src.bin); echo 'echo hi' | kaish-validate $b")
+        .await
+        .unwrap();
+    assert_ne!(result.code, 0, "err={}", result.err);
+    assert!(result.err.contains("cannot be used as"), "err={:?}", result.err);
+}
+
+#[tokio::test]
+async fn checksum_binary_check_override_is_loud() {
+    assert_loud_binary("b=$(cat src.bin); checksum --check=$b").await;
+}
+
+// `spawn`'s bareword `command=value` form actually routes through the
+// (separately tracked, #116) WordAssign-reconstruction fallback rather than a
+// named arg — `--command=`/`--cwd=` is the form that reaches `ToolArgs.named`
+// untouched, which is what these two are testing.
+
+#[cfg(feature = "subprocess")]
+#[tokio::test]
+async fn spawn_binary_command_is_loud() {
+    assert_loud_binary("b=$(cat src.bin); spawn --command=$b").await;
+}
+
+#[cfg(all(target_os = "linux", feature = "subprocess"))]
+#[tokio::test]
+async fn spawn_binary_cwd_is_loud() {
+    assert_loud_binary(r#"b=$(cat src.bin); spawn --command="/bin/true" --cwd=$b"#).await;
+}
+
 /// A binary value spliced into a heredoc body. Heredocs in real scripts
 /// resolve through the async evaluator (`kernel.rs`), which already composes
 /// through the guarded `eval_string_part_async` — this locks in that the

--- a/crates/kaish-kernel/tests/binary_text_sink_tests.rs
+++ b/crates/kaish-kernel/tests/binary_text_sink_tests.rs
@@ -403,6 +403,16 @@ async fn checksum_binary_check_override_is_loud() {
     assert_loud_binary("b=$(cat src.bin); checksum --check=$b").await;
 }
 
+/// `cmp`'s two file operands used to be read off `parsed.paths` (the
+/// clap-parsed, `to_argv()`-serialized field) instead of `args.positional` —
+/// found via a third kaibo pass over this PR. A binary first operand silently
+/// became a "No such file" error for a nonexistent `[binary: N bytes]` path
+/// rather than naming the real problem.
+#[tokio::test]
+async fn cmp_binary_first_operand_is_loud() {
+    assert_loud_binary("b=$(cat src.bin); cmp $b src.bin").await;
+}
+
 // `spawn`'s bareword `command=value` form actually routes through the
 // (separately tracked, #116) WordAssign-reconstruction fallback rather than a
 // named arg — `--command=`/`--cwd=` is the form that reaches `ToolArgs.named`

--- a/crates/kaish-kernel/tests/binary_text_sink_tests.rs
+++ b/crates/kaish-kernel/tests/binary_text_sink_tests.rs
@@ -25,7 +25,13 @@ const BIN: &[u8] = b"\xff\x00\xfe\x80\x01\xc0kaish\xf5";
 
 /// Assert a script ran loud: either `execute` returned `Err`, or it returned a
 /// nonzero `ExecResult` whose error names the binary problem — and in NO case
-/// did the `[binary: N bytes]` placeholder leak into stdout.
+/// did the `[binary: N bytes]` placeholder leak into stdout OR stderr.
+///
+/// Checks for `"cannot be used as"` rather than a bare `"binary"` substring —
+/// every text-sink guard in this PR (`value_to_text_sink[_named]`) shares that
+/// exact wording, whereas a merely-coincidental "binary" (e.g. the leaked
+/// placeholder itself embedded in an unrelated "No such file or directory"
+/// message) would false-pass a bare substring check.
 async fn assert_loud_binary(script: &str) {
     let dir = tempdir().unwrap();
     fs::write(dir.path().join("src.bin"), BIN).unwrap();
@@ -34,20 +40,26 @@ async fn assert_loud_binary(script: &str) {
         Ok(r) => {
             assert_ne!(r.code, 0, "binary at a text sink must be a nonzero exit: {script:?}");
             assert!(
-                r.err.contains("binary"),
+                r.err.contains("cannot be used as"),
                 "error should name the binary problem, got err={:?} for {script:?}",
                 r.err
             );
             assert!(
-                !r.text_out().contains("[binary"),
-                "the placeholder must NOT leak to stdout: {:?}",
-                r.text_out()
+                !r.text_out().contains("[binary") && !r.err.contains("[binary"),
+                "the placeholder must NOT leak to stdout or stderr: out={:?} err={:?}",
+                r.text_out(),
+                r.err
             );
         }
         Err(e) => {
-            let msg = e.to_string();
+            // The alternate `{:#}` form walks the full `anyhow` cause chain —
+            // some paths (e.g. `Stmt::Assignment`) wrap the real cause behind
+            // a generic `.context("failed to evaluate assignment")`, so a
+            // bare `{}` would only show that wrapper and miss the actual
+            // binary-data message underneath.
+            let msg = format!("{:#}", e);
             assert!(
-                msg.contains("binary"),
+                msg.contains("cannot be used as"),
                 "execute error should name the binary problem, got {msg:?} for {script:?}"
             );
         }
@@ -106,4 +118,131 @@ async fn text_capture_bare_word_is_unaffected() {
 #[tokio::test]
 async fn bare_word_binary_into_external_argv_is_loud() {
     assert_loud_binary("b=$(cat src.bin); /bin/echo $b").await;
+}
+
+// ── Remaining text sinks (GH #93 item 1) ──
+//
+// The primary sinks above (string interpolation, bare-word external argv,
+// `echo`) were fixed in 0.11.0 via `value_to_text_sink`. These tests cover
+// the sinks that still fell through to `value_to_string`'s `[binary: N
+// bytes]` placeholder: builtin path-positional coercion, env-var export, the
+// redirect target, and the `==`/`in`/`case`-glob semantic ops.
+
+/// `mkdir`'s path-positional loop used to `value_to_string` a `Value::Bytes`
+/// operand straight into a directory name.
+#[tokio::test]
+async fn mkdir_binary_path_positional_is_loud() {
+    assert_loud_binary("b=$(cat src.bin); mkdir $b").await;
+}
+
+/// `rm`'s path-positional loop, same class as `mkdir`.
+#[tokio::test]
+async fn rm_binary_path_positional_is_loud() {
+    assert_loud_binary("b=$(cat src.bin); rm $b").await;
+}
+
+/// `cp`'s destination operand — also exercises the restructured single-source
+/// gate-overwrite path that used to stringify the source a second time.
+#[tokio::test]
+async fn cp_binary_dest_is_loud() {
+    assert_loud_binary("b=$(cat src.bin); cp src.bin $b").await;
+}
+
+/// `ls`'s multi-path positional list (the `.map(value_to_string).collect()`
+/// pattern shared by `find`/`grep`/`sed -i`).
+#[tokio::test]
+async fn ls_binary_path_positional_is_loud() {
+    assert_loud_binary("b=$(cat src.bin); ls $b").await;
+}
+
+/// `[[ -f $b ]]` — the VFS-aware `FileTest` arm in `kernel.rs::eval_test_async`
+/// used to stat a file literally named `[binary: N bytes]`.
+#[tokio::test]
+async fn double_bracket_file_test_binary_path_is_loud() {
+    assert_loud_binary("b=$(cat src.bin); if [[ -f $b ]]; then echo hit; fi").await;
+}
+
+/// `test -f $b` — the `test` builtin's own (separate) file-test implementation,
+/// which mirrors `[[`'s but must independently guard the same way.
+#[tokio::test]
+async fn test_builtin_file_test_binary_path_is_loud() {
+    assert_loud_binary("b=$(cat src.bin); test -f $b").await;
+}
+
+/// A bare `$b` binary word as a redirect target used to become a file
+/// literally named `[binary: N bytes]` instead of erroring — the collection
+/// guard (`structured_boundary_error`) already fired for lists/records, but
+/// binary fell through `eval_redirect_target`'s local `value_to_string`.
+#[tokio::test]
+async fn redirect_target_binary_is_loud() {
+    assert_loud_binary("b=$(cat src.bin); echo hi > $b").await;
+}
+
+/// `case $b in ...)` glob-matched against the `[binary: N bytes]` placeholder
+/// instead of erroring — Decision E territory, same as `==`/`in`.
+#[tokio::test]
+async fn case_glob_binary_operand_is_loud() {
+    assert_loud_binary(
+        r#"b=$(cat src.bin); case $b in
+    x) echo matched ;;
+    *) echo default ;;
+esac"#,
+    )
+    .await;
+}
+
+/// `[[ $b == x ]]` used to fall through `values_equal`'s mixed-scalar arm and
+/// silently compare the *other* side's text against the `[binary: N bytes]`
+/// placeholder rather than erroring.
+#[tokio::test]
+async fn equality_binary_operand_is_loud() {
+    assert_loud_binary(r#"b=$(cat src.bin); if [[ $b == x ]]; then echo hit; fi"#).await;
+}
+
+/// `[[ $b in $record ]]` — record-key membership used to stringify the
+/// binary needle into a lookup key via `value_to_string`.
+#[tokio::test]
+async fn membership_binary_needle_against_record_is_loud() {
+    assert_loud_binary(r#"b=$(cat src.bin); r={"k": 1}; if [[ $b in $r ]]; then echo hit; fi"#)
+        .await;
+}
+
+/// Exporting a binary value and then running ANY external command used to
+/// silently pass `[binary: N bytes]` as the child's env var value. Gated like
+/// the argv test above — spawns a real process.
+#[cfg(all(target_os = "linux", feature = "subprocess"))]
+#[tokio::test]
+async fn env_export_of_binary_value_is_loud() {
+    assert_loud_binary("b=$(cat src.bin); export BIN=$b; /bin/true").await;
+}
+
+/// A binary value spliced into a heredoc body. Heredocs in real scripts
+/// resolve through the async evaluator (`kernel.rs`), which already composes
+/// through the guarded `eval_string_part_async` — this locks in that the
+/// user-visible behavior is loud (the *sync* evaluator's own heredoc
+/// assembly, `interpreter/eval.rs`, is covered directly in eval.rs's unit
+/// tests since it isn't reachable from a real script).
+#[tokio::test]
+async fn heredoc_body_binary_var_is_loud() {
+    assert_loud_binary("b=$(cat src.bin); cat <<EOF\n$b\nEOF").await;
+}
+
+/// A binary value used as a record's interpolated key (`{"$b": 1}`). Same
+/// async-composition note as the heredoc test above.
+#[tokio::test]
+async fn record_key_binary_var_is_loud() {
+    assert_loud_binary(r#"b=$(cat src.bin); r={"$b": 1}"#).await;
+}
+
+/// Control: `${#b}` is the byte count, not a loud error — binary length is
+/// well-defined (unlike splicing it into text), so this must NOT regress into
+/// erroring. Locks in the existing `value_length` behavior this PR relies on.
+#[tokio::test]
+async fn length_of_binary_is_byte_count_not_loud() {
+    let dir = tempdir().unwrap();
+    fs::write(dir.path().join("src.bin"), BIN).unwrap();
+    let kernel = kernel_at(dir.path());
+    let result = kernel.execute("b=$(cat src.bin); echo ${#b}").await.unwrap();
+    assert_eq!(result.code, 0, "err={}", result.err);
+    assert_eq!(result.text_out().trim(), BIN.len().to_string());
 }

--- a/crates/kaish-kernel/tests/binary_text_sink_tests.rs
+++ b/crates/kaish-kernel/tests/binary_text_sink_tests.rs
@@ -413,6 +413,25 @@ async fn cmp_binary_first_operand_is_loud() {
     assert_loud_binary("b=$(cat src.bin); cmp $b src.bin").await;
 }
 
+/// `exec`'s command name — the argv loop was already guarded, but the command
+/// word itself read via `get_string`'s silent `None`, so `exec $BIN` used to
+/// misreport as "exec: missing command" rather than the binary-sink error
+/// (kaibo review of this PR). Gated on subprocess since exec is subprocess-only.
+#[cfg(feature = "subprocess")]
+#[tokio::test]
+async fn exec_binary_command_is_loud() {
+    assert_loud_binary("b=$(cat src.bin); exec $b arg1").await;
+}
+
+/// `printf`'s format positional — its format *arguments* were already
+/// guarded, but the format string itself read via `get_string`'s silent
+/// `None`, so `printf $BIN` used to misreport as "printf: missing format
+/// argument" (kaibo review of this PR).
+#[tokio::test]
+async fn printf_binary_format_is_loud() {
+    assert_loud_binary("b=$(cat src.bin); printf $b").await;
+}
+
 // `spawn`'s bareword `command=value` form actually routes through the
 // (separately tracked, #116) WordAssign-reconstruction fallback rather than a
 // named arg — `--command=`/`--cwd=` is the form that reaches `ToolArgs.named`

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -14,6 +14,110 @@ before it ships.
 
 ---
 
+## Binary at the remaining text sinks, and `&>` streaming (2026-07-06, GH #93)
+
+0.11.0 made `Value::Bytes` go loud at the three primary text sinks — string
+interpolation, bare-word external argv, `echo` — via `value_to_text_sink()`.
+#93 item 1 asked for the rest of the sinks that still fell through to
+`value_to_string`'s infallible `[binary: N bytes]` placeholder. Rather than a
+bespoke fix per sink, added `value_to_text_sink_named(value, sink)` (and a
+`values_to_text_sink_named` for a whole positional list) — same guard,
+parameterized so the error names the actual boundary ("a path", "an exported
+environment variable value", "a redirect target") instead of the generic
+"text", mirroring the `sink` parameter `structured_boundary_error` already
+uses for the collection-vs-process-boundary guard.
+
+**The five named sinks, and one the sweep turned up.** Builtin
+path-positional coercion touched ~17 files (`mkdir`/`cp`/`mv`/`rm`/`touch`/
+`dirname`/`cut`/`stat`/`readlink`/`realpath`/`tee`/`sort`/`find`/`grep`/`sed
+-i`/`ls`) — all the same shape, so `cp`/`mv`/`tee` also got a small cleanup:
+they were stringifying the same source value twice (once for a
+gate-overwrite preview, again in the write loop) — computed once now. Widened
+"path-positional" to cover `[[ -f $x ]]`/`test -f $x` too (kernel.rs's
+`eval_test_async` and the `test` builtin's own separate file-test impl,
+matching in comments) since a binary operand there silently stats a file
+literally named `[binary: N bytes]` — same bug, different entry point.
+Env-var export needed three call sites in sync (kernel.rs's production spawn,
+its `dispatch.rs` test-only twin, and `env`'s own `execute_with_env`), all
+already following the collection guard's precedent of a separate binary
+check after `structured_export_error`. The redirect target
+(`pipeline.rs::eval_redirect_target`) had a private, single-caller
+`value_to_string` shim living in the same file — deleted once its call site
+converted, rather than leaving it as dead code. Sweeping the codebase for the
+"bare-word external argv" pattern (already fixed in `build_args_flat`) turned
+up a fourth spawn site nobody had touched: `exec`'s own argv loop, built
+straight from typed positionals with no shared helper — same class of bug,
+now fixed the same way.
+
+**The semantic ops split three ways on inspection**, not the four the issue
+guessed. `${#…}` on binary was *already* correct (`value_length` special-cases
+`Bytes` to the byte count before ever reaching `value_to_string` — locked in
+with a regression test, no fix needed). `==`/`!=` needed a new guard arm in
+`values_equal` ahead of the generic mixed-scalar fallback: `Value::Bytes`
+against anything but another `Value::Bytes` is now a loud type error, not a
+silent compare-the-placeholder-text. `in` needed the same treatment only for
+the record-key branch of `eval_membership` (a `Value::Bytes` needle stringified
+into a lookup key); the list-membership branch (`element_matches`) keeps
+treating a shape mismatch as "not a match, not an abort" — consistent with how
+it already treats a nested-collection element, and it's what keeps `x in
+$heterogeneous_list` from dying partway through the scan. `case`-glob needed
+one line in `kernel.rs`'s `Stmt::Case` handler.
+
+**Heredoc body and record-key interpolation turned out to be a non-finding
+worth writing down anyway.** The sync `Evaluator`'s `HereDocBody` and
+`RecordKey::Interpolated` arms (`interpreter/eval.rs`) are the ones the issue
+named, but tracing every real call site of the sync `eval_expr` showed
+heredocs and record literals in an actual script always resolve through the
+kernel's *async* evaluator, which already composes through the guarded
+`eval_string_part_async` — the sync arms are unreachable with a live
+`Value::Bytes` in production (only reachable by an embedder driving the sync
+`Evaluator` directly, or by a unit test). Swapped `value_to_string` for
+`value_to_text_sink` there anyway — cheap, correct, and stops the code from
+leaning on a non-local invariant — but it's a defense-in-depth edit with no
+behavior change, not a bug fix; said so plainly rather than overclaiming a
+fourth "fixed" sink. Confirmed by literally reverting just those two lines
+and rerunning the new eval.rs unit tests: both still passed.
+
+**A test-helper trap almost hid a false pass.** The shared `assert_loud_binary`
+helper (from 0.11.0) checked `err.contains("binary")` — true of a real
+"cannot be used as a path" message, but *also* true of `rm`'s ordinary "No such
+file or directory" once the path itself is the literal string `[binary: N
+bytes]` (the placeholder text contains the word "binary"). `rm`'s new test
+silently passed against the *unfixed* code for exactly that reason. Caught it
+by deliberately reverting the whole PR's `src/` diff (keeping the new tests)
+and rerunning — 11 of the 21 new/touched tests failed as expected, but `rm`'s
+didn't. Tightened the helper to `contains("cannot be used as")` — the
+consistent wording all these guards now share (reworded `values_equal`'s
+message to fit) — and added a stderr placeholder-leak check alongside the
+existing stdout one. Reran the full revert to confirm: all 11 fail pre-fix,
+all pass post-fix.
+
+**Item 6 (`&>` streaming) is an honest equivalence test, not a failing one.**
+`RedirectKind::Both` now uses `take_output_for_stream`/`write_canonical`
+like `>`/`>>`, instead of forcing structured output through a full
+`to_canonical_string()` `String` first — a memory-copy optimization, not an
+output-correctness fix, so the file bytes are identical either way and a
+test can't observe the difference by content alone. Wrote it up front as
+that: byte-for-byte equivalence + a large-table completeness check, in
+`pipeline.rs`'s own `apply_redirects` test module (unit-level, not
+`kernel.execute()` — there's no builtin under test, just the redirect
+machinery, and the existing merge-redirect tests already use this pattern).
+Verified honestly by reverting just that hunk: same tests, same pass. Applied
+the identical streaming swap to the inter-stage pipe write next to it
+(`run_pipeline`) since it shares the exact `out_bytes()`/
+`text_out().into_owned().into_bytes()` shape — not `&>`-specific, but the
+same anti-pattern sitting right next to the one the issue named.
+
+**Deferred, tracked in #116, not fixed here:** a `WordAssign`→positional/named
+reconstruction cluster (`dd if=$BIN`, `awk -v a=$BIN`, `cat foo=$BIN`) across
+four call sites in `kernel.rs`/`pipeline.rs` that embeds a value into a
+`key=value` string the same lossy way — real, but a distinct code shape from
+the five named sinks, and out of scope for one PR. Also verified in passing
+that #93's two SUSPECTED findings (S3/S4: binary crossing into `fromjson`/
+`fromjsonl`) are already handled — both already reject a binary positional
+loudly and route stdin through the shared `read_stdin_to_text`, which already
+errors on invalid UTF-8.
+
 ## Interpreter allocation/stack pass (2026-07-05, GH #48)
 
 #46/#47 landed a recursion depth guard sized against a measured ~380 KB of

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -118,6 +118,61 @@ that #93's two SUSPECTED findings (S3/S4: binary crossing into `fromjson`/
 loudly and route stdin through the shared `read_stdin_to_text`, which already
 errors on invalid UTF-8.
 
+**A kaibo review of the diff (deepseek, whole-file, not just the patch) found
+a second wave the grep-for-`value_to_string` sweep missed entirely**, because
+it's a different anti-pattern: `ExecContext::expand_paths` (the shared path
+list builder behind `cat`/`head`/`tail`/`wc`/`checksum`/`file`/`base64_tool`/
+`tac`/`xxd`) matched non-string positionals with `_ => continue` — a
+`Value::Bytes` operand didn't get stringified into a placeholder, it just
+*vanished* from the list. Worse than the placeholder bug: every one of those
+callers falls back to reading stdin when the path list comes back empty, so
+`head $BIN` (say) silently read whatever was piped in instead of erroring on
+the binary path — confirmed with a test that pipes distinguishable stdin
+content through and asserts it never appears in the output. Same shape at
+`cd` (`get_string`'s silent `None` → falls back to `$HOME`) and `awk`'s input
+operand (→ falls back to stdin); `basename`/`diff` already failed loudly on
+`None`, just with a generic "missing" message, fixed for consistency.
+`get_string` itself lives in the `kaish-types` leaf crate with no
+`EvalError` machinery to explain *why* it saw nothing, so the fix is a
+`get_path_string` helper in `tools/builtin/mod.rs` that checks for
+`Value::Bytes` before falling through to `get_string`, used at each of the
+four call sites — not a change to `get_string`'s own signature, which is used
+far too broadly (for non-path args too) to safely touch here. Same
+revert-and-confirm discipline as the rest of this PR: all 7 new tests fail
+against the pre-fix code, pass after.
+
+**A second kaibo pass over the same `get_path_string`/`expand_paths` fix
+found 10 more builtins with the identical `get_string` shape** — `sed`
+(streaming-mode input) and `uniq` silently fell back to stdin exactly like
+`awk`; `jq`'s `path` positional the same; `tree` silently used `.`; `write`/
+`ln`/`patch`/`validate`/`checksum`/`spawn` already failed loudly on `None`
+(just with a generic "missing" message), converted for consistency. All
+mechanical once `get_path_string` existed: swap `args.get_string` for it, add
+the `Err` arm.
+
+**Two of those ten (`checksum --check=$BIN`, `patch --file=$BIN`) exposed a
+second, deeper bug while writing their tests — the tests kept passing against
+unfixed code, for the wrong reason.** Both builtins check their own
+clap-parsed field (`parsed.check`/`parsed.file`) *before* falling back to
+`args.get_string`, and clap's field is populated from `ToolArgs::to_argv()` —
+which stringifies `Value::Bytes` into the *exact same* `[binary: N bytes]`
+placeholder via its own `value_to_argv_token`, a separate, pre-existing,
+explicitly-commented-as-deferred gap in the `kaish-types` leaf crate. So
+`parsed.check` was never `None` for a binary `--check=$BIN` — it was
+`Some("[binary: N bytes]")`, and the `get_path_string` fallback (only reached
+on `None`) never ran. Fixed by reordering: check the untouched `ToolArgs`
+value first (via `get_path_string`), fall back to the clap field only when
+genuinely absent — correct for both the binary case and the ordinary one
+(the raw `ToolArgs` map already has whatever clap would have parsed, from
+before `to_argv()` ever ran). Audited the rest of the `parsed.foo.clone()
+.or_else(|| args.get_string(...))` sites in the codebase for the same
+ordering hazard — none of the others (`algo`, `template`, `encoding`,
+`separator`, `field_separator`, …) are path-typed, so out of *this* PR's
+reach, but the root cause (`to_argv()`/`value_to_argv_token`) is filed as
+#120 rather than silently left for the next person to rediscover the hard
+way. Every genuinely-fixed builtin (11 new tests this round) verified
+fail-first the same way as the rest of the PR.
+
 ## Interpreter allocation/stack pass (2026-07-05, GH #48)
 
 #46/#47 landed a recursion depth guard sized against a measured ~380 KB of

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -173,6 +173,20 @@ reach, but the root cause (`to_argv()`/`value_to_argv_token`) is filed as
 way. Every genuinely-fixed builtin (11 new tests this round) verified
 fail-first the same way as the rest of the PR.
 
+**A third pass (gemini, asked specifically to sweep for the same ordering
+hazard in every builtin touched so far) found one more: `cmp.rs`** read its
+two file operands off `parsed.paths` (the clap-parsed field) instead of
+`args.positional` — the exact CLAUDE.md gotcha ("read `Value`-typed
+positionals off `args.positional`, not the clap struct") that the other
+path-positional builtins already followed correctly. Fixed the same way as
+`mkdir`/`cp`/etc.: `values_to_text_sink_named(&args.positional, "a path")`.
+Three review passes, three distinct bug shapes (`_ => continue` drop,
+clap-field-checked-before-raw-value ordering, clap-field-read-directly) —
+each caught because the review asked "is this ACTUALLY the shape you think
+it is" against the live code rather than trusting the pattern to have been
+applied uniformly. Stopped the loop here rather than keep sweeping
+indefinitely; #116/#120 carry the remaining known-adjacent gaps forward.
+
 ## Interpreter allocation/stack pass (2026-07-05, GH #48)
 
 #46/#47 landed a recursion depth guard sized against a measured ~380 KB of


### PR DESCRIPTION
## Summary

Part of #93 (items 1, 6).

0.11.0 made `Value::Bytes` go loud at the three primary text sinks (string
interpolation, bare-word external argv, `echo`) via `value_to_text_sink()`.
Item 1 asked for the rest of the sinks that still fell through to the
infallible `value_to_string()` and its `[binary: N bytes]` placeholder:

- **Builtin path-positional coercion** — `mkdir`/`cp`/`mv`/`rm`/`touch`/
  `dirname`/`cut`/`stat`/`readlink`/`realpath`/`tee`/`sort`/`find`/`grep`/
  `sed -i`/`ls` all read a typed positional and stringified it into a path.
  Widened this to also cover `[[ -f $x ]]`/`test -f $x` (two independent
  file-test implementations) since a binary operand there silently stats a
  file literally named the placeholder.
- **Env-var export** — the production spawn site, its test-only twin in
  `dispatch.rs`, and `env`'s own `execute_with_env` all fed a binary value's
  placeholder straight into a child process's environment.
- **Redirect target** — `pipeline.rs::eval_redirect_target` guarded a bare
  collection but not binary; a `$BIN` redirect target became a file literally
  named `[binary: N bytes]`.
- **Semantic ops** — `==`/`!=` (`values_equal`) and `in`'s record-key branch
  (`eval_membership`) silently stringified binary before comparing/looking it
  up; `case`-glob matched against the placeholder. `${#…}` turned out to
  already be correct (byte count, not stringify) — locked in with a
  regression test, no fix needed.
- A sweep for the already-fixed "bare-word external argv" pattern turned up a
  fourth spawn site nobody had touched: `exec`'s own argv loop.

Added `value_to_text_sink_named(value, sink)` (and `values_to_text_sink_named`
for a whole positional list) so each new call site names its own boundary
("a path", "an exported environment variable value", "a redirect target")
rather than a generic "text" — mirrors the `sink` parameter
`structured_boundary_error` already uses for the collection guard.

Heredoc-body and record-key interpolation's *sync*-evaluator arms
(`interpreter/eval.rs`) turned out to be unreachable with a live
`Value::Bytes` in production — real scripts always resolve heredocs/record
literals through the async evaluator, which already composes through the
guarded `eval_string_part_async`. Swapped `value_to_string` for
`value_to_text_sink` there anyway (defense-in-depth, not a behavior change —
verified by reverting just those two lines and confirming the new unit tests
still passed either way).

**Item 6**: `&>` (`RedirectKind::Both`) now uses
`take_output_for_stream`/`write_canonical` like `>`/`>>`, instead of forcing
structured output through a full `to_canonical_string()` `String` first —
same streaming swap applied to the inter-stage pipe write next to it, which
shared the identical anti-pattern. This is a memory-copy optimization, not an
output-correctness fix, so the new tests are an honest byte-for-byte
equivalence + large-payload completeness check rather than a failing-first
one (confirmed via revert that both old and new code produce identical file
bytes).

## Round 2 — a kaibo review found a second wave

Asked kaibo (deepseek, whole-file review, not just the diff) to review the
first commit. It found `ExecContext::expand_paths` (shared by `cat`/`head`/
`tail`/`wc`/`checksum`/`file`/`base64_tool`/`tac`/`xxd`) silently *dropped* a
`Value::Bytes` positional (`_ => continue`) rather than stringifying it —
worse than the placeholder bug, since those builtins then fall back to
reading stdin when the path list comes back empty. Same shape reached
through `ToolArgs::get_string`'s silent `None` at `cd` (→ `$HOME`), `awk`/
`sed`/`uniq`/`jq` (→ stdin), and `tree` (→ `.`); `basename`/`diff`/`write`/
`ln`/`patch`/`validate`/`checksum`/`spawn` already failed loudly, just with a
generic "missing" message, fixed for consistency. Added a `get_path_string`
helper (`tools/builtin/mod.rs`) rather than changing `get_string`'s own
signature (used far too broadly for non-path args).

Two of those (`checksum --check=$BIN`, `patch --file=$BIN`) exposed a deeper,
separate bug: both check their own clap-parsed field before falling back to
`get_string`, and clap's field comes from `ToolArgs::to_argv()`, which has
its own binary-stringify gap (`value_to_argv_token`, already commented in the
`kaish-types` source as a deferred "Phase 2" item). So the clap field was
never `None` for a binary value — fixed by reordering to check the untouched
`ToolArgs` value first. Root cause filed as #120 (fixing `to_argv()` itself
means making it fallible, which ripples into every caller — too big for this
PR).


## Round 3 — one more of the same ordering hazard

Asked a third model (gemini) to sweep specifically for the checksum/patch
ordering hazard across every builtin touched so far. Found one more: `cmp.rs`
read its two file operands off `parsed.paths` (the clap-parsed field)
instead of `args.positional` — the exact CLAUDE.md gotcha ("read
`Value`-typed positionals off `args.positional`, not the clap struct") the
other path-positional builtins already followed correctly. Fixed the same
way as `mkdir`/`cp`/etc.

## Decisions / things found along the way

- `cp`/`mv`/`tee` were stringifying the same source value twice (once for a
  gate-overwrite preview, again in the write loop) — computed once now as
  part of the fix.
- `in`'s list-membership branch (`element_matches`) keeps treating a
  shape-mismatched element as "not a match, not an abort" (consistent with
  how it already treats a nested-collection element) — only the record-key
  branch got the loud guard, since that's where a value actually gets
  stringified into a lookup key.
- A test-helper trap: the shared `assert_loud_binary` helper's
  `err.contains("binary")` check silently passed `rm`'s new test against
  *unfixed* code, because the leaked placeholder text (`[binary: N bytes]`)
  itself contains the word "binary". Caught by deliberately reverting the
  whole diff and rerunning (11 of 21 tests should fail pre-fix; `rm`'s
  didn't). Tightened the helper to `contains("cannot be used as")` — the
  wording every guard here now shares — plus a stderr placeholder-leak check.
- A `WordAssign`→positional/named reconstruction cluster (`dd if=$BIN`,
  `awk -v a=$BIN`) shares the same silent-stringify shape but is a distinct
  code path (4 call sites in `kernel.rs`/`pipeline.rs`) — filed as #116
  rather than folded in here.
- Confirmed #93's two SUSPECTED findings (S3/S4: binary into
  `fromjson`/`fromjsonl`) are already handled — both reject a binary
  positional loudly and route stdin through `read_stdin_to_text`, which
  already errors on invalid UTF-8.

## Test plan

- [x] `cargo test --all` — green (workspace, default features)
- [x] `cargo test --all --all-features` — green
- [x] `cargo clippy --all --all-targets` and `--all-features` — zero warnings
- [x] `cargo check -p kaish-kernel --no-default-features` — green
- [x] `cargo insta test --check` — no pending snapshots
- [x] Every genuinely-fixed sink verified fail-first: reverted the affected
      `src/` files (keeping the new tests), confirmed the corresponding
      tests fail against the unfixed code, then restored the fix and
      confirmed all pass — done separately for each commit (21 tests for the
      first, 18 more for the second)
- [x] New unit tests in `interpreter/eval.rs` for `values_equal`,
      `eval_membership`, and the sync `HereDocBody`/`RecordLiteral` arms
- [x] New unit tests in `scheduler/pipeline.rs`'s own `apply_redirects` test
      module for the `&>` streaming equivalence

🤖 Generated with [Claude Code](https://claude.com/claude-code)
