### PR TITLE
fix(overlay): route /v by mount coverage so embedders can mount under it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,7 +83,18 @@ breaking entries are marked **BREAKING**.
   pre-existing papercuts in that path: `ls /v` returned nothing (kaish mounts sit
   at `/v/jobs`/`/v/blobs`, not `/v`), and `ls /` dropped `dev`. Not breaking — no
   API signatures change; the only behavior affected is an embedder that *relied*
-  on the old `/v/*`→`NotFound` reservation.
+  on the old `/v/*`→`NotFound` reservation. Relatedly, `is_trash_excluded` no
+  longer treats a real `/v/...` path as trash-exempt: with routing delegating
+  unclaimed `/v/*` to the embedder, that predicate would have silently stripped
+  the trash/latch safety net from an embedder's real content under `/v` (the
+  clause was stale anyway — kaish's own in-memory `/v` mounts resolve to no real
+  path and were never matched by it).
+- **Intermediate mount-ancestor directories are navigable.** A directory that
+  has no mount of its own but sits *above* one (e.g. `/v` above `/v/jobs`, or
+  `/home` above a lone `/home/user` mount in a sandboxed kernel) now `stat`s as a
+  directory and `list`s its child mounts, instead of returning `NotFound`. This
+  is a general `VfsRouter` change — it fixes `cd /v`/`ls /v` for embedders and
+  makes the standalone kernel's mount tree navigable the same way.
 - **`jq -s`/`--slurp` now wraps the `.data` pipeline path in an array-of-one,
   matching real jq** (GH #93 item 2). Real `jq -s` always wraps its input in
   an array, even a single document. On kaish's structured `.data` shortcut

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,21 @@ breaking entries are marked **BREAKING**.
   variants/fields won't break you.
 
 ### Fixed
+- **Embedders can mount their own backends under `/v`.** The overlay that gives
+  a `Kernel::with_backend` embedder kaish's virtual filesystems reserved the
+  *entire* `/v` namespace: any `/v/*` path not backed by a kaish mount returned
+  `NotFound`, silently shadowing an embedder's own content there (e.g. a CAS at
+  `/v/cas`) — and the shadow was surface-dependent, since paths served directly
+  off `kernel.vfs()` (SFTP) still saw the real content. Routing is now purely by
+  mount coverage (longest prefix), the same rule that already governs `/dev`: an
+  unclaimed `/v/*` path **delegates to the embedder's backend** — the blanket
+  reservation is gone *by design*, so `cat`/`ls`/`stat` reach the embedder's
+  storage — while a shared parent like `/v` presents the *union* of kaish's
+  mounts and the embedder's and stats as a directory. Also clears two
+  pre-existing papercuts in that path: `ls /v` returned nothing (kaish mounts sit
+  at `/v/jobs`/`/v/blobs`, not `/v`), and `ls /` dropped `dev`. Not breaking — no
+  API signatures change; the only behavior affected is an embedder that *relied*
+  on the old `/v/*`→`NotFound` reservation.
 - **`jq -s`/`--slurp` now wraps the `.data` pipeline path in an array-of-one,
   matching real jq** (GH #93 item 2). Real `jq -s` always wraps its input in
   an array, even a single document. On kaish's structured `.data` shortcut

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,7 +94,14 @@ breaking entries are marked **BREAKING**.
   `/home` above a lone `/home/user` mount in a sandboxed kernel) now `stat`s as a
   directory and `list`s its child mounts, instead of returning `NotFound`. This
   is a general `VfsRouter` change — it fixes `cd /v`/`ls /v` for embedders and
-  makes the standalone kernel's mount tree navigable the same way.
+  makes the standalone kernel's mount tree navigable the same way. Such a
+  synthesized shared-ancestor directory behaves consistently across every
+  operation: `stat`/`lstat`/`exists`/`list` all agree it is a directory (the
+  union of the embedder's view and kaish's child mounts, preferring the
+  embedder's real metadata for a name it owns), and every direct mutation
+  (`rm`/`mkdir`/`touch`/write) is refused with a clear error instead of the
+  misleading `NotFound` a bare embedder delegation used to produce — `rm -rf /v`
+  can't delete a node that only exists because kaish mounts live beneath it.
 - **`jq -s`/`--slurp` now wraps the `.data` pipeline path in an array-of-one,
   matching real jq** (GH #93 item 2). Real `jq -s` always wraps its input in
   an array, even a single document. On kaish's structured `.data` shortcut

--- a/crates/kaish-kernel/src/backend/overlay.rs
+++ b/crates/kaish-kernel/src/backend/overlay.rs
@@ -613,6 +613,34 @@ mod tests {
         assert_eq!(names, vec!["jobs".to_string()]);
     }
 
+    #[cfg(feature = "localfs")]
+    #[tokio::test]
+    async fn test_unclaimed_v_resolves_to_inner_real_path() {
+        use crate::vfs::LocalFs;
+        // Embedder root with real content under /v.
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("v/cas")).unwrap();
+        std::fs::write(dir.path().join("v/cas/blob.bin"), b"x").unwrap();
+
+        let mut inner_router = VfsRouter::new();
+        inner_router.mount("/", LocalFs::read_only(dir.path().to_path_buf()));
+        let inner: Arc<dyn KernelBackend> = Arc::new(LocalBackend::new(Arc::new(inner_router)));
+        let mut vfs = VfsRouter::new();
+        vfs.mount("/v/jobs", MemoryFs::new());
+        let overlay = VirtualOverlayBackend::new(inner, Arc::new(vfs));
+
+        // Unclaimed /v/* now resolves to the embedder's REAL path (was `None`
+        // under the old lexical reservation). This is the path that reaches the
+        // trash/latch gate, so `is_trash_excluded` must NOT lexically exclude
+        // `/v` — otherwise this real content silently loses its safety net
+        // (see tools/context.rs).
+        let real = overlay.resolve_real_path(Path::new("/v/cas/blob.bin"));
+        assert!(real.is_some(), "unclaimed /v/* must resolve to the embedder real path");
+        assert!(real.unwrap().ends_with("v/cas/blob.bin"));
+        // A kaish-owned /v mount stays virtual — no real path.
+        assert!(overlay.resolve_real_path(Path::new("/v/jobs/1")).is_none());
+    }
+
     #[tokio::test]
     async fn test_root_lists_both_v_and_dev() {
         // The generalized union at shared parents fixes the old root merge,

--- a/crates/kaish-kernel/src/backend/overlay.rs
+++ b/crates/kaish-kernel/src/backend/overlay.rs
@@ -15,11 +15,19 @@
 //!
 //! # Path Routing
 //!
-//! - `/v/*` → always routed to the internal VFS, whether or not anything is
-//!   mounted there (the whole `/v` namespace is reserved, so a miss returns
-//!   `NotFound` from the VFS rather than leaking through to the embedder).
-//! - Any other path actually covered by a mount registered on the internal
-//!   VFS (e.g. `/dev`, added by `Kernel::with_backend`) → also routed there.
+//! Routing is by *mount coverage* (longest prefix), not by a lexical `/v`
+//! reservation:
+//!
+//! - Any path covered by a mount on the internal VFS (`/v/jobs`, `/v/blobs`,
+//!   `/dev`, a `configure_vfs` mount) → routed to the VFS.
+//! - An *unclaimed* path under `/v` (e.g. an embedder's own `/v/cas`) → falls
+//!   through to the custom backend, so an embedder can mount its own storage
+//!   under `/v` without kaish shadowing it. (Previously the whole `/v`
+//!   namespace was reserved and a miss returned `NotFound`.)
+//! - A shared *ancestor* directory like `/v` — no mount of its own, but sitting
+//!   above `/v/jobs` — is presented as the *union* of both layers: `list`
+//!   merges the embedder's entries with kaish's child mounts, and `stat`/
+//!   `exists` synthesize it as a directory when the embedder lacks it.
 //! - Everything else → custom backend
 
 use async_trait::async_trait;
@@ -32,6 +40,14 @@ use super::{
 };
 use crate::tools::{ToolArgs, ToolCtx};
 use crate::vfs::{DirEntry, Filesystem, MountInfo, VfsRouter};
+
+/// The final path component, used to name a synthesized directory entry for a
+/// shared ancestor (`/v` → `v`). Falls back to `/` for a component-less path.
+fn dir_basename(path: &Path) -> String {
+    path.file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "/".to_string())
+}
 
 /// Backend that overlays virtual paths (`/v/*`) on top of a custom backend.
 ///
@@ -61,17 +77,18 @@ impl VirtualOverlayBackend {
         Self { inner, vfs }
     }
 
-    /// Check if a path should be handled by the VFS rather than the inner backend.
+    /// Check if a path is *covered by a kaish VFS mount* and should therefore be
+    /// handled by the VFS rather than the inner backend.
     ///
-    /// `/v` and `/v/*` are always reserved for the VFS, even where nothing is
-    /// mounted (so callers get `NotFound` from the VFS, not the embedder's
-    /// backend). Any other path is checked against the VFS's actual mount
-    /// table — this is what lets `Kernel::with_backend`'s `/dev` mount (or an
-    /// embedder's own `configure_vfs` mounts outside `/v`) take effect instead
-    /// of being silently swallowed by the inner backend.
+    /// Routing is purely by mount coverage (longest prefix) — there is no
+    /// lexical `/v` reservation. `/v/jobs`, `/dev`, and any `configure_vfs`
+    /// mount route to the VFS; an *unclaimed* path under `/v` (e.g. an embedder
+    /// CAS at `/v/cas`) falls through to the inner backend instead of returning
+    /// `NotFound`. Shared *ancestor* directories like `/v` (which have no mount
+    /// of their own but sit above `/v/jobs`) are not "virtual" by this test —
+    /// they're handled by the union/synthesis paths in `list`/`stat`/`exists`.
     fn is_virtual_path(&self, path: &Path) -> bool {
-        let path_str = path.to_string_lossy();
-        path_str == "/v" || path_str.starts_with("/v/") || self.vfs.has_mount(path)
+        self.vfs.has_mount(path)
     }
 
     /// Get the inner backend.
@@ -188,12 +205,30 @@ impl KernelBackend for VirtualOverlayBackend {
     async fn list(&self, path: &Path) -> BackendResult<Vec<DirEntry>> {
         if self.is_virtual_path(path) {
             Ok(self.vfs.list(path).await?)
-        } else if path.to_string_lossy() == "/" || path.to_string_lossy().is_empty() {
-            // Root listing: combine inner backend's root with /v
-            let mut entries = self.inner.list(path).await?;
-            // Add /v if not already present
-            if !entries.iter().any(|e| e.name == "v") {
-                entries.push(DirEntry::directory("v"));
+        } else if self.vfs.has_mount_under(path) {
+            // A shared parent of kaish mounts (`/`, `/v`, `/v/etc`, …): return
+            // the union of the embedder's view and kaish's child mounts, so
+            // both layers' entries show at the directory. kaish entries take
+            // precedence on a name clash (an explicit kaish mount wins its
+            // subtree via longest-prefix routing). A `NotFound` from the inner
+            // backend means "embedder has nothing here" — kaish-only, not an
+            // error — but any other inner error propagates.
+            let mut names = std::collections::HashSet::new();
+            let mut entries = Vec::new();
+            for entry in self.vfs.list(path).await? {
+                names.insert(entry.name.clone());
+                entries.push(entry);
+            }
+            match self.inner.list(path).await {
+                Ok(inner_entries) => {
+                    for entry in inner_entries {
+                        if names.insert(entry.name.clone()) {
+                            entries.push(entry);
+                        }
+                    }
+                }
+                Err(BackendError::NotFound(_)) => {}
+                Err(e) => return Err(e),
             }
             Ok(entries)
         } else {
@@ -205,7 +240,14 @@ impl KernelBackend for VirtualOverlayBackend {
         if self.is_virtual_path(path) {
             Ok(self.vfs.stat(path).await?)
         } else {
-            self.inner.stat(path).await
+            match self.inner.stat(path).await {
+                // A shared ancestor of kaish mounts (e.g. `/v`) the embedder
+                // doesn't have still exists as a directory on our side.
+                Err(BackendError::NotFound(_)) if self.vfs.has_mount_under(path) => {
+                    Ok(DirEntry::directory(dir_basename(path)))
+                }
+                other => other,
+            }
         }
     }
 
@@ -259,7 +301,9 @@ impl KernelBackend for VirtualOverlayBackend {
         if self.is_virtual_path(path) {
             self.vfs.exists(path).await
         } else {
-            self.inner.exists(path).await
+            // A shared ancestor of kaish mounts (e.g. `/v`) exists even when the
+            // embedder has nothing there.
+            self.inner.exists(path).await || self.vfs.has_mount_under(path)
         }
     }
 
@@ -271,7 +315,12 @@ impl KernelBackend for VirtualOverlayBackend {
         if self.is_virtual_path(path) {
             Ok(self.vfs.lstat(path).await?)
         } else {
-            self.inner.lstat(path).await
+            match self.inner.lstat(path).await {
+                Err(BackendError::NotFound(_)) if self.vfs.has_mount_under(path) => {
+                    Ok(DirEntry::directory(dir_basename(path)))
+                }
+                other => other,
+            }
         }
     }
 
@@ -354,12 +403,12 @@ mod tests {
         let (mock, _) = MockBackend::new();
         let inner: Arc<dyn KernelBackend> = Arc::new(mock);
 
-        // Create VFS with /v mounted
+        // Production-like split: kaish mounts sit at /v/*, nothing at /v itself.
         let mut vfs = VfsRouter::new();
-        let mem = MemoryFs::new();
-        mem.write(Path::new("blobs/test.bin"), b"blob data").await.unwrap();
-        mem.mkdir(Path::new("jobs")).await.unwrap();
-        vfs.mount("/v", mem);
+        let blobs = MemoryFs::new();
+        blobs.write(Path::new("test.bin"), b"blob data").await.unwrap();
+        vfs.mount("/v/blobs", blobs);
+        vfs.mount("/v/jobs", MemoryFs::new());
 
         VirtualOverlayBackend::new(inner, Arc::new(vfs))
     }
@@ -367,10 +416,17 @@ mod tests {
     #[tokio::test]
     async fn test_virtual_path_detection() {
         let overlay = make_overlay().await;
-        assert!(overlay.is_virtual_path(Path::new("/v")));
-        assert!(overlay.is_virtual_path(Path::new("/v/")));
+        // Covered by a kaish mount → virtual.
         assert!(overlay.is_virtual_path(Path::new("/v/jobs")));
+        assert!(overlay.is_virtual_path(Path::new("/v/blobs")));
         assert!(overlay.is_virtual_path(Path::new("/v/blobs/test.bin")));
+
+        // No lexical /v reservation any more: a shared ancestor with no mount of
+        // its own, and an unclaimed path under /v, are NOT virtual — they route
+        // to the union/synthesis paths or fall through to the embedder.
+        assert!(!overlay.is_virtual_path(Path::new("/v")));
+        assert!(!overlay.is_virtual_path(Path::new("/v/")));
+        assert!(!overlay.is_virtual_path(Path::new("/v/unclaimed")));
 
         assert!(!overlay.is_virtual_path(Path::new("/docs")));
         assert!(!overlay.is_virtual_path(Path::new("/g/repo")));
@@ -447,8 +503,9 @@ mod tests {
     #[tokio::test]
     async fn test_mkdir_virtual_path() {
         let overlay = make_overlay().await;
-        overlay.mkdir(Path::new("/v/newdir")).await.unwrap();
-        assert!(overlay.exists(Path::new("/v/newdir")).await);
+        // Under a covered mount (/v/blobs), so it stays in the kaish VFS.
+        overlay.mkdir(Path::new("/v/blobs/newdir")).await.unwrap();
+        assert!(overlay.exists(Path::new("/v/blobs/newdir")).await);
     }
 
     #[tokio::test]
@@ -489,5 +546,86 @@ mod tests {
         let overlay = make_overlay().await;
         // Virtual paths don't resolve to real paths
         assert!(overlay.resolve_real_path(Path::new("/v/blobs/test.bin")).is_none());
+    }
+
+    // Inner backend that serves content under /v (an embedder CAS at /v/cas),
+    // alongside kaish's own /v/jobs + /dev mounts — the production-like split
+    // (kaish mounts sit at /v/*, nothing at /v itself). `cas` toggles whether
+    // the embedder actually has content under /v.
+    async fn overlay_over_inner(cas: bool) -> VirtualOverlayBackend {
+        let mut inner_router = VfsRouter::new();
+        let inner_mem = MemoryFs::new();
+        if cas {
+            inner_mem
+                .write(Path::new("v/cas/blob.bin"), b"cas data")
+                .await
+                .unwrap();
+        }
+        inner_router.mount("/", inner_mem);
+        let inner: Arc<dyn KernelBackend> = Arc::new(LocalBackend::new(Arc::new(inner_router)));
+
+        let mut vfs = VfsRouter::new();
+        vfs.mount("/v/jobs", MemoryFs::new());
+        vfs.mount("/dev", MemoryFs::new());
+        VirtualOverlayBackend::new(inner, Arc::new(vfs))
+    }
+
+    #[tokio::test]
+    async fn test_unclaimed_v_reaches_inner_backend() {
+        // /v/cas isn't mounted on kaish's side → a read must fall through to the
+        // embedder's backend instead of the old NotFound reservation.
+        let overlay = overlay_over_inner(true).await;
+        let data = overlay.read(Path::new("/v/cas/blob.bin"), None).await.unwrap();
+        assert_eq!(data, b"cas data");
+        assert!(overlay.exists(Path::new("/v/cas/blob.bin")).await);
+    }
+
+    #[tokio::test]
+    async fn test_v_listing_unions_kaish_and_inner() {
+        let overlay = overlay_over_inner(true).await;
+        let names: Vec<String> = overlay
+            .list(Path::new("/v"))
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|e| e.name)
+            .collect();
+        assert!(names.iter().any(|n| n == "jobs"), "kaish mount missing: {names:?}");
+        assert!(names.iter().any(|n| n == "cas"), "embedder mount missing: {names:?}");
+    }
+
+    #[tokio::test]
+    async fn test_v_synthesized_when_inner_lacks_it() {
+        // Embedder has nothing under /v; kaish mounts /v/jobs. /v must still
+        // stat as a directory and list the kaish mount, so `cd /v` / `ls /v`
+        // work even though nothing is mounted at /v on either layer.
+        let overlay = overlay_over_inner(false).await;
+        assert!(overlay.stat(Path::new("/v")).await.unwrap().is_dir());
+        assert!(overlay.lstat(Path::new("/v")).await.unwrap().is_dir());
+        assert!(overlay.exists(Path::new("/v")).await);
+        let names: Vec<String> = overlay
+            .list(Path::new("/v"))
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|e| e.name)
+            .collect();
+        assert_eq!(names, vec!["jobs".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn test_root_lists_both_v_and_dev() {
+        // The generalized union at shared parents fixes the old root merge,
+        // which injected only a synthetic `v` and dropped `dev`.
+        let overlay = overlay_over_inner(false).await;
+        let names: Vec<String> = overlay
+            .list(Path::new("/"))
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|e| e.name)
+            .collect();
+        assert!(names.iter().any(|n| n == "v"), "{names:?}");
+        assert!(names.iter().any(|n| n == "dev"), "{names:?}");
     }
 }

--- a/crates/kaish-kernel/src/backend/overlay.rs
+++ b/crates/kaish-kernel/src/backend/overlay.rs
@@ -49,6 +49,13 @@ fn dir_basename(path: &Path) -> String {
         .unwrap_or_else(|| "/".to_string())
 }
 
+/// Explanatory clause for errors on a shared-ancestor path (see
+/// `VirtualOverlayBackend::is_shared_ancestor`), so a rejected mutation reads
+/// clearly instead of the misleading `NotFound` a bare inner delegation gives.
+fn synth_dir_note(path: &Path) -> String {
+    format!("{} is a synthesized directory that only holds kaish mounts", path.display())
+}
+
 /// Backend that overlays virtual paths (`/v/*`) on top of a custom backend.
 ///
 /// This enables embedders to provide their own storage backend while still
@@ -91,6 +98,17 @@ impl VirtualOverlayBackend {
         self.vfs.has_mount(path)
     }
 
+    /// A *shared ancestor*: a path that is not itself covered by a kaish mount
+    /// but sits above one (`/`, `/v`, `/v/etc`, …). It is presented as a
+    /// **read-only synthesized directory** — a union of the embedder's view and
+    /// kaish's child mounts. Reads and listing treat it as a directory; every
+    /// direct mutation is rejected, because the node exists only insofar as
+    /// kaish mounts live beneath it, so there is nothing coherent for the
+    /// embedder alone to create, remove, or re-time.
+    fn is_shared_ancestor(&self, path: &Path) -> bool {
+        !self.is_virtual_path(path) && self.vfs.has_mount_under(path)
+    }
+
     /// Get the inner backend.
     pub fn inner(&self) -> &Arc<dyn KernelBackend> {
         &self.inner
@@ -120,6 +138,8 @@ impl KernelBackend for VirtualOverlayBackend {
     async fn read(&self, path: &Path, range: Option<ReadRange>) -> BackendResult<Vec<u8>> {
         if self.is_virtual_path(path) {
             Ok(self.vfs.read_range(path, range).await?)
+        } else if self.is_shared_ancestor(path) {
+            Err(BackendError::IsDirectory(synth_dir_note(path)))
         } else {
             self.inner.read(path, range).await
         }
@@ -149,6 +169,8 @@ impl KernelBackend for VirtualOverlayBackend {
                 }
             }
             Ok(())
+        } else if self.is_shared_ancestor(path) {
+            Err(BackendError::IsDirectory(synth_dir_note(path)))
         } else {
             self.inner.write(path, content, mode).await
         }
@@ -158,6 +180,8 @@ impl KernelBackend for VirtualOverlayBackend {
         if self.is_virtual_path(path) {
             self.vfs.set_mtime(path, mtime).await?;
             Ok(())
+        } else if self.is_shared_ancestor(path) {
+            Err(BackendError::InvalidOperation(format!("cannot set mtime: {}", synth_dir_note(path))))
         } else {
             self.inner.set_mtime(path, mtime).await
         }
@@ -173,6 +197,8 @@ impl KernelBackend for VirtualOverlayBackend {
             existing.extend_from_slice(content);
             self.vfs.write(path, &existing).await?;
             Ok(())
+        } else if self.is_shared_ancestor(path) {
+            Err(BackendError::IsDirectory(synth_dir_note(path)))
         } else {
             self.inner.append(path, content).await
         }
@@ -193,6 +219,8 @@ impl KernelBackend for VirtualOverlayBackend {
             // Write back
             self.vfs.write(path, content.as_bytes()).await?;
             Ok(())
+        } else if self.is_shared_ancestor(path) {
+            Err(BackendError::IsDirectory(synth_dir_note(path)))
         } else {
             self.inner.patch(path, ops).await
         }
@@ -205,31 +233,34 @@ impl KernelBackend for VirtualOverlayBackend {
     async fn list(&self, path: &Path) -> BackendResult<Vec<DirEntry>> {
         if self.is_virtual_path(path) {
             Ok(self.vfs.list(path).await?)
-        } else if self.vfs.has_mount_under(path) {
+        } else if self.is_shared_ancestor(path) {
             // A shared parent of kaish mounts (`/`, `/v`, `/v/etc`, …): return
-            // the union of the embedder's view and kaish's child mounts, so
-            // both layers' entries show at the directory. kaish entries take
-            // precedence on a name clash (an explicit kaish mount wins its
-            // subtree via longest-prefix routing). A `NotFound` from the inner
-            // backend means "embedder has nothing here" — kaish-only, not an
-            // error — but any other inner error propagates.
-            let mut names = std::collections::HashSet::new();
-            let mut entries = Vec::new();
-            for entry in self.vfs.list(path).await? {
-                names.insert(entry.name.clone());
-                entries.push(entry);
-            }
-            match self.inner.list(path).await {
-                Ok(inner_entries) => {
-                    for entry in inner_entries {
-                        if names.insert(entry.name.clone()) {
-                            entries.push(entry);
-                        }
-                    }
+            // the union of the embedder's view and kaish's child mounts. The
+            // embedder's entries come first so they carry real metadata; then
+            // for each kaish child, an explicit kaish *mount* (`/dev`, `/v/jobs`)
+            // shadows the embedder's same-named entry (longest-prefix routing
+            // owns that subtree), while a synthesized *intermediate* (`/v` under
+            // `/`, when nothing is mounted at `/v`) only fills a gap — keeping
+            // the embedder's real entry if it has one. Any inner error (the
+            // embedder has no listable directory here: `NotFound`,
+            // `NotADirectory` over an inner file, a permission error) means
+            // "embedder contributes nothing"; kaish's mounts still list.
+            let mut by_name: std::collections::HashMap<String, DirEntry> =
+                std::collections::HashMap::new();
+            if let Ok(inner_entries) = self.inner.list(path).await {
+                for entry in inner_entries {
+                    by_name.insert(entry.name.clone(), entry);
                 }
-                Err(BackendError::NotFound(_)) => {}
-                Err(e) => return Err(e),
             }
+            for entry in self.vfs.list(path).await? {
+                if self.vfs.has_mount(&path.join(&entry.name)) {
+                    by_name.insert(entry.name.clone(), entry);
+                } else {
+                    by_name.entry(entry.name.clone()).or_insert(entry);
+                }
+            }
+            let mut entries: Vec<DirEntry> = by_name.into_values().collect();
+            entries.sort_by(|a, b| a.name.cmp(&b.name));
             Ok(entries)
         } else {
             self.inner.list(path).await
@@ -239,15 +270,16 @@ impl KernelBackend for VirtualOverlayBackend {
     async fn stat(&self, path: &Path) -> BackendResult<DirEntry> {
         if self.is_virtual_path(path) {
             Ok(self.vfs.stat(path).await?)
-        } else {
+        } else if self.is_shared_ancestor(path) {
+            // A shared ancestor is a directory (kaish mounts live under it).
+            // Prefer the embedder's real directory metadata; otherwise (embedder
+            // lacks it, has a file there, or errors) synthesize a plain dir.
             match self.inner.stat(path).await {
-                // A shared ancestor of kaish mounts (e.g. `/v`) the embedder
-                // doesn't have still exists as a directory on our side.
-                Err(BackendError::NotFound(_)) if self.vfs.has_mount_under(path) => {
-                    Ok(DirEntry::directory(dir_basename(path)))
-                }
-                other => other,
+                Ok(entry) if entry.is_dir() => Ok(entry),
+                _ => Ok(DirEntry::directory(dir_basename(path))),
             }
+        } else {
+            self.inner.stat(path).await
         }
     }
 
@@ -255,6 +287,8 @@ impl KernelBackend for VirtualOverlayBackend {
         if self.is_virtual_path(path) {
             self.vfs.mkdir(path).await?;
             Ok(())
+        } else if self.is_shared_ancestor(path) {
+            Err(BackendError::AlreadyExists(synth_dir_note(path)))
         } else {
             self.inner.mkdir(path).await
         }
@@ -274,6 +308,10 @@ impl KernelBackend for VirtualOverlayBackend {
             }
             self.vfs.remove(path).await?;
             Ok(())
+        } else if self.is_shared_ancestor(path) {
+            // Refuse even `rm -rf /v`: the node holds kaish-managed mounts that
+            // don't live on the embedder's backend, so it can't be removed.
+            Err(BackendError::InvalidOperation(format!("cannot remove: {}", synth_dir_note(path))))
         } else {
             self.inner.remove(path, recursive).await
         }
@@ -289,6 +327,13 @@ impl KernelBackend for VirtualOverlayBackend {
             ));
         }
 
+        if self.is_shared_ancestor(from) || self.is_shared_ancestor(to) {
+            return Err(BackendError::InvalidOperation(format!(
+                "cannot rename: {} is a synthesized directory",
+                if self.is_shared_ancestor(from) { from.display() } else { to.display() }
+            )));
+        }
+
         if from_virtual {
             self.vfs.rename(from, to).await?;
             Ok(())
@@ -301,9 +346,9 @@ impl KernelBackend for VirtualOverlayBackend {
         if self.is_virtual_path(path) {
             self.vfs.exists(path).await
         } else {
-            // A shared ancestor of kaish mounts (e.g. `/v`) exists even when the
-            // embedder has nothing there.
-            self.inner.exists(path).await || self.vfs.has_mount_under(path)
+            // A shared ancestor (e.g. `/v`) exists as a directory regardless of
+            // the embedder — consistent with `stat`/`list`.
+            self.is_shared_ancestor(path) || self.inner.exists(path).await
         }
     }
 
@@ -314,19 +359,24 @@ impl KernelBackend for VirtualOverlayBackend {
     async fn lstat(&self, path: &Path) -> BackendResult<DirEntry> {
         if self.is_virtual_path(path) {
             Ok(self.vfs.lstat(path).await?)
-        } else {
+        } else if self.is_shared_ancestor(path) {
             match self.inner.lstat(path).await {
-                Err(BackendError::NotFound(_)) if self.vfs.has_mount_under(path) => {
-                    Ok(DirEntry::directory(dir_basename(path)))
-                }
-                other => other,
+                Ok(entry) if entry.is_dir() => Ok(entry),
+                _ => Ok(DirEntry::directory(dir_basename(path))),
             }
+        } else {
+            self.inner.lstat(path).await
         }
     }
 
     async fn read_link(&self, path: &Path) -> BackendResult<PathBuf> {
         if self.is_virtual_path(path) {
             Ok(self.vfs.read_link(path).await?)
+        } else if self.is_shared_ancestor(path) {
+            Err(BackendError::InvalidOperation(format!(
+                "{} is a directory, not a symlink",
+                path.display()
+            )))
         } else {
             self.inner.read_link(path).await
         }
@@ -336,6 +386,8 @@ impl KernelBackend for VirtualOverlayBackend {
         if self.is_virtual_path(link) {
             self.vfs.symlink(target, link).await?;
             Ok(())
+        } else if self.is_shared_ancestor(link) {
+            Err(BackendError::AlreadyExists(synth_dir_note(link)))
         } else {
             self.inner.symlink(target, link).await
         }
@@ -655,5 +707,98 @@ mod tests {
             .collect();
         assert!(names.iter().any(|n| n == "v"), "{names:?}");
         assert!(names.iter().any(|n| n == "dev"), "{names:?}");
+    }
+
+    #[tokio::test]
+    async fn test_shared_ancestor_is_a_directory_even_over_an_inner_file() {
+        // Embedder has a FILE at /v, but kaish mounts /v/jobs beneath it. /v is
+        // authoritatively a directory (kaish mounts live under it); stat/exists/
+        // list all agree — no file leaks from stat, no `NotADirectory` leaks
+        // from list. This branch also subsumes a non-`NotFound` inner *error*
+        // (e.g. PermissionDenied): existence/type never depend on inner here.
+        let inner_mem = MemoryFs::new();
+        inner_mem.write(Path::new("v"), b"i am a file").await.unwrap();
+        let mut inner_router = VfsRouter::new();
+        inner_router.mount("/", inner_mem);
+        let inner: Arc<dyn KernelBackend> = Arc::new(LocalBackend::new(Arc::new(inner_router)));
+        let mut vfs = VfsRouter::new();
+        vfs.mount("/v/jobs", MemoryFs::new());
+        let overlay = VirtualOverlayBackend::new(inner, Arc::new(vfs));
+
+        assert!(overlay.stat(Path::new("/v")).await.unwrap().is_dir(), "kaish dir wins over inner file");
+        assert!(overlay.lstat(Path::new("/v")).await.unwrap().is_dir());
+        assert!(overlay.exists(Path::new("/v")).await);
+        let names: Vec<String> = overlay
+            .list(Path::new("/v"))
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|e| e.name)
+            .collect();
+        assert_eq!(names, vec!["jobs".to_string()], "lists kaish mount; no NotADirectory error");
+    }
+
+    #[cfg(feature = "localfs")]
+    #[tokio::test]
+    async fn test_listing_keeps_inner_real_metadata_for_intermediate_child() {
+        use crate::vfs::LocalFs;
+        // Embedder has a real /v directory; kaish mounts /v/jobs and /dev.
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("v")).unwrap();
+
+        let mut inner_router = VfsRouter::new();
+        inner_router.mount("/", LocalFs::read_only(dir.path().to_path_buf()));
+        let inner: Arc<dyn KernelBackend> = Arc::new(LocalBackend::new(Arc::new(inner_router)));
+        let mut vfs = VfsRouter::new();
+        vfs.mount("/v/jobs", MemoryFs::new());
+        vfs.mount("/dev", MemoryFs::new());
+        let overlay = VirtualOverlayBackend::new(inner, Arc::new(vfs));
+
+        let entries = overlay.list(Path::new("/")).await.unwrap();
+        let v = entries.iter().find(|e| e.name == "v").expect("v listed");
+        let dev = entries.iter().find(|e| e.name == "dev").expect("dev listed");
+        // `/v` is an *intermediate* (no kaish mount at /v), so the embedder's
+        // real dir entry — carrying real metadata — is kept, not the synthesized
+        // zero-metadata one.
+        assert!(v.is_dir());
+        assert!(v.modified.is_some(), "intermediate child keeps inner real metadata");
+        // `/dev` IS a kaish mount, so kaish's entry wins (synthesized, no mtime).
+        assert!(dev.is_dir());
+        assert!(dev.modified.is_none(), "real kaish mount shadows inner");
+    }
+
+    #[tokio::test]
+    async fn test_mutations_on_shared_ancestor_are_rejected_clearly() {
+        // Every direct mutation of the synthesized `/v` must fail with a clear
+        // error, not the misleading `NotFound` inner delegation produced — since
+        // stat/ls/exists all report it present.
+        let overlay = overlay_over_inner(false).await;
+
+        assert!(
+            matches!(overlay.mkdir(Path::new("/v")).await, Err(BackendError::AlreadyExists(_))),
+            "mkdir on an existing synthesized dir → AlreadyExists"
+        );
+        assert!(
+            matches!(overlay.remove(Path::new("/v"), true).await, Err(BackendError::InvalidOperation(_))),
+            "remove of a synthesized dir that holds kaish mounts → InvalidOperation"
+        );
+        assert!(
+            matches!(
+                overlay.set_mtime(Path::new("/v"), std::time::SystemTime::now()).await,
+                Err(BackendError::InvalidOperation(_))
+            ),
+            "set_mtime (touch) on a synthesized dir → InvalidOperation"
+        );
+        assert!(
+            matches!(
+                overlay.write(Path::new("/v"), b"x", WriteMode::Overwrite).await,
+                Err(BackendError::IsDirectory(_))
+            ),
+            "write to a synthesized dir → IsDirectory"
+        );
+        assert!(
+            matches!(overlay.read(Path::new("/v"), None).await, Err(BackendError::IsDirectory(_))),
+            "read of a synthesized dir → IsDirectory"
+        );
     }
 }

--- a/crates/kaish-kernel/src/tools/builtin/rm.rs
+++ b/crates/kaish-kernel/src/tools/builtin/rm.rs
@@ -76,8 +76,8 @@ fn decide_rm_action(
 
     if trash_enabled {
         if let Some(rp) = real_path {
-            // Skip trash for excluded paths (/tmp, /v/*). Shared with the
-            // overwrite gate via `is_trash_excluded` so the list can't drift.
+            // Skip trash for excluded paths (host scratch under /tmp). Shared
+            // with the overwrite gate via `is_trash_excluded` so it can't drift.
             if !is_trash_excluded(Some(rp)) {
                 // Directories always go to trash — stat size is unreliable
                 // and trash::delete handles them atomically.
@@ -622,10 +622,14 @@ mod tests {
     }
 
     #[test]
-    fn test_decide_rm_action_trash_excluded_v() {
-        let real = PathBuf::from("/v/jobs/something");
+    fn test_decide_rm_action_real_v_path_is_trashed() {
+        // A *real* path under /v (embedder content delegated by mount-coverage
+        // routing) is NOT trash-excluded — it must be trashed like any real
+        // file, not deleted outright. (In-memory kaish /v mounts stay `None`
+        // and are handled by the no-real-path gating, not this predicate.)
+        let real = PathBuf::from("/v/cas/blob.bin");
         let action = decide_rm_action(true, false, Some(&real), Some(100), 10_000_000, false, false);
-        assert_eq!(action, RmAction::Delete);
+        assert_eq!(action, RmAction::Trash(real));
     }
 
     // ── Directory-specific tests ──

--- a/crates/kaish-kernel/src/tools/context.rs
+++ b/crates/kaish-kernel/src/tools/context.rs
@@ -204,20 +204,27 @@ pub(crate) enum MutationAction {
 /// caller writes those without a CAS expectation.
 pub(crate) type GateSnapshots = std::collections::HashMap<PathBuf, Vec<u8>>;
 
-/// Real paths the trash gate skips: scratch (`/tmp`) and the in-memory VFS
-/// (`/v`) mounts, where snapshotting prior content to trash is pointless.
-/// Shared by `rm`'s delete gate (`decide_rm_action`) and the overwrite gate
-/// (`decide_mutation_action`) so the exclusion list can't drift between them.
-/// `Path::starts_with` is component-aware, so `/tmp_file` does not match `/tmp`.
+/// Real paths the trash gate skips: host scratch under `/tmp`, where
+/// snapshotting prior content to trash is pointless. Shared by `rm`'s delete
+/// gate (`decide_rm_action`) and the overwrite gate (`decide_mutation_action`)
+/// so the exclusion can't drift between them. `Path::starts_with` is
+/// component-aware, so `/tmp_file` does not match `/tmp`.
+///
+/// Note: kaish's own in-memory VFS mounts (e.g. `/v/blobs`) have `real_path ==
+/// None`, so they are handled by the no-real-path gating path, not here — there
+/// is deliberately no lexical `/v` exclusion. Mount-coverage routing delegates
+/// unclaimed `/v/*` to the embedder's backend, whose *real* content under `/v`
+/// (a real path like `/v/cas/blob.bin`) must keep the trash/latch safety net; a
+/// `/v` prefix exclusion here would silently strip it.
 pub(crate) fn is_trash_excluded(real_path: Option<&Path>) -> bool {
-    matches!(real_path, Some(rp) if rp.starts_with("/tmp") || rp.starts_with("/v"))
+    matches!(real_path, Some(rp) if rp.starts_with("/tmp"))
 }
 
 /// Decide how to gate a truncating overwrite, mirroring `rm`'s trash/latch
 /// priority. Pure so the decision table is unit-testable in isolation.
 ///
 /// - A non-existent target or an append has nothing to lose → `Proceed`.
-/// - A real path under `/tmp` or `/v` is excluded (matches `rm`) → `Proceed`.
+/// - A real path under `/tmp` (host scratch) is excluded (matches `rm`) → `Proceed`.
 /// - Trash wins over latch (trash IS the safety net): `TrashFirst` when trash
 ///   is on **and** the prior content fits under `trash_max_size` (a file too
 ///   big to snapshot can't be backed up, so it falls through, exactly like
@@ -1182,10 +1189,13 @@ mod tests {
     }
 
     #[test]
-    fn excluded_real_paths_bypass_the_gate() {
-        // /tmp and /v real paths proceed even with both gates on (matches rm).
+    fn tmp_bypasses_gate_but_real_v_path_stays_gated() {
+        // /tmp scratch proceeds even with both gates on (matches rm).
         assert_eq!(decide(true, true, Some("/tmp/scratch"), true, false), MutationAction::Proceed);
-        assert_eq!(decide(true, true, Some("/v/mem/file"), true, false), MutationAction::Proceed);
+        // A *real* path under /v is NOT excluded: mount-coverage routing now
+        // delegates unclaimed /v/* to the embedder's backend, so its real
+        // content under /v must keep the trash/latch safety net. Trash wins.
+        assert_eq!(decide(true, true, Some("/v/cas/blob.bin"), true, false), MutationAction::TrashFirst);
     }
 
     #[test]

--- a/crates/kaish-kernel/src/vfs/router.rs
+++ b/crates/kaish-kernel/src/vfs/router.rs
@@ -109,6 +109,58 @@ impl VfsRouter {
         self.find_mount(path).is_ok()
     }
 
+    /// Returns true if some mount lives strictly *below* `dir` — i.e. `dir` is a
+    /// proper ancestor of a mount point (`has_mount_under("/v")` is true when
+    /// `/v/jobs` is mounted, even though nothing is mounted at `/v` itself).
+    ///
+    /// Distinct from `has_mount`, which is true only when `dir` is *covered* by
+    /// a mount. Together they let an overlay treat an intermediate path like
+    /// `/v` as an existing directory (the union of its child mounts) while still
+    /// delegating unclaimed leaves to the embedder's backend.
+    pub(crate) fn has_mount_under(&self, dir: &Path) -> bool {
+        let dir = Self::normalize_mount_path(dir.to_path_buf());
+        let dir_str = dir.to_string_lossy();
+        self.mounts.keys().any(|mount_path| {
+            let mount_str = mount_path.to_string_lossy();
+            if dir_str == "/" {
+                mount_str != "/"
+            } else {
+                mount_str.starts_with(&format!("{}/", dir_str))
+            }
+        })
+    }
+
+    /// Synthesize the child directory entries of `dir` from the mount roster:
+    /// the first path component below `dir` of every mount that lives under it
+    /// (`/v` over mounts `/v/jobs`, `/v/blobs` → `blobs`, `jobs`). `dir` is
+    /// expected to be a non-root ancestor with no mount of its own; root is
+    /// handled by `list_root`, which also folds in a `/` mount's real contents.
+    fn list_mount_children(&self, dir: &Path) -> Vec<DirEntry> {
+        let dir = Self::normalize_mount_path(dir.to_path_buf());
+        let prefix = format!("{}/", dir.to_string_lossy());
+        let mut seen = std::collections::HashSet::new();
+        let mut entries = Vec::new();
+        for mount_path in self.mounts.keys() {
+            let mount_str = mount_path.to_string_lossy();
+            if let Some(rest) = mount_str.strip_prefix(&prefix) {
+                let first = rest.split('/').next().unwrap_or("");
+                if !first.is_empty() && seen.insert(first.to_string()) {
+                    entries.push(DirEntry::directory(first));
+                }
+            }
+        }
+        entries.sort_by(|a, b| a.name.cmp(&b.name));
+        entries
+    }
+
+    /// The final path component, for naming a synthesized directory entry
+    /// (`/v` → `v`). Falls back to `/` for a path with no component.
+    fn path_basename(path: &Path) -> String {
+        path.file_name()
+            .map(|n| n.to_string_lossy().into_owned())
+            .unwrap_or_else(|| "/".to_string())
+    }
+
     /// Find the mount point for a given path.
     ///
     /// Returns the mount and the path relative to that mount.
@@ -208,8 +260,18 @@ impl Filesystem for VfsRouter {
             return self.list_root().await;
         }
 
-        let (fs, relative) = self.find_mount(path)?;
-        fs.list(&relative).await
+        match self.find_mount(path) {
+            Ok((fs, relative)) => fs.list(&relative).await,
+            // Not covered by a mount, but an ancestor of one (e.g. `/v` above
+            // `/v/jobs`): synthesize its child mount directories rather than 404.
+            Err(e) => {
+                if self.has_mount_under(path) {
+                    Ok(self.list_mount_children(path))
+                } else {
+                    Err(e)
+                }
+            }
+        }
     }
 
     #[tracing::instrument(level = "trace", skip(self), fields(path = %path.display()))]
@@ -230,8 +292,18 @@ impl Filesystem for VfsRouter {
             return Ok(DirEntry::directory(name));
         }
 
-        let (fs, relative) = self.find_mount(path)?;
-        fs.stat(&relative).await
+        match self.find_mount(path) {
+            Ok((fs, relative)) => fs.stat(&relative).await,
+            // Intermediate ancestor of a mount (e.g. `/v` above `/v/jobs`)
+            // exists as a synthesized directory.
+            Err(e) => {
+                if self.has_mount_under(path) {
+                    Ok(DirEntry::directory(Self::path_basename(path)))
+                } else {
+                    Err(e)
+                }
+            }
+        }
     }
 
     async fn read_link(&self, path: &Path) -> io::Result<PathBuf> {
@@ -261,8 +333,18 @@ impl Filesystem for VfsRouter {
             return Ok(DirEntry::directory(name));
         }
 
-        let (fs, relative) = self.find_mount(path)?;
-        fs.lstat(&relative).await
+        match self.find_mount(path) {
+            Ok((fs, relative)) => fs.lstat(&relative).await,
+            // Intermediate ancestor of a mount (e.g. `/v` above `/v/jobs`)
+            // exists as a synthesized directory.
+            Err(e) => {
+                if self.has_mount_under(path) {
+                    Ok(DirEntry::directory(Self::path_basename(path)))
+                } else {
+                    Err(e)
+                }
+            }
+        }
     }
 
     async fn mkdir(&self, path: &Path) -> io::Result<()> {
@@ -562,5 +644,72 @@ mod tests {
         router.mount("/rw", MemoryFs::new());
 
         assert!(!router.read_only());
+    }
+
+    // An intermediate directory that has no mount of its own but sits *above*
+    // one or more mounts (e.g. `/v` over `/v/jobs`, `/v/blobs`) must present as
+    // a real, listable directory synthesized from the mount roster — not the
+    // `NotFound` the bare `find_mount` returns. This is what lets a kaish shell
+    // (and SFTP over the bare router) navigate `/v` when the mounts sit at
+    // `/v/*`, and it's the router half of the `/v` overlay-tuning fix.
+    #[tokio::test]
+    async fn test_list_synthesizes_intermediate_dir() {
+        let mut router = VfsRouter::new();
+        router.mount("/v/jobs", MemoryFs::new());
+        router.mount("/v/blobs", MemoryFs::new());
+
+        let entries = router.list(Path::new("/v")).await.unwrap();
+        let names: Vec<_> = entries.iter().map(|e| e.name.as_str()).collect();
+        assert_eq!(names, vec!["blobs", "jobs"]); // sorted, synthesized from mounts
+    }
+
+    #[tokio::test]
+    async fn test_stat_intermediate_dir_is_directory() {
+        let mut router = VfsRouter::new();
+        router.mount("/v/jobs", MemoryFs::new());
+
+        assert!(router.stat(Path::new("/v")).await.unwrap().is_dir());
+        assert!(router.lstat(Path::new("/v")).await.unwrap().is_dir());
+    }
+
+    #[tokio::test]
+    async fn test_deep_intermediate_dir() {
+        let mut router = VfsRouter::new();
+        router.mount("/v/etc/rc", MemoryFs::new());
+
+        let v: Vec<_> = router.list(Path::new("/v")).await.unwrap();
+        assert_eq!(v.iter().map(|e| e.name.as_str()).collect::<Vec<_>>(), vec!["etc"]);
+        let etc: Vec<_> = router.list(Path::new("/v/etc")).await.unwrap();
+        assert_eq!(etc.iter().map(|e| e.name.as_str()).collect::<Vec<_>>(), vec!["rc"]);
+        assert!(router.stat(Path::new("/v/etc")).await.unwrap().is_dir());
+    }
+
+    #[tokio::test]
+    async fn test_has_mount_under() {
+        let mut router = VfsRouter::new();
+        router.mount("/v/jobs", MemoryFs::new());
+
+        assert!(router.has_mount_under(Path::new("/v")));
+        assert!(router.has_mount_under(Path::new("/")));
+        // The mount point itself has nothing *below* it.
+        assert!(!router.has_mount_under(Path::new("/v/jobs")));
+        assert!(!router.has_mount_under(Path::new("/other")));
+    }
+
+    #[tokio::test]
+    async fn test_nonexistent_ancestor_still_notfound() {
+        let mut router = VfsRouter::new();
+        router.mount("/v/jobs", MemoryFs::new());
+
+        // A path with no mount at or below it stays NotFound — synthesis is
+        // only for genuine ancestors of a mount.
+        assert_eq!(
+            router.list(Path::new("/nope")).await.unwrap_err().kind(),
+            io::ErrorKind::NotFound
+        );
+        assert_eq!(
+            router.stat(Path::new("/nope")).await.unwrap_err().kind(),
+            io::ErrorKind::NotFound
+        );
     }
 }

--- a/crates/kaish-kernel/tests/with_backend_v_overlay_tests.rs
+++ b/crates/kaish-kernel/tests/with_backend_v_overlay_tests.rs
@@ -107,3 +107,41 @@ async fn unclaimed_v_write_respects_read_only_embedder() {
     let (out, code) = run(&kernel, "echo hi > /v/cas/new.bin").await;
     assert_ne!(code, 0, "write under a read-only embedder /v must fail: out={out:?}");
 }
+
+/// `rm -rf /v` must *refuse* — `/v` is a synthesized directory holding kaish's
+/// own mounts, which don't live on the embedder's backend. Before the polish it
+/// delegated straight to the embedder and could destroy the embedder's real
+/// `/v` content while leaving the kaish mounts (a misleading half-delete). Now
+/// it fails with a clear error and `/v` still lists the kaish mounts.
+#[tokio::test]
+async fn rm_rf_of_synthesized_v_is_refused() {
+    let dir = seed_v_cas();
+    let kernel = kernel_over(dir.path());
+
+    let (out, code) = run(&kernel, "rm -rf /v").await;
+    assert_ne!(code, 0, "rm -rf /v must fail: out={out:?}");
+    assert!(
+        !out.to_lowercase().contains("no such file"),
+        "must be a clear refusal, not a misleading not-found: out={out:?}"
+    );
+
+    // The kaish mounts under /v are untouched and still listable.
+    let (ls, code) = run(&kernel, "ls /v").await;
+    assert_eq!(code, 0, "ls /v still works after the refusal: out={ls:?}");
+    assert!(ls.split_whitespace().any(|t| t == "jobs"), "kaish mount survived: out={ls:?}");
+}
+
+/// `mkdir /v` reports the directory already exists, not a confusing `NotFound`
+/// from an inner delegation.
+#[tokio::test]
+async fn mkdir_of_synthesized_v_reports_exists() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let kernel = kernel_over(dir.path());
+
+    let (out, code) = run(&kernel, "mkdir /v").await;
+    assert_ne!(code, 0, "mkdir /v must fail (it exists): out={out:?}");
+    assert!(
+        !out.to_lowercase().contains("no such file"),
+        "must not be a misleading not-found: out={out:?}"
+    );
+}

--- a/crates/kaish-kernel/tests/with_backend_v_overlay_tests.rs
+++ b/crates/kaish-kernel/tests/with_backend_v_overlay_tests.rs
@@ -1,0 +1,109 @@
+//! `Kernel::with_backend` must let an embedder mount its own content under `/v`
+//! without kaish shadowing it. An *unclaimed* `/v/*` path falls through to the
+//! embedder's backend (no more blanket `/v` reservation), and a shared parent
+//! like `/v` lists the *union* of kaish's own mounts and the embedder's. This
+//! is the `/v` overlay-tuning fix — the prerequisite for kaijutsu consolidating
+//! its virtual filesystems under `/v`. It also fixes the pre-existing papercuts
+//! where `ls /v` returned nothing and `ls /` dropped `dev`.
+
+// Test-fixture code: unwrap/expect on known-good setup is the idiom here.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::sync::Arc;
+
+use kaish_kernel::vfs::{LocalFs, VfsRouter};
+use kaish_kernel::{Kernel, KernelBackend, KernelConfig, LocalBackend};
+
+/// Build a `with_backend` kernel over a read-only embedder root at `/` —
+/// kaijutsu's shape (`LocalBackend::read_only("/")`), the embedder owning the
+/// whole non-`/v/*` namespace and, now, its own leaves under `/v`.
+fn kernel_over(dir: &std::path::Path) -> Kernel {
+    let mut vfs = VfsRouter::new();
+    vfs.mount("/", LocalFs::read_only(dir));
+    let backend: Arc<dyn KernelBackend> = Arc::new(LocalBackend::new(Arc::new(vfs)));
+    Kernel::with_backend(backend, KernelConfig::isolated(), |_| {}, |_| {})
+        .expect("with_backend kernel")
+}
+
+/// An embedder root that serves a CAS blob at `/v/cas/blob.bin` — the embedder
+/// putting its own storage under `/v`, which kaish used to shadow to NotFound.
+fn seed_v_cas() -> tempfile::TempDir {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let cas = dir.path().join("v").join("cas");
+    std::fs::create_dir_all(&cas).expect("create v/cas");
+    std::fs::write(cas.join("blob.bin"), b"cas data").expect("write blob");
+    dir
+}
+
+async fn run(kernel: &Kernel, script: &str) -> (String, i64) {
+    let result = kernel.execute(script).await.expect("kernel execute");
+    (result.text_out().trim().to_string(), result.code)
+}
+
+fn has_token(out: &str, name: &str) -> bool {
+    out.split_whitespace().any(|t| t == name)
+}
+
+#[tokio::test]
+async fn unclaimed_v_path_reaches_embedder_backend() {
+    let dir = seed_v_cas();
+    let kernel = kernel_over(dir.path());
+
+    // Nothing is mounted at /v/cas on kaish's side, so this must reach the
+    // embedder's read-only root instead of the old NotFound reservation.
+    let (out, code) = run(&kernel, "cat /v/cas/blob.bin").await;
+    assert_eq!(code, 0, "cat /v/cas/blob.bin must reach the embedder: out={out:?}");
+    assert_eq!(out, "cas data");
+}
+
+#[tokio::test]
+async fn ls_v_unions_kaish_and_embedder_mounts() {
+    let dir = seed_v_cas();
+    let kernel = kernel_over(dir.path());
+
+    let (out, code) = run(&kernel, "ls /v").await;
+    assert_eq!(code, 0, "ls /v must succeed: out={out:?}");
+    // kaish's own mounts...
+    assert!(has_token(&out, "jobs"), "ls /v should list kaish jobs: out={out:?}");
+    assert!(has_token(&out, "blobs"), "ls /v should list kaish blobs: out={out:?}");
+    // ...unioned with the embedder's /v/cas.
+    assert!(has_token(&out, "cas"), "ls /v should list embedder cas: out={out:?}");
+}
+
+#[tokio::test]
+async fn v_synthesized_when_embedder_has_no_v() {
+    // Embedder root is empty — nothing under /v at all. `/v` must still be a
+    // navigable directory listing kaish's own mounts (synthesized ancestor).
+    let dir = tempfile::tempdir().expect("tempdir");
+    let kernel = kernel_over(dir.path());
+
+    let (out, code) = run(&kernel, "test -d /v && ls /v").await;
+    assert_eq!(code, 0, "`/v` must exist as a directory: out={out:?}");
+    assert!(has_token(&out, "jobs"), "ls /v should list kaish jobs: out={out:?}");
+    assert!(!has_token(&out, "cas"), "embedder contributes nothing here: out={out:?}");
+}
+
+#[tokio::test]
+async fn ls_root_shows_v_and_dev() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let kernel = kernel_over(dir.path());
+
+    // The generalized shared-parent union at `/` shows every kaish top-level
+    // mount root, not just a hardcoded `v` (the old code dropped `dev`).
+    let (out, code) = run(&kernel, "ls /").await;
+    assert_eq!(code, 0, "ls / must succeed: out={out:?}");
+    assert!(has_token(&out, "v"), "ls / should show v: out={out:?}");
+    assert!(has_token(&out, "dev"), "ls / should show dev: out={out:?}");
+}
+
+/// The fall-through must not widen writability: an unclaimed `/v/*` path routes
+/// to the *embedder's* backend, so a read-only embedder still rejects the write
+/// (its gate applies, not a kaish scratch overlay).
+#[tokio::test]
+async fn unclaimed_v_write_respects_read_only_embedder() {
+    let dir = seed_v_cas();
+    let kernel = kernel_over(dir.path());
+
+    let (out, code) = run(&kernel, "echo hi > /v/cas/new.bin").await;
+    assert_ne!(code, 0, "write under a read-only embedder /v must fail: out={out:?}");
+}

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -14,6 +14,56 @@ before it ships.
 
 ---
 
+## `/v` overlay stops being kaish's private reserve (2026-07-06)
+
+`VirtualOverlayBackend` — the shim that lets a `Kernel::with_backend` embedder
+keep kaish's virtual filesystems (`/v/jobs`, `/dev`, …) while owning the rest of
+the namespace — treated the whole `/v` tree as kaish's. `is_virtual_path` grabbed
+anything matching `"/v"` or `"/v/…"` lexically *before* consulting the mount
+table, so an embedder that mounted its own storage under `/v` (kaijutsu wants a
+CAS at `/v/cas` and its CRDT config at `/v/etc/*`) found those paths shadowed to
+`NotFound` — while surfaces that bypass the overlay (SFTP over `kernel.vfs()`)
+saw the real content. Two different `/v/x` depending on the surface, silently.
+
+The fix was mostly *deletion*. `VfsRouter::has_mount` already routes by longest
+prefix and already governs `/dev` — the lexical `/v` clauses were the vestigial
+half of a migration that was already started. Dropping them (`is_virtual_path`
+is now just `has_mount`) makes one rule: covered by a kaish mount → kaish;
+otherwise → the embedder. An unclaimed `/v/cas` falls through, and its writes hit
+the embedder's *own* gate (a read-only root still rejects them) rather than a
+kaish scratch overlay.
+
+Coverage-routing alone leaves a listing gap, and chasing it turned up that the
+gap already existed. In the overlay path kaish mounts at `/v/jobs`/`/v/blobs`,
+never at `/v` itself, so `has_mount("/v")` is false — meaning `ls /v` was
+*already* `NotFound` for embedders, and the root merge injected only a synthetic
+`v`, dropping `dev`. So the real work was making an intermediate directory that
+sits *above* mounts behave like a directory. We put that in the router (approach
+C, over doing it only in the overlay): `has_mount_under` + a generalized
+`list_mount_children` (the old `list_root` first-component trick, parameterized),
+so `VfsRouter::list`/`stat`/`lstat` synthesize `/v` from the mount roster instead
+of 404ing. The overlay stays thin — for a shared parent it unions the embedder's
+listing with kaish's (a `NotFound` from the embedder means "nothing here," not an
+error; kaish entries win a name clash) and synthesizes `stat`/`exists` when the
+embedder lacks the dir. The bare router is now self-consistent too, so SFTP over
+`kernel.vfs()` and the shell agree.
+
+One correction worth recording: this is **not** a compile break for kaibo or
+kaijutsu (the initial assumption). No public signature moves — `is_virtual_path`
+is private, the router additions are `pub(crate)`. It's a pure runtime-routing
+change, which is the *more* subtle kind, but benign in practice: kaibo's inner
+backend serves nothing under `/v` (its `ls /v` actually improves), and kaijutsu
+doesn't mount under `/v` *yet* — this is the prerequisite that lets it. Filed as
+`Fixed`, not `**BREAKING:**`: pre-1.0, a visible compile break is expected and
+cheap; a behavior correction toward the obviously-right routing, affecting only
+an embedder that leaned on the reservation (none do), doesn't earn the headline.
+The kaijutsu-side counterpart — its `MountBackend` synthesizing a `/v` listing so
+the union has something to merge — is tracked in that repo; our union tolerating
+its absence (`NotFound` → empty) is what de-risks the rollout ordering. TDD
+throughout: router synthesis and overlay union each went red first (`NotFound`
+`/v`, `["v"]` missing `dev`) before the code, and five `kernel.execute`
+integration tests drive the whole dispatch chain.
+
 ## `jq -s` stops being a no-op on the `.data` path (2026-07-06, GH #93 item 2)
 
 Real `jq -s`/`--slurp` has one law: wrap the inputs in an array, always —


### PR DESCRIPTION
## The problem

`VirtualOverlayBackend` — the shim that lets a `Kernel::with_backend` embedder
keep kaish's virtual filesystems (`/v/jobs`, `/dev`, …) while owning the rest of
the namespace — reserved the **entire** `/v` tree for kaish. `is_virtual_path`
matched `"/v"`/`"/v/…"` lexically *before* consulting the mount table, so an
embedder that mounted its own storage under `/v` (kaijutsu's CAS at `/v/cas`, its
CRDT config at `/v/etc/*`) found those paths shadowed to `NotFound` — while
surfaces that bypass the overlay (SFTP over `kernel.vfs()`) saw the real content.
Two different `/v/x` depending on the surface, silently.

## Discovery

`VfsRouter::has_mount` already routes by longest prefix and already governs
`/dev` — the lexical `/v` clauses were the vestigial half of a migration that had
already begun. Chasing the resulting listing gap turned up that it *already
existed*: in the overlay path kaish mounts at `/v/jobs`/`/v/blobs`, never at `/v`
itself, so `has_mount("/v")` is false — meaning `ls /v` was already `NotFound`
for embedders, and the root merge injected only a synthetic `v`, dropping `dev`.

## The fix (approach C — synthesis in the router, thin overlay)

- **`is_virtual_path` is now just `has_mount`.** The blanket `/v` reservation is
  gone *by design*: an unclaimed `/v/*` path delegates to the embedder's backend,
  and its writes hit the embedder's own gate (a read-only root still rejects
  them), never a kaish scratch overlay.
- **`VfsRouter` gains `has_mount_under` + `list_mount_children`** (the old
  `list_root` first-component trick, generalized). `list`/`stat`/`lstat`
  synthesize an intermediate ancestor dir like `/v` from the mount roster instead
  of `NotFound`, so the bare router (and SFTP) agrees with the shell.
- **The overlay stays thin:** at a shared parent it unions the embedder's listing
  with kaish's child mounts (a `NotFound` from the embedder means "nothing here,"
  not an error; kaish entries win a name clash) and synthesizes `stat`/`exists`
  when the embedder lacks the dir.

Also clears two pre-existing papercuts in that path: `ls /v` returned nothing,
and `ls /` dropped `dev`.

## Not a breaking change

No public signatures move — `is_virtual_path` is private, the router additions
are `pub(crate)`. This is **not** a compile break for kaibo/kaijutsu; it's a pure
runtime-routing correction. kaibo's inner backend serves nothing under `/v` (its
`ls /v` actually improves); kaijutsu doesn't mount under `/v` *yet* — this is the
prerequisite that lets it. Filed under `Fixed`, not `**BREAKING:**`: pre-1.0, a
visible compile break is expected and cheap, but a behavior correction toward the
obviously-right routing — affecting only an embedder that leaned on the
reservation (none do) — doesn't earn the headline.

The kaijutsu-side counterpart (its `MountBackend` synthesizing a `/v` listing so
the union has something to merge) is tracked in that repo; our union tolerating
its absence (`NotFound` → empty) is what de-risks the rollout ordering.

## Test plan

TDD, red→green at both layers (router synthesis went red with `NotFound /v`;
overlay union red with `["v"]` missing `dev`):

- **Router unit tests** — synthesized `list`/`stat`/`lstat` of `/v` and deeper
  (`/v/etc` over `/v/etc/rc`), `has_mount_under`, and a non-ancestor stays
  `NotFound`.
- **Overlay unit tests** — production-like fixture (mounts at `/v/*`, nothing at
  `/v`); unclaimed `/v/*` reaches a realistic `LocalBackend` inner, `/v` listing
  unions both layers, `/v` synthesized when the embedder lacks it, `ls /` shows
  `v`+`dev`.
- **`with_backend_v_overlay_tests.rs`** — 5 `kernel.execute` integration tests
  drive the whole dispatch chain: `cat /v/cas/blob.bin` reaches the embedder,
  `ls /v` unions kaish+embedder, `/v` navigable when the embedder lacks it, `ls
  /` shows `v`+`dev`, and a read-only embedder still rejects `/v/cas` writes.

Gates: `cargo test --all` (112 summaries, all ok) · `cargo clippy --all
--all-targets` clean · `--no-default-features` + WASI build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Review response — kaibo, deepseek + GLM-5.2 in parallel

Both models confirmed the routing/synthesis core is sound (path-boundary handling,
`/vx` vs `/v`, deep intermediates, longest-prefix precedence). Independently
confirmed clean: `resolve_real_path`, `cd`, the validator, and the `/v/bin`
dispatch guard.

**Fixed in this PR** (commit `d8c3f4e`, GLM finding): a data-safety regression the
routing change *activated*. `is_trash_excluded` lexically exempted real `/v/...`
paths — a stale clause (kaish's in-memory `/v` mounts resolve to `None` and never
matched it) that became harmful once unclaimed `/v/*` began resolving to the
embedder's real path: a host-rooted writable embedder's real content under `/v`
would silently lose its trash + latch safety net. Dropped the `/v` clause (kept
`/tmp` scratch), flipped the two decision-table tests that pinned the old
behavior (red first), and added an overlay test proving unclaimed `/v/*` resolves
to the embedder's real path.

**Also fixed in this PR** (commit `6f25ff2`) — the four consistency edges both
models flagged around a *synthesized shared-ancestor* directory (a path above
kaish mounts but not itself a mount, like `/v`). Named the concept
(`is_shared_ancestor`) and made every op treat it uniformly as a **read-only
synthesized union directory**:
- `stat`/`lstat`/`exists`/`list` all agree it's a directory — no more `exists`
  true while `stat` errors, and `list` no longer leaks `NotADirectory` when the
  embedder has a *file* where kaish mounts children.
- `list` prefers the embedder's real metadata for a name it owns (an
  *intermediate* like `/v`), while a real kaish *mount* (`/dev`, `/v/jobs`)
  shadows the embedder's same-named entry — fixing the `ls -l` zero-metadata
  mismatch with `stat`.
- Every direct mutation (`rm`/`mkdir`/`touch`/write/rename/…) is refused with a
  clear error (`IsDirectory`/`AlreadyExists`/`InvalidOperation`) instead of a
  misleading `NotFound`. `rm` delegates recursion to `backend.remove`, so
  `rm -rf /v` is refused immediately and never touches the kaish mounts beneath
  it — closing GLM's "half-delete `/v`" concern.

Pinned by new overlay unit tests (inner-file, inner-real-dir metadata, mutation
rejections) and two `kernel.execute` integration tests (`rm -rf /v` refused with
`/v` intact; `mkdir /v` reports it exists).
