### PR TITLE
fix(glob): pattern passthrough — glob **/*.rs no longer eats its own pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,22 @@ breaking entries are marked **BREAKING**.
 
 ## [Unreleased]
 
+### Fixed
+- **Unquoted `glob **/*.rs` now works: the pattern reaches the builtin as
+  written.** Previously the kernel's argv glob expansion pre-expanded the bare
+  pattern into matching paths, so `glob` bound the first path as its "pattern",
+  silently ignored the rest, and printed exactly one file — after walking the
+  tree twice. The builtin's own examples (and agents following them) spell the
+  pattern unquoted. Quoted patterns behave as before.
+
 ### Added
+- **`ToolSchema::glob_passthrough` (+ `with_glob_passthrough()`)** — a tool
+  whose input *is* a glob pattern (like `glob`) can now tell the argv binder to
+  pass bare patterns through as literal text instead of expanding them.
+  Embedder tools with pattern-shaped inputs can opt in the same way.
+- **`glob` accepts multiple patterns** (`glob **/*.rs **/*.toml`): matches are
+  the deduped union in pattern order; any pattern with zero matches fails the
+  whole command (exit 1) naming the pattern that missed.
 - **A backgrounded confirmation latch is now surfaced and fulfillable** (GH
   #96). A destructive op gated under `set -o latch` and run in the background
   (`rm x &`) stored its `LatchRequest` but no consumer exposed it, so the nonce

--- a/crates/kaish-help/content/en/syntax.md
+++ b/crates/kaish-help/content/en/syntax.md
@@ -288,7 +288,9 @@ set +o glob               # disable bare glob expansion
 set -o glob               # re-enable (on by default)
 ```
 
-Zero matches is an error (exit code 1). The `glob` builtin still works for `--exclude` and `**`.
+Zero matches is an error (exit code 1). The `glob` builtin receives its
+pattern as written — `glob **/*.rs` needs no quotes, takes multiple patterns,
+and adds `--exclude`, `--ftype`, and depth control.
 
 ## Regex (grep, sed, awk)
 

--- a/crates/kaish-help/src/fragments.rs
+++ b/crates/kaish-help/src/fragments.rs
@@ -553,7 +553,9 @@ set +o glob               # disable bare glob expansion
 set -o glob               # re-enable (on by default)
 ```
 
-Zero matches is an error (exit code 1). The `glob` builtin still works for `--exclude` and `**`."#,
+Zero matches is an error (exit code 1). The `glob` builtin receives its
+pattern as written — `glob **/*.rs` needs no quotes, takes multiple patterns,
+and adds `--exclude`, `--ftype`, and depth control."#,
     ),
     syntax_section(
         "regex",

--- a/crates/kaish-kernel/src/kernel.rs
+++ b/crates/kaish-kernel/src/kernel.rs
@@ -3413,6 +3413,13 @@ impl Kernel {
         let mut tool_args = ToolArgs::new();
         let home = self.scope_home().await;
 
+        // A glob-passthrough tool (`glob`) consumes patterns as data: skip
+        // argv glob expansion so the pattern reaches the tool as written —
+        // otherwise `glob **/*.rs` binds the first *matching path* as its
+        // pattern. The eval fallback turns `Expr::GlobPattern` into its
+        // literal string.
+        let glob_passthrough = schema.is_some_and(|s| s.glob_passthrough);
+
         // Raw-argv fast path (POSIX `test`): bind every argument to `positional`
         // in source order with types preserved — operators (`-f`, `=`, `!`) as
         // strings, operands keeping their `Value` — leaving `flags`/`named`
@@ -3427,7 +3434,8 @@ impl Kernel {
                 match arg {
                     Arg::Positional(expr) => {
                         let glob = if let Expr::GlobPattern(p) = expr {
-                            self.scope.read().await.glob_enabled().then(|| p.clone())
+                            (!glob_passthrough && self.scope.read().await.glob_enabled())
+                                .then(|| p.clone())
                         } else {
                             None
                         };
@@ -3549,7 +3557,7 @@ impl Kernel {
                                 let scope = self.scope.read().await;
                                 scope.glob_enabled()
                             };
-                            if glob_enabled {
+                            if glob_enabled && !glob_passthrough {
                                 let (paths, cwd) = {
                                     let ctx = self.exec_ctx.read().await;
                                     let paths = ctx.expand_glob(pattern).await

--- a/crates/kaish-kernel/src/tools/builtin/glob.rs
+++ b/crates/kaish-kernel/src/tools/builtin/glob.rs
@@ -75,6 +75,9 @@ impl Tool for Glob {
     }
 
     fn schema(&self) -> ToolSchema {
+        // glob_passthrough: the argv binder hands bare patterns through as
+        // written — without it, `glob **/*.rs` (as every example here spells
+        // it) would bind the first *matching path* as the pattern.
         schema_from_clap(
             &GlobArgs::command(),
             "glob",
@@ -82,6 +85,7 @@ impl Tool for Glob {
             [
                 ("Find all Rust files", "glob **/*.rs"),
                 ("Find in specific directory", "glob src/**/*.rs"),
+                ("Multiple patterns", "glob **/*.rs **/*.toml"),
                 ("Multiple extensions", "glob **/*.{rs,go,py}"),
                 ("With depth limit", "glob **/*.rs -d 3"),
                 ("Include hidden files", "glob **/*.rs -a"),
@@ -89,6 +93,7 @@ impl Tool for Glob {
                 ("Exclude test files", "glob **/*.rs --exclude='*_test.rs'"),
             ],
         )
+        .with_glob_passthrough()
     }
 
     async fn execute(&self, mut args: ToolArgs, ctx: &mut dyn ToolCtx) -> ExecResult {
@@ -127,39 +132,18 @@ impl Tool for Glob {
             Err(e) => return ExecResult::failure(2, format!("glob: {e}")),
         };
 
-        // Get the pattern
-        let pattern = match args.get_string("pattern", 0) {
-            Some(p) => p,
-            None => return ExecResult::failure(1, "glob: missing pattern argument"),
-        };
-
-        // Parse the glob pattern
-        let glob = match GlobPath::new(&pattern) {
-            Ok(g) => g,
-            Err(e) => return ExecResult::failure(1, format!("glob: invalid pattern: {}", e)),
-        };
-
-        // Names are reported relative to the conventional root — `/` for an
-        // anchored pattern, the cwd otherwise — regardless of where the walk
-        // actually starts.
-        let report_root = if glob.is_anchored() {
-            ctx.resolve_path("/")
-        } else {
-            ctx.resolve_path(".")
-        };
-
-        // Walk from the pattern's deepest static directory, not from `/`.
-        // Walking from `/` is O(filesystem) and — fatally — the walker skips
-        // hidden intermediate directories, so an anchored pattern routed
-        // through a hidden dir (e.g. tempfile's `/tmp/.tmpXXXX/*.txt`) matched
-        // nothing. `split_static_dir` peels the literal leading components into
-        // the walk root and leaves the remainder as the match pattern.
-        let (static_dir, glob) = glob.split_static_dir();
-        let root = if static_dir.as_os_str().is_empty() {
-            report_root.clone()
-        } else {
-            report_root.join(&static_dir)
-        };
+        // Every positional is a pattern. The argv binder hands bare patterns
+        // through as written (ToolSchema::glob_passthrough), so this is the
+        // whole pattern list; Value-typed positionals are read off
+        // `args.positional`, not the clap struct (to_argv is lossy).
+        let patterns: Vec<String> = args
+            .positional
+            .iter()
+            .map(crate::interpreter::value_to_string)
+            .collect();
+        if patterns.is_empty() {
+            return ExecResult::failure(1, "glob: missing pattern argument");
+        }
 
         // Parse options
         let max_depth = args.get("depth", usize::MAX).and_then(|v| match v {
@@ -216,57 +200,90 @@ impl Tool for Glob {
             filter.exclude(exc);
         }
 
-        let options = WalkOptions {
-            max_depth,
-            entry_types,
-            respect_gitignore: if no_ignore { false } else { ctx.ignore_config.auto_gitignore() },
-            include_hidden,
-            filter,
-            types: file_types.clone(),
-            ..WalkOptions::default()
-        };
-
-        // Create walker
         let fs = BackendWalkerFs(ctx.backend.as_ref());
-        let mut walker = FileWalker::new(&fs, &root)
-            .with_pattern(glob)
-            .with_options(options);
+        let mut nodes: Vec<OutputNode> = Vec::new();
+        let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
 
-        // Inject ignore filter from config (unless --no-ignore)
-        if !no_ignore {
-            if let Some(ignore_filter) = ctx.build_ignore_filter(&root).await {
-                walker = walker.with_ignore(ignore_filter);
+        for pattern in &patterns {
+            let glob = match GlobPath::new(pattern) {
+                Ok(g) => g,
+                Err(e) => return ExecResult::failure(1, format!("glob: invalid pattern: {}", e)),
+            };
+
+            // Names are reported relative to the conventional root — `/` for an
+            // anchored pattern, the cwd otherwise — regardless of where the walk
+            // actually starts.
+            let report_root = if glob.is_anchored() {
+                ctx.resolve_path("/")
+            } else {
+                ctx.resolve_path(".")
+            };
+
+            // Walk from the pattern's deepest static directory, not from `/`.
+            // Walking from `/` is O(filesystem) and — fatally — the walker skips
+            // hidden intermediate directories, so an anchored pattern routed
+            // through a hidden dir (e.g. tempfile's `/tmp/.tmpXXXX/*.txt`) matched
+            // nothing. `split_static_dir` peels the literal leading components into
+            // the walk root and leaves the remainder as the match pattern.
+            let (static_dir, glob) = glob.split_static_dir();
+            let root = if static_dir.as_os_str().is_empty() {
+                report_root.clone()
+            } else {
+                report_root.join(&static_dir)
+            };
+
+            let options = WalkOptions {
+                max_depth,
+                entry_types,
+                respect_gitignore: if no_ignore { false } else { ctx.ignore_config.auto_gitignore() },
+                include_hidden,
+                filter: filter.clone(),
+                types: file_types.clone(),
+                ..WalkOptions::default()
+            };
+
+            let mut walker = FileWalker::new(&fs, &root)
+                .with_pattern(glob)
+                .with_options(options);
+
+            // Inject ignore filter from config (unless --no-ignore)
+            if !no_ignore {
+                if let Some(ignore_filter) = ctx.build_ignore_filter(&root).await {
+                    walker = walker.with_ignore(ignore_filter);
+                }
             }
-        }
 
-        // Collect results
-        let paths = match walker.collect().await {
-            Ok(p) => p,
-            Err(e) => return ExecResult::failure(1, format!("glob: {}", e)),
-        };
+            let paths = match walker.collect().await {
+                Ok(p) => p,
+                Err(e) => return ExecResult::failure(1, format!("glob: {}", e)),
+            };
 
-        // Strict-glob guarantee: zero matches is an error, not silent success.
-        // This is consistent with how the kernel treats a bare glob in argv
-        // position (no matches → error). The `glob` builtin must enforce the
-        // same contract so agents can rely on a non-zero exit to detect misses.
-        if paths.is_empty() {
-            return ExecResult::failure(1, format!("glob: no matches for pattern '{pattern}'"));
-        }
+            // Strict-glob guarantee, per pattern: zero matches is an error
+            // naming the pattern that missed, not silent success. This is
+            // consistent with how the kernel treats a bare glob in argv
+            // position (no matches → error). The `glob` builtin must enforce
+            // the same contract so agents can rely on a non-zero exit to
+            // detect misses.
+            if paths.is_empty() {
+                return ExecResult::failure(1, format!("glob: no matches for pattern '{pattern}'"));
+            }
 
-        // Build OutputNodes for each matched path (relative to root)
-        let nodes: Vec<OutputNode> = paths
-            .iter()
-            .map(|p| {
+            // Build OutputNodes for each matched path (relative to root),
+            // deduped across patterns by reported name.
+            for p in &paths {
                 let rel = p.strip_prefix(&report_root).unwrap_or(p);
                 let name = rel.to_string_lossy().to_string();
+                if !seen.insert(name.clone()) {
+                    continue;
+                }
                 let entry_type = if p.extension().is_none() && name.ends_with('/') {
                     EntryType::Directory
                 } else {
                     EntryType::File
                 };
-                OutputNode::new(name).with_entry_type(entry_type)
-            })
-            .collect();
+                nodes.push(OutputNode::new(name).with_entry_type(entry_type));
+            }
+        }
 
         // Build JSON array for structured pipeline flow (same pattern as seq/split/find)
         let json_array: Vec<serde_json::Value> = nodes

--- a/crates/kaish-kernel/tests/glob_pattern_passthrough_tests.rs
+++ b/crates/kaish-kernel/tests/glob_pattern_passthrough_tests.rs
@@ -1,0 +1,180 @@
+//! Kernel-routed tests: the `glob` builtin receives its pattern *as written*.
+//!
+//! The bug: an unquoted pattern (`glob **/*.rs`) was pre-expanded by the
+//! kernel's argv glob expansion before the builtin ran. The builtin then read
+//! the first matching path as its "pattern", silently ignored the rest, and
+//! printed exactly one file — after walking the tree twice (once at bind
+//! time, once inside the builtin). The builtin's own schema examples teach
+//! the unquoted spelling, so agents hit this constantly.
+//!
+//! The fix: `ToolSchema::glob_passthrough` tells the argv binder to hand
+//! bare glob patterns through as literal text for tools whose input IS the
+//! pattern. Alongside it, `glob` accepts multiple patterns (its schema
+//! always said "pattern(s)") instead of silently dropping extras.
+
+// Test-fixture code: unwrap/expect on known-good setup is the idiom here.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+#![cfg(feature = "localfs")]
+
+mod common;
+
+use std::fs;
+use tempfile::tempdir;
+
+use common::{kernel_at, run};
+
+fn touch(dir: &std::path::Path, name: &str) {
+    let path = dir.join(name);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).expect("create parent dirs");
+    }
+    fs::write(path, b"x").expect("write file");
+}
+
+/// The headline bug: unquoted `glob **/*.rs` must match every .rs file,
+/// not bind the first pre-expanded path as the pattern and return one file.
+#[tokio::test]
+async fn unquoted_recursive_pattern_matches_all_files() {
+    let dir = tempdir().unwrap();
+    touch(dir.path(), "src/alpha.rs");
+    touch(dir.path(), "src/deep/beta.rs");
+    touch(dir.path(), "README.md");
+    let kernel = kernel_at(dir.path());
+
+    let (out, code) = run(&kernel, "glob **/*.rs").await;
+    assert_eq!(code, 0, "glob should succeed, got: {out:?}");
+    assert!(out.contains("alpha.rs"), "missing alpha.rs in: {out:?}");
+    assert!(out.contains("beta.rs"), "missing nested beta.rs in: {out:?}");
+    assert!(!out.contains("README.md"), "README.md must not match: {out:?}");
+    assert!(
+        out.lines().count() >= 2,
+        "must match all .rs files, not just the first pre-expanded path: {out:?}"
+    );
+}
+
+/// Unquoted and quoted spellings must be equivalent.
+#[tokio::test]
+async fn unquoted_and_quoted_patterns_agree() {
+    let dir = tempdir().unwrap();
+    touch(dir.path(), "one.txt");
+    touch(dir.path(), "two.txt");
+    touch(dir.path(), "three.md");
+    let kernel = kernel_at(dir.path());
+
+    let (unquoted, code_a) = run(&kernel, "glob *.txt").await;
+    let (quoted, code_b) = run(&kernel, "glob '*.txt'").await;
+    assert_eq!(code_a, 0);
+    assert_eq!(code_b, 0);
+    assert_eq!(unquoted, quoted, "unquoted pattern must behave like quoted");
+    assert!(unquoted.contains("one.txt") && unquoted.contains("two.txt"));
+}
+
+/// Multiple patterns union their matches (the schema always said
+/// "pattern(s)"); previously every positional past the first was
+/// silently dropped.
+#[tokio::test]
+async fn multiple_patterns_union_matches() {
+    let dir = tempdir().unwrap();
+    touch(dir.path(), "main.rs");
+    touch(dir.path(), "notes.md");
+    touch(dir.path(), "data.json");
+    let kernel = kernel_at(dir.path());
+
+    let (out, code) = run(&kernel, "glob *.rs *.md").await;
+    assert_eq!(code, 0, "multi-pattern glob should succeed: {out:?}");
+    assert!(out.contains("main.rs"), "missing *.rs match in: {out:?}");
+    assert!(out.contains("notes.md"), "missing *.md match in: {out:?}");
+    assert!(!out.contains("data.json"), "unrequested match in: {out:?}");
+}
+
+/// Overlapping patterns must not emit duplicate paths.
+#[tokio::test]
+async fn overlapping_patterns_dedupe() {
+    let dir = tempdir().unwrap();
+    touch(dir.path(), "main.rs");
+    let kernel = kernel_at(dir.path());
+
+    let (out, code) = run(&kernel, "glob '*.rs' 'main*'").await;
+    assert_eq!(code, 0);
+    let hits = out.lines().filter(|l| l.contains("main.rs")).count();
+    assert_eq!(hits, 1, "main.rs must appear exactly once: {out:?}");
+}
+
+/// Strict-glob applies per pattern: one pattern with zero matches fails
+/// the whole command and names the offending pattern.
+#[tokio::test]
+async fn zero_match_pattern_among_multiple_errors() {
+    let dir = tempdir().unwrap();
+    touch(dir.path(), "main.rs");
+    let kernel = kernel_at(dir.path());
+
+    let result = kernel.execute("glob '*.rs' '*.none'").await.expect("execute");
+    assert_ne!(result.code, 0, "a no-match pattern must fail the command");
+    assert!(
+        result.err.contains("*.none"),
+        "error must name the pattern that matched nothing: {:?}",
+        result.err
+    );
+}
+
+/// `set +o glob` already handed the builtin its literal pattern; that
+/// spelling must keep working identically with passthrough.
+#[tokio::test]
+async fn noglob_mode_still_reaches_builtin() {
+    let dir = tempdir().unwrap();
+    touch(dir.path(), "one.txt");
+    touch(dir.path(), "two.txt");
+    let kernel = kernel_at(dir.path());
+
+    let (out, code) = run(&kernel, "set +o glob\nglob *.txt").await;
+    assert_eq!(code, 0, "glob must work under set +o glob: {out:?}");
+    assert!(out.contains("one.txt") && out.contains("two.txt"), "got: {out:?}");
+}
+
+/// Regression guard: passthrough is scoped to tools that opt in — every
+/// other command still gets shell glob expansion in argv position.
+#[tokio::test]
+async fn other_builtins_still_expand_argv_globs() {
+    let dir = tempdir().unwrap();
+    touch(dir.path(), "one.txt");
+    touch(dir.path(), "two.txt");
+    let kernel = kernel_at(dir.path());
+
+    let (out, code) = run(&kernel, "echo *.txt").await;
+    assert_eq!(code, 0);
+    assert!(
+        out.contains("one.txt") && out.contains("two.txt"),
+        "echo must still receive expanded paths, got: {out:?}"
+    );
+    assert!(!out.contains('*'), "pattern must not leak literally: {out:?}");
+}
+
+/// Zero matches for other commands stays a bind-time error (strict glob).
+#[tokio::test]
+async fn other_builtins_keep_strict_no_match_error() {
+    let dir = tempdir().unwrap();
+    touch(dir.path(), "one.txt");
+    let kernel = kernel_at(dir.path());
+
+    let result = kernel.execute("echo *.none").await.expect("execute");
+    assert_ne!(result.code, 0, "strict glob: zero matches must fail");
+}
+
+/// Structured output survives the change: `glob` still sets `.data` to a
+/// JSON array of paths so for-loops iterate per element.
+#[tokio::test]
+async fn multi_pattern_result_data_is_json_array() {
+    let dir = tempdir().unwrap();
+    touch(dir.path(), "main.rs");
+    touch(dir.path(), "notes.md");
+    let kernel = kernel_at(dir.path());
+
+    let (out, code) = run(
+        &kernel,
+        "for f in $(glob *.rs *.md); do echo \"got:$f\"; done",
+    )
+    .await;
+    assert_eq!(code, 0, "for over glob output should succeed: {out:?}");
+    assert!(out.contains("got:main.rs"), "missing element iteration: {out:?}");
+    assert!(out.contains("got:notes.md"), "missing element iteration: {out:?}");
+}

--- a/crates/kaish-types/src/tool.rs
+++ b/crates/kaish-types/src/tool.rs
@@ -246,6 +246,18 @@ pub struct ToolSchema {
     /// operands. See [`ToolSchema::with_raw_argv`].
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub raw_argv: bool,
+    /// The tool consumes glob patterns **as data** — the argv binder must pass
+    /// a bare glob pattern through as literal text instead of expanding it to
+    /// matching paths.
+    ///
+    /// Default false: shell semantics — `cat *.rs` sees matching files and
+    /// zero matches is a bind-time error. Set true for a tool whose input *is*
+    /// the pattern (`glob`), so the natural unquoted spelling
+    /// (`glob **/*.rs`) hands the pattern text to the tool instead of walking
+    /// the tree at bind time and binding the first match as the "pattern".
+    /// See [`ToolSchema::with_glob_passthrough`].
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub glob_passthrough: bool,
 }
 
 impl ToolSchema {
@@ -261,6 +273,7 @@ impl ToolSchema {
             aliases: Vec::new(),
             owns_output: false,
             raw_argv: false,
+            glob_passthrough: false,
         }
     }
 
@@ -268,6 +281,14 @@ impl ToolSchema {
     /// preserved (no flag/positional split). See [`ToolSchema::raw_argv`].
     pub fn with_raw_argv(mut self) -> Self {
         self.raw_argv = true;
+        self
+    }
+
+    /// Declare that this tool consumes glob patterns as data: the argv binder
+    /// passes bare patterns through as literal text instead of expanding them.
+    /// See [`ToolSchema::glob_passthrough`].
+    pub fn with_glob_passthrough(mut self) -> Self {
+        self.glob_passthrough = true;
         self
     }
 

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -841,10 +841,14 @@ Glob expansion is enabled by default (`set -o glob`). Disable it with `set +o gl
 
 If a glob matches zero files, the command fails with exit code 1 rather than passing the literal pattern through. This prevents silent bugs where a typo in a pattern goes undetected.
 
-The `glob` builtin still works for advanced options like `--exclude` and recursive `**` patterns:
+The `glob` builtin is the exception: it consumes patterns as data, so the
+binder hands them through as written — no quoting needed, and it accepts
+multiple patterns. Use it for advanced options like `--exclude` and recursive
+`**` patterns:
 
 ```sh
-glob "**/*.rs" --exclude="*_test.rs"
+glob **/*.rs --exclude="*_test.rs"   # pattern reaches glob unexpanded
+glob **/*.rs **/*.toml               # multiple patterns, deduped union
 ```
 
 ### Hidden files (dotfiles)

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -14,6 +14,38 @@ before it ships.
 
 ---
 
+## `glob **/*.rs` stops eating its own pattern (2026-07-06)
+
+Amy hit it live at the REPL: `glob **/*.rs` at the kaish repo root took a long
+time, then printed exactly one file — `crates/kaish-client/src/embedded.rs`.
+Contributing factors, in order: (1) an unquoted pattern in argv position is a
+`GlobPattern` token, and the kernel's argv binder pre-expands those into
+matching paths before the tool runs — correct shell semantics for `cat *.rs`,
+fatal for a tool whose *input is the pattern*; (2) the `glob` builtin read
+positional 0 as its pattern and silently dropped the rest, so the first
+pre-expanded path (alphabetically first — kaish-client sorts first) became the
+"pattern", an all-literal glob that matches exactly itself; (3) the REPL runs
+`IgnoreConfig::none()`, so the bind-time walk descended all of `target/`
+unfiltered — that was the "long time", paid twice because the builtin then
+walked again to match the literal path. The builtin's own schema examples
+teach the unquoted spelling, so every agent following the help walks into it.
+
+The fix is a first-class seam, not a special case: `ToolSchema` grows a
+`glob_passthrough` flag (sibling of `raw_argv`/`owns_output`) telling the
+binder to hand bare patterns through as written; the eval fallback already
+binds `Expr::GlobPattern` to its literal text (it's what `set +o glob` used).
+`glob` opts in and now consumes *all* positionals as patterns — deduped union
+in pattern order, strict per-pattern no-match errors that name the missing
+pattern — instead of silently ignoring everything past the first. This is
+also consistent with the builtin-side expansion family: cat/head/tail/ls/…
+already do their own glob eval on string args via `ctx.expand_paths`, so the
+tool owning pattern semantics was the established pattern; the binder just
+had to stop pre-chewing glob's input. Embedder tools with pattern-shaped
+inputs get the same opt-in. The REPL's unfiltered `target/` walk (slow even
+when correct) stays open as a follow-up.
+
+---
+
 ## `jq -s` stops being a no-op on the `.data` path (2026-07-06, GH #93 item 2)
 
 Real `jq -s`/`--slurp` has one law: wrap the inputs in an array, always —


### PR DESCRIPTION
## Problem

Live repro at the REPL: `glob **/*.rs` at the kaish repo root took a long time, then printed exactly one file — `crates/kaish-client/src/embedded.rs`.

Contributing factors, in order:

1. **The argv binder pre-expands bare glob patterns.** An unquoted `**/*.rs` is a `GlobPattern` token, and `build_args_async` expands it into matching paths before the tool runs. Correct shell semantics for `cat *.rs` — fatal for a tool whose *input is the pattern*.
2. **The builtin silently dropped everything past positional 0.** Its clap struct declares `pattern: Vec<String>` ("Glob pattern(s) to expand"), but execute read only the first — so the alphabetically-first pre-expanded path became the "pattern", an all-literal glob that matches exactly itself.
3. **The walk was paid twice** (bind-time expansion, then the builtin's own walk), unfiltered through `target/` under the REPL's `IgnoreConfig::none()` — that was the "long time".

The builtin's own schema examples teach the unquoted spelling, so agents following the help walk straight into this.

## Decision

A first-class seam, not a special case: `ToolSchema` grows **`glob_passthrough`** (sibling of `raw_argv`/`owns_output`) telling the binder to hand bare patterns through as written — the existing eval fallback already binds `Expr::GlobPattern` to its literal text (it's the path `set +o glob` always used). `glob` opts in, and now consumes **all** positionals as patterns: deduped union in pattern order, strict per-pattern no-match errors that name the pattern that missed.

Builtins owning pattern semantics is the established shape — `cat`/`head`/`tail`/`ls`/… already re-expand string args via `ctx.expand_paths` — the binder just stops pre-chewing glob's input. Embedder tools with pattern-shaped inputs get the same opt-in (additive field on the non_exhaustive struct).

## Verified

- 9 new kernel-routed tests (`glob_pattern_passthrough_tests.rs`): unquoted/quoted parity, multi-pattern union + dedupe, per-pattern no-match naming, noglob mode, and regression guards that other builtins keep shell expansion + strict no-match.
- End-to-end via the real REPL (`-c` and the interactive loop): the original repro now returns all 295 `.rs` files at the repo root in 0.27s.
- `cargo test --all` and `cargo clippy --all --all-targets` clean; `regen_syntax` run (drift test green).

## Follow-up (out of scope)

The REPL's `IgnoreConfig::none()` still walks `target/` unfiltered on any repo-root recursive glob — correct but slow on cold cache. Worth its own design discussion (REPL default vs `agent()` config).

🤖 Generated with [Claude Code](https://claude.com/claude-code)