### PR TITLE
fix(#96): jobs --cleanup and kill %N no longer destroy a latch silently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,14 @@ breaking entries are marked **BREAKING**.
   variants/fields won't break you.
 
 ### Fixed
+- **A backgrounded confirmation latch can no longer be destroyed silently**
+  (GH #96 follow-up). `jobs --cleanup` used to reap a latched job like any
+  completed one, and `kill %N` removed it outright — both silently dropped the
+  stored `LatchRequest`, leaving the gated operation permanently
+  unconfirmable. `jobs --cleanup` now keeps latched jobs and says so; `kill
+  %N` on a latched job refuses with a pointer to the nonce; the new `kill
+  --discard %N` abandons the gate explicitly and loudly (the gated operation
+  never runs).
 - **README install instructions pointed at a crate that doesn't exist.**
   `cargo install kaish` fails — there is no `kaish` package on crates.io; the
   binary named `kaish` ships in the `kaish-repl` crate. The README now says

--- a/crates/kaish-kernel/src/scheduler/job.rs
+++ b/crates/kaish-kernel/src/scheduler/job.rs
@@ -362,7 +362,15 @@ impl Job {
                     std::task::Poll::Ready(Err(e)) => {
                         ExecResult::failure(1, format!("job panicked: {}", e))
                     }
-                    std::task::Poll::Pending => return false, // shouldn't happen
+                    std::task::Poll::Pending => {
+                        // is_finished() promised Ready, but if the runtime
+                        // ever says Pending anyway, dropping the taken handle
+                        // would strand the job as "Running" forever with its
+                        // result silently lost. Put it back and retry on a
+                        // later poll.
+                        self.handle = Some(handle);
+                        return false;
+                    }
                 };
                 self.result = Some(result);
                 return true;
@@ -638,10 +646,15 @@ impl JobManager {
     }
 
     /// Remove completed jobs from tracking and clean up their temp files.
+    ///
+    /// A latched job is "done" but its cached result holds the only
+    /// `LatchRequest` for the gated operation — reaping it would silently
+    /// destroy the pending confirmation (GH #96). It stays until confirmed
+    /// or explicitly discarded (`kill --discard %N`).
     pub async fn cleanup(&self) {
         let mut jobs = self.jobs.lock().await;
         jobs.retain(|_, job| {
-            if job.is_done() {
+            if job.is_done() && job.latch().is_none() {
                 job.cleanup_files();
                 false
             } else {
@@ -654,6 +667,14 @@ impl JobManager {
     pub async fn exists(&self, id: JobId) -> bool {
         let jobs = self.jobs.lock().await;
         jobs.contains_key(&id)
+    }
+
+    /// Whether the job's cached result is a pending confirmation gate
+    /// (`JobStatus::Latched`). Consumers that would drop the job (`kill`,
+    /// cleanup paths) check this so a latch is never destroyed silently.
+    pub async fn is_latched(&self, id: JobId) -> bool {
+        let mut jobs = self.jobs.lock().await;
+        jobs.get_mut(&id).is_some_and(|job| job.latch().is_some())
     }
 
     /// Get info for a specific job.

--- a/crates/kaish-kernel/src/scheduler/job.rs
+++ b/crates/kaish-kernel/src/scheduler/job.rs
@@ -851,6 +851,11 @@ impl JobManager {
     }
 
     /// Remove a job from tracking.
+    ///
+    /// NOTE: this bypasses the latch guard — a caller that might hit a
+    /// latched job must check [`is_latched`](Self::is_latched) first (see
+    /// the `kill` builtin), or the job's pending confirmation is destroyed
+    /// with it. `cleanup()` is the latch-safe bulk path.
     pub async fn remove(&self, id: JobId) {
         let mut jobs = self.jobs.lock().await;
         if let Some(mut job) = jobs.remove(&id) {

--- a/crates/kaish-kernel/src/tools/builtin/jobs.rs
+++ b/crates/kaish-kernel/src/tools/builtin/jobs.rs
@@ -59,9 +59,17 @@ impl Tool for Jobs {
         if parsed.cleanup {
             let before = manager.list().await.len();
             manager.cleanup().await;
-            let after = manager.list().await.len();
-            let removed = before - after;
-            return ExecResult::with_output(OutputData::text(format!("Cleaned up {} completed job(s)\n", removed)));
+            let remaining = manager.list().await;
+            let removed = before - remaining.len();
+            let latched = remaining.iter().filter(|j| j.latch.is_some()).count();
+            let mut msg = format!("Cleaned up {} completed job(s)\n", removed);
+            if latched > 0 {
+                msg.push_str(&format!(
+                    "Kept {latched} latched job(s) awaiting confirmation — \
+                     confirm via the nonce or abandon with kill --discard %N\n"
+                ));
+            }
+            return ExecResult::with_output(OutputData::text(msg));
         }
 
         let jobs = manager.list().await;

--- a/crates/kaish-kernel/src/tools/builtin/kill.rs
+++ b/crates/kaish-kernel/src/tools/builtin/kill.rs
@@ -28,6 +28,11 @@ struct KillArgs {
     #[arg(short = 's', long, default_value_t = String::from("TERM"))]
     signal: String,
 
+    /// Abandon a latched (confirmation-pending) job. Without this flag, kill
+    /// refuses to destroy a job's pending confirmation gate.
+    #[arg(long)]
+    discard: bool,
+
     #[command(flatten)]
     global: GlobalFlags,
 
@@ -97,6 +102,26 @@ impl Tool for Kill {
                 Some(m) => m.clone(),
                 None => return ExecResult::failure(1, "kill: no job manager"),
             };
+            // A latched job's cached result is the only handle to its pending
+            // confirmation — killing it would silently destroy the gate
+            // (GH #96). Refuse unless the caller explicitly discards.
+            if manager.is_latched(job_id).await {
+                if !parsed.discard {
+                    return ExecResult::failure(
+                        1,
+                        format!(
+                            "kill: job {job_id} is latched awaiting confirmation — \
+                             fulfill it (see /v/jobs/{job_id}/latch) or abandon it \
+                             with: kill --discard %{job_id}"
+                        ),
+                    );
+                }
+                manager.cancel(job_id).await;
+                manager.remove(job_id).await;
+                return ExecResult::success(format!(
+                    "kill: discarded pending latch for job {job_id}"
+                ));
+            }
             return kill_job(&manager, job_id, &signal_name).await;
         }
 

--- a/crates/kaish-kernel/src/tools/builtin/kill.rs
+++ b/crates/kaish-kernel/src/tools/builtin/kill.rs
@@ -29,8 +29,9 @@ struct KillArgs {
     signal: String,
 
     /// Abandon a latched (confirmation-pending) job. Without this flag, kill
-    /// refuses to destroy a job's pending confirmation gate.
-    #[arg(long)]
+    /// refuses to destroy a job's pending confirmation gate. Conflicts with
+    /// --signal: discarding a gate delivers nothing to anyone.
+    #[arg(long, conflicts_with = "signal")]
     discard: bool,
 
     #[command(flatten)]
@@ -105,6 +106,12 @@ impl Tool for Kill {
             // A latched job's cached result is the only handle to its pending
             // confirmation — killing it would silently destroy the gate
             // (GH #96). Refuse unless the caller explicitly discards.
+            //
+            // TOCTOU note: a Running job can race into Latched between this
+            // check and kill_job's cancel+remove. That's acceptable — the
+            // guard protects an already-visible confirmation request from
+            // accidental destruction; a job killed while still running is the
+            // caller's stated intent, whatever it was about to become.
             if manager.is_latched(job_id).await {
                 if !parsed.discard {
                     return ExecResult::failure(

--- a/crates/kaish-kernel/tests/latch_trash_tests.rs
+++ b/crates/kaish-kernel/tests/latch_trash_tests.rs
@@ -1174,3 +1174,101 @@ async fn backgrounded_latch_vfs_node_renders_json() {
     let parsed = run(&kernel, "cat /v/jobs/1/latch | fromjson").await;
     assert_eq!(parsed.code, 0, "latch node is valid JSON: {}", parsed.err);
 }
+
+/// `jobs --cleanup` must not reap a latched job — its cached result holds the
+/// only LatchRequest for the gated operation, so reaping silently destroys the
+/// pending confirmation (the #96 guarantee).
+#[tokio::test]
+async fn jobs_cleanup_keeps_latched_job() {
+    let dir = tempdir();
+    let kernel = kernel_at(dir.path());
+    let precious = dir.path().join("precious.txt");
+    std::fs::write(&precious, "keep me").expect("write");
+
+    run(&kernel, "set -o latch").await;
+    run(&kernel, "rm precious.txt &").await;
+    run(&kernel, "wait 1").await; // job reaches the gate
+
+    let cleaned = run(&kernel, "jobs --cleanup").await;
+    assert!(
+        cleaned.text_out().contains("Kept 1 latched job(s)"),
+        "cleanup says loudly that it kept the latched job: {}",
+        cleaned.text_out()
+    );
+
+    let jobs = run(&kernel, "jobs").await;
+    assert!(
+        jobs.text_out().contains("Latched"),
+        "cleanup must keep the latched job: {}",
+        jobs.text_out()
+    );
+
+    // The gate is still fulfillable end-to-end after the cleanup pass.
+    let waited = run(&kernel, "wait 1").await;
+    let latch = waited.latch_request().expect("latch survives cleanup");
+    let confirmed = kernel.confirm(&latch).await.expect("confirm");
+    assert_eq!(confirmed.code, 0, "confirm deletes: {}", confirmed.err);
+    assert!(!precious.exists(), "file removed after confirm");
+}
+
+/// `kill %N` on a latched job refuses instead of silently destroying the only
+/// handle to the pending confirmation.
+#[tokio::test]
+async fn kill_refuses_latched_job() {
+    let dir = tempdir();
+    let kernel = kernel_at(dir.path());
+    let precious = dir.path().join("precious.txt");
+    std::fs::write(&precious, "keep me").expect("write");
+
+    run(&kernel, "set -o latch").await;
+    run(&kernel, "rm precious.txt &").await;
+    run(&kernel, "wait 1").await;
+
+    let killed = run(&kernel, "kill %1").await;
+    assert_eq!(killed.code, 1, "kill refuses a latched job: {killed:?}");
+    assert!(killed.err.contains("latched"), "names the reason: {}", killed.err);
+    assert!(
+        killed.err.contains("--discard"),
+        "points at the escape hatch: {}",
+        killed.err
+    );
+
+    // Still present, still confirmable.
+    let jobs = run(&kernel, "jobs").await;
+    assert!(jobs.text_out().contains("Latched"), "job survives: {}", jobs.text_out());
+    let waited = run(&kernel, "wait 1").await;
+    let latch = waited.latch_request().expect("latch survives the refused kill");
+    let confirmed = kernel.confirm(&latch).await.expect("confirm");
+    assert_eq!(confirmed.code, 0, "confirm deletes: {}", confirmed.err);
+    assert!(!precious.exists(), "file removed after confirm");
+}
+
+/// `kill --discard %N` is the explicit way to abandon a pending gate: loud
+/// about what it destroyed, and the gated operation never runs.
+#[tokio::test]
+async fn kill_discard_abandons_latch_loudly() {
+    let dir = tempdir();
+    let kernel = kernel_at(dir.path());
+    let precious = dir.path().join("precious.txt");
+    std::fs::write(&precious, "keep me").expect("write");
+
+    run(&kernel, "set -o latch").await;
+    run(&kernel, "rm precious.txt &").await;
+    run(&kernel, "wait 1").await;
+
+    let killed = run(&kernel, "kill --discard %1").await;
+    assert_eq!(killed.code, 0, "discard succeeds: {killed:?}");
+    assert!(
+        killed.text_out().contains("discard"),
+        "says what it did: {}",
+        killed.text_out()
+    );
+
+    let jobs = run(&kernel, "jobs").await;
+    assert!(
+        !jobs.text_out().contains("Latched"),
+        "job gone after discard: {}",
+        jobs.text_out()
+    );
+    assert!(precious.exists(), "the gated rm never ran — file survives the discard");
+}

--- a/crates/kaish-kernel/tests/latch_trash_tests.rs
+++ b/crates/kaish-kernel/tests/latch_trash_tests.rs
@@ -1272,3 +1272,36 @@ async fn kill_discard_abandons_latch_loudly() {
     );
     assert!(precious.exists(), "the gated rm never ran — file survives the discard");
 }
+
+/// `kill --discard` on a job that doesn't exist fails loudly, and on a
+/// running (non-latched) job it degrades to a plain kill — pinned so the
+/// flag never becomes a silent no-op or a silent success.
+#[tokio::test]
+async fn kill_discard_edge_cases() {
+    let dir = tempdir();
+    let kernel = kernel_at(dir.path());
+
+    let missing = run(&kernel, "kill --discard %7").await;
+    assert_eq!(missing.code, 1, "nonexistent job is loud: {missing:?}");
+    assert!(missing.err.contains("not found"), "names the problem: {}", missing.err);
+
+    // A running, non-latched job: --discard is a no-op qualifier; the job
+    // is killed normally.
+    run(&kernel, "sleep 30 &").await;
+    let killed = run(&kernel, "kill --discard %1").await;
+    assert_eq!(killed.code, 0, "plain kill still works under --discard: {killed:?}");
+    let jobs = run(&kernel, "jobs").await;
+    assert!(
+        !jobs.text_out().contains("Running"),
+        "job gone after kill: {}",
+        jobs.text_out()
+    );
+
+    // --discard conflicts with --signal: discarding delivers nothing.
+    std::fs::write(dir.path().join("p.txt"), "x").expect("write");
+    run(&kernel, "set -o latch").await;
+    run(&kernel, "rm p.txt &").await;
+    run(&kernel, "wait 2").await;
+    let conflict = run(&kernel, "kill --discard --signal STOP %2").await;
+    assert_eq!(conflict.code, 2, "--discard + --signal is a usage error: {conflict:?}");
+}

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -14,6 +14,43 @@ before it ships.
 
 ---
 
+## The latch survives its consumers (2026-07-06)
+
+A pre-release "fishing expedition" — Amy's cross-model combo, a gemini-pro
+batch over the whole scheduler/jobs/REPL surface as whole files plus a
+deepseek consult over the same waters, no diff so the models read the code
+cold — converged independently on the same finding: the backgrounded latch
+that #96 had just made *reachable* was still *destructible*, silently, by
+both of its housekeeping consumers. `jobs --cleanup` reaped a latched job
+because `is_done()` counts Latched as done; `kill %N` ran cancel+remove
+unconditionally. Both verified against the binary before believing the
+models: "Cleaned up 1 completed job(s)", gate gone, the destructive op
+permanently unconfirmable. The stored LatchRequest is the *only* handle to a
+backgrounded gate — dropping the job drops the contract.
+
+The decisions: cleanup keeps latched jobs and says so ("Kept 1 latched
+job(s)…"), because a silently-retained job is just a differently-shaped
+surprise. `kill %N` refuses with a pointer to `/v/jobs/N/latch` — kill is
+not repurposed as the discard path, since fat-fingering kill at a gate you
+meant to confirm was precisely the found failure mode. The explicit path is
+`kill --discard %N`: loud about what it abandoned, conflicts with `--signal`
+at the clap layer (discarding delivers nothing to anyone). Review (deepseek,
+worktree checkout) mapped every other job-dropping path — fg/bg structurally
+can't reach a latched job (no pid/pgid, not stopped), shutdown waits but
+never removes — and flagged the one unguarded seam, `JobManager::remove`,
+now documented as latch-bypassing with `cleanup()` named as the safe bulk
+path. Rider from the same sweep: `Job::try_poll`'s "shouldn't happen"
+Pending branch had already taken the JoinHandle and would have dropped it,
+stranding the job as Running forever with its result silently lost; it puts
+the handle back now.
+
+The latch-visibility residuals the sweep also surfaced (wait --json renders
+`"[1] Latched\n"` with no nonce; jobs --json rows omit the latch; scatter
+rows can't carry one; mid-pipeline gates lose their exit code) were filed as
+#124/#125 rather than stretched into this PR.
+
+---
+
 ## `glob **/*.rs` stops eating its own pattern (2026-07-06)
 
 Amy hit it live at the REPL: `glob **/*.rs` at the kaish repo root took a long


### PR DESCRIPTION
## What

A pre-release fishing sweep (gemini-pro batch + deepseek consult over the whole scheduler/jobs surface, findings verified against the binary) caught two holes in the backgrounded-latch guarantee #96 just shipped. The stored `LatchRequest` is the **only** handle to a gated background operation, and both job-dropping consumers destroyed it without a word:

- `jobs --cleanup` reaped a latched job like any completed one (`is_done()` counts `Latched` as done) — verified: "Cleaned up 1 completed job(s)", latch gone, operation permanently unconfirmable.
- `kill %N` ran `cancel()`+`remove()` unconditionally — verified: no warning, no trace.

## Decisions

- **`jobs --cleanup` keeps latched jobs** and reports `Kept N latched job(s)` so the survivor is loud, not a surprise in the next `jobs` listing.
- **`kill %N` refuses a latched job** (exit 1, points at `/v/jobs/N/latch` and the escape hatch) rather than being repurposed as the discard path — fat-fingering `kill` at a gate you meant to confirm was exactly the failure scenario found.
- **`kill --discard %N` is the escape hatch**: explicit, loud about what it abandoned, and the gated operation never runs.
- **Rider:** `Job::try_poll`'s "shouldn't happen" `Pending` branch now puts the taken `JoinHandle` back instead of dropping it — if the runtime ever returns `Pending` after `is_finished()`, the old code stranded the job as Running forever with its result silently lost.

New guard tests extend the #96 section of `latch_trash_tests.rs` (cleanup keeps + still confirmable end-to-end; kill refuses + still confirmable; discard is loud and the gated `rm` never runs). Gates: `cargo test --all` + `cargo clippy --all --all-targets` clean.

Related surfacing residuals (wait --json shape, jobs --json latch column, scatter rows, mid-pipeline latch policy) are being filed as issues rather than stretched into this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)