### PR TITLE
fix(walk-filters): --include works, repeats accumulate, bad values go loud

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,26 @@ breaking entries are marked **BREAKING**.
 ## [Unreleased]
 
 ### Fixed
+- **`glob --include` now actually filters.** It was a complete no-op: the
+  walker consulted only exclude rules, so `glob '*' --include='*.rs'` listed
+  everything. Include semantics are now rg-like: when include patterns exist a
+  file must match one of them (by relative path or basename); directories are
+  still traversed so included files below them are reached; exclude patterns
+  still prune whole subtrees. (`grep --include` half-worked through a separate
+  walk-pattern hack, now removed in favor of the same filter.)
+- **Repeated `--include`/`--exclude` accumulate in `glob` and `grep`.** Both
+  were bound single-valued, so repeating the flag silently kept only the LAST
+  pattern — `glob` while its help said "can be repeated", and `grep -r TODO .
+  --include='*.rs' --include='*.toml'` silently searched only the toml files
+  (a false negative). Repeats now accumulate like `--ftype` always has.
+- **A malformed numeric flag value errors instead of silently meaning
+  "unlimited"/"disabled".** `glob --depth=abc`, `tree -L abc`, and
+  `find -maxdepth xyz` all exited 0 and walked without a depth limit;
+  `spawn timeout=abc` silently DISABLED the timeout (unbounded child);
+  `split --limit` and `head -c` wrapped negative values through `usize`.
+  All now fail loudly, and negative values are refused rather than wrapped.
+  `glob --type=<unknown>` similarly errored silently into "files only" and is
+  now a usage error.
 - **Unquoted `glob **/*.rs` now works: the pattern reaches the builtin as
   written.** Previously the kernel's argv glob expansion pre-expanded the bare
   pattern into matching paths, so `glob` bound the first path as its "pattern",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,11 @@ breaking entries are marked **BREAKING**.
   All now fail loudly, and negative values are refused rather than wrapped.
   `glob --type=<unknown>` similarly errored silently into "files only" and is
   now a usage error.
+- **`spawn`'s own help examples didn't work.** `help spawn` taught
+  `spawn command="cargo" argv=["build"]`, but that word-assign form never
+  binds for spawn — the whole token became the program name and exited 127.
+  The examples now show the working flag form (`spawn --command cargo --argv
+  build`).
 - **Unquoted `glob **/*.rs` now works: the pattern reaches the builtin as
   written.** Previously the kernel's argv glob expansion pre-expanded the bare
   pattern into matching paths, so `glob` bound the first path as its "pattern",

--- a/crates/kaish-glob/src/filter.rs
+++ b/crates/kaish-glob/src/filter.rs
@@ -124,12 +124,30 @@ impl IncludeExclude {
         FilterResult::NoMatch
     }
 
-    /// Check if a path should be filtered out.
+    /// Decide whether a walk entry is filtered out.
     ///
-    /// Returns true if the path should be excluded (either explicitly excluded
-    /// or not matching any include patterns when in strict mode).
-    pub fn should_exclude(&self, path: &Path) -> bool {
-        matches!(self.check(path), FilterResult::Exclude)
+    /// `relative` is the walk-relative path and `name` the basename (patterns
+    /// like `*_test.rs` are written against filenames); the first
+    /// representation that matches any rule decides. When include rules
+    /// exist, a *file* matching none of them is excluded — but a directory
+    /// never is, so traversal can still reach included files below it.
+    /// Exclude rules apply to directories too (pruning the subtree).
+    pub fn excludes_entry(&self, relative: &Path, name: Option<&Path>, is_dir: bool) -> bool {
+        for path in [Some(relative), name].into_iter().flatten() {
+            match self.check(path) {
+                FilterResult::Exclude => return true,
+                FilterResult::Include => return false,
+                FilterResult::NoMatch => {}
+            }
+        }
+        !is_dir && self.has_includes()
+    }
+
+    /// Whether any include rules are present.
+    pub fn has_includes(&self) -> bool {
+        self.rules
+            .iter()
+            .any(|(action, _)| *action == FilterAction::Include)
     }
 
     /// Check if any rules are defined.
@@ -151,7 +169,7 @@ mod tests {
     fn test_empty_filter() {
         let filter = IncludeExclude::new();
         assert_eq!(filter.check(Path::new("any.txt")), FilterResult::NoMatch);
-        assert!(!filter.should_exclude(Path::new("any.txt")));
+        assert!(!filter.excludes_entry(Path::new("any.txt"), None, false));
     }
 
     #[test]
@@ -169,8 +187,8 @@ mod tests {
         filter.exclude("*.log");
 
         assert_eq!(filter.check(Path::new("app.log")), FilterResult::Exclude);
-        assert!(filter.should_exclude(Path::new("app.log")));
-        assert!(!filter.should_exclude(Path::new("app.txt")));
+        assert!(filter.excludes_entry(Path::new("app.log"), None, false));
+        assert!(!filter.excludes_entry(Path::new("app.txt"), None, false));
     }
 
     #[test]
@@ -212,8 +230,8 @@ mod tests {
         let mut filter = IncludeExclude::new();
         filter.exclude("logs/*");
 
-        assert!(filter.should_exclude(Path::new("logs/app.log")));
-        assert!(!filter.should_exclude(Path::new("other/app.log")));
+        assert!(filter.excludes_entry(Path::new("logs/app.log"), None, false));
+        assert!(!filter.excludes_entry(Path::new("other/app.log"), None, false));
     }
 
     #[test]
@@ -238,5 +256,32 @@ mod tests {
         assert_eq!(filter.check(Path::new("main.go")), FilterResult::Include);
         assert_eq!(filter.check(Path::new("main.py")), FilterResult::Include);
         assert_eq!(filter.check(Path::new("main.js")), FilterResult::NoMatch);
+    }
+
+    #[test]
+    fn include_list_excludes_nonmatching_files_but_not_dirs() {
+        let mut filter = IncludeExclude::new();
+        filter.include("*.rs");
+
+        // A file matching no include rule is out...
+        assert!(filter.excludes_entry(Path::new("notes.txt"), None, false));
+        // ...a matching file is in (by relative path or by basename)...
+        assert!(!filter.excludes_entry(Path::new("main.rs"), None, false));
+        assert!(!filter.excludes_entry(
+            Path::new("src/lib.rs"),
+            Some(Path::new("lib.rs")),
+            false
+        ));
+        // ...and a directory is never excluded by include-miss.
+        assert!(!filter.excludes_entry(Path::new("src"), None, true));
+    }
+
+    #[test]
+    fn exclude_rules_still_prune_directories() {
+        let mut filter = IncludeExclude::new();
+        filter.include("*.rs");
+        filter.exclude("target");
+
+        assert!(filter.excludes_entry(Path::new("target"), None, true));
     }
 }

--- a/crates/kaish-glob/src/walker.rs
+++ b/crates/kaish-glob/src/walker.rs
@@ -288,21 +288,20 @@ impl<'a, F: WalkerFs> FileWalker<'a, F> {
                         continue;
                     }
 
-                // Check include/exclude filter
+                // Check include/exclude filter. Both the relative path and the
+                // bare filename are offered (patterns like "*_test.rs" are
+                // written against filenames); a directory is only pruned by an
+                // explicit exclude — an include list must not stop traversal.
                 if !self.options.filter.is_empty() {
                     let relative = self.relative_path(&full_path);
-                    if self.options.filter.should_exclude(&relative) {
+                    let name = full_path.file_name().map(Path::new);
+                    if self
+                        .options
+                        .filter
+                        .excludes_entry(&relative, name, entry_is_dir)
+                    {
                         continue;
                     }
-                    // Also check filename only for patterns like "*_test.rs"
-                    if let Some(name) = full_path.file_name()
-                        && self
-                            .options
-                            .filter
-                            .should_exclude(Path::new(name))
-                        {
-                            continue;
-                        }
                 }
 
                 if entry_is_dir {

--- a/crates/kaish-kernel/src/tools/builtin/find.rs
+++ b/crates/kaish-kernel/src/tools/builtin/find.rs
@@ -136,11 +136,20 @@ impl Tool for Find {
             None => EntryTypes::all(),
         };
 
-        // -maxdepth: parse from the clap struct.
-        let max_depth: Option<usize> = parsed
-            .maxdepth
-            .as_deref()
-            .and_then(|s| s.parse().ok());
+        // -maxdepth: parse from the clap struct. A malformed value is refused
+        // rather than silently walking unlimited.
+        let max_depth: Option<usize> = match parsed.maxdepth.as_deref() {
+            None => None,
+            Some(s) => match s.parse() {
+                Ok(d) => Some(d),
+                Err(_) => {
+                    return ExecResult::failure(
+                        1,
+                        format!("find: invalid -maxdepth '{s}': expected a non-negative integer"),
+                    )
+                }
+            },
+        };
 
         // -mindepth: parse from the clap struct.
         //
@@ -150,10 +159,18 @@ impl Tool for Find {
         // "entries inside the root dir" — so a 1-based GNU depth maps to
         // (N-1)-based walker depth.  Translation: GNU N → walker N-1 (clamped
         // at 0 / None for N <= 1, since the start dir is never emitted anyway).
-        let gnu_mindepth: Option<usize> = parsed
-            .mindepth
-            .as_deref()
-            .and_then(|s| s.parse().ok());
+        let gnu_mindepth: Option<usize> = match parsed.mindepth.as_deref() {
+            None => None,
+            Some(s) => match s.parse() {
+                Ok(d) => Some(d),
+                Err(_) => {
+                    return ExecResult::failure(
+                        1,
+                        format!("find: invalid -mindepth '{s}': expected a non-negative integer"),
+                    )
+                }
+            },
+        };
         let min_depth: Option<usize> = match gnu_mindepth {
             None | Some(0) | Some(1) => None, // walker already skips the start dir
             Some(n) => Some(n - 1),

--- a/crates/kaish-kernel/src/tools/builtin/glob.rs
+++ b/crates/kaish-kernel/src/tools/builtin/glob.rs
@@ -21,7 +21,7 @@ pub struct Glob;
 struct GlobArgs {
     /// Maximum depth to recurse.
     #[arg(short = 'd', long = "depth")]
-    depth: Option<String>,
+    depth: Option<i64>,
 
     /// Include ignored files like .git, node_modules.
     #[arg(long = "no-ignore", visible_alias = "no_ignore")]
@@ -53,13 +53,14 @@ struct GlobArgs {
     #[arg(short = '0', long = "null")]
     null: bool,
 
-    /// Include pattern (can be repeated).
+    /// Include pattern: only matches also matching one of these are kept
+    /// (repeatable).
     #[arg(long = "include")]
-    include: Option<String>,
+    include: Vec<String>,
 
-    /// Exclude pattern (can be repeated).
+    /// Exclude pattern: matches are dropped, directories pruned (repeatable).
     #[arg(long = "exclude")]
-    exclude: Option<String>,
+    exclude: Vec<String>,
 
     #[command(flatten)]
     global: GlobalFlags,
@@ -145,59 +146,45 @@ impl Tool for Glob {
             return ExecResult::failure(1, "glob: missing pattern argument");
         }
 
-        // Parse options
-        let max_depth = args.get("depth", usize::MAX).and_then(|v| match v {
-            Value::Int(i) => Some(*i as usize),
-            Value::String(s) => s.parse().ok(),
-            _ => None,
-        });
+        // Parse options off the clap struct. A non-numeric `--depth` was
+        // already a loud clap error; a negative one is refused here rather
+        // than wrapping to "effectively unlimited".
+        let max_depth: Option<usize> = match parsed.depth {
+            Some(d) if d < 0 => {
+                return ExecResult::failure(
+                    2,
+                    format!("glob: invalid --depth {d}: must be >= 0"),
+                )
+            }
+            other => other.map(|d| d as usize),
+        };
 
-        // Also check short flags
-        let max_depth = max_depth.or_else(|| {
-            args.get("d", usize::MAX).and_then(|v| match v {
-                Value::Int(i) => Some(*i as usize),
-                Value::String(s) => s.parse().ok(),
-                _ => None,
-            })
-        });
+        let no_ignore = parsed.no_ignore;
+        let include_hidden = parsed.hidden;
+        let null_sep = parsed.null;
 
-        let no_ignore = args.has_flag("no-ignore") || args.has_flag("no-ignore");
-        let include_hidden = args.has_flag("hidden") || args.has_flag("a");
-        let null_sep = args.has_flag("null") || args.has_flag("0");
-
-        // Entry types
-        let entry_types = match args.get_string("type", usize::MAX).as_deref() {
+        // Entry types: f=files (default), d=dirs, a=all. Anything else used
+        // to silently mean "files"; now it's a usage error.
+        let entry_types = match parsed.type_.as_deref() {
+            None | Some("f") => EntryTypes::files_only(),
             Some("d") => EntryTypes::dirs_only(),
             Some("a") => EntryTypes::all(),
-            _ => {
-                // Check -t flag
-                if args.has_flag("t") {
-                    if let Some(Value::String(t)) = args.get("t", usize::MAX) {
-                        match t.as_str() {
-                            "d" => EntryTypes::dirs_only(),
-                            "a" => EntryTypes::all(),
-                            _ => EntryTypes::files_only(),
-                        }
-                    } else {
-                        EntryTypes::files_only()
-                    }
-                } else {
-                    EntryTypes::files_only()
-                }
+            Some(other) => {
+                return ExecResult::failure(
+                    2,
+                    format!("glob: invalid --type '{other}': expected f, d, or a"),
+                )
             }
         };
 
-        // Build include/exclude filter
+        // Build the include/exclude filter. Repeatable value flags arrive as
+        // `Json(Array)`; read them off the raw args like `--ftype` above.
         let mut filter = IncludeExclude::new();
-
-        // Handle include patterns
-        if let Some(Value::String(inc)) = args.get("include", usize::MAX) {
-            filter.include(inc);
+        for pattern in read_repeatable_strings(&args, "include") {
+            filter.include(&pattern);
         }
-
-        // Handle exclude patterns
-        if let Some(Value::String(exc)) = args.get("exclude", usize::MAX) {
-            filter.exclude(exc);
+        for pattern in read_repeatable_strings(&args, "exclude") {
+            filter.exclude(&pattern);
         }
 
         let fs = BackendWalkerFs(ctx.backend.as_ref());

--- a/crates/kaish-kernel/src/tools/builtin/grep.rs
+++ b/crates/kaish-kernel/src/tools/builtin/grep.rs
@@ -1377,6 +1377,7 @@ fn match_record_to_json(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ast::Value;
     use crate::vfs::{Filesystem, MemoryFs, VfsRouter};
     use std::sync::Arc;
 

--- a/crates/kaish-kernel/src/tools/builtin/grep.rs
+++ b/crates/kaish-kernel/src/tools/builtin/grep.rs
@@ -12,7 +12,6 @@ use grep_searcher::{BinaryDetection, Encoding, SearcherBuilder};
 use regex::RegexBuilder;
 use std::path::{Path, PathBuf};
 
-use crate::ast::Value;
 use crate::backend_walker_fs::BackendWalkerFs;
 use crate::interpreter::{ExecResult, OutputData, OutputNode};
 use crate::tools::builtin::grep_engine::{AccumulatorSink, ContextKind, SearchEvent};
@@ -98,13 +97,13 @@ struct GrepArgs {
     #[arg(short = 'C', long = "context")]
     context: Option<String>,
 
-    /// Include only files matching pattern.
+    /// Include only files matching pattern (repeatable).
     #[arg(long = "include")]
-    include: Option<String>,
+    include: Vec<String>,
 
-    /// Exclude files matching pattern.
+    /// Exclude files matching pattern (repeatable).
     #[arg(long = "exclude")]
-    exclude: Option<String>,
+    exclude: Vec<String>,
 
     /// Force a specific text encoding.
     #[arg(long = "encoding")]
@@ -416,20 +415,19 @@ impl Tool for Grep {
                 let fs = BackendWalkerFs(ctx.backend.as_ref());
                 let mut files: Vec<PathBuf> = Vec::new();
                 for root in &dir_roots {
-                    // include/exclude + glob are walk-only (see the validation
-                    // note above); rebuilt per root since `with_options` moves.
+                    // include/exclude are walk-only (see the validation note
+                    // above); rebuilt per root since `with_options` moves.
+                    // Repeatable value flags arrive as `Json(Array)` — read
+                    // them off the raw args like `--ftype`; the filter itself
+                    // enforces include semantics (a file must match one).
                     let mut filter = IncludeExclude::new();
-                    if let Some(Value::String(inc)) = args.get("include", usize::MAX) {
-                        filter.include(inc);
+                    for pattern in read_repeatable_strings(&args, "include") {
+                        filter.include(&pattern);
                     }
-                    if let Some(Value::String(exc)) = args.get("exclude", usize::MAX) {
-                        filter.exclude(exc);
+                    for pattern in read_repeatable_strings(&args, "exclude") {
+                        filter.exclude(&pattern);
                     }
-                    let glob = if let Some(Value::String(inc)) = args.get("include", usize::MAX) {
-                        GlobPath::new(&format!("**/{}", inc)).ok()
-                    } else {
-                        GlobPath::new("**/*").ok()
-                    };
+                    let glob = GlobPath::new("**/*").ok();
 
                     let options = WalkOptions {
                         max_depth: None,

--- a/crates/kaish-kernel/src/tools/builtin/head.rs
+++ b/crates/kaish-kernel/src/tools/builtin/head.rs
@@ -99,7 +99,7 @@ impl Tool for Head {
         let bytes: Option<usize> = match parsed.bytes {
             Some(b) if b < 0 => {
                 return ExecResult::failure(
-                    1,
+                    2,
                     format!("head: invalid byte count {b}: negative -c is not supported"),
                 )
             }

--- a/crates/kaish-kernel/src/tools/builtin/head.rs
+++ b/crates/kaish-kernel/src/tools/builtin/head.rs
@@ -92,6 +92,20 @@ impl Tool for Head {
             Err(e) => return ExecResult::failure(1, format!("head: {}", e)),
         };
 
+        // Byte count (-c) off the clap struct: clap already rejected
+        // non-numeric values loudly; negative (GNU's "all but the last N
+        // bytes") is unsupported and refused rather than usize-wrapped into
+        // a huge count.
+        let bytes: Option<usize> = match parsed.bytes {
+            Some(b) if b < 0 => {
+                return ExecResult::failure(
+                    1,
+                    format!("head: invalid byte count {b}: negative -c is not supported"),
+                )
+            }
+            other => other.map(|b| b as usize),
+        };
+
         // Multiple files: show each with header
         if paths.len() > 1 {
             return self.head_files(ctx, &args, &paths).await;
@@ -100,11 +114,6 @@ impl Tool for Head {
         // Streaming path: read from pipe_stdin line by line, stop after N lines
         // This enables early termination — `seq 1 1000000 | head -5` stops after 5 lines
         if paths.is_empty() && let Some(pipe_in) = ctx.pipe_stdin.take() {
-            let bytes = args.get("bytes", usize::MAX).and_then(|v| match v {
-                Value::Int(i) => Some(*i as usize),
-                Value::String(s) => s.parse().ok(),
-                _ => None,
-            });
             let (count, all_but_last) = Self::line_spec(&args);
             if bytes.is_some() || all_but_last {
                 // Bytes mode and `-n -N` (all but last N) both need the whole
@@ -116,16 +125,11 @@ impl Tool for Head {
             }
         }
 
-        // Byte count (-c) is resolved up front so a single-file read can ask
-        // the backend for exactly that many bytes. That keeps `head -c N` from
-        // pulling whole files into memory and, crucially, lets it read endless
-        // devices like /dev/zero — a whole-file read of those is a hard error.
-        let bytes = args.get("bytes", usize::MAX).and_then(|v| match v {
-            Value::Int(i) => Some(*i as usize),
-            Value::String(s) => s.parse().ok(),
-            _ => None,
-        });
-
+        // Byte count (-c) is resolved up front (see `bytes` above) so a
+        // single-file read can ask the backend for exactly that many bytes.
+        // That keeps `head -c N` from pulling whole files into memory and,
+        // crucially, lets it read endless devices like /dev/zero — a
+        // whole-file read of those is a hard error.
         // Single-file byte mode: request exactly N bytes via the read range.
         if let (Some(byte_count), Some(path)) = (bytes, paths.first()) {
             let resolved = ctx.resolve_path(path);

--- a/crates/kaish-kernel/src/tools/builtin/spawn.rs
+++ b/crates/kaish-kernel/src/tools/builtin/spawn.rs
@@ -150,14 +150,31 @@ impl Tool for Spawn {
             Err(e) => return ExecResult::failure(1, format!("spawn: {e}")),
         };
 
-        // Get timeout (optional, in milliseconds)
-        let timeout_ms: Option<u64> = args
-            .get_named("timeout")
-            .and_then(|v| match v {
-                Value::Int(i) => Some(*i as u64),
-                Value::String(s) => s.parse().ok(),
-                _ => None,
-            });
+        // Get timeout (optional, in milliseconds). A malformed or negative
+        // value is a usage error — the old parse().ok() fallback silently
+        // DISABLED the timeout, the worst possible reading of a typo.
+        let timeout_ms: Option<u64> = match args.get_named("timeout") {
+            None => None,
+            Some(Value::Int(i)) if *i >= 0 => Some(*i as u64),
+            Some(Value::String(s)) => match s.parse::<u64>() {
+                Ok(ms) => Some(ms),
+                Err(_) => {
+                    return ExecResult::failure(
+                        2,
+                        format!("spawn: invalid timeout '{s}': expected non-negative milliseconds"),
+                    )
+                }
+            },
+            Some(other) => {
+                return ExecResult::failure(
+                    2,
+                    format!(
+                        "spawn: invalid timeout '{}': expected non-negative milliseconds",
+                        crate::interpreter::value_to_string(other)
+                    ),
+                )
+            }
+        };
 
         // Get clear_env flag
         let clear_env = args.has_flag("clear-env");

--- a/crates/kaish-kernel/src/tools/builtin/spawn.rs
+++ b/crates/kaish-kernel/src/tools/builtin/spawn.rs
@@ -7,11 +7,10 @@
 //! # Examples
 //!
 //! ```kaish
-//! spawn command="/usr/bin/jq" argv=["-r", ".foo"]
-//! spawn command="/bin/echo" argv=["hello", "world"]
-//! spawn command="/usr/bin/env" env={"MY_VAR": "value"}
-//! spawn command="cargo" cwd="/workspace"             # with working directory
-//! spawn command="sleep" argv=["10"] timeout=1000     # with 1 second timeout
+//! spawn --command /usr/bin/jq --argv '["-r", ".foo"]'
+//! spawn --command /bin/echo --argv '["hello", "world"]'
+//! spawn --command cargo --cwd /workspace              # with working directory
+//! spawn --command sleep --argv 10 --timeout 1000      # with 1 second timeout
 //! ```
 
 use async_trait::async_trait;
@@ -75,8 +74,8 @@ impl Tool for Spawn {
             "spawn",
             "Spawn an external command as a subprocess",
             [
-                ("Run a command", "spawn command=\"cargo\" argv=[\"build\"]"),
-                ("With timeout", "spawn command=\"sleep\" argv=[\"10\"] timeout=1000"),
+                ("Run a command", "spawn --command cargo --argv build"),
+                ("With timeout", "spawn --command sleep --argv 10 --timeout 1000"),
             ],
         )
     }

--- a/crates/kaish-kernel/src/tools/builtin/split.rs
+++ b/crates/kaish-kernel/src/tools/builtin/split.rs
@@ -114,13 +114,17 @@ impl Tool for Split {
         let delimiter = args.get_string("delimiter", delim_idx);
         let regex_pat = args.get_string("regex", usize::MAX)
             .or_else(|| args.get_string("r", usize::MAX));
-        let limit = args.get("limit", usize::MAX)
-            .and_then(|v| match v {
-                Value::Int(i) => Some(*i as usize),
-                Value::String(s) => s.parse().ok(),
-                _ => None,
-            })
-            .unwrap_or(0);
+        // `--limit` off the clap struct (clap already rejected non-numeric
+        // values loudly); negative is refused rather than usize-wrapped.
+        let limit: usize = match parsed.limit {
+            Some(l) if l < 0 => {
+                return ExecResult::failure(
+                    2,
+                    format!("split: invalid --limit {l}: must be >= 0"),
+                )
+            }
+            other => other.unwrap_or(0) as usize,
+        };
 
         // Perform the split
         let parts: Vec<&str> = if let Some(pattern) = regex_pat {

--- a/crates/kaish-kernel/src/tools/builtin/tree.rs
+++ b/crates/kaish-kernel/src/tools/builtin/tree.rs
@@ -308,6 +308,7 @@ impl Tool for Tree {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ast::Value;
     use crate::vfs::{Filesystem, MemoryFs, VfsRouter};
     use std::sync::Arc;
 

--- a/crates/kaish-kernel/src/tools/builtin/tree.rs
+++ b/crates/kaish-kernel/src/tools/builtin/tree.rs
@@ -5,7 +5,6 @@ use clap::{CommandFactory, Parser};
 use std::collections::BTreeMap;
 use std::path::Path;
 
-use crate::ast::Value;
 use crate::interpreter::{EntryType, ExecResult, OutputData, OutputNode};
 use crate::tools::builtin::get_path_string;
 use crate::tools::{schema_from_clap, ExecContext, ToolCtx, GlobalFlags, Tool, ToolArgs, ToolSchema};
@@ -19,7 +18,7 @@ pub struct Tree;
 struct TreeArgs {
     /// Maximum depth to display.
     #[arg(short = 'L', long = "level")]
-    level: Option<String>,
+    level: Option<i64>,
 
     /// Traditional tree format with box-drawing.
     #[arg(long = "traditional")]
@@ -192,27 +191,24 @@ impl Tool for Tree {
             return ExecResult::failure(1, format!("tree: {}: No such file or directory", path));
         }
 
-        // Parse options
-        let max_depth = args
-            .get("level", usize::MAX)
-            .and_then(|v| match v {
-                Value::Int(i) => Some(*i as usize),
-                Value::String(s) => s.parse().ok(),
-                _ => None,
-            })
-            .or_else(|| {
-                args.get("L", usize::MAX).and_then(|v| match v {
-                    Value::Int(i) => Some(*i as usize),
-                    Value::String(s) => s.parse().ok(),
-                    _ => None,
-                })
-            });
+        // Parse options off the clap struct. A non-numeric `-L`/`--level` was
+        // already a loud clap error; a negative one is refused here rather
+        // than wrapping to "effectively unlimited".
+        let max_depth: Option<usize> = match parsed.level {
+            Some(l) if l < 0 => {
+                return ExecResult::failure(
+                    2,
+                    format!("tree: invalid --level {l}: must be >= 0"),
+                )
+            }
+            other => other.map(|l| l as usize),
+        };
 
-        let traditional = args.has_flag("traditional");
-        let flat = args.has_flag("flat");
-        let files_only = args.has_flag("files-only") || args.has_flag("f");
-        let show_hidden = args.has_flag("all") || args.has_flag("a");
-        let no_ignore = args.has_flag("no-ignore") || args.has_flag("no-ignore");
+        let traditional = parsed.traditional;
+        let flat = parsed.flat;
+        let files_only = parsed.files_only;
+        let show_hidden = parsed.all;
+        let no_ignore = parsed.no_ignore;
 
         // Build tree by walking directory
         let mut tree = TreeNode::default();

--- a/crates/kaish-kernel/tests/walk_filter_flags_tests.rs
+++ b/crates/kaish-kernel/tests/walk_filter_flags_tests.rs
@@ -164,11 +164,11 @@ async fn spawn_bad_timeout_is_loud() {
     let kernel = kernel_at(tmp.path());
 
     // The parse error fires before any process is spawned.
-    let r = run(&kernel, r#"spawn command="/bin/true" timeout=abc"#).await;
+    let r = run(&kernel, "spawn --command=/bin/true --timeout=abc").await;
     assert_eq!(r.code, 2, "bad timeout refuses instead of running unbounded: {r:?}");
     assert!(r.err.contains("timeout"), "names the flag: {}", r.err);
 
-    let neg = run(&kernel, r#"spawn command="/bin/true" timeout=-5"#).await;
+    let neg = run(&kernel, "spawn --command=/bin/true --timeout=-5").await;
     assert_eq!(neg.code, 2, "negative timeout refused, not u64-wrapped: {neg:?}");
 }
 

--- a/crates/kaish-kernel/tests/walk_filter_flags_tests.rs
+++ b/crates/kaish-kernel/tests/walk_filter_flags_tests.rs
@@ -1,0 +1,219 @@
+//! The walk-filter flag family: `--include`/`--exclude` must actually filter
+//! (including when repeated), directories must still be traversed when an
+//! include list is present, and a malformed depth/level/timeout value must be
+//! loud — never a silent "unlimited"/"disabled" fallback.
+//!
+//! Pre-fix behavior this pins against regressing:
+//! - `glob --include` was a complete no-op (the walker only consulted
+//!   exclude rules).
+//! - repeating `--include`/`--exclude` silently kept only the LAST value
+//!   (bound `Option<String>`, last-write-wins) while glob's help claimed
+//!   "can be repeated" — grep's variant produced silent false negatives.
+//! - `glob --depth=abc`, `tree -L abc`, `find -maxdepth xyz` exited 0 and
+//!   walked unlimited; `spawn timeout=abc` silently disabled the timeout.
+
+// Test-fixture code: unwrap/expect on known-good setup is the idiom here.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+#![cfg(feature = "localfs")]
+
+use kaish_kernel::interpreter::ExecResult;
+use kaish_kernel::{Kernel, KernelConfig};
+use std::fs;
+use std::path::Path;
+
+fn kernel_at(dir: &Path) -> Kernel {
+    let config = KernelConfig::repl().with_cwd(dir.to_path_buf());
+    Kernel::new(config).expect("kernel")
+}
+
+async fn run(kernel: &Kernel, script: &str) -> ExecResult {
+    kernel.execute(script).await.expect("kernel execute")
+}
+
+/// A small tree with three file types and a subdirectory: TODO markers in
+/// one file per extension so grep hits are attributable.
+fn seed(dir: &std::path::Path) {
+    fs::write(dir.join("a.rs"), "TODO alpha\n").unwrap();
+    fs::write(dir.join("b.rs"), "beta\n").unwrap();
+    fs::write(dir.join("c.toml"), "TODO gamma\n").unwrap();
+    fs::write(dir.join("d.md"), "TODO delta\n").unwrap();
+    fs::create_dir(dir.join("sub")).unwrap();
+    fs::write(dir.join("sub/e.rs"), "TODO epsilon\n").unwrap();
+}
+
+// ─── glob: include/exclude do what they say ─────────────────────────────────
+
+#[tokio::test]
+async fn glob_include_actually_filters() {
+    let tmp = tempfile::tempdir().unwrap();
+    seed(tmp.path());
+    let kernel = kernel_at(tmp.path());
+
+    let r = run(&kernel, "glob '*' --include='*.rs'").await;
+    assert_eq!(r.code, 0, "glob succeeds: {}", r.err);
+    let out = r.text_out();
+    assert!(out.contains("a.rs") && out.contains("b.rs"), "keeps .rs: {out}");
+    assert!(!out.contains("c.toml") && !out.contains("d.md"), "--include filters: {out}");
+}
+
+#[tokio::test]
+async fn glob_include_repeats_accumulate() {
+    let tmp = tempfile::tempdir().unwrap();
+    seed(tmp.path());
+    let kernel = kernel_at(tmp.path());
+
+    let r = run(&kernel, "glob '*' --include='*.rs' --include='*.toml'").await;
+    assert_eq!(r.code, 0, "glob succeeds: {}", r.err);
+    let out = r.text_out();
+    assert!(out.contains("a.rs") && out.contains("c.toml"), "both includes kept: {out}");
+    assert!(!out.contains("d.md"), "non-included dropped: {out}");
+}
+
+#[tokio::test]
+async fn glob_exclude_repeats_accumulate() {
+    let tmp = tempfile::tempdir().unwrap();
+    seed(tmp.path());
+    let kernel = kernel_at(tmp.path());
+
+    let r = run(&kernel, "glob '*' --exclude='a.rs' --exclude='b.rs'").await;
+    assert_eq!(r.code, 0, "glob succeeds: {}", r.err);
+    let out = r.text_out();
+    assert!(
+        !out.contains("a.rs") && !out.contains("b.rs"),
+        "BOTH excludes apply (first one used to be silently dropped): {out}"
+    );
+    assert!(out.contains("c.toml"), "non-excluded survive: {out}");
+}
+
+/// An include list must not stop directory traversal: `sub` matches no
+/// include pattern but the `.rs` file inside it must still be found.
+#[tokio::test]
+async fn glob_include_does_not_block_recursion() {
+    let tmp = tempfile::tempdir().unwrap();
+    seed(tmp.path());
+    let kernel = kernel_at(tmp.path());
+
+    let r = run(&kernel, "glob '**/*' --include='*.rs'").await;
+    assert_eq!(r.code, 0, "glob succeeds: {}", r.err);
+    let out = r.text_out();
+    assert!(out.contains("e.rs"), "recursion reaches sub/e.rs: {out}");
+    assert!(!out.contains("c.toml"), "include still filters files: {out}");
+}
+
+/// Excluding a directory name still prunes the whole subtree.
+#[tokio::test]
+async fn glob_exclude_still_prunes_directories() {
+    let tmp = tempfile::tempdir().unwrap();
+    seed(tmp.path());
+    let kernel = kernel_at(tmp.path());
+
+    let r = run(&kernel, "glob '**/*.rs' --exclude=sub").await;
+    assert_eq!(r.code, 0, "glob succeeds: {}", r.err);
+    let out = r.text_out();
+    assert!(out.contains("a.rs"), "top-level files kept: {out}");
+    assert!(!out.contains("e.rs"), "excluded dir pruned: {out}");
+}
+
+// ─── loud bad values ─────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn glob_bad_depth_is_loud() {
+    let tmp = tempfile::tempdir().unwrap();
+    seed(tmp.path());
+    let kernel = kernel_at(tmp.path());
+
+    let r = run(&kernel, "glob '*' --depth=abc").await;
+    assert_eq!(r.code, 2, "bad depth is a usage error, not unlimited: {r:?}");
+    assert!(r.err.contains("depth"), "names the flag: {}", r.err);
+
+    let neg = run(&kernel, "glob '*' --depth=-1").await;
+    assert_eq!(neg.code, 2, "negative depth is refused, not wrapped: {neg:?}");
+}
+
+#[tokio::test]
+async fn tree_bad_level_is_loud() {
+    let tmp = tempfile::tempdir().unwrap();
+    seed(tmp.path());
+    let kernel = kernel_at(tmp.path());
+
+    let r = run(&kernel, "tree -L abc .").await;
+    assert_eq!(r.code, 2, "bad -L is a usage error, not unlimited: {r:?}");
+
+    let neg = run(&kernel, "tree --level=-3 .").await;
+    assert_eq!(neg.code, 2, "negative level refused: {neg:?}");
+}
+
+#[tokio::test]
+async fn find_bad_maxdepth_is_loud() {
+    let tmp = tempfile::tempdir().unwrap();
+    seed(tmp.path());
+    let kernel = kernel_at(tmp.path());
+
+    let r = run(&kernel, "find . -maxdepth xyz").await;
+    assert_ne!(r.code, 0, "bad -maxdepth errors instead of walking unlimited: {r:?}");
+    assert!(r.err.contains("maxdepth"), "names the flag: {}", r.err);
+
+    let r = run(&kernel, "find . -mindepth xyz").await;
+    assert_ne!(r.code, 0, "bad -mindepth errors instead of no-filter: {r:?}");
+}
+
+#[cfg(all(unix, feature = "subprocess"))]
+#[tokio::test]
+async fn spawn_bad_timeout_is_loud() {
+    let tmp = tempfile::tempdir().unwrap();
+    let kernel = kernel_at(tmp.path());
+
+    // The parse error fires before any process is spawned.
+    let r = run(&kernel, r#"spawn command="/bin/true" timeout=abc"#).await;
+    assert_eq!(r.code, 2, "bad timeout refuses instead of running unbounded: {r:?}");
+    assert!(r.err.contains("timeout"), "names the flag: {}", r.err);
+
+    let neg = run(&kernel, r#"spawn command="/bin/true" timeout=-5"#).await;
+    assert_eq!(neg.code, 2, "negative timeout refused, not u64-wrapped: {neg:?}");
+}
+
+// ─── grep: repeated include/exclude across a recursive walk ─────────────────
+
+#[tokio::test]
+async fn grep_include_repeats_accumulate() {
+    let tmp = tempfile::tempdir().unwrap();
+    seed(tmp.path());
+    let kernel = kernel_at(tmp.path());
+
+    let r = run(&kernel, "grep -rn TODO . --include='*.rs' --include='*.toml'").await;
+    assert_eq!(r.code, 0, "matches exist: {r:?}");
+    let out = r.text_out();
+    assert!(out.contains("a.rs"), "first include searched (used to be silently dropped): {out}");
+    assert!(out.contains("c.toml"), "second include searched: {out}");
+    assert!(out.contains("e.rs"), "recursion under include list still works: {out}");
+    assert!(!out.contains("d.md"), "non-included files not searched: {out}");
+}
+
+#[tokio::test]
+async fn grep_exclude_repeats_accumulate() {
+    let tmp = tempfile::tempdir().unwrap();
+    seed(tmp.path());
+    let kernel = kernel_at(tmp.path());
+
+    let r = run(&kernel, "grep -rn TODO . --exclude='*.toml' --exclude='*.md'").await;
+    assert_eq!(r.code, 0, "matches exist: {r:?}");
+    let out = r.text_out();
+    assert!(out.contains("a.rs") && out.contains("e.rs"), ".rs TODOs found: {out}");
+    assert!(
+        !out.contains("c.toml") && !out.contains("d.md"),
+        "BOTH excludes apply: {out}"
+    );
+}
+
+#[tokio::test]
+async fn grep_single_include_still_works() {
+    let tmp = tempfile::tempdir().unwrap();
+    seed(tmp.path());
+    let kernel = kernel_at(tmp.path());
+
+    let r = run(&kernel, "grep -rn TODO . --include='*.rs'").await;
+    assert_eq!(r.code, 0, "matches exist: {r:?}");
+    let out = r.text_out();
+    assert!(out.contains("a.rs") && out.contains("e.rs"), "rs files searched: {out}");
+    assert!(!out.contains("c.toml"), "single include filters: {out}");
+}

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -14,6 +14,42 @@ before it ships.
 
 ---
 
+## `--include` learns to filter; the family goes loud (2026-07-06)
+
+The same fishing sweep grep-trawled for siblings of #122's bug classes —
+flags read off the raw ToolArgs map instead of the parsed clap struct,
+`Option<String>` numerics with `parse().ok()` fallbacks — and the walk-filter
+family turned out worse than the deferred nits suggested. The headline:
+`glob --include` had never filtered anything. `IncludeExclude` pushed Include
+rules into its list, but `should_exclude` only ever acted on Exclude matches;
+the "strict mode" its own doc comment promised was never written, and the
+walker only asked the exclude question. grep's `--include` merely *looked*
+functional because it separately baked the single include into its walk
+pattern as `**/{inc}`. On top of that, repeating `--include`/`--exclude`
+silently kept only the last value (glob's help said "can be repeated"), so
+`grep -r TODO . --include='*.rs' --include='*.toml'` answered with a silent
+false negative — the worst shape of wrong for an agent. And the numeric
+cousins all failed toward danger: `--depth=abc`/`-L abc`/`-maxdepth xyz`
+walked unlimited at exit 0, `spawn timeout=abc` silently *disabled* the
+timeout.
+
+The include semantics decision: rg-like. When include rules exist a file must
+match one — checked against the relative path, then the basename, first
+Include/Exclude verdict wins — but a directory is never excluded by
+include-miss, so traversal still reaches included files below it; excludes
+keep pruning subtrees. That distinction (files strict, dirs traversable) is
+the part the old two-call walker check could never express: the basename call
+would have rescued `src/lib.rs` against `*.rs` only *after* the relative-path
+call had already dropped it. One entry-aware `excludes_entry()` replaced the
+pair, `should_exclude` was deleted rather than kept as a shim, and grep's
+pattern hack went with it. Repeatables became `Vec<String>` +
+`read_repeatable_strings` — the ftype pattern that was ten lines away all
+along — and every numeric in the family now refuses bad and negative values
+loudly. Eleven kernel-routed tests pin it, including the
+include-doesn't-block-recursion case.
+
+---
+
 ## `glob **/*.rs` stops eating its own pattern (2026-07-06)
 
 Amy hit it live at the REPL: `glob **/*.rs` at the kaish repo root took a long


### PR DESCRIPTION
## What

A fishing sweep for siblings of #122's bug classes (flags read off the raw `ToolArgs` map instead of the parsed clap struct; `Option<String>` numerics with `parse().ok()` fallbacks) found the walk-filter family broken three ways. Every finding was verified against the binary before fixing:

1. **`glob --include` never filtered at all.** `IncludeExclude::should_exclude` only acted on explicit Exclude rules — the "strict mode" its own doc comment described was never implemented. (`grep --include` only appeared to work because it separately baked the single include into its walk pattern.)
2. **Repeating `--include`/`--exclude` silently kept only the last value** in glob and grep — glob's help even claimed "can be repeated", and `grep -r TODO . --include='*.rs' --include='*.toml'` silently searched only toml (a false negative).
3. **Malformed numeric values fell back silently**: `glob --depth=abc` / `tree -L abc` / `find -maxdepth xyz` walked unlimited at exit 0; `spawn timeout=abc` silently **disabled** the timeout; `split --limit` and `head -c` wrapped negatives through `usize`.

## Decisions

- The filter now owns include semantics via a single entry-aware `excludes_entry()`: a file must match an include when includes exist (relative path or basename), **directories are never pruned by include-miss** (traversal still reaches included files below), and excludes still prune subtrees. The walker's two-call check collapsed into one; grep's `**/{inc}` pattern hack is deleted.
- Repeatables bind `Vec<String>` and read via `read_repeatable_strings` — the `--ftype` pattern.
- Numerics moved to clap-validated `Option<i64>` (or loud hand parses where the argv is domain-shaped: find, spawn); negatives are refused, not wrapped. `glob --type=<unknown>` (silently "files only") is now a usage error too.
- Remaining raw-map reads of clap-declared flags in these builtins moved to the parsed struct per the CLAUDE.md convention — which also deletes the `no-ignore || no-ignore` copy-paste dupes in glob and tree.

New kernel-routed suite `walk_filter_flags_tests.rs` (11 tests) pins all of it, including the traversal-vs-include-miss distinction. Gates: full tests green (one unrelated known flake, #135) and clippy `--all --all-targets` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)