### PR TITLE
feat(#134): the reference REPL is ignore-aware by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,21 @@ breaking entries are marked **BREAKING**.
 
 ## [Unreleased]
 
+### Changed
+- **The reference REPL is ignore-aware by default** (GH #134). Interactive,
+  `-c`, and script modes now load `.gitignore` and the default ignore list
+  (`.git`, `target`, `node_modules`, …) at Advisory scope: glob/tree/grep/ls
+  filter, `find` stays POSIX-unrestricted, and the unfiltered view is one
+  `--no-ignore` (per call) or `kaish-ignore clear` (per session) away. A new
+  `IgnoreConfig::interactive()` preset carries this; bare embedded kernels
+  (`transient`/`named`/`isolated`) keep the unfiltered default.
+
 ### Fixed
+- **`kaish-ignore` changes now persist past their own statement.** Every
+  runtime ignore mutation (`add`/`clear`/`defaults`/`scope`) was silently
+  dropped at the end of the statement that made it — the per-command context
+  sync copied back cwd/aliases/output-limit but not the ignore config — so
+  the documented `kaish-ignore add .gitignore` rc-file recipe did nothing.
 - **`glob --include` now actually filters.** It was a complete no-op: the
   walker consulted only exclude rules, so `glob '*' --include='*.rs'` listed
   everything. Include semantics are now rg-like: when include patterns exist a

--- a/crates/kaish-help/content/en/ignore.md
+++ b/crates/kaish-help/content/en/ignore.md
@@ -6,8 +6,9 @@ Controls which files are filtered by file-walking tools (glob, tree, ls -R, grep
 
 | Mode | Scope | Defaults | Auto-gitignore | Effect |
 |------|-------|----------|----------------|--------|
-| REPL | Advisory | off | off | No filtering. `find` always unrestricted. |
+| REPL | Advisory | on | on | Polite tools filter (.gitignore + defaults); `find` unrestricted. Recover per call with `--no-ignore`, per session with `kaish-ignore clear`. |
 | Agent | Enforced | on | on | All tools filter. Prevents context flooding. |
+| Embedded | Advisory | off | off | No filtering unless the embedder configures it. |
 
 ## Scope
 
@@ -32,12 +33,13 @@ kaish-ignore auto on|off              # toggle nested .gitignore loading
 kaish-ignore scope advisory|enforced  # change scope
 ```
 
-## REPL Setup
+## REPL Opt-Out
 
-Add to `~/.kaishrc` for filtering in interactive mode:
+Interactive mode filters by default. To see everything, add to
+`~/.config/kaish/init.kai` (or run ad hoc):
 
 ```sh
-kaish-ignore add .gitignore
-kaish-ignore defaults on
-kaish-ignore auto on
+kaish-ignore clear      # this session: no filtering at all
 ```
+
+or reach past the filter per call: `glob '**/*' --no-ignore`.

--- a/crates/kaish-kernel/src/ignore_config.rs
+++ b/crates/kaish-kernel/src/ignore_config.rs
@@ -1,8 +1,10 @@
 //! Configurable ignore file policy for file-walking tools.
 //!
 //! Controls which gitignore-format files are loaded and how broadly
-//! ignore rules apply. Per-mode defaults protect sandboxed agents from
-//! context flooding while leaving REPL users unrestricted.
+//! ignore rules apply. Per-mode defaults: sandboxed agents get `Enforced`
+//! filtering (context-flood protection), the interactive REPL gets the same
+//! filters at `Advisory` scope (recoverable per call via `--no-ignore` or
+//! per session via `kaish-ignore`), and bare embedded/test kernels get none.
 
 use std::path::{Path, PathBuf};
 
@@ -41,7 +43,7 @@ pub struct IgnoreConfig {
 }
 
 impl IgnoreConfig {
-    /// No filtering — REPL/embedded/test default.
+    /// No filtering — embedded/test default.
     pub fn none() -> Self {
         Self {
             scope: IgnoreScope::Advisory,
@@ -50,6 +52,18 @@ impl IgnoreConfig {
             auto_gitignore: false,
             use_global_gitignore: false,
             global_gitignore_path_override: None,
+        }
+    }
+
+    /// Interactive-REPL defaults (GH #134): the same filters as `agent()` —
+    /// `.gitignore` loaded, default ignore list on — but at **Advisory**
+    /// scope, so `find` stays POSIX-unrestricted and a human can recover the
+    /// unfiltered view per call (`--no-ignore`) or per session
+    /// (`kaish-ignore clear`).
+    pub fn interactive() -> Self {
+        Self {
+            scope: IgnoreScope::Advisory,
+            ..Self::agent()
         }
     }
 

--- a/crates/kaish-kernel/src/ignore_config.rs
+++ b/crates/kaish-kernel/src/ignore_config.rs
@@ -68,6 +68,10 @@ impl IgnoreConfig {
     }
 
     /// Sandboxed-agent defaults: enforced scope, .gitignore loaded, defaults on.
+    ///
+    /// NOTE: `interactive()` inherits every field but `scope` from here via
+    /// struct-update syntax — a new field added to this preset carries into
+    /// the REPL preset unless `interactive()` overrides it.
     pub fn agent() -> Self {
         Self {
             scope: IgnoreScope::Enforced,

--- a/crates/kaish-kernel/src/kernel.rs
+++ b/crates/kaish-kernel/src/kernel.rs
@@ -447,7 +447,9 @@ impl KernelConfig {
             cwd,
             skip_validation: false,
             interactive: false,
-            ignore_config: crate::ignore_config::IgnoreConfig::none(),
+            // Ignore-aware by default (GH #134): .gitignore + default ignores
+            // at Advisory scope — `--no-ignore` / `kaish-ignore clear` recover.
+            ignore_config: crate::ignore_config::IgnoreConfig::interactive(),
             output_limit: crate::output_limit::OutputLimitConfig::none(),
             allow_external_commands: cfg!(feature = "subprocess"),
             latch_enabled: std::env::var("KAISH_LATCH").is_ok_and(|v| v == "1"),
@@ -3269,6 +3271,11 @@ impl Kernel {
             // dropped here and never reaches dispatch_command's read-back, so
             // it would not survive past the current statement.
             ec.output_limit = ctx.output_limit.clone();
+            // Same for `kaish-ignore` (add/clear/defaults/scope): this field
+            // was missing from this sync, so every runtime ignore mutation
+            // silently died at the end of its own statement — including the
+            // documented `kaish-ignore add .gitignore` rc-file recipe.
+            ec.ignore_config = ctx.ignore_config.clone();
             ec.pipe_stdin = ctx.pipe_stdin.take();
             ec.pipe_stdout = ctx.pipe_stdout.take();
         }

--- a/crates/kaish-kernel/tests/repl_ignore_default_tests.rs
+++ b/crates/kaish-kernel/tests/repl_ignore_default_tests.rs
@@ -1,0 +1,106 @@
+//! The reference REPL's kernel preset is ignore-aware by default (GH #134):
+//! `KernelConfig::repl()` loads `.gitignore` and the default ignore list
+//! (.git, target, node_modules, …) at **Advisory** scope — the polite walkers
+//! (glob, tree, grep -r, ls) filter, `find` stays POSIX-unrestricted, and
+//! both `--no-ignore` and `kaish-ignore clear` recover the unfiltered view
+//! per call / per session.
+
+// Test-fixture code: unwrap/expect on known-good setup is the idiom here.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+#![cfg(feature = "localfs")]
+
+use kaish_kernel::interpreter::ExecResult;
+use kaish_kernel::{Kernel, KernelConfig};
+use std::fs;
+use std::path::Path;
+
+fn kernel_at(dir: &Path) -> Kernel {
+    let config = KernelConfig::repl().with_cwd(dir.to_path_buf());
+    Kernel::new(config).expect("kernel")
+}
+
+async fn run(kernel: &Kernel, script: &str) -> ExecResult {
+    kernel.execute(script).await.expect("kernel execute")
+}
+
+/// A repo-shaped fixture: a kept source file, a .gitignore'd log, and a
+/// default-ignored target/ dir — with a NEEDLE in each searchable file.
+fn seed(dir: &Path) {
+    fs::write(dir.join("keep.rs"), "NEEDLE in keep\n").unwrap();
+    fs::write(dir.join("secret.log"), "NEEDLE in secret\n").unwrap();
+    fs::write(dir.join(".gitignore"), "secret.log\n").unwrap();
+    fs::create_dir(dir.join("target")).unwrap();
+    fs::write(dir.join("target/dep.rs"), "NEEDLE in dep\n").unwrap();
+}
+
+#[tokio::test]
+async fn repl_glob_respects_gitignore_and_defaults() {
+    let tmp = tempfile::tempdir().unwrap();
+    seed(tmp.path());
+    let kernel = kernel_at(tmp.path());
+
+    let r = run(&kernel, "glob '**/*'").await;
+    assert_eq!(r.code, 0, "glob succeeds: {}", r.err);
+    let out = r.text_out();
+    assert!(out.contains("keep.rs"), "visible file listed: {out}");
+    assert!(!out.contains("secret.log"), ".gitignore respected: {out}");
+    assert!(!out.contains("dep.rs"), "default ignore (target/) respected: {out}");
+}
+
+#[tokio::test]
+async fn repl_grep_respects_ignores() {
+    let tmp = tempfile::tempdir().unwrap();
+    seed(tmp.path());
+    let kernel = kernel_at(tmp.path());
+
+    let r = run(&kernel, "grep -rn NEEDLE .").await;
+    assert_eq!(r.code, 0, "match exists: {r:?}");
+    let out = r.text_out();
+    assert!(out.contains("keep.rs"), "visible match found: {out}");
+    assert!(!out.contains("secret.log"), "ignored file not searched: {out}");
+    assert!(!out.contains("dep.rs"), "target/ not searched: {out}");
+}
+
+/// Advisory scope: `--no-ignore` recovers the unfiltered view per call.
+#[tokio::test]
+async fn no_ignore_flag_recovers_everything() {
+    let tmp = tempfile::tempdir().unwrap();
+    seed(tmp.path());
+    let kernel = kernel_at(tmp.path());
+
+    let r = run(&kernel, "glob '**/*' --no-ignore").await;
+    assert_eq!(r.code, 0, "glob succeeds: {}", r.err);
+    let out = r.text_out();
+    assert!(out.contains("secret.log"), "--no-ignore sees gitignored files: {out}");
+    assert!(out.contains("dep.rs"), "--no-ignore sees target/: {out}");
+}
+
+/// Advisory scope: `find` keeps its POSIX everything-visible tradition.
+#[tokio::test]
+async fn find_stays_unrestricted_under_advisory() {
+    let tmp = tempfile::tempdir().unwrap();
+    seed(tmp.path());
+    let kernel = kernel_at(tmp.path());
+
+    let r = run(&kernel, "find .").await;
+    assert_eq!(r.code, 0, "find succeeds: {}", r.err);
+    let out = r.text_out();
+    assert!(out.contains("secret.log"), "find sees gitignored files: {out}");
+    assert!(out.contains("dep.rs"), "find walks target/: {out}");
+}
+
+/// The session-wide opt-out still works: `kaish-ignore clear` disables all
+/// filtering at runtime.
+#[tokio::test]
+async fn kaish_ignore_clear_disables_filtering() {
+    let tmp = tempfile::tempdir().unwrap();
+    seed(tmp.path());
+    let kernel = kernel_at(tmp.path());
+
+    run(&kernel, "kaish-ignore clear").await;
+    let r = run(&kernel, "glob '**/*'").await;
+    assert_eq!(r.code, 0, "glob succeeds: {}", r.err);
+    let out = r.text_out();
+    assert!(out.contains("secret.log"), "clear disables .gitignore: {out}");
+    assert!(out.contains("dep.rs"), "clear disables defaults: {out}");
+}

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -14,6 +14,30 @@ before it ships.
 
 ---
 
+## The REPL learns to read .gitignore — and kaish-ignore learns to persist (2026-07-06)
+
+Amy's call on #134: default to ignore-aware. The reference REPL had always run
+`IgnoreConfig::none()` — zero filtering — so every interactive `glob '**/*'`
+or `grep -r` walked `target/`, `.git/`, and `node_modules/` in full (it was
+half of the "glob walked forever" repro behind #122). The new
+`IgnoreConfig::interactive()` preset is `agent()`'s filters at **Advisory**
+scope: `.gitignore` plus the default ignore list for the polite walkers,
+`find` still POSIX-unrestricted, and two escape hatches — `--no-ignore` per
+call, `kaish-ignore clear` per session. Bare embedded kernels keep `none()`;
+the choice is per-frontend, not global.
+
+The trap discovered while testing the opt-out: `kaish-ignore clear` printed a
+cleared config and then the very next statement saw the old one. The
+per-command context sync in `execute_command` copied back cwd, aliases, and
+output-limit — with a comment documenting exactly this bug class for
+output-limit — but never `ignore_config`, so every runtime ignore mutation
+died at the end of its own statement. The documented `.kaishrc` recipe
+(`kaish-ignore add .gitignore`) had been a no-op the whole time. One line in
+the sync closes it, and the missing-field-in-a-manual-sync class gets another
+tally mark for the "extract the ctx-sync helper" backlog entry.
+
+---
+
 ## The latch survives its consumers (2026-07-06)
 
 A pre-release "fishing expedition" — Amy's cross-model combo, a gemini-pro


### PR DESCRIPTION
## What

Amy's design call on #134: interactive kaish should default to ignore-aware walking. A new `IgnoreConfig::interactive()` preset — `agent()`'s filters (`.gitignore` + default ignore list + auto-gitignore) at **Advisory** scope — becomes `KernelConfig::repl()`'s default. glob/tree/grep/ls filter; `find` keeps its POSIX everything-visible tradition; recovery is `--no-ignore` per call or `kaish-ignore clear` per session. Embedded presets (`transient`/`named`/`isolated`) keep unfiltered `none()` — the choice belongs to the frontend.

## The bug found on the way

Pinning the opt-out path exposed a pre-existing hole: **`kaish-ignore` mutations never persisted past their own statement.** `execute_command`'s post-tool sync copies back cwd/aliases/output-limit — with a comment documenting exactly this missing-field class for output-limit — but not `ignore_config`. So `add`/`clear`/`defaults`/`scope` all silently died at the statement boundary, and the help's documented rc-file recipe (`kaish-ignore add .gitignore`) had been a no-op. One line in the sync fixes it; it's another tally for the "extract the ctx-sync helper" backlog entry (third manual sync site, second missing field).

## Verification

Five kernel-routed tests (`repl_ignore_default_tests.rs`): filtering via glob and grep, `--no-ignore` recovery, `find` unrestricted under Advisory, and `kaish-ignore clear` persisting across statements. E2E on this repo: `glob '**/*.rs'` = 294 filtered vs 298 with `--no-ignore`; `find target` still lists build artifacts. `help ignore` content updated (modes table + opt-out section). Gates: full tests green (only the known flake #135), clippy clean.

Closes #134.

🤖 Generated with [Claude Code](https://claude.com/claude-code)