### PR TITLE
fix(job-control): bg/fg accept the %N jobspec form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ breaking entries are marked **BREAKING**.
   (`transient`/`named`/`isolated`) keep the unfiltered default.
 
 ### Fixed
+- **`bg %1` / `fg %1` no longer reject the POSIX jobspec form.** Both builtins
+  parsed the job argument with a bare numeric parse, so the standard `%N`
+  jobspec (already accepted by `kill`/`wait`) failed with "invalid job id: %1".
+  `bg`/`fg` now strip a leading `%` before parsing, matching `kill`/`wait`.
 - **`kaish-ignore` changes now persist past their own statement.** Every
   runtime ignore mutation (`add`/`clear`/`defaults`/`scope`) was silently
   dropped at the end of the statement that made it — the per-command context

--- a/crates/kaish-kernel/src/tools/builtin/bg.rs
+++ b/crates/kaish-kernel/src/tools/builtin/bg.rs
@@ -73,10 +73,16 @@ impl Tool for Bg {
             let job_id = if let Some(val) = args.get_positional(0) {
                 match val {
                     Value::Int(i) => JobId(*i as u64),
-                    Value::String(s) => match s.parse::<u64>() {
-                        Ok(i) => JobId(i),
-                        Err(_) => return ExecResult::failure(1, format!("bg: invalid job id: {}", s)),
-                    },
+                    Value::String(s) => {
+                        // Accept the bash jobspec form `%N` as well as a bare
+                        // number; the `%` is a job marker, not part of the id
+                        // (mirrors `kill`/`wait`).
+                        let digits = s.strip_prefix('%').unwrap_or(s);
+                        match digits.parse::<u64>() {
+                            Ok(i) => JobId(i),
+                            Err(_) => return ExecResult::failure(1, format!("bg: invalid job id: {}", s)),
+                        }
+                    }
                     _ => return ExecResult::failure(1, "bg: job id must be a number"),
                 }
             } else {

--- a/crates/kaish-kernel/src/tools/builtin/fg.rs
+++ b/crates/kaish-kernel/src/tools/builtin/fg.rs
@@ -76,10 +76,16 @@ impl Tool for Fg {
             let job_id = if let Some(val) = args.get_positional(0) {
                 match val {
                     Value::Int(i) => JobId(*i as u64),
-                    Value::String(s) => match s.parse::<u64>() {
-                        Ok(i) => JobId(i),
-                        Err(_) => return ExecResult::failure(1, format!("fg: invalid job id: {}", s)),
-                    },
+                    Value::String(s) => {
+                        // Accept the bash jobspec form `%N` as well as a bare
+                        // number; the `%` is a job marker, not part of the id
+                        // (mirrors `kill`/`wait`).
+                        let digits = s.strip_prefix('%').unwrap_or(s);
+                        match digits.parse::<u64>() {
+                            Ok(i) => JobId(i),
+                            Err(_) => return ExecResult::failure(1, format!("fg: invalid job id: {}", s)),
+                        }
+                    }
                     _ => return ExecResult::failure(1, "fg: job id must be a number"),
                 }
             } else {

--- a/crates/kaish-repl/tests/pty_job_control.rs
+++ b/crates/kaish-repl/tests/pty_job_control.rs
@@ -234,6 +234,45 @@ fn test_fg_resumes_stopped_job() {
 }
 
 #[test]
+fn test_fg_with_percent_jobspec() {
+    // GH #126 part A: `fg %1` (the POSIX jobspec form) must be accepted, not
+    // rejected with "invalid job id: %1".
+    let mut session = PtySession::new();
+
+    session.send_line("sh -c 'sleep 60'");
+    std::thread::sleep(Duration::from_millis(300));
+    session.send_ctrl_z();
+    session
+        .wait_for("会sh> ", Duration::from_secs(3))
+        .expect("prompt after Ctrl-Z");
+
+    // Resume with fg "%1", then Ctrl-C to kill it. The output captured by the
+    // next wait_for includes whatever `fg "%1"` printed immediately (an error,
+    // pre-fix) as well as anything printed after Ctrl-C.
+    session.send_line("fg \"%1\"");
+    std::thread::sleep(Duration::from_millis(300));
+    session.send_ctrl_c();
+
+    let output = session
+        .wait_for("会sh> ", Duration::from_secs(3))
+        .expect("prompt after fg \"%1\" + Ctrl-C");
+    assert!(
+        !output.contains("invalid job id"),
+        "fg \"%1\" should be accepted as a jobspec, got:\n{}",
+        output
+    );
+
+    // Job should be gone now — this also fails pre-fix, since a rejected
+    // `fg "%1"` never touches the stopped job at all.
+    let output = session.run_command("jobs");
+    assert!(
+        output.contains("no jobs"),
+        "jobs should be empty after fg \"%1\" + Ctrl-C, got:\n{}",
+        output
+    );
+}
+
+#[test]
 fn test_bg_resumes_in_background() {
     let mut session = PtySession::new();
 
@@ -250,6 +289,35 @@ fn test_bg_resumes_in_background() {
     assert!(
         output.contains("&"),
         "bg should print job with &, got:\n{}",
+        output
+    );
+
+    // Kill it to clean up
+    session.run_command("kill \"%1\"");
+}
+
+#[test]
+fn test_bg_with_percent_jobspec() {
+    // GH #126 part A: `bg %1` (the POSIX jobspec form, not just a bare job
+    // number) must be accepted — `kill`/`wait` already strip the leading `%`.
+    let mut session = PtySession::new();
+
+    session.send_line("sh -c 'sleep 60'");
+    std::thread::sleep(Duration::from_millis(300));
+    session.send_ctrl_z();
+    session
+        .wait_for("会sh> ", Duration::from_secs(3))
+        .expect("prompt after Ctrl-Z");
+
+    let output = session.run_command("bg \"%1\"");
+    assert!(
+        !output.contains("invalid job id"),
+        "bg \"%1\" should be accepted as a jobspec, got:\n{}",
+        output
+    );
+    assert!(
+        output.contains("&"),
+        "bg \"%1\" should print job with &, got:\n{}",
         output
     );
 


### PR DESCRIPTION
## Summary

Part of #126 (part A — the "easy" finding). `bg %1` / `fg %1` (the standard POSIX jobspec form) failed with `invalid job id: %1`: both builtins parsed the job-id positional with a bare `s.parse::<u64>()`, never stripping a leading `%`. `kill` and `wait` already handle this correctly (`kill.rs` via `target_str.strip_prefix('%')`, `wait.rs` via `s.strip_prefix('%').unwrap_or(s)`), so the same argument worked in half the job-control builtins and not the other half.

- Mirrors `wait.rs`'s existing `strip_prefix('%')` idiom in `bg.rs` and  `fg.rs`. The error message still echoes the original (unstripped) string, so  the user sees exactly what they typed.
- Added two PTY tests (`test_bg_with_percent_jobspec`,  `test_fg_with_percent_jobspec`) mirroring the existing bare-jobspec bg/fg  tests. Confirmed both fail against the pre-fix code with the exact reported  `invalid job id: %1` message, and pass after the fix. `bg`/`fg` had zero prior test coverage; `fg` specifically can't be unit-tested without a real controlling terminal (`TerminalState::init()` has no test-friendly constructor — it calls real `tcsetpgrp`/`setpgid`), so PTY is the only viable harness here, matching this test file's existing convention.
- CHANGELOG bullet under `Fixed`.

kaibo-reviewed (cast: deepseek) — confirmed no missing call sites (kill/wait/bg/fg are the only four job-id parse sites in the codebase), walked the %-stripping edge cases (bare `%`, `%%1`, bash-extended `%+`/`%-`/`%string` forms — none of which kaish claims to support, and all fail with a clear, if terse, error consistent with kill/wait's existing terseness), and confirmed the new PTY tests are sound and follow the file's conventions. No changes requested.

## Test plan
- [x] New PTY tests fail on pre-fix code with the exact reported error, pass post-fix
- [x] `cargo test --all` — full workspace suite green (including all 7
      `pty_job_control.rs` tests, no regressions)
- [x] `cargo clippy --all --all-targets` — zero warnings
- [x] kaibo review (cast: deepseek) — no changes requested

🤖 Generated with [Claude Code](https://claude.com/claude-code)