### PR TITLE
fix(pipeline): propagate a mid-pipeline confirmation latch (#125)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ breaking entries are marked **BREAKING**.
   (`transient`/`named`/`isolated`) keep the unfiltered default.
 
 ### Fixed
+- **A confirmation latch raised mid-pipeline (`set -o latch`) no longer gets
+  swallowed by a later stage's success.** `rm x | echo done` used to exit 0
+  with `.latch` dropped, even though `rm` genuinely gated and the file was
+  never touched — only the last pipeline stage's result used to survive. Any
+  gated stage now overrides the pipeline's exit code (2) and carries its
+  structured `.latch` through; first latch wins if more than one stage gates.
 - **`kaish-ignore` changes now persist past their own statement.** Every
   runtime ignore mutation (`add`/`clear`/`defaults`/`scope`) was silently
   dropped at the end of the statement that made it — the per-command context

--- a/crates/kaish-kernel/src/scheduler/pipeline.rs
+++ b/crates/kaish-kernel/src/scheduler/pipeline.rs
@@ -623,9 +623,20 @@ impl PipelineRunner {
         // (e.g., `echo "Alice" | read NAME`).
         let mut last_result = ExecResult::success("");
         let mut panics: Vec<String> = Vec::new();
+        // GH #125: a confirmation gate (`set -o latch`) raised by an EARLIER
+        // stage must not be swallowed by a later stage's nominal success —
+        // `rm x | echo done` used to exit 0 with `.latch` dropped even though
+        // `rm` genuinely gated (the op never ran; only its stderr text hinted at
+        // the gate). First latch wins if more than one stage gates, mirroring
+        // `wait.rs`'s `classify()` "first latch wins" precedent — captured here
+        // in stage order, so the first `Some` set below IS the first stage.
+        let mut gated: Option<ExecResult> = None;
         for (i, handle) in handles.into_iter().enumerate() {
             match handle.await {
                 Ok((result, stage_ctx)) => {
+                    if result.latch.is_some() {
+                        gated.get_or_insert_with(|| result.clone());
+                    }
                     if i == last_idx {
                         last_result = result;
                         // Sync last stage's scope and cwd changes back
@@ -641,6 +652,18 @@ impl PipelineRunner {
             }
         }
 
+        // A pending gate is a control-plane fact about the WHOLE pipeline, not
+        // stage-local trivia — override the last stage's nominal result so the
+        // exit code (2) and the structured `.latch` both survive.
+        if let Some(gate) = gated {
+            last_result = gate;
+        }
+
+        // Checked LAST (so it wins over the latch override above): mirrors the
+        // existing precedent that ANY stage panicking overrides `last_result`
+        // regardless of which stage, and keeps a gate raised earlier in the same
+        // run HELD (unconfirmed) rather than presenting a ready-to-confirm nonce
+        // after a crash elsewhere in the pipeline.
         if !panics.is_empty() {
             last_result = ExecResult::failure(
                 1,

--- a/crates/kaish-kernel/tests/latch_trash_tests.rs
+++ b/crates/kaish-kernel/tests/latch_trash_tests.rs
@@ -365,6 +365,65 @@ async fn latch_off_by_default_rm_deletes_directly() {
     assert!(!dir.path().join("plain.txt").exists());
 }
 
+#[tokio::test]
+async fn latch_in_a_pipeline_stage_overrides_later_success() {
+    // GH #125: a confirmation gate raised by an EARLIER pipeline stage must
+    // survive a later stage's nominal success. `rm x | echo done` used to exit
+    // 0 with the latch dropped (only the last stage's result survived), so an
+    // agent gating on exit codes saw success while `rm` never ran. The gate is a
+    // control-plane fact about the whole pipeline: exit 2, `.latch` present, and
+    // the file untouched.
+    let dir = tempdir();
+    std::fs::write(dir.path().join("precious.txt"), "data").expect("write");
+    let kernel = kernel_at(dir.path());
+
+    run(&kernel, "set -o latch").await;
+    let piped = run(&kernel, "rm precious.txt | echo done").await;
+
+    assert_eq!(
+        piped.code, 2,
+        "an earlier stage's gate must set the pipeline exit code, not the last \
+         stage's 0: {}",
+        piped.err
+    );
+    let req = piped
+        .latch_request()
+        .expect("the earlier stage's latch must ride the pipeline result");
+    assert_eq!(req.command, "rm", "the gated command is rm, not echo");
+    assert!(!req.nonce.is_empty(), "a usable nonce must be present");
+    assert!(
+        dir.path().join("precious.txt").exists(),
+        "the gated file must survive — the gate held, the op never ran"
+    );
+}
+
+#[tokio::test]
+async fn latch_first_stage_wins_when_two_stages_gate() {
+    // Two gated stages in one pipeline: first latch wins (matches wait.rs
+    // classify()'s first-latch-wins). `rm a | rm b` under latch surfaces a's
+    // gate, and BOTH files survive (each stage gated independently).
+    let dir = tempdir();
+    std::fs::write(dir.path().join("a.txt"), "a").expect("write");
+    std::fs::write(dir.path().join("b.txt"), "b").expect("write");
+    let kernel = kernel_at(dir.path());
+
+    run(&kernel, "set -o latch").await;
+    let piped = run(&kernel, "rm a.txt | rm b.txt").await;
+
+    assert_eq!(piped.code, 2, "err: {}", piped.err);
+    let req = piped.latch_request().expect("a latch must ride the result");
+    // First stage's gate authorizes a.txt; the surfaced nonce must be usable to
+    // confirm it (the FIRST gate, not the last stage's).
+    let confirm_a = run(&kernel, &format!("rm --confirm={} a.txt", req.nonce)).await;
+    assert_eq!(
+        confirm_a.code, 0,
+        "the surfaced nonce must confirm the FIRST stage's path: {}",
+        confirm_a.err
+    );
+    assert!(!dir.path().join("a.txt").exists(), "a.txt confirmed and removed");
+    assert!(dir.path().join("b.txt").exists(), "b.txt still gated, untouched");
+}
+
 // ============================================================================
 // Trash-on-delete — mock TrashBackend covering the RmAction::Trash arm
 // ============================================================================


### PR DESCRIPTION
## Summary

`run_pipeline`'s stage-collection loop only kept the *last* stage's `ExecResult`. Under `set -o latch`, a confirmation gate raised by an earlier stage was silently discarded if a later stage succeeded — `set -o latch; rm x | echo done` used to exit `0` with `.latch` gone entirely, even though `rm` genuinely gated and the file was never touched (only `rm`'s stderr text hinted at the gate, unreachable by exit-code checks).

## Fix

Mirrors the *existing* precedent eleven lines below in the same function: "any stage panicked overrides `last_result`, regardless of which stage." The fix does the same for a latch: any stage's `.latch` now overrides the pipeline's terminal result (exit 2 + the structured `.latch`), first-latch-wins if more than one stage gates (matching `wait.rs`'s `classify()`, which already documents "first latch wins" for multiple gated background jobs).

The latch override is applied *before* the panic-override block, so a genuine stage panic still wins — this keeps a pending gate raised earlier in the same run **held** (unconfirmed) rather than presenting a ready-to-confirm nonce after some other stage crashed. (Note: I did not use "mirrors `did_spill`" as justification anywhere — `did_spill` is only preserved across a single-result backend-dispatch seam, there's no existing OR-across-pipeline-stages precedent for it. The panics-override block is the real, applicable precedent.)

## Tests

Two new kernel-routed tests in `latch_trash_tests.rs`, both verified to **fail before** the fix and **pass after** (confirmed via a temporary `git apply -R` of the pipeline.rs patch, ran red, then reapplied and ran green):
- `latch_in_a_pipeline_stage_overrides_later_success` — `rm precious.txt | echo done` now exits 2 with the latch attached and the file untouched.
- `latch_first_stage_wins_when_two_stages_gate` — `rm a.txt | rm b.txt` surfaces a's nonce (confirmed via replay), b stays gated/untouched.

## Review

Reviewed via `kaibo` (cast `deepseek`) — approved with no changes requested (confirmed first-latch-wins correctness, panic/latch ordering, no silent data loss on override, and that the clone in `get_or_insert_with` is the idiomatic/cheap choice given `result` is later moved).

Closes #125