### PR TITLE
fix(cmdsubst): $(...) now isolates aliases/ignore_config/output_limit (#139)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,12 @@ breaking entries are marked **BREAKING**.
   dropped at the end of the statement that made it — the per-command context
   sync copied back cwd/aliases/output-limit but not the ignore config — so
   the documented `kaish-ignore add .gitignore` rc-file recipe did nothing.
+- **Command substitution (`$(...)`) no longer leaks session-config
+  mutations.** `x=$(kaish-ignore clear)`, `$(kaish-output-limit off)`, or
+  `$(unalias name)` used to silently mutate the persistent kernel session
+  past the end of the `$(...)` — command substitution already isolated `cd`
+  and variable assignments but not `aliases`/`ignore_config`/`output_limit`,
+  the same missing-field class #138 just fixed for the plain-statement path.
 - **`glob --include` now actually filters.** It was a complete no-op: the
   walker consulted only exclude rules, so `glob '*' --include='*.rs'` listed
   everything. Include semantics are now rg-like: when include patterns exist a

--- a/crates/kaish-kernel/src/kernel.rs
+++ b/crates/kaish-kernel/src/kernel.rs
@@ -4015,15 +4015,25 @@ impl Kernel {
                 }
             },
             Expr::CommandSubst(stmts) => {
-                // Snapshot scope+cwd before running — only output escapes,
-                // not side effects like `cd` or variable assignments.
+                // Snapshot scope, cwd, and session config before running —
+                // only output escapes, not side effects like `cd`, variable
+                // assignments, or config mutations (`kaish-ignore`,
+                // `kaish-output-limit`, `alias`/`unalias`) — matching how
+                // every other execution context (background forks, scatter
+                // workers) already isolates mutations (GH #139).
                 // Boxed: this ~470 B scope snapshot is held across the nested
                 // `$(…)` recursion await below, so inlining it grows every
                 // command-substitution level's future (GH #48, item 4).
                 let saved_scope = Box::new(self.scope.read().await.clone());
-                let saved_cwd = {
+                let saved_ec = {
                     let ec = self.exec_ctx.read().await;
-                    (ec.cwd.clone(), ec.prev_cwd.clone())
+                    (
+                        ec.cwd.clone(),
+                        ec.prev_cwd.clone(),
+                        ec.aliases.clone(),
+                        ec.ignore_config.clone(),
+                        ec.output_limit.clone(),
+                    )
                 };
 
                 // Capture result without `?` — restore state unconditionally
@@ -4039,8 +4049,12 @@ impl Kernel {
                 }
                 {
                     let mut ec = self.exec_ctx.write().await;
-                    ec.cwd = saved_cwd.0;
-                    ec.prev_cwd = saved_cwd.1;
+                    let (cwd, prev_cwd, aliases, ignore_config, output_limit) = saved_ec;
+                    ec.cwd = cwd;
+                    ec.prev_cwd = prev_cwd;
+                    ec.aliases = aliases;
+                    ec.ignore_config = ignore_config;
+                    ec.output_limit = output_limit;
                 }
 
                 // Now propagate the error
@@ -4385,15 +4399,26 @@ impl Kernel {
                 }
             }
             StringPart::CommandSubst(stmts) => {
-                // Snapshot scope+cwd — command substitution in strings must
-                // not leak side effects (e.g., `"dir: $(cd /; pwd)"` must not change cwd).
+                // Snapshot scope, cwd, and session config — command
+                // substitution in strings must not leak side effects (e.g.,
+                // `"dir: $(cd /; pwd)"` must not change cwd, and
+                // `"$(kaish-ignore clear)"` must not change the session's
+                // ignore config) — matching how every other execution
+                // context (background forks, scatter workers) already
+                // isolates mutations (GH #139).
                 // Boxed: this ~470 B scope snapshot is held across the nested
                 // `$(…)` recursion await below, so inlining it grows every
                 // command-substitution level's future (GH #48, item 4).
                 let saved_scope = Box::new(self.scope.read().await.clone());
-                let saved_cwd = {
+                let saved_ec = {
                     let ec = self.exec_ctx.read().await;
-                    (ec.cwd.clone(), ec.prev_cwd.clone())
+                    (
+                        ec.cwd.clone(),
+                        ec.prev_cwd.clone(),
+                        ec.aliases.clone(),
+                        ec.ignore_config.clone(),
+                        ec.output_limit.clone(),
+                    )
                 };
 
                 // Capture result without `?` — restore state unconditionally
@@ -4409,8 +4434,12 @@ impl Kernel {
                 }
                 {
                     let mut ec = self.exec_ctx.write().await;
-                    ec.cwd = saved_cwd.0;
-                    ec.prev_cwd = saved_cwd.1;
+                    let (cwd, prev_cwd, aliases, ignore_config, output_limit) = saved_ec;
+                    ec.cwd = cwd;
+                    ec.prev_cwd = prev_cwd;
+                    ec.aliases = aliases;
+                    ec.ignore_config = ignore_config;
+                    ec.output_limit = output_limit;
                 }
 
                 // Now propagate the error

--- a/crates/kaish-kernel/tests/cmdsubst_config_isolation_tests.rs
+++ b/crates/kaish-kernel/tests/cmdsubst_config_isolation_tests.rs
@@ -1,0 +1,107 @@
+//! Command substitution `$(...)` must isolate session-config mutations, not
+//! just scope/cwd (GH #139).
+//!
+//! `Expr::CommandSubst` (bare `$(...)`) and `StringPart::CommandSubst`
+//! (`"...$(...)..."` interpolation) both save/restore `scope`/`cwd`/`prev_cwd`
+//! around the substitution's execution, but left `aliases`/`ignore_config`/
+//! `output_limit` unguarded — so `x=$(kaish-ignore clear)`,
+//! `$(kaish-output-limit off)`, or `$(unalias name)` silently mutated the
+//! persistent kernel session, the same class of bug #138 fixed for the
+//! plain-statement path. Every test runs the mutation inside `$(...)`, then
+//! reads the config back via a LATER, separate `kernel.execute()` call —
+//! matching how `cd`/variable-assignment isolation is already proven for
+//! command substitution.
+
+// Test-fixture code: unwrap/expect on known-good setup is the idiom here.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use kaish_kernel::{IgnoreConfig, Kernel, KernelConfig, OutputLimitConfig};
+
+async fn run(kernel: &Kernel, script: &str) -> (String, i64) {
+    let result = kernel.execute(script).await.expect("kernel execute");
+    (result.text_out().to_string(), result.code)
+}
+
+// ─────────────────────────── ignore_config ───────────────────────────
+
+fn ignore_kernel() -> Kernel {
+    let config = KernelConfig::isolated().with_ignore_config(IgnoreConfig::agent());
+    Kernel::new(config).expect("kernel")
+}
+
+#[tokio::test]
+async fn bare_cmd_subst_kaish_ignore_clear_does_not_leak() {
+    let kernel = ignore_kernel();
+
+    let (_, code) = run(&kernel, "x=$(kaish-ignore clear)").await;
+    assert_eq!(code, 0);
+
+    let (out, code) = run(&kernel, "kaish-ignore").await;
+    assert_eq!(code, 0);
+    assert!(
+        out.contains(".gitignore"),
+        "ignore_config must survive a bare $(...) mutation: {out}"
+    );
+}
+
+#[tokio::test]
+async fn string_interpolated_cmd_subst_kaish_ignore_clear_does_not_leak() {
+    let kernel = ignore_kernel();
+
+    // Quoted-string interpolation is the OTHER command-substitution call site
+    // (`StringPart::CommandSubst`) — must be fixed identically to the bare form.
+    let (_, code) = run(&kernel, r#"echo "before $(kaish-ignore clear) after""#).await;
+    assert_eq!(code, 0);
+
+    let (out, code) = run(&kernel, "kaish-ignore").await;
+    assert_eq!(code, 0);
+    assert!(
+        out.contains(".gitignore"),
+        "ignore_config must survive a string-interpolated $(...) mutation: {out}"
+    );
+}
+
+// ─────────────────────────── output_limit ───────────────────────────
+
+fn output_limit_kernel() -> Kernel {
+    // in_memory(): no disk spill, so the test leaves nothing on the host fs.
+    let config =
+        KernelConfig::isolated().with_output_limit(OutputLimitConfig::agent().in_memory());
+    Kernel::new(config).expect("kernel")
+}
+
+#[tokio::test]
+async fn cmd_subst_kaish_output_limit_off_does_not_leak() {
+    let kernel = output_limit_kernel();
+
+    let (_, code) = run(&kernel, "x=$(kaish-output-limit off)").await;
+    assert_eq!(code, 0);
+
+    let (out, code) = run(&kernel, "kaish-output-limit").await;
+    assert_eq!(code, 0);
+    assert!(
+        out.contains("8K"),
+        "output_limit must survive $(...): the agent 8K default must still be set: {out}"
+    );
+}
+
+// ─────────────────────────── aliases ───────────────────────────
+
+fn alias_kernel() -> Kernel {
+    Kernel::new(KernelConfig::isolated()).expect("kernel")
+}
+
+#[tokio::test]
+async fn cmd_subst_unalias_does_not_leak() {
+    let kernel = alias_kernel();
+
+    let (_, code) = run(&kernel, "alias greet='echo hi'").await;
+    assert_eq!(code, 0);
+
+    let (_, code) = run(&kernel, "x=$(unalias greet)").await;
+    assert_eq!(code, 0);
+
+    let (out, code) = run(&kernel, "greet").await;
+    assert_eq!(code, 0, "alias must still resolve after $(...): {out}");
+    assert_eq!(out.trim(), "hi");
+}


### PR DESCRIPTION
## Summary

- Command substitution (`$(...)`) already isolated `cd`/variable-assignment side effects by snapshotting `scope`/`cwd`/`prev_cwd` before running and restoring them afterward — but left `aliases`, `ignore_config`, and `output_limit` unguarded, so a script innocently doing `x=$(kaish-ignore clear)` for its return value silently mutated the persistent kernel session's ignore config for the rest of the run. Bash subshells isolate everything; kaish's `$(...)` should too.
- This is the same missing-field class GH #138 just fixed for the plain-statement path — this time in **both** command-substitution call sites (bare `x=$(...)` and quoted `"...$(...)..."` interpolation), mirroring `execute_pipeline`'s existing sync-back field list exactly.
- Kaibo-reviewed (cast `deepseek`): confirmed both arms match the precedent and traced that nested pipelines-in-`$()`, backgrounded jobs-in-`$()`, and nested `$(...)` all still stay correctly isolated (the outer restore always wins after an inner sync-back; forked background jobs never sync back to the parent at all).

Closes #139

## Test plan

- [x] Added `crates/kaish-kernel/tests/cmdsubst_config_isolation_tests.rs` with 4 tests (ignore_config via both the bare and string-interpolated `$(...)` forms, output_limit, aliases), each mutating state inside `$(...)` and reading it back via a later, separate `kernel.execute()` call.
- [x] Confirmed all 4 tests fail against unfixed `origin/main`, then pass after the fix.
- [x] `cargo test --all` clean.
- [x] `cargo clippy --all --all-targets` — zero warnings, zero errors.
- [x] Rebased onto latest `origin/main` (siblings #140/#141 had landed); re-ran both gates clean after rebase.