### PR TITLE
fix(lexer): a dash-only operand no longer loses its leading dashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,13 @@ breaking entries are marked **BREAKING**.
   silently ignored the rest, and printed exactly one file — after walking the
   tree twice. The builtin's own examples (and agents following them) spell the
   pattern unquoted. Quoted patterns behave as before.
+- **A dash-only operand no longer loses its leading dashes.** `echo ---`
+  printed `-` instead of `---`: the lexer's plain `--` literal always won a
+  length tie against any `--`-prefixed word whose 3rd character wasn't a
+  letter, silently truncating the word and swallowing the rest as a spurious
+  end-of-flags marker. Also broke `echo --=x` (→ `= x`), `echo --1` (→ `1`),
+  and made `echo -- ---` a parse error (the spurious marker collided with the
+  real `--`). All now lex as one literal word (#137).
 
 ### Added
 - **`ToolSchema::glob_passthrough` (+ `with_glob_passthrough()`)** — a tool

--- a/crates/kaish-kernel/src/kernel.rs
+++ b/crates/kaish-kernel/src/kernel.rs
@@ -6008,8 +6008,9 @@ fn classify_argv_token(token: &Value) -> Arg {
     }
 
     // Long flag: the lexer requires `--[a-zA-Z]…`. `---`, `--=v`, `--1` are NOT
-    // long-flag words (the string door tokenizes them differently and often
-    // errors), so they fall through to a literal positional rather than a
+    // long-flag words — the lexer now tokenizes each as one `DoubleDashBare`
+    // literal word (GH #137), matching this classifier's own literal
+    // fallback — so they fall through to a literal positional rather than a
     // silently-misbound `LongFlag("-")` / empty-key `Named{ key: "" }`.
     if let Some(rest) = s.strip_prefix("--") {
         if rest.starts_with(|c: char| c.is_ascii_alphabetic()) {
@@ -6294,7 +6295,8 @@ mod argv_classify_tests {
     #[test]
     fn double_dash_only_matches_exactly() {
         // `--` is the marker; `--x` is a long flag. `---` is not a flag word
-        // (the lexer splits it `--` + `-`); as a single argv token it's literal.
+        // (the lexer lexes it as one `DoubleDashBare` literal word, GH #137);
+        // as a single argv token here it's likewise literal.
         assert_eq!(classify("--"), Arg::DoubleDash);
         assert_eq!(classify("--x"), Arg::LongFlag("x".into()));
         assert_eq!(classify("---"), Arg::Positional(Expr::Literal(Value::String("---".into()))));

--- a/crates/kaish-kernel/src/lexer.rs
+++ b/crates/kaish-kernel/src/lexer.rs
@@ -452,8 +452,10 @@ pub enum Token {
     /// internal hyphens like `-not-a-flag`. Internal hyphens are part of the
     /// single shell word — without them the word fragments into separate flag
     /// tokens, which breaks `echo -- -not-a-flag` and the like. A leading `--`
-    /// is still `DoubleDash` (the second char must be a letter here), and
-    /// whether the word is a flag or a literal is the binding layer's call.
+    /// is still `DoubleDash` (the second char must be a letter here) unless
+    /// the third char isn't a letter either, in which case it's
+    /// `DoubleDashBare` — see below — and whether the word is a flag or a
+    /// literal is the binding layer's call.
     #[regex(r"-[a-zA-Z][a-zA-Z0-9-]*", lex_short_flag, priority = 3)]
     ShortFlag(String),
 
@@ -461,9 +463,26 @@ pub enum Token {
     #[regex(r"\+[a-zA-Z][a-zA-Z0-9]*", lex_plus_flag, priority = 3)]
     PlusFlag(String),
 
-    /// Double dash: `--` alone marks end of flags
+    /// Double dash: `--` alone marks end of flags. Only matches when nothing
+    /// else follows (a longer match always wins) — a `--`-prefixed word with
+    /// more characters after it either lexes as `LongFlag` (3rd char is a
+    /// letter) or `DoubleDashBare` (3rd char is anything else).
     #[token("--")]
     DoubleDash,
+
+    /// Bare word starting with `--` whose continuation isn't a valid
+    /// long-flag name: `---`, `----`, `--=x`, `--1`, etc. Without this, the
+    /// plain `--` literal above always won the length tie against a lone
+    /// `--`, silently truncating a dash-only operand to its trailing
+    /// remainder (`echo ---` printed `-` instead of `---` — GH #137). Mirrors
+    /// `MinusBare`/`PlusBare` (bare-word fallback for an unrecognized
+    /// flag-shaped prefix), just generalized to the `--` prefix. A standalone
+    /// `--` (followed by whitespace/EOF) still lexes as `DoubleDash` — this
+    /// regex requires at least one more non-whitespace character, so the two
+    /// never tie in match length and no priority tiebreak is load-bearing;
+    /// `priority = 2` is set for consistency with `PlusBare`'s tier.
+    #[regex(r"--[^a-zA-Z\s][^\s]*", lex_double_dash_bare, priority = 2)]
+    DoubleDashBare(String),
 
     /// Bare word starting with + followed by non-letter: `+%s`, `+%Y-%m-%d`
     /// For date format strings and similar. Lower priority than PlusFlag.
@@ -778,6 +797,7 @@ impl Token {
             Token::Ident(_)
             | Token::PlusBare(_)
             | Token::MinusBare(_)
+            | Token::DoubleDashBare(_)
             | Token::MinusAlone
             | Token::NumberIdent(_)
             | Token::DashNumWord(_)
@@ -926,6 +946,12 @@ fn lex_minus_bare(lex: &mut logos::Lexer<Token>) -> String {
     lex.slice().to_string()
 }
 
+/// Lex a double-dash bare word: `---` → `---`, `--=x` → `--=x` (keep the
+/// full string; see GH #137).
+fn lex_double_dash_bare(lex: &mut logos::Lexer<Token>) -> String {
+    lex.slice().to_string()
+}
+
 /// Lex a job specifier: `%1` → `%1` (keep the leading `%`).
 fn lex_job_spec(lex: &mut logos::Lexer<Token>) -> String {
     lex.slice().to_string()
@@ -1027,6 +1053,7 @@ impl fmt::Display for Token {
             Token::ShortFlag(s) => write!(f, "-{}", s),
             Token::PlusFlag(s) => write!(f, "+{}", s),
             Token::DoubleDash => write!(f, "--"),
+            Token::DoubleDashBare(s) => write!(f, "{}", s),
             Token::PlusBare(s) => write!(f, "{}", s),
             Token::MinusBare(s) => write!(f, "{}", s),
             Token::JobSpec(s) => write!(f, "{}", s),

--- a/crates/kaish-kernel/src/parser.rs
+++ b/crates/kaish-kernel/src/parser.rs
@@ -2456,11 +2456,14 @@ where
     }
     .map(|s| Expr::Literal(Value::String(s.to_string())));
 
-    // Bare words starting with + or - (e.g., date +%s, cat -)
+    // Bare words starting with + or - (e.g., date +%s, cat -), and a
+    // `--`-prefixed word that isn't a valid long flag (`echo ---`,
+    // `echo --=x`, GH #137).
     let plus_minus_bare = select! {
         Token::PlusBare(s) => Expr::Literal(Value::String(s)),
         Token::MinusBare(s) => Expr::Literal(Value::String(s)),
         Token::MinusAlone => Expr::Literal(Value::String("-".to_string())),
+        Token::DoubleDashBare(s) => Expr::Literal(Value::String(s)),
     };
 
     // Glob patterns: merged GlobWord tokens and bare Star/Question

--- a/crates/kaish-kernel/tests/lexer_tests.rs
+++ b/crates/kaish-kernel/tests/lexer_tests.rs
@@ -106,6 +106,7 @@ fn format_token(token: &Token) -> String {
         // Bare words starting with + or -
         Token::PlusBare(s) => format!("PLUSBARE({})", s),
         Token::MinusBare(s) => format!("MINUSBARE({})", s),
+        Token::DoubleDashBare(s) => format!("DOUBLEDASHBARE({})", s),
         Token::JobSpec(s) => format!("JOBSPEC({})", s),
         Token::MinusAlone => "MINUSALONE".to_string(),
 
@@ -565,11 +566,19 @@ fn lexer_double_dash(#[case] input: &str, #[case] expected: &[&str]) {
     run_lexer_test(input, expected);
 }
 
-// Note: Single dash "-" is now valid as MinusAlone (for cat - stdin indicator)
-// Triple dash "---" is DoubleDash + MinusAlone
+// Note: Single dash "-" is now valid as MinusAlone (for cat - stdin indicator).
+// A `--`-prefixed word whose 3rd char isn't a letter is ONE `DoubleDashBare`
+// token — it used to fragment into `DoubleDash` + a leftover token, silently
+// truncating a dash-only operand (`echo ---` printed `-` instead of `---`,
+// GH #137). A lone `--` (nothing following) is unaffected: it still lexes as
+// plain `DOUBLEDASH`.
 #[rstest]
 #[case::single_dash("-", &["MINUSALONE"])]
-#[case::triple_dash("---", &["DOUBLEDASH", "MINUSALONE"])]
+#[case::triple_dash("---", &["DOUBLEDASHBARE(---)"])]
+#[case::quad_dash("----", &["DOUBLEDASHBARE(----)"])]
+#[case::double_dash_equals("--=x", &["DOUBLEDASHBARE(--=x)"])]
+#[case::double_dash_digit("--1", &["DOUBLEDASHBARE(--1)"])]
+#[case::double_dash_then_word("---foo", &["DOUBLEDASHBARE(---foo)"])]
 fn lexer_dash_variants(#[case] input: &str, #[case] expected: &[&str]) {
     run_lexer_test(input, expected);
 }

--- a/crates/kaish-kernel/tests/printf_format_tests.rs
+++ b/crates/kaish-kernel/tests/printf_format_tests.rs
@@ -363,3 +363,27 @@ async fn printf_little_g_large_number() {
     let result = k.execute("printf '%g' 1234567").await.expect("execute");
     assert_eq!(result.text_out(), "1.23457e+06", "printf '%g' 1234567 should produce 1.23457e+06");
 }
+
+// ---------------------------------------------------------------------------
+// Dash-only format operand (GH #137 sibling — same lexer bug as `echo ---`)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn printf_dash_only_literal() {
+    // printf --- (unquoted) → literal "---" as the format string, no
+    // conversions. Used to print "-" (the lexer's plain `--` literal
+    // swallowed the leading two dashes as a spurious end-of-flags marker).
+    let k = kernel();
+    let result = k.execute("printf ---").await.expect("execute");
+    assert_eq!(result.text_out(), "---", "printf --- should produce ---");
+}
+
+#[tokio::test]
+async fn printf_dash_only_after_double_dash() {
+    // printf -- --- : a real `--` end-of-flags marker followed by the
+    // dash-only operand. Used to parse-error (a spurious second `--` token
+    // fell out of mis-lexing `---`, with no grammar production for it).
+    let k = kernel();
+    let result = k.execute("printf -- ---").await.expect("execute");
+    assert_eq!(result.text_out(), "---", "printf -- --- should produce ---");
+}

--- a/crates/kaish-kernel/tests/realworld_builtin_tests.rs
+++ b/crates/kaish-kernel/tests/realworld_builtin_tests.rs
@@ -562,6 +562,60 @@ mod echo_realworld {
         assert_eq!(out, "---");
     }
 
+    // GH #137: an *unquoted* dash-only operand used to lose its leading `--`
+    // (the lexer's plain `--` literal always won the length tie against a
+    // 3rd non-letter char), so `echo ---` printed `-` instead of `---`.
+    #[tokio::test]
+    async fn test_echo_separator_unquoted() {
+        let (_dir, kernel) = fixture();
+        let (out, code) = run(&kernel, "echo ---").await;
+        assert_eq!(code, 0, "echo --- failed: {out:?}");
+        assert_eq!(out, "---");
+    }
+
+    // GH #137: the spurious second `--` token from mis-lexing `---` used to
+    // collide with the real end-of-flags `--`, and `post_dash_arg` had no
+    // production for it — the whole statement parse-errored.
+    #[tokio::test]
+    async fn test_echo_double_dash_then_dash_run() {
+        let (_dir, kernel) = fixture();
+        let (out, code) = run(&kernel, "echo -- ---").await;
+        assert_eq!(code, 0, "echo -- --- failed: {out:?}");
+        assert_eq!(out, "---");
+    }
+
+    // GH #137 sibling: `--=x` isn't a valid long flag (3rd char is `=`, not a
+    // letter), so it must lex/print as one literal word, not fragment into
+    // a swallowed `--` plus stray `=`/`x` positionals.
+    #[tokio::test]
+    async fn test_echo_double_dash_equals() {
+        let (_dir, kernel) = fixture();
+        let (out, code) = run(&kernel, "echo --=x").await;
+        assert_eq!(code, 0, "echo --=x failed: {out:?}");
+        assert_eq!(out, "--=x");
+    }
+
+    // GH #137 sibling found during investigation: same root cause as `---`
+    // (3rd char after `--` is a digit, not a letter).
+    #[tokio::test]
+    async fn test_echo_double_dash_digit() {
+        let (_dir, kernel) = fixture();
+        let (out, code) = run(&kernel, "echo --1").await;
+        assert_eq!(code, 0, "echo --1 failed: {out:?}");
+        assert_eq!(out, "--1");
+    }
+
+    // GH #137 "also check" sibling: a lone `-` (unquoted, the `cat -` stdin
+    // convention) was already correct before this fix — pinned here as a
+    // regression guard, not a behavior change.
+    #[tokio::test]
+    async fn test_echo_lone_dash_unquoted() {
+        let (_dir, kernel) = fixture();
+        let (out, code) = run(&kernel, "echo -").await;
+        assert_eq!(code, 0, "echo - failed: {out:?}");
+        assert_eq!(out, "-");
+    }
+
     // Pattern: echo "" (empty string)
     #[tokio::test]
     async fn test_echo_empty() {


### PR DESCRIPTION
Closes #137

`echo ---` printed `-` instead of `---`: the lexer's `LongFlag`/`ShortFlag` regexes both require a letter right after the dash(es) (`--[a-zA-Z]...` / `-[a-zA-Z]...`), so whenever a `--`-prefixed word's 3rd character was anything else, the plain `#[token("--")]` literal always won the match, silently truncating the word and swallowing the leading `--` as a spurious end-of-flags marker. The same mechanism produced a *second*, spurious `DoubleDash` token when lexing `---`, which the post-`--` argument grammar had no production for — so `echo -- ---` parse-errored outright.

## The fix

One new lexer token, `Token::DoubleDashBare`, mirroring the existing `MinusBare`/`PlusBare` bare-word-fallback idiom already in `lexer.rs` — just generalized to the `--` prefix (`--[^a-zA-Z\s][^\s]*`). Longest-match resolves the ambiguity against the plain `--` literal automatically (a standalone `--` is untouched — the regex requires ≥1 more character). Because both the pre-`--` and post-`--` argument grammars already share `primary_expr_parser()` via the parser's `plus_minus_bare` production, **one new arm there** was enough to fix `echo ---` *and* `echo -- ---` simultaneously — no grammar change or new escape syntax was needed. Also updated two `kernel.rs` comments on `classify_argv_token` (the argv-native embedder door) that described this lexer bug as accepted fact — that classifier was already correct, so the two doors now agree, comment-only change there.

## Sibling status (from the issue's "also check" list)

- `printf ---` — **was broken, now fixed** (same mechanism as `echo`, both are `schema_from_clap` builtins).
- `--=x` — **was broken, now fixed** (`echo --=x` printed `= x`; now prints `--=x`).
- a lone `-` by itself — **was already fine**; added as a regression-pin test only, no fix needed.
- `--1` and `----` — found during investigation (same root cause), also fixed.
- `echo ---foo` (dash-run immediately followed by letters) — not explicitly listed in the issue, but turned out to be fixed as a natural side effect of the same regex (previously printed `-foo`).

## Testing

- TDD: updated the existing lexer test that pinned the *old buggy* tokenization of `---` as correct (`crates/kaish-kernel/tests/lexer_tests.rs`), and added new cases for `----`, `--=x`, `--1`, `---foo`.
- Added execution-level tests through `kernel.execute()` (per house convention) in `realworld_builtin_tests.rs` (echo) and `printf_format_tests.rs` (printf) covering both repro strings from the issue plus the siblings.
- `cargo test --all` (every crate) and `cargo clippy --all --all-targets` are both clean. `cargo insta test --check` has no pending snapshots.
- Manually re-verified every repro/sibling against the built `kaish` binary, plus a battery of adjacent dash/flag forms (`--foo-bar`, `-la`, `awk -F:`, `cut -f1-3`, `date +%Y-%m-%d`, `--key=value`, `git checkout --`-style `cmd -- file`) to confirm no regressions.

## Review

Reviewed via `kaibo` (deepseek cast) against the diff, specifically probing for regressions on combined short flags, the `awk -F:` colon-fusion merge pass, `cut -f1-3`/`DashNumWord`, `date +%s`/`PlusBare`, negative `Int` literals, `--key=value`, and glob merges — clean on all of them. It surfaced two informational findings, both out of scope for this fix:
- `case` statement patterns don't accept any `DoubleDash`-family token (`case ---) ... esac` fails) — a **pre-existing** gap (same failure before this change, just via a different token shape), not introduced here. Filed as #144.
- A glued, no-space `--*` now lexes as one literal word rather than `DoubleDash` + a glob-expanding `Star` — an untested, pathological edge case whose new behavior is more consistent with this fix than the old silent-swallow-plus-glob-expand behavior was.

🤖 Generated with [Claude Code](https://claude.com/claude-code)