### PR TITLE
fix(#121): expand_paths goes loud on list/record/bool/null path operands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,12 @@ breaking entries are marked **BREAKING**.
   parsed the job argument with a bare numeric parse, so the standard `%N`
   jobspec (already accepted by `kill`/`wait`) failed with "invalid job id: %1".
   `bg`/`fg` now strip a leading `%` before parsing, matching `kill`/`wait`.
+- **`expand_paths` now goes loud on a list/record/bool/null path operand**
+  (GH #121), closing the gap the `Value::Bytes` guard (#117) left in the same
+  function's catch-all. `cat`/`head`/`tail`/`wc`/etc. silently dropped a
+  structured, bool, or null path argument and fell back to reading stdin
+  instead of erroring on the operand actually given — the same silent-fallback
+  class #93/#117 set out to kill.
 - **`kaish-ignore` changes now persist past their own statement.** Every
   runtime ignore mutation (`add`/`clear`/`defaults`/`scope`) was silently
   dropped at the end of the statement that made it — the per-command context

--- a/crates/kaish-kernel/src/tools/context.rs
+++ b/crates/kaish-kernel/src/tools/context.rs
@@ -1009,11 +1009,15 @@ impl ExecContext {
     /// glob patterns in their path arguments. Non-string values are converted
     /// to strings (matching shell conventions).
     ///
-    /// A `Value::Bytes` operand goes LOUD (GH #93 item 1) rather than being
-    /// silently dropped from the list by the old catch-all — every caller here
-    /// falls back to reading stdin (or a generic "missing path" error) when the
-    /// path list comes back empty, so a binary path used to vanish into a wrong
-    /// data source instead of erroring.
+    /// A `Value::Bytes` operand goes LOUD (GH #93 item 1), and `Value::Json`
+    /// (list/record), `Value::Bool`, and `Value::Null` operands go LOUD too
+    /// (GH #121) — none is silently dropped by a catch-all anymore. Every
+    /// caller here falls back to reading stdin (or a generic "missing path"
+    /// error) when the path list comes back empty, so a structured, bool, or
+    /// null path used to vanish into a wrong data source instead of erroring.
+    /// The match is exhaustive over all 7 `Value` variants on purpose: a
+    /// future new variant fails to compile here until handled, rather than
+    /// silently falling through a wildcard arm.
     pub async fn expand_paths(&self, positional: &[Value]) -> Result<Vec<String>, String> {
         let mut paths = Vec::new();
         for arg in positional {
@@ -1024,7 +1028,12 @@ impl ExecContext {
                 Value::Bytes(_) => {
                     crate::interpreter::value_to_text_sink_named(arg, "a path").map_err(|e| e.to_string())?
                 }
-                _ => continue,
+                Value::Json(_) => {
+                    return Err(crate::interpreter::structured_boundary_error("a path", arg)
+                        .unwrap_or_else(|| "cannot use this value as a path".to_string()));
+                }
+                Value::Bool(b) => return Err(format!("cannot use a bool ({b}) as a path")),
+                Value::Null => return Err("cannot use null as a path".to_string()),
             };
             if crate::glob::contains_glob(&s) {
                 let expanded = self.expand_glob(&s).await?;

--- a/crates/kaish-kernel/tests/binary_text_sink_tests.rs
+++ b/crates/kaish-kernel/tests/binary_text_sink_tests.rs
@@ -256,6 +256,68 @@ async fn wc_binary_path_positional_is_loud() {
     assert_loud_binary("b=$(cat src.bin); wc $b").await;
 }
 
+// ── `expand_paths` again — GH #121: the same `_ => continue` catch-all also
+// silently dropped `Value::Json` (list/record), `Value::Bool`, and
+// `Value::Null` path operands (only `Value::Bytes` was fixed above, by #117).
+// These land via `fromjson`, mirroring the `$(cat src.bin)` capture idiom the
+// Bytes tests above use.
+
+#[tokio::test]
+async fn cat_list_path_positional_is_loud() {
+    let dir = tempdir().unwrap();
+    let kernel = kernel_at(dir.path());
+    let result = kernel.execute("xs=$(fromjson '[1,2,3]'); cat $xs").await.unwrap();
+    assert_ne!(result.code, 0);
+    assert!(result.err.contains("cannot use a list as a path"), "err={:?}", result.err);
+}
+
+#[tokio::test]
+async fn cat_record_path_positional_is_loud() {
+    let dir = tempdir().unwrap();
+    let kernel = kernel_at(dir.path());
+    let result = kernel.execute(r#"r=$(fromjson '{"k":1}'); cat $r"#).await.unwrap();
+    assert_ne!(result.code, 0);
+    assert!(result.err.contains("cannot use a record as a path"), "err={:?}", result.err);
+}
+
+#[tokio::test]
+async fn cat_bool_path_positional_is_loud() {
+    let dir = tempdir().unwrap();
+    let kernel = kernel_at(dir.path());
+    let result = kernel.execute("b=$(fromjson true); cat $b").await.unwrap();
+    assert_ne!(result.code, 0);
+    assert!(result.err.contains("cannot use a bool (true) as a path"), "err={:?}", result.err);
+}
+
+#[tokio::test]
+async fn cat_null_path_positional_is_loud() {
+    let dir = tempdir().unwrap();
+    let kernel = kernel_at(dir.path());
+    let result = kernel.execute("n=$(fromjson null); cat $n").await.unwrap();
+    assert_ne!(result.code, 0);
+    assert!(result.err.contains("cannot use null as a path"), "err={:?}", result.err);
+}
+
+#[tokio::test]
+async fn head_list_path_does_not_silently_fall_back_to_stdin() {
+    // Same "prove it's not just loud, it genuinely refuses the stdin
+    // fallback" shape as `head_binary_path_does_not_silently_fall_back_to_stdin`
+    // above, but for a list operand instead of binary.
+    let dir = tempdir().unwrap();
+    let kernel = kernel_at(dir.path());
+    let result = kernel
+        .execute("xs=$(fromjson '[1,2,3]'); echo from-stdin | head $xs")
+        .await
+        .unwrap();
+    assert_ne!(result.code, 0, "err={}", result.err);
+    assert!(result.err.contains("cannot use a list as a path"), "err={:?}", result.err);
+    assert!(
+        !result.text_out().contains("from-stdin"),
+        "must not silently read stdin instead of erroring on the list path: {:?}",
+        result.text_out()
+    );
+}
+
 // ── `cd`/`awk`/`basename`/`diff` — `ToolArgs::get_string`-based path reads
 // (found via the same review) ──
 //


### PR DESCRIPTION
## Summary

`ExecContext::expand_paths` (`crates/kaish-kernel/src/tools/context.rs`) had a `_ => continue` catch-all that silently dropped any non-scalar path operand. `Value::Bytes` was already fixed to go loud in #117; this closes the gap for the three remaining variants that fell through the same wildcard: `Value::Json` (list/record), `Value::Bool`, and `Value::Null`.

- Removed the wildcard entirely — the match over all 7 `Value` variants is now exhaustive, so a future new variant fails to compile here until handled, instead of silently falling through.
- `Value::Json(_)` reuses the existing shared `structured_boundary_error("a path", ..)` helper (already used at the command-argument/redirect-target boundaries), so the message and phrasing stay consistent across every boundary that guards against a bare collection.
- `Value::Bool`/`Value::Null` get direct, matching "cannot use a `<kind>` ... as a path" error arms (no existing helper covers these, since they aren't collections).

This is the same silent-fallback class the binary-data work (#93/#117) set out to kill: readers that fall back to stdin on an empty path list (`cat`/`head`/`tail`/`wc`) used to silently read stdin instead of erroring when given e.g. `cat $LIST` where `$LIST` is a list — a structured/bool/null path argument should never be silently swapped for a stdin read.

Closes #121

## Test plan

- [x] Added 5 new tests to `crates/kaish-kernel/tests/binary_text_sink_tests.rs`: loud-error cases for a list, record, bool, and null path positional to `cat`, plus a `head`-with-piped-stdin case proving the fix isn't just a louder error but genuinely refuses the stdin fallback (mirrors the existing `head_binary_path_does_not_silently_fall_back_to_stdin` pattern).
- [x] Confirmed all 5 new tests fail against the pre-fix code (TDD red), then pass after the fix (green).
- [x] `cargo test --all` — clean.
- [x] `cargo clippy --all --all-targets` — zero warnings, zero errors.
- [x] Reviewed via `mcp__kaibo__consult` (cast `deepseek`) — confirmed the exhaustive match compiles cleanly and is correct, the new error messages are consistent in tone with the existing `Value::Bytes` guard, and the tests correctly assert per-variant error text rather than reusing the Bytes-only `assert_loud_binary` helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)