### PR TITLE
fix(repl): preserve line numbers when stripping a script's shebang

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,12 @@ breaking entries are marked **BREAKING**.
   parsed the job argument with a bare numeric parse, so the standard `%N`
   jobspec (already accepted by `kill`/`wait`) failed with "invalid job id: %1".
   `bg`/`fg` now strip a leading `%` before parsing, matching `kill`/`wait`.
+- **Shebang'd `.kai` scripts now report correct parse-error line numbers** (GH
+  #127). `run_script` used to strip the shebang line entirely
+  (`.lines().skip(1)`), which deleted a line and shifted every subsequent
+  line's reported number down by one — a syntax error on line 43 was reported
+  at line 42. The shebang line is now blanked out instead of removed, so line
+  accounting stays correct.
 - **`kaish-ignore` changes now persist past their own statement.** Every
   runtime ignore mutation (`add`/`clear`/`defaults`/`scope`) was silently
   dropped at the end of the statement that made it — the per-command context

--- a/crates/kaish-repl/src/main.rs
+++ b/crates/kaish-repl/src/main.rs
@@ -230,9 +230,14 @@ fn run_script(path: &str, overlay: bool) -> Result<ExitCode> {
     let source = std::fs::read_to_string(path)
         .with_context(|| format!("Failed to read script: {path}"))?;
 
-    // Skip shebang if present
+    // Blank out the shebang line (rather than removing it) so every
+    // subsequent line keeps its original 1-based line number for error
+    // reporting (GH #127).
     let source = if source.starts_with("#!") {
-        source.lines().skip(1).collect::<Vec<_>>().join("\n")
+        match source.find('\n') {
+            Some(idx) => format!("\n{}", &source[idx + 1..]),
+            None => String::new(), // whole file is a single shebang line
+        }
     } else {
         source
     };

--- a/crates/kaish-repl/tests/script_shebang_tests.rs
+++ b/crates/kaish-repl/tests/script_shebang_tests.rs
@@ -1,0 +1,61 @@
+//! Regression test for GH #127: a shebang'd `.kai` script must not shift
+//! reported parse-error line numbers. `run_script` (kaish-repl/src/main.rs)
+//! used to strip the shebang line entirely via `.lines().skip(1)`, which
+//! deletes a line and shifts every subsequent line's reported number down by
+//! one. This spawns the real `kaish` binary because the bug lives in the
+//! frontend's script-loading path, below the kernel's own parser (which
+//! reports correct line numbers against whatever source string it's given).
+//!
+//! Test-fixture code: unwrap/expect on known-good setup is the idiom here.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::io::Write;
+use std::process::Command;
+
+/// Write `contents` to a temp `.kai` file and run it with the `kaish` binary,
+/// returning stderr as a `String`.
+fn run_script(contents: &str) -> String {
+    let kaish = env!("CARGO_BIN_EXE_kaish");
+    let dir = tempfile::tempdir().expect("tempdir");
+    let script_path = dir.path().join("script.kai");
+    let mut file = std::fs::File::create(&script_path).expect("create script");
+    file.write_all(contents.as_bytes()).expect("write script");
+    drop(file);
+
+    let output = Command::new(kaish)
+        .arg(&script_path)
+        .output()
+        .expect("run kaish script");
+    String::from_utf8_lossy(&output.stderr).into_owned()
+}
+
+#[test]
+fn shebang_script_reports_correct_error_line() {
+    // Line 1 is the shebang; line 2 is blank; line 3 has a deliberate parse
+    // error (a bare `)` token, which the parser rejects at its own position
+    // rather than at end-of-input). Without the fix, the parser sees the
+    // shebang line removed and everything shifts up by one, so this error is
+    // (mis)reported at line 2 instead of line 3.
+    let script = "#!/usr/bin/env kaish\n\n)\n";
+    let stderr = run_script(script);
+    assert!(
+        stderr.contains("3:1"),
+        "expected error to be reported at line 3, got stderr: {stderr:?}"
+    );
+    assert!(
+        !stderr.contains("2:1"),
+        "error line number regressed to the pre-shebang-strip line, stderr: {stderr:?}"
+    );
+}
+
+#[test]
+fn non_shebang_script_reports_correct_error_line() {
+    // Control case: no shebang, so no stripping happens at all. The error is
+    // on line 2 here (no leading shebang line to shift anything).
+    let script = "echo hi\n)\n";
+    let stderr = run_script(script);
+    assert!(
+        stderr.contains("2:1"),
+        "expected error to be reported at line 2, got stderr: {stderr:?}"
+    );
+}


### PR DESCRIPTION
## Summary
- `run_script` stripped a script's shebang line via `.lines().skip(1).collect::<Vec<_>>().join("\n")`, which deletes the line and shifts every subsequent line's reported parse-error number down by one — a syntax error on line 43 of a shebang'd `.kai` script was reported at line 42, sending users and agents to the wrong place.
- Fix: blank the shebang line out (replace it with an empty line) instead of removing it, so the parser's line:col accounting (which counts `\n` bytes up to the error's offset) stays aligned 1:1 with the file on disk.
- Added a process-level regression test (`crates/kaish-repl/tests/script_shebang_tests.rs`) that spawns the real `kaish` binary against a temp shebang'd script with a deliberate parse error and asserts the reported line number, plus a non-shebang control case.

Closes #127

## Test plan
- [x] `cargo test --all` — clean
- [x] `cargo clippy --all --all-targets` — zero warnings
- [x] New test confirmed red on the old `.lines().skip(1)` code and green after the fix
- [x] kaibo-reviewed (cast: deepseek) — confirmed the byte-slicing logic and edge cases (CRLF, no-trailing-newline, shebang-only file, empty file) are correct, and that `$0`/positional args are set from the file path (not the source text) so this change has no other downstream effect