### PR TITLE
fix(repl): use display width, not byte length, for table/column alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@ breaking entries are marked **BREAKING**.
   (`transient`/`named`/`isolated`) keep the unfiltered default.
 
 ### Fixed
+- **The REPL's interactive table and column output align CJK/emoji cells
+  correctly** (GH #130). Column widths were computed from UTF-8 byte length
+  (`cell.len()`), not display width — a CJK cell like "你好" is 6 bytes but
+  only 4 display columns, so byte-length padding under-padded it and
+  misaligned every column after it. Width math now uses the `unicode-width`
+  crate's `UnicodeWidthStr::width()`. Cosmetic/interactive-only; `--json` and
+  other structured output are unaffected.
 - **A confirmation latch raised mid-pipeline (`set -o latch`) no longer gets
   swallowed by a later stage's success.** `rm x | echo done` used to exit 0
   with `.latch` dropped, even though `rm` genuinely gated and the file was

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1070,6 +1070,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "unicode-width",
 ]
 
 [[package]]

--- a/crates/kaish-repl/Cargo.toml
+++ b/crates/kaish-repl/Cargo.toml
@@ -42,6 +42,9 @@ tokio = { workspace = true }
 owo-colors = "4"
 terminal_size = "0.4"
 
+# Display-width-aware column alignment (CJK/emoji are wider than 1 byte/col)
+unicode-width = "0.2"
+
 [dev-dependencies]
 serde_json = { workspace = true }
 tempfile = { workspace = true }

--- a/crates/kaish-repl/src/format.rs
+++ b/crates/kaish-repl/src/format.rs
@@ -13,6 +13,7 @@ use std::io::IsTerminal;
 
 use kaish_kernel::interpreter::{EntryType, ExecResult, OutputData, OutputNode};
 use kaish_kernel::tools::OutputContext;
+use unicode_width::UnicodeWidthStr;
 
 /// Format an ExecResult for display based on the output context.
 ///
@@ -134,11 +135,14 @@ fn format_table_from_output_data(output: &OutputData) -> String {
     let num_cols = rows.iter().map(|r| r.len()).max().unwrap_or(0);
     let mut col_widths = vec![0; num_cols];
 
-    // Include headers in width calculation
+    // Include headers in width calculation. Widths are display columns
+    // (`UnicodeWidthStr::width`), not UTF-8 byte counts — a CJK cell like
+    // "你好" is 6 bytes but 4 display columns, and byte-length padding would
+    // misalign every column after it (GH #130).
     if let Some(ref headers) = output.headers {
         for (i, header) in headers.iter().enumerate() {
             if i < col_widths.len() {
-                col_widths[i] = col_widths[i].max(header.len());
+                col_widths[i] = col_widths[i].max(header.width());
             }
         }
     }
@@ -147,7 +151,7 @@ fn format_table_from_output_data(output: &OutputData) -> String {
     for row in &rows {
         for (i, cell) in row.iter().enumerate() {
             if i < col_widths.len() {
-                col_widths[i] = col_widths[i].max(cell.len());
+                col_widths[i] = col_widths[i].max(cell.width());
             }
         }
     }
@@ -162,7 +166,7 @@ fn format_table_from_output_data(output: &OutputData) -> String {
             }
             result.push_str(header);
             if i < headers.len() - 1 {
-                let padding = col_widths[i].saturating_sub(header.len());
+                let padding = col_widths[i].saturating_sub(header.width());
                 for _ in 0..padding {
                     result.push(' ');
                 }
@@ -189,7 +193,7 @@ fn format_table_from_output_data(output: &OutputData) -> String {
 
             // Only add padding if not the last column
             if i < row.len() - 1 {
-                let padding = col_widths[i].saturating_sub(cell.len());
+                let padding = col_widths[i].saturating_sub(cell.width());
                 for _ in 0..padding {
                     result.push(' ');
                 }
@@ -214,9 +218,10 @@ fn format_columns_from_output_data(output: &OutputData) -> String {
 
     let items: Vec<_> = output.root.iter().collect();
 
-    // Find the longest item
+    // Find the longest item. Display width, not byte length (GH #130) — see
+    // the aligned-table renderer above for why.
     let max_len = items.iter()
-        .map(|n| n.display_name().len())
+        .map(|n| n.display_name().width())
         .max()
         .unwrap_or(0);
 
@@ -239,7 +244,7 @@ fn format_columns_from_output_data(output: &OutputData) -> String {
         if col > 0 {
             // Pad previous item to column width
             let prev_len = items.get(i.saturating_sub(1))
-                .map(|n| n.display_name().len())
+                .map(|n| n.display_name().width())
                 .unwrap_or(0);
             let padding = col_width.saturating_sub(prev_len);
             for _ in 0..padding {
@@ -405,5 +410,76 @@ mod tests {
         let output_data = OutputData::text("direct test");
         let formatted = format_output_data(&output_data, OutputContext::Interactive);
         assert_eq!(formatted, "direct test");
+    }
+
+    /// GH #130: table column widths must use display width, not UTF-8 byte
+    /// length — "你好" is 6 bytes but 4 display columns, so byte-length
+    /// padding under-pads it and misaligns every column after it.
+    #[test]
+    fn test_table_alignment_uses_display_width_not_byte_length() {
+        let nodes = vec![
+            OutputNode::new("你好")
+                .with_cells(vec!["1".to_string()])
+                .with_entry_type(EntryType::File),
+            OutputNode::new("ab")
+                .with_cells(vec!["22".to_string()])
+                .with_entry_type(EntryType::File),
+        ];
+        let output_data = OutputData::table(
+            vec!["Name".to_string(), "Val".to_string()],
+            nodes,
+        );
+        let result = ExecResult::with_output(output_data);
+        let formatted = format_output(&result, OutputContext::Interactive);
+
+        let lines: Vec<&str> = formatted.lines().collect();
+        assert_eq!(lines.len(), 3, "header + 2 data rows: {formatted:?}");
+
+        // The second column must start at the same DISPLAY column on every
+        // row — that's what "aligned" means. Byte-length padding put the CJK
+        // row's second column 2 display-columns earlier than the ASCII row's.
+        let second_col_display_start = |line: &str| -> usize {
+            let sep = line.rfind("  ").expect("a two-space column separator");
+            UnicodeWidthStr::width(&line[..sep])
+        };
+        let header_start = second_col_display_start(lines[0]);
+        let cjk_row_start = second_col_display_start(lines[1]);
+        let ascii_row_start = second_col_display_start(lines[2]);
+        assert_eq!(
+            cjk_row_start, header_start,
+            "CJK row's second column misaligned with the header: {formatted:?}"
+        );
+        assert_eq!(
+            ascii_row_start, header_start,
+            "ASCII row's second column misaligned with the header: {formatted:?}"
+        );
+    }
+
+    /// GH #130: the `ls`-style multi-column layout has the same byte-length
+    /// bug in its own width calculation.
+    #[test]
+    fn test_columns_alignment_uses_display_width_not_byte_length() {
+        // "1234567" is 7 bytes / 7 display columns (ASCII). "你好你好" is 12
+        // bytes but only 8 display columns (4 CJK chars x 2 cols each). Byte
+        // length picks it as the widest item at 12; display width picks it at
+        // 8 — same item, different column budget, so the padding after the
+        // FIRST (all-ASCII) item comes out different depending which metric
+        // sizes the column, exposing the bug even though "你好你好" itself
+        // isn't the item being padded.
+        let nodes = vec![
+            OutputNode::new("1234567").with_entry_type(EntryType::File),
+            OutputNode::new("你好你好").with_entry_type(EntryType::File),
+        ];
+        let output_data = OutputData::nodes(nodes);
+        let formatted = format_columns_from_output_data(&output_data);
+
+        let sep_start = formatted.find("1234567").expect("first item present");
+        let second_start = formatted.find("你好你好").expect("second item present");
+        let between = &formatted[sep_start + "1234567".len()..second_start];
+        assert_eq!(
+            UnicodeWidthStr::width(between),
+            3, // col_width (8 + 2 padding = 10) - display width of "1234567" (7) = 3
+            "gap between columns should be display-width-aware: {formatted:?}"
+        );
     }
 }


### PR DESCRIPTION
## Summary
- `crates/kaish-repl/src/format.rs`'s two interactive-only renderers (the aligned-table renderer and the `ls`-style multi-column layout) computed column/item widths with `.len()` — UTF-8 byte count, not display width. A CJK cell like "你好" is 6 bytes but only 4 display columns, so byte-length padding under-padded it and misaligned every column after it. Ironic for 会sh.
- Switches every width-affecting `.len()` call in both renderers to `unicode_width::UnicodeWidthStr::width()`, and adds `unicode-width` as a direct `kaish-repl` dependency (it was already in the dependency graph transitively via `rustyline`, so this doesn't add a new version).
- Cosmetic/interactive-only — `--json` and other structured output never touch this code path.

Closes #130

## Test plan
- [x] Two new regression tests: one for the aligned table (CJK header/cell alignment), one for the `ls`-style columns (a case specifically chosen so a byte-vs-display-width mismatch changes the column budget itself, not just the immediate padding — confirmed both fail on the pre-fix code and pass after)
- [x] `cargo test --all` — clean
- [x] `cargo clippy --all --all-targets` — zero warnings
- [x] kaibo-reviewed (cast: deepseek) — confirmed all width-affecting `.len()` calls were replaced (no third rendering path missed), confirmed ANSI colorization always happens after width calculation in both renderers (no double-break), and flagged inherent `unicode-width`/UAX#11 limitations (ZWJ emoji sequences, skin-tone modifiers) as out-of-scope edge cases, not regressions. It also surfaced a same-class bug in `printf`'s `%Ns` width padding (`kaish-kernel/src/tools/builtin/format_string.rs`) — filed as #154, out of scope here.