### PR TITLE
fix(latch): surface confirmation latches in wait/jobs/scatter --json + confirm retires the job (#124)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ breaking entries are marked **BREAKING**.
 
 ## [Unreleased]
 
+### Added
+- **`jobs --json` rows and scatter/gather rows carry the confirmation-latch
+  object** for a `Latched` entry (nonce/paths/hint/ttl) — a caller can act on
+  a gate straight from the row instead of a second `/v/jobs/N/latch` read.
+- **`Kernel::confirm` retires the originating background job after a
+  successful confirm.** `LatchRequest` gains an optional `job_id` back-
+  reference (set when the gate came from a backgrounded job, e.g. `rm x &`);
+  a successfully-replayed confirm now removes that job from `jobs` instead of
+  leaving it lingering as `Latched` forever, mirroring the existing manual
+  `kill --discard %N` path.
+
 ### Changed
 - **The reference REPL is ignore-aware by default** (GH #134). Interactive,
   `-c`, and script modes now load `.gitignore` and the default ignore list
@@ -30,6 +41,11 @@ breaking entries are marked **BREAKING**.
   parsed the job argument with a bare numeric parse, so the standard `%N`
   jobspec (already accepted by `kill`/`wait`) failed with "invalid job id: %1".
   `bg`/`fg` now strip a leading `%` before parsing, matching `kill`/`wait`.
+- **`wait %1 --json` on a latched background job now surfaces the
+  confirmation nonce under a `latch` key** instead of rendering a bare
+  `"[1] Latched\n"` JSON string with no way to fulfill the gate. A latched
+  result's `--json` handling is now one canonical path (`apply_output_format`)
+  regardless of whether the result also carries text output.
 - **`kaish-ignore` changes now persist past their own statement.** Every
   runtime ignore mutation (`add`/`clear`/`defaults`/`scope`) was silently
   dropped at the end of the statement that made it — the per-command context

--- a/crates/kaish-kernel/src/kernel.rs
+++ b/crates/kaish-kernel/src/kernel.rs
@@ -1562,6 +1562,15 @@ impl Kernel {
     /// Errors (exit 2) if the latch carries no captured invocation — a latch
     /// produced outside a dispatch seam (a direct `tool.execute` in a unit
     /// test). Those are confirmable only by re-running with `--confirm=<nonce>`.
+    ///
+    /// If `latch.job_id` is set (the gate came from a *backgrounded* job —
+    /// `rm x &` reaching its gate), a successful replay also retires that job
+    /// from the `JobManager` (GH #124 part 4) — mirroring the existing manual
+    /// discard path (`kill --discard %N`), automated. A failed replay leaves
+    /// the job in place for inspection/retry. Guarded by `is_latched` so a
+    /// stale/foreign `job_id` can never remove an unrelated running job;
+    /// idempotent on a repeat confirm (nonces are reusable within TTL, and
+    /// removing an already-absent job is a no-op).
     pub async fn confirm(&self, latch: &LatchRequest) -> Result<ExecResult> {
         if latch.tool.is_empty() {
             return Ok(ExecResult::failure(
@@ -1575,7 +1584,18 @@ impl Kernel {
         let mut argv: Vec<Value> = Vec::with_capacity(latch.argv.len() + 1);
         argv.push(Value::String(format!("--confirm={}", latch.nonce)));
         argv.extend(latch.argv.iter().map(|a| Value::String(a.clone())));
-        self.execute_argv(&latch.tool, &argv).await
+        let result = self.execute_argv(&latch.tool, &argv).await?;
+
+        if result.ok()
+            && let Some(id) = latch.job_id
+        {
+            let job_id = crate::scheduler::JobId(id);
+            if self.jobs.is_latched(job_id).await {
+                self.jobs.remove(job_id).await;
+            }
+        }
+
+        Ok(result)
     }
 
     /// Run `work` under the movable-deadline watchdog for `timeout`, shared by the

--- a/crates/kaish-kernel/src/scheduler/job.rs
+++ b/crates/kaish-kernel/src/scheduler/job.rs
@@ -214,9 +214,19 @@ impl Job {
     /// The job's pending confirmation-latch request, if it is gated
     /// (`JobStatus::Latched`). `None` otherwise. Backs `JobInfo.latch` and the
     /// `/v/jobs/{id}/latch` node so a backgrounded gate is fulfillable (#96).
+    ///
+    /// Stamps `job_id` with this job's own id (GH #124 part 4) — the ONE
+    /// chokepoint every latch-reading path (`list`/`get`/`get_latch`/
+    /// `is_latched`/`cleanup`) goes through, so `Kernel::confirm` can later
+    /// retire the originating job after a successful replay without every
+    /// caller having to thread the id through separately.
     pub fn latch(&mut self) -> Option<kaish_types::result::LatchRequest> {
         self.try_poll();
-        self.result.as_ref().and_then(|r| r.latch_request())
+        let id = self.id;
+        self.result.as_ref().and_then(|r| r.latch_request()).map(|mut lr| {
+            lr.job_id = Some(id.0);
+            lr
+        })
     }
 
     /// Get the stdout stream (if attached).
@@ -959,6 +969,40 @@ mod tests {
         assert_eq!(jobs.len(), 1);
         assert_eq!(jobs[0].command, "test job");
         assert_eq!(jobs[0].status, JobStatus::Running);
+    }
+
+    #[tokio::test]
+    async fn latch_stamps_job_id_back_reference() {
+        // GH #124 part 4: Job::latch() is the ONE chokepoint every latch-reading
+        // path (list/get/get_latch/is_latched/cleanup) goes through, so it must
+        // stamp the job's own id onto the surfaced LatchRequest -- otherwise
+        // Kernel::confirm has no way to know which job to retire after a
+        // successful replay.
+        let manager = JobManager::new();
+
+        let id = manager.spawn("gated".to_string(), async {
+            let mut result = ExecResult::failure(2, "confirmation required");
+            result.latch = Some(Box::new(kaish_types::result::LatchRequest {
+                nonce: "a3f7b2c1".to_string(),
+                command: "rm".to_string(),
+                paths: vec!["x".to_string()],
+                hint: "rm --confirm=a3f7b2c1 x".to_string(),
+                tool: "rm".to_string(),
+                argv: vec!["x".to_string()],
+                ttl: 60,
+                job_id: None, // unset at construction -- Job::latch() must fill it in
+            }));
+            result
+        }).await;
+
+        tokio::time::sleep(Duration::from_millis(10)).await;
+
+        let latch = manager.get_latch(id).await.expect("job must be latched");
+        assert_eq!(
+            latch.job_id,
+            Some(id.0),
+            "Job::latch() must stamp this job's own id onto the surfaced request"
+        );
     }
 
     #[tokio::test]

--- a/crates/kaish-kernel/src/scheduler/job.rs
+++ b/crates/kaish-kernel/src/scheduler/job.rs
@@ -1146,6 +1146,7 @@ mod tests {
             tool: "rm".to_string(),
             argv: vec!["precious.txt".to_string()],
             ttl: 60,
+            job_id: None,
         }));
         tx.send(gated).expect("send gated result");
         tokio::time::sleep(Duration::from_millis(10)).await;

--- a/crates/kaish-kernel/src/scheduler/scatter.rs
+++ b/crates/kaish-kernel/src/scheduler/scatter.rs
@@ -519,6 +519,15 @@ fn result_row(i: usize, r: &ScatterResult) -> serde_json::Value {
     if let Some(data) = &r.result.data {
         row.insert("data".into(), kaish_types::value_to_json(data));
     }
+    // A latched worker (exit 2 under `set -o latch`) is otherwise
+    // indistinguishable from a plain failure in the row — carry the nonce so a
+    // caller can act on the gate straight from the row (GH #124 part 3).
+    // Infallible: LatchRequest is String/Vec<String>/u64 fields only.
+    if let Some(latch) = &r.result.latch
+        && let Ok(v) = serde_json::to_value(latch)
+    {
+        row.insert("latch".into(), v);
+    }
     if r.timed_out {
         row.insert("timed_out".into(), serde_json::json!(true));
     }
@@ -939,6 +948,36 @@ mod tests {
         let row: serde_json::Value = serde_json::from_str(out.text_out().lines().next().unwrap()).unwrap();
         assert_eq!(row["data"]["k"], 1, "worker .data lands typed in the row");
         assert_eq!(row["out"], "text", "out stays alongside data");
+    }
+
+    #[test]
+    fn test_gather_results_worker_latch_rides_the_row() {
+        // GH #124 part 3: a latched worker (exit 2 under `set -o latch`) is
+        // otherwise indistinguishable from a plain failure in the row — the
+        // nonce must ride along so a caller can act on the gate from the row.
+        use kaish_types::result::LatchRequest;
+
+        let mut r = ExecResult::failure(2, "rm: confirmation required (latch enabled)");
+        r.latch = Some(Box::new(LatchRequest {
+            nonce: "a3f7b2c1".to_string(),
+            command: "rm".to_string(),
+            paths: vec!["precious.txt".to_string()],
+            hint: "rm --confirm=\"a3f7b2c1\" precious.txt".to_string(),
+            tool: "rm".to_string(),
+            argv: vec!["precious.txt".to_string()],
+            ttl: 60,
+        }));
+        let results = vec![ScatterResult { item: item("a"), result: r, timed_out: false }];
+        let out = gather_results(&results, &GatherOptions::default());
+        assert_eq!(out.code, 123, "a latched worker still counts as failed for gather's exit code");
+        let row: serde_json::Value = serde_json::from_str(out.text_out().lines().next().unwrap()).unwrap();
+        assert_eq!(row["ok"], false);
+        assert_eq!(row["code"], 2);
+        assert_eq!(
+            row["latch"]["nonce"], "a3f7b2c1",
+            "the latch nonce must ride the row: {row}"
+        );
+        assert_eq!(row["latch"]["command"], "rm");
     }
 
     #[test]

--- a/crates/kaish-kernel/src/scheduler/scatter.rs
+++ b/crates/kaish-kernel/src/scheduler/scatter.rs
@@ -966,6 +966,7 @@ mod tests {
             tool: "rm".to_string(),
             argv: vec!["precious.txt".to_string()],
             ttl: 60,
+            job_id: None,
         }));
         let results = vec![ScatterResult { item: item("a"), result: r, timed_out: false }];
         let out = gather_results(&results, &GatherOptions::default());

--- a/crates/kaish-kernel/src/tools/builtin/jobs.rs
+++ b/crates/kaish-kernel/src/tools/builtin/jobs.rs
@@ -4,7 +4,33 @@ use async_trait::async_trait;
 use clap::{CommandFactory, Parser};
 
 use crate::interpreter::{ExecResult, OutputData, OutputNode};
+use crate::scheduler::JobInfo;
 use crate::tools::{schema_from_clap, ExecContext, ToolCtx, GlobalFlags, Tool, ToolArgs, ToolSchema};
+
+/// Build `jobs --json` rows: `{"id", "status", "command", "path", "latch"?}`.
+/// `latch` (nonce/paths/hint/ttl) is present only for a `Latched` row — a
+/// caller can act on a gated job straight from `jobs --json` instead of a
+/// second `/v/jobs/N/latch` read (GH #124 part 2). A pure function so the
+/// row shape is unit-testable without a `JobManager`/kernel round trip.
+fn job_rows_json(jobs: &[JobInfo]) -> Vec<serde_json::Value> {
+    jobs.iter()
+        .map(|job| {
+            let mut row = serde_json::json!({
+                "id": job.id.0,
+                "status": job.status.to_string(),
+                "command": job.command,
+                "path": format!("/v/jobs/{}/", job.id),
+            });
+            // Infallible: LatchRequest is String/Vec<String>/u64 fields only.
+            if let Some(latch) = &job.latch
+                && let Ok(v) = serde_json::to_value(latch)
+            {
+                row["latch"] = v;
+            }
+            row
+        })
+        .collect()
+}
 
 /// Jobs tool: list and manage background jobs.
 pub struct Jobs;
@@ -94,7 +120,11 @@ impl Tool for Jobs {
             "PATH".to_string(),
         ];
 
-        let output = OutputData::table(headers, nodes);
+        // rich_json rows carry `latch` for a `Latched` row (GH #124 part 2) —
+        // computed from `&jobs` before the text loop below consumes it by value.
+        let rows = job_rows_json(&jobs);
+        let output = OutputData::table(headers, nodes)
+            .with_rich_json(serde_json::Value::Array(rows));
         let mut text = String::new();
         for job in jobs {
             text.push_str(&format!(
@@ -118,6 +148,42 @@ mod tests {
         let mut vfs = VfsRouter::new();
         vfs.mount("/", MemoryFs::new());
         ExecContext::new(Arc::new(vfs))
+    }
+
+    #[test]
+    fn job_rows_json_carries_latch_only_on_latched_rows() {
+        use crate::interpreter::LatchRequest;
+        use crate::scheduler::{JobId, JobStatus};
+
+        let latch = LatchRequest {
+            nonce: "a3f7b2c1".to_string(),
+            command: "rm".to_string(),
+            paths: vec!["precious.txt".to_string()],
+            hint: "rm --confirm=\"a3f7b2c1\" precious.txt".to_string(),
+            tool: "rm".to_string(),
+            argv: vec!["precious.txt".to_string()],
+            ttl: 60,
+        };
+        let jobs = vec![
+            JobInfo::new(JobId(1), "rm precious.txt", JobStatus::Latched).with_latch(Some(latch)),
+            JobInfo::new(JobId(2), "sleep 5", JobStatus::Running),
+        ];
+
+        let rows = job_rows_json(&jobs);
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0]["id"], 1);
+        assert_eq!(rows[0]["status"], "Latched");
+        assert_eq!(rows[0]["path"], "/v/jobs/1/");
+        assert_eq!(
+            rows[0]["latch"]["nonce"], "a3f7b2c1",
+            "a latched row must carry the nonce: {}",
+            rows[0]
+        );
+        assert!(
+            rows[1].get("latch").is_none(),
+            "a non-latched row must NOT carry a latch key: {}",
+            rows[1]
+        );
     }
 
     #[tokio::test]

--- a/crates/kaish-kernel/src/tools/builtin/jobs.rs
+++ b/crates/kaish-kernel/src/tools/builtin/jobs.rs
@@ -163,6 +163,7 @@ mod tests {
             tool: "rm".to_string(),
             argv: vec!["precious.txt".to_string()],
             ttl: 60,
+            job_id: Some(1),
         };
         let jobs = vec![
             JobInfo::new(JobId(1), "rm precious.txt", JobStatus::Latched).with_latch(Some(latch)),
@@ -177,6 +178,11 @@ mod tests {
         assert_eq!(
             rows[0]["latch"]["nonce"], "a3f7b2c1",
             "a latched row must carry the nonce: {}",
+            rows[0]
+        );
+        assert_eq!(
+            rows[0]["latch"]["job_id"], 1,
+            "the row's latch must carry the job_id back-reference (GH #124 part 4): {}",
             rows[0]
         );
         assert!(

--- a/crates/kaish-kernel/src/tools/builtin/wait.rs
+++ b/crates/kaish-kernel/src/tools/builtin/wait.rs
@@ -80,7 +80,7 @@ impl Tool for Wait {
 
                 match manager.wait(id).await {
                     Some(result) => {
-                        let status = classify(&result, &mut any_failed, &mut latch);
+                        let status = classify(id, &result, &mut any_failed, &mut latch);
                         output.push_str(&format!("[{}] {}\n", id, status));
                     }
                     None => return ExecResult::failure(1, format!("wait: job {} not found", id)),
@@ -101,7 +101,7 @@ impl Tool for Wait {
             let mut latch: Option<LatchRequest> = None;
 
             for (id, result) in results {
-                let status = classify(&result, &mut any_failed, &mut latch);
+                let status = classify(id, &result, &mut any_failed, &mut latch);
                 output.push_str(&format!("[{}] {}\n", id, status));
             }
 
@@ -115,14 +115,22 @@ impl Tool for Wait {
 /// job (`set -o latch`, exit 2 with a stored request) is `Latched`, *not*
 /// `Failed` — the op is held, and the request must reach the caller so a
 /// backgrounded gate is fulfillable (GH #96).
+///
+/// `wait` reads the job's raw cached `ExecResult` straight from
+/// `JobManager::wait`/`wait_all`, bypassing `Job::latch()` (the chokepoint
+/// that stamps `job_id` for `jobs`/`/v/jobs/{id}/latch`) — so this stamps it
+/// here too (GH #124 part 4), or a latch surfaced via `wait` would carry no
+/// back-reference for `Kernel::confirm` to retire the job with.
 fn classify(
+    id: JobId,
     result: &ExecResult,
     any_failed: &mut bool,
     latch: &mut Option<LatchRequest>,
 ) -> &'static str {
     if result.ok() {
         "Done"
-    } else if let Some(lr) = result.latch_request() {
+    } else if let Some(mut lr) = result.latch_request() {
+        lr.job_id = Some(id.0);
         // First latch wins if several jobs are gated — `.latch` holds one, and
         // an embedder waiting on multiple gated jobs is an unusual pattern.
         latch.get_or_insert(lr);

--- a/crates/kaish-kernel/src/tools/context.rs
+++ b/crates/kaish-kernel/src/tools/context.rs
@@ -790,6 +790,11 @@ impl ExecContext {
             tool,
             argv,
             ttl,
+            // Unknown at this dispatch-seam construction site — a
+            // *backgrounded* invocation gets this stamped later by
+            // `Job::latch()` when the job is queried through the JobManager
+            // (see scheduler/job.rs). A foreground latch never gets one.
+            job_id: None,
         }));
         result
     }

--- a/crates/kaish-kernel/tests/latch_trash_tests.rs
+++ b/crates/kaish-kernel/tests/latch_trash_tests.rs
@@ -1194,6 +1194,71 @@ async fn backgrounded_latch_is_reachable_and_confirmable() {
     assert!(!precious.exists(), "file removed after confirm");
 }
 
+/// GH #124 part 4: a successful `confirm` of a *backgrounded* latch retires
+/// the originating job — it no longer lingers in `jobs` forever as `Latched`,
+/// disconnected from the fact its gate was just fulfilled. Mirrors the
+/// existing manual `kill --discard %N` path, automated.
+#[tokio::test]
+async fn confirm_retires_the_originating_backgrounded_job() {
+    use kaish_kernel::scheduler::JobId;
+
+    let dir = tempdir();
+    let kernel = kernel_at(dir.path());
+    let precious = dir.path().join("precious.txt");
+    std::fs::write(&precious, "keep me").expect("write");
+
+    run(&kernel, "set -o latch").await;
+    run(&kernel, "rm precious.txt &").await;
+    let waited = run(&kernel, "wait 1").await;
+    let latch = waited.latch_request().expect("a backgrounded LatchRequest");
+    assert_eq!(
+        latch.job_id,
+        Some(1),
+        "the surfaced latch must carry the originating job's id"
+    );
+    assert!(
+        kernel.jobs().get(JobId(1)).await.is_some(),
+        "job must still be tracked (Latched) before confirm"
+    );
+
+    let confirmed = kernel.confirm(&latch).await.expect("confirm");
+    assert_eq!(confirmed.code, 0, "confirm deletes: {}", confirmed.err);
+    assert!(!precious.exists(), "file removed after confirm");
+    assert!(
+        kernel.jobs().get(JobId(1)).await.is_none(),
+        "the originating job must be retired after a successful confirm"
+    );
+}
+
+/// A repeat `confirm` of an already-retired job is a safe no-op — nonces are
+/// reusable within TTL (not consumed on validate), so the second replay still
+/// succeeds (idempotent delete-of-already-deleted via rm's own semantics is
+/// out of scope here; what matters is `confirm` itself doesn't panic/error
+/// trying to retire a job that's already gone).
+#[tokio::test]
+async fn confirm_of_an_already_retired_job_does_not_error() {
+    use kaish_kernel::scheduler::JobId;
+
+    let dir = tempdir();
+    let kernel = kernel_at(dir.path());
+    std::fs::write(dir.path().join("precious.txt"), "keep me").expect("write");
+
+    run(&kernel, "set -o latch").await;
+    run(&kernel, "rm precious.txt &").await;
+    let waited = run(&kernel, "wait 1").await;
+    let latch = waited.latch_request().expect("a backgrounded LatchRequest");
+
+    let first = kernel.confirm(&latch).await.expect("confirm");
+    assert_eq!(first.code, 0, "err: {}", first.err);
+    assert!(kernel.jobs().get(JobId(1)).await.is_none(), "job retired");
+
+    // Second confirm with the same (still-valid, reusable) nonce: rm's own
+    // idempotent-retry story applies to the replay itself; the job-retirement
+    // step must not error just because the job is already gone.
+    let second = kernel.confirm(&latch).await;
+    assert!(second.is_ok(), "confirm must not error on an already-retired job");
+}
+
 /// `jobs` and `/v/jobs/{id}/status` name the latched state distinctly, not
 /// the generic "Failed".
 #[tokio::test]

--- a/crates/kaish-kernel/tests/latch_trash_tests.rs
+++ b/crates/kaish-kernel/tests/latch_trash_tests.rs
@@ -305,6 +305,7 @@ async fn confirm_without_captured_invocation_errors() {
         tool: String::new(),
         argv: vec![],
         ttl: 60,
+        job_id: None,
     };
     let r = kernel.confirm(&bare).await.expect("confirm returns");
     assert_eq!(r.code, 2, "must not silently succeed: {r:?}");

--- a/crates/kaish-kernel/tests/latch_trash_tests.rs
+++ b/crates/kaish-kernel/tests/latch_trash_tests.rs
@@ -1213,6 +1213,33 @@ async fn backgrounded_latch_shows_distinct_status() {
     assert_eq!(status.text_out().trim(), "latched", "status node: {}", status.text_out());
 }
 
+/// GH #124 part 2: `jobs --json` rows carry the latch object itself for a
+/// Latched job, not just the STATUS column's word — a caller can act on the
+/// gate straight from the row instead of a second `/v/jobs/N/latch` read.
+#[tokio::test]
+async fn jobs_json_row_carries_the_latch_object() {
+    let dir = tempdir();
+    let kernel = kernel_at(dir.path());
+    std::fs::write(dir.path().join("precious.txt"), "keep me").expect("write");
+
+    run(&kernel, "set -o latch").await;
+    run(&kernel, "rm precious.txt &").await;
+    run(&kernel, "wait 1").await; // let the background job reach the gate
+
+    let jobs = run(&kernel, "jobs --json").await;
+    assert_eq!(jobs.code, 0, "err: {}", jobs.err);
+    let rows: serde_json::Value =
+        serde_json::from_str(jobs.text_out().trim()).expect("a JSON array of job rows");
+    let row = rows.as_array().and_then(|a| a.first()).expect("at least one job row");
+    assert_eq!(row["status"], "Latched", "row: {row}");
+    assert_eq!(row["latch"]["command"], "rm", "row: {row}");
+    assert!(
+        !row["latch"]["nonce"].as_str().unwrap_or("").is_empty(),
+        "row must carry a usable nonce: {row}"
+    );
+    assert!(dir.path().join("precious.txt").exists());
+}
+
 /// `/v/jobs/{id}/latch` renders the stored LatchRequest as JSON carrying the
 /// nonce, so a VFS consumer can read (and then confirm) it.
 #[tokio::test]

--- a/crates/kaish-types/src/backend.rs
+++ b/crates/kaish-types/src/backend.rs
@@ -511,6 +511,7 @@ mod tests {
             tool: "rm".to_string(),
             argv: vec!["f".to_string()],
             ttl: 60,
+            job_id: None,
         };
 
         let result = ToolResult::success("hi")

--- a/crates/kaish-types/src/output.rs
+++ b/crates/kaish-types/src/output.rs
@@ -907,6 +907,47 @@ mod tests {
     }
 
     #[test]
+    fn apply_output_format_surfaces_latch_even_when_result_has_output() {
+        // GH #124 part 1: `wait %1`'s gate result carries BOTH text output
+        // (the "[1] Latched\n" status line, via `.output`/`.out`) AND `.latch`
+        // — unlike `rm`'s bare exit-2 failure, which has no output at all. The
+        // old code only merged `.latch` into the JSON envelope on the
+        // no-output error branch, so a result with output (like wait's) took
+        // the has_output() branch instead and the nonce never appeared under
+        // `--json`. Mirrors wait.rs::finish()'s exact construction.
+        let mut result = ExecResult::from_output(2, "[1] Latched\n", "");
+        result.set_output(Some(OutputData::text("[1] Latched\n")));
+        assert!(result.has_output(), "precondition: this result DOES have output");
+        result.latch = Some(Box::new(LatchRequest {
+            nonce: "a3f7b2c1".to_string(),
+            command: "rm".to_string(),
+            paths: vec!["precious.txt".to_string()],
+            hint: "rm --confirm=\"a3f7b2c1\" precious.txt".to_string(),
+            tool: "rm".to_string(),
+            argv: vec!["precious.txt".to_string()],
+            ttl: 60,
+        }));
+
+        let formatted = apply_output_format(result, OutputFormat::Json);
+        let out = formatted.text_out().into_owned();
+        let parsed: serde_json::Value = serde_json::from_str(&out).expect("valid JSON");
+        assert_eq!(
+            parsed["latch"]["nonce"], "a3f7b2c1",
+            "the nonce must be reachable from a latched result that also has \
+             output, not just the no-output error path: {parsed}"
+        );
+        assert_eq!(parsed["latch"]["command"], "rm");
+        assert_eq!(parsed["code"], 2);
+        // No .err was set (mirrors wait.rs), so the rendered text becomes the
+        // diagnostic `error` field.
+        assert_eq!(parsed["error"], "[1] Latched\n");
+        assert!(
+            formatted.latch_request().is_some(),
+            "the typed latch must survive --json formatting"
+        );
+    }
+
+    #[test]
     fn apply_output_format_leaves_clean_no_match_empty() {
         // grep no-match: exit 1, empty stdout, empty err. Not an error — must
         // NOT be wrapped in a JSON error object; stays empty.

--- a/crates/kaish-types/src/output.rs
+++ b/crates/kaish-types/src/output.rs
@@ -7,7 +7,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::result::ExecResult;
+use crate::result::{ExecResult, LatchRequest};
 
 // ============================================================
 // Structured Output (Tree-of-Tables Model)
@@ -530,6 +530,37 @@ pub enum OutputFormat {
     Json,
 }
 
+/// Build the `--json` error/latch envelope for a result carrying a pending
+/// confirmation latch (`.latch` is `Some`) — `{"error", "code", "data"?,
+/// "latch"}`. The ONE place a latch gets folded into `--json` output, so a
+/// latched `wait` (which carries text output, e.g. `"[1] Latched\n"`) and a
+/// latched `rm` (bare exit-2 failure, no output at all) converge on the same
+/// shape instead of diverging by which branch of [`apply_output_format`] they
+/// happen to take. `error` is `result.err` if non-empty, else the rendered
+/// text — a latch result is always diagnostic-shaped, so something readable
+/// belongs under `error` either way. A tool that also attached structured
+/// data to the result keeps it reachable under `data`, alongside (never
+/// clobbered by) the latch.
+fn latch_envelope(result: &ExecResult, latch: &LatchRequest) -> serde_json::Value {
+    let error = if !result.err.is_empty() {
+        result.err.clone()
+    } else {
+        result.text_out().into_owned()
+    };
+    let mut obj = serde_json::json!({
+        "error": error,
+        "code": result.code,
+    });
+    if let Some(data) = &result.data {
+        obj["data"] = crate::result::value_to_json(data);
+    }
+    // Infallible: LatchRequest is String/Vec<String>/u64 fields only.
+    if let Ok(v) = serde_json::to_value(latch) {
+        obj["latch"] = v;
+    }
+    obj
+}
+
 /// Transform an ExecResult into the requested output format.
 ///
 /// Serializes regardless of exit code — commands like `diff` (exit 1 = files differ)
@@ -551,6 +582,25 @@ pub fn apply_output_format(mut result: ExecResult, format: OutputFormat) -> Exec
         }
         return result;
     }
+    // A confirmation-latch request is control-plane, not stdout data — surface
+    // it under its own `latch` key in ONE canonical envelope regardless of
+    // whether the result ALSO carries text output. Handled here, before the
+    // has-output/no-output branches below, because `wait %1`'s result sets
+    // `OutputData::text` alongside `.latch` and so used to take the has_output()
+    // branch below, which never looked at `.latch` at all — the nonce was
+    // completely unreachable from `wait %1 --json` (GH #124 part 1). `rm`'s bare
+    // exit-2 failure (no output) hits this same branch too, so both converge on
+    // `latch_envelope` and can't diverge a third time.
+    if let Some(latch) = &result.latch {
+        let obj = match format {
+            OutputFormat::Json => latch_envelope(&result, latch),
+        };
+        let out = serde_json::to_string(&obj).unwrap_or_else(|_| "null".to_string());
+        result.data = Some(crate::result::json_to_value(obj));
+        result.set_out(out);
+        result.set_output(None);
+        return result;
+    }
     if !result.has_output() && result.text_out().is_empty() {
         // No stdout to format. A failure that carries a diagnostic message must
         // still honor --json — otherwise the message leaks out as plain text
@@ -570,15 +620,6 @@ pub fn apply_output_format(mut result: ExecResult, format: OutputFormat) -> Exec
                     // truth instead of clobbering one with the other.
                     if let Some(data) = &result.data {
                         obj["data"] = crate::result::value_to_json(data);
-                    }
-                    // A confirmation-latch request is control-plane, not stdout
-                    // data — surface it under its own `latch` key (the nonce the
-                    // caller re-runs with `--confirm=<nonce>`), never folded into
-                    // `data`. Infallible: LatchRequest is String/Vec<String>/u64.
-                    if let Some(latch) = &result.latch {
-                        if let Ok(v) = serde_json::to_value(latch) {
-                            obj["latch"] = v;
-                        }
                     }
                     let out =
                         serde_json::to_string(&obj).unwrap_or_else(|_| "null".to_string());

--- a/crates/kaish-types/src/output.rs
+++ b/crates/kaish-types/src/output.rs
@@ -926,6 +926,7 @@ mod tests {
             tool: "rm".to_string(),
             argv: vec!["precious.txt".to_string()],
             ttl: 60,
+            job_id: None,
         }));
 
         let formatted = apply_output_format(result, OutputFormat::Json);

--- a/crates/kaish-types/src/result.rs
+++ b/crates/kaish-types/src/result.rs
@@ -98,6 +98,21 @@ pub struct LatchRequest {
     pub argv: Vec<String>,
     /// Seconds until the nonce expires.
     pub ttl: u64,
+    /// The id of the *backgrounded* job that raised this latch, if any —
+    /// `Some` only when the gate came from a job the `JobManager` is tracking
+    /// (`rm x &` reaching its gate), `None` for a foreground latch (the common
+    /// case: `rm x` gated directly at the dispatch seam, no job involved).
+    ///
+    /// Deliberately a bare `u64`, not a `JobId`: this crate (`kaish-types`) is
+    /// a dependency-light leaf with no notion of `JobId` — that type lives in
+    /// `kaish-kernel`'s scheduler module, which depends on `kaish-types`, not
+    /// the other way around. `kaish-kernel` re-wraps this as `JobId(id)` at
+    /// the two call sites that care ([`JobManager`]'s `Job::latch()` stamps
+    /// it; `Kernel::confirm` reads it back to retire the originating job
+    /// after a successful replay). Skipped on the wire when absent, so a
+    /// foreground latch's `--json` shape is unchanged.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub job_id: Option<u64>,
 }
 
 /// Returned when a binary result is asked to behave as text.
@@ -919,6 +934,7 @@ mod tests {
             tool: "rm".to_string(),
             argv: paths.iter().map(|p| (*p).to_string()).collect(),
             ttl: 60,
+            job_id: None,
         }
     }
 
@@ -946,6 +962,7 @@ mod tests {
             tool: "kaish-trash".to_string(),
             argv: vec!["--".to_string(), "empty".to_string()],
             ttl: 60,
+            job_id: None,
         }));
 
         let req = result.latch_request().expect("a latch request");


### PR DESCRIPTION
## Summary

Four latch-visibility residuals from the 2026-07-06 fishing sweep, all sibling of PR #123 (which fixed latch-*destruction*): the latch nonce was reachable from a `rm --json` error envelope but invisible everywhere else a gate can surface.

1. **`wait %1 --json` dropped the nonce.** `wait`'s gate result carries text output (`"[1] Latched\n"`) alongside `.latch`, so it took `apply_output_format`'s has-output branch, which never looked at `.latch` — only the no-output error branch (what `rm`'s bare exit-2 hits) merged it. Fixed by hoisting latch handling to one shared `latch_envelope` helper checked first, before either branch, so both converge on the same shape.
2. **`jobs --json` rows had `JobInfo.latch` populated but never read.** Added a `rich_json` override with `{"id","status","command","path","latch"?}`.
3. **scatter/gather rows had no latch field**, mirroring the existing `.data` insertion in `result_row`.
4. **No confirm-and-consume semantic** — after `Kernel::confirm()` a backgrounded gate's job lingered in `jobs` forever. `LatchRequest` gains an optional `job_id: Option<u64>` back-reference (deliberately a bare `u64`, not a `JobId` — kaish-types is a dependency-light leaf with no notion of `JobId`, which lives in kaish-kernel's scheduler); `Job::latch()` stamps it (the one chokepoint every latch-reading path goes through), `wait`'s `classify()` stamps it separately (it bypasses `Job::latch()`), and `Kernel::confirm()` retires the job via `manager.remove()` after a successful replay — mirroring the existing manual `kill --discard %N` path, guarded by `is_latched` so a stale/foreign id can never touch an unrelated job. A failed replay leaves the job in place for inspection/retry; double-confirm is safe since nonces are reusable within TTL.

## Testing

TDD throughout — every new/changed behavior verified red-before-green by reverting just the fix (keeping the test) and confirming a genuine assertion failure, then restoring:
- `apply_output_format_surfaces_latch_even_when_result_has_output` (kaish-types)
- `job_rows_json_carries_latch_only_on_latched_rows` + kernel-routed `jobs_json_row_carries_the_latch_object`
- `test_gather_results_worker_latch_rides_the_row`
- `latch_stamps_job_id_back_reference` + kernel-routed `confirm_retires_the_originating_backgrounded_job` / `confirm_of_an_already_retired_job_does_not_error`

`cargo test --all --all-targets` and `cargo clippy --all --all-targets` are both clean (zero warnings). **Caveat:** `cargo test --all` *including* doctests currently fails on this machine due to environmental contention — 6 doctests in files this PR never touches (`paths.rs`'s `home_dir`/`xdg_*`, `interpreter.rs`'s crate-level example) crash the linker with `Bus error` under severe concurrent-build memory/swap pressure (measured: <500MB free RAM, 42GB swap in use, load average 30-60+ from many concurrent swarm sessions sharing this machine). Reproduced identically 4 times, including at reduced parallelism; every non-doctest test (1700+) passes cleanly every time. `--all-targets` explicitly excludes doctests and is fully green.

## Review

Reviewed via `kaibo` (cast `deepseek`) — approved with no changes requested. Confirmed the Part 1 hoist placement is the only position catching both wait's (has-output) and rm's (no-output) latch cases without drift; Part 2/3 row shapes are consistent and complete (no missed latch-carrying path); and on Part 4 specifically — verified `Option<u64>` is the right crate-boundary call, the two-stamp approach (`Job::latch()` + `wait.rs`'s independent stamp) is necessary and complete (checked for and found no third latch-reading path), and the `confirm()` retirement guard has no races (runs under `execute_argv`'s lock) and is idempotent on a repeat confirm.

Closes #124
