### PR TITLE
feat(repl): notify and auto-reap finished background jobs at the prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,12 @@ breaking entries are marked **BREAKING**.
   real `--`). All now lex as one literal word (#137).
 
 ### Added
+- **The REPL announces finished background jobs at the next prompt and reaps
+  them automatically** (GH #131). `sleep 5 &` used to complete silently — no
+  `[1] Done sleep 5`-style line, and the completed job stayed in the
+  `JobManager` until an explicit `jobs --cleanup`. A `Latched` job (gated on a
+  pending confirmation under `set -o latch`) is never auto-reaped or reported
+  as finished — it stays tracked until confirmed or explicitly discarded.
 - **`ToolSchema::glob_passthrough` (+ `with_glob_passthrough()`)** — a tool
   whose input *is* a glob pattern (like `glob`) can now tell the argv binder to
   pass bare patterns through as literal text instead of expanding them.

--- a/crates/kaish-kernel/src/scheduler/job.rs
+++ b/crates/kaish-kernel/src/scheduler/job.rs
@@ -645,22 +645,44 @@ impl JobManager {
         count
     }
 
-    /// Remove completed jobs from tracking and clean up their temp files.
+    /// Remove completed jobs from tracking and clean up their temp files,
+    /// returning info for each job removed.
     ///
     /// A latched job is "done" but its cached result holds the only
     /// `LatchRequest` for the gated operation — reaping it would silently
     /// destroy the pending confirmation (GH #96). It stays until confirmed
     /// or explicitly discarded (`kill --discard %N`).
-    pub async fn cleanup(&self) {
+    ///
+    /// Shared by `jobs --cleanup` (which only needs a count) and the REPL's
+    /// pre-prompt notification (GH #131, which needs the id/command/status of
+    /// each job so it can print `[N]+ Done ...` before reaping it) — one rule
+    /// for "is this job safe to reap", not two copies that could drift.
+    pub async fn reap_finished(&self) -> Vec<JobInfo> {
         let mut jobs = self.jobs.lock().await;
-        jobs.retain(|_, job| {
-            if job.is_done() && job.latch().is_none() {
-                job.cleanup_files();
-                false
-            } else {
-                true
-            }
-        });
+        let done_ids: Vec<JobId> = jobs
+            .iter_mut()
+            .filter_map(|(id, job)| (job.is_done() && job.latch().is_none()).then_some(*id))
+            .collect();
+
+        let mut removed = Vec::with_capacity(done_ids.len());
+        for id in done_ids {
+            let Some(mut job) = jobs.remove(&id) else {
+                continue;
+            };
+            let status = job.status();
+            let info = JobInfo::new(job.id, job.command.clone(), status).with_pid(job.pid);
+            job.cleanup_files();
+            removed.push(info);
+        }
+        removed
+    }
+
+    /// Remove completed jobs from tracking and clean up their temp files.
+    ///
+    /// See [`reap_finished`](Self::reap_finished) for the latch-safety rule;
+    /// this is the count-only form `jobs --cleanup` reports.
+    pub async fn cleanup(&self) {
+        self.reap_finished().await;
     }
 
     /// Check if a specific job exists.
@@ -1031,6 +1053,72 @@ mod tests {
             !path.exists(),
             "temp file should be removed after cleanup: {}",
             path.display()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_reap_finished_returns_removed_job_info() {
+        // GH #131: the REPL's pre-prompt notification needs the id/command/
+        // status of each reaped job, not just a count.
+        let manager = JobManager::new();
+        manager.set_persist_output_files(false);
+
+        let id = manager
+            .spawn("sleep 0.1".to_string(), async { ExecResult::success("") })
+            .await;
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        let _ = manager.wait(id).await;
+
+        let removed = manager.reap_finished().await;
+        assert_eq!(removed.len(), 1);
+        assert_eq!(removed[0].id, id);
+        assert_eq!(removed[0].command, "sleep 0.1");
+        assert_eq!(removed[0].status, JobStatus::Done);
+
+        // And it's actually gone from tracking.
+        assert!(manager.list().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_reap_finished_never_reaps_latched_jobs() {
+        // GH #131 / GH #96: a Latched job is "done" in the sense that its
+        // future resolved, but it's awaiting confirmation of a pending
+        // destructive-operation gate — reaping it would silently destroy the
+        // only copy of the LatchRequest. Must never be auto-reaped or
+        // reported as a finished job.
+        use kaish_types::result::LatchRequest;
+
+        let manager = JobManager::new();
+        manager.set_persist_output_files(false);
+        let (tx, rx) = oneshot::channel();
+        let id = manager.register("rm precious.txt".to_string(), rx).await;
+
+        let mut gated = ExecResult::failure(2, "rm: confirmation required (latch enabled)");
+        gated.latch = Some(Box::new(LatchRequest {
+            nonce: "a3f7b2c1".to_string(),
+            command: "rm".to_string(),
+            paths: vec!["precious.txt".to_string()],
+            hint: "rm --confirm=\"a3f7b2c1\" precious.txt".to_string(),
+            tool: "rm".to_string(),
+            argv: vec!["precious.txt".to_string()],
+            ttl: 60,
+        }));
+        tx.send(gated).expect("send gated result");
+        tokio::time::sleep(Duration::from_millis(10)).await;
+
+        // Confirm it's actually seen as Latched before reaping.
+        let info = manager.get(id).await.expect("job exists");
+        assert_eq!(info.status, JobStatus::Latched);
+
+        let removed = manager.reap_finished().await;
+        assert!(
+            removed.is_empty(),
+            "a latched job must never be auto-reaped: {removed:?}"
+        );
+        assert_eq!(
+            manager.list().await.len(),
+            1,
+            "the latched job must still be tracked so its gate can be fulfilled"
         );
     }
 

--- a/crates/kaish-repl/src/lib.rs
+++ b/crates/kaish-repl/src/lib.rs
@@ -735,6 +735,22 @@ fn resolve_prompt(repl: &Repl) -> String {
     "会sh> ".to_string()
 }
 
+/// Check the JobManager for jobs that finished since the last prompt, print a
+/// one-line notification for each (matching the `jobs` builtin's own
+/// `[id] status command` line), and reap them.
+///
+/// A `Latched` job is excluded by `reap_finished` itself — it's "done" in the
+/// sense that its future resolved, but it's awaiting confirmation of a
+/// pending destructive-operation gate (`set -o latch`) and must stay tracked
+/// until confirmed or explicitly discarded (GH #96), not be silently
+/// destroyed by an automatic background sweep (GH #131).
+fn notify_finished_jobs(repl: &Repl) {
+    let manager = repl.client.kernel().jobs();
+    for info in repl.runtime.block_on(manager.reap_finished()) {
+        println!("[{}] {} {}", info.id, info.status, info.command);
+    }
+}
+
 // ── Entry points ────────────────────────────────────────────────────
 
 /// Run the REPL with optional overlay mode.
@@ -771,6 +787,7 @@ pub fn run_with_overlay(overlay: bool) -> Result<()> {
     let history_path = load_history(&mut rl);
 
     loop {
+        notify_finished_jobs(&repl);
         let prompt_string = resolve_prompt(&repl);
         let prompt: &str = &prompt_string;
 
@@ -843,6 +860,7 @@ pub fn run() -> Result<()> {
     let history_path = load_history(&mut rl);
 
     loop {
+        notify_finished_jobs(&repl);
         // Dynamic prompt: call kaish_prompt() if defined, else default
         let prompt_string = resolve_prompt(&repl);
         let prompt: &str = &prompt_string;

--- a/crates/kaish-repl/tests/pty_job_control.rs
+++ b/crates/kaish-repl/tests/pty_job_control.rs
@@ -395,3 +395,37 @@ fn test_multiple_stopped_jobs() {
     // Clean up
     session.run_command("kill \"%1\"");
 }
+
+#[test]
+fn test_background_job_completion_is_notified_and_reaped() {
+    // GH #131: a completed background job used to vanish silently — no
+    // `[1]... Done` line before the next prompt, and its entry stayed in the
+    // JobManager until an explicit `jobs --cleanup`. It should now announce
+    // itself and be gone from `jobs` without any manual cleanup.
+    let mut session = PtySession::new();
+
+    session.send_line("sleep 0.2 &");
+    session
+        .wait_for("会sh> ", Duration::from_secs(3))
+        .expect("prompt right after backgrounding");
+
+    // Let the job actually finish before the next prompt render checks for it.
+    std::thread::sleep(Duration::from_millis(500));
+
+    // Any command triggers the next prompt render, which is where the
+    // notification is printed (before the prompt itself).
+    let output = session.run_command("true");
+    assert!(
+        output.contains("Done") && output.contains("sleep 0.2"),
+        "expected a completion notification for the finished job, got:\n{}",
+        output
+    );
+
+    // The job must have been reaped automatically — no leftover entry.
+    let output = session.run_command("jobs");
+    assert!(
+        output.contains("no jobs"),
+        "the finished job should have been auto-reaped, got:\n{}",
+        output
+    );
+}


### PR DESCRIPTION
## Summary
- No job-completion notification machinery existed: `sleep 5 &` completed silently, with no `[1] Done sleep 5`-style line before the next prompt, and the completed job's cached output stayed in the `JobManager` forever until an explicit `jobs --cleanup` — a slow memory leak in long interactive sessions and a surprise for anyone with bash muscle memory.
- Adds `JobManager::reap_finished(&self) -> Vec<JobInfo>` (`crates/kaish-kernel/src/scheduler/job.rs`), which applies the same latch-safety rule as the existing `cleanup()` — a `Latched` job (gated on a pending confirmation under `set -o latch`, e.g. `rm x &`) is never auto-reaped, since its cached result holds the only copy of the `LatchRequest` needed to later fulfill the gate (GH #96) — but returns the removed jobs' info instead of just a count. `cleanup()` now delegates to it so there's one implementation of "is this job safe to reap," not two that could drift apart.
- The REPL calls this once per prompt render (both the interactive and overlay loops), printing one `[id] status command` line per newly-finished job — matching the `jobs` builtin's own line format — before reaping it.

Closes #131

## Test plan
- [x] Two new `JobManager` unit tests: `reap_finished` returns the removed job's info and empties tracking; a `Latched` job is never reaped or reported
- [x] New PTY-based integration test (`crates/kaish-repl/tests/pty_job_control.rs`): a backgrounded `sleep 0.2 &` is announced ("Done"/command) at the next prompt render and no longer appears in `jobs` afterward — confirmed failing without the fix and passing with it
- [x] `cargo test --all` — clean (all existing `jobs --cleanup` tests unaffected by the `cleanup()` refactor)
- [x] `cargo clippy --all --all-targets` — zero warnings
- [x] kaibo-reviewed (cast: deepseek), with explicit attention to concurrency/races and the latch-safety guarantee given this is the most behaviorally novel of the four fixes in this sweep — confirmed no double-reap/double-notify (the mutex-guarded removal is atomic with respect to the filter check), confirmed every `Job` state (Running/Stopped/Done/Failed/Latched) is handled correctly by the `is_done() && latch().is_none()` filter with no transitional window, confirmed the `cleanup()` refactor is behavior-preserving for its existing callers/tests, and confirmed polling once per prompt render is a reasonable, idiomatic cost (comparable to the existing `block_on` in `resolve_prompt`).