### PR TITLE
fix(job-control): bg only marks a job Running after confirmed SIGCONT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,12 @@ breaking entries are marked **BREAKING**.
   structured, bool, or null path argument and fell back to reading stdin
   instead of erroring on the operand actually given — the same silent-fallback
   class #93/#117 set out to kill.
+- **`bg` no longer marks a job Running when its `SIGCONT` fails.** `resume_job()`
+  (clearing the job's Stopped flag) ran *before* the `killpg(SIGCONT)` call, so
+  a failed signal (e.g. the process already died) left the job looking
+  Running in `jobs`/`wait` with no live process and no reaper ever spawned to
+  clean it up. `bg` now only marks the job Running after a confirmed
+  successful `SIGCONT`.
 - **`kaish-ignore` changes now persist past their own statement.** Every
   runtime ignore mutation (`add`/`clear`/`defaults`/`scope`) was silently
   dropped at the end of the statement that made it — the per-command context

--- a/crates/kaish-kernel/src/tools/builtin/bg.rs
+++ b/crates/kaish-kernel/src/tools/builtin/bg.rs
@@ -101,13 +101,15 @@ impl Tool for Bg {
             let cmd = manager.get_command(job_id).await.unwrap_or_default();
             let pgid = nix::unistd::Pid::from_raw(pgid_raw as i32);
 
-            // Mark as resumed (no terminal transfer — it runs in background)
-            manager.resume_job(job_id).await;
-
-            // Send SIGCONT
+            // Confirm SIGCONT before marking the job Running (no terminal
+            // transfer — it runs in background). If the signal fails (e.g.
+            // the process already died), the job must stay Stopped rather
+            // than be marked Running with no live process and no reaper ever
+            // spawned to collect it (GH #126 part B).
             if let Err(e) = nix::sys::signal::killpg(pgid, nix::sys::signal::Signal::SIGCONT) {
                 return ExecResult::failure(1, format!("bg: failed to continue job: {}", e));
             }
+            manager.resume_job(job_id).await;
 
             // Spawn a background reaper task
             let jobs = manager.clone();
@@ -131,5 +133,71 @@ impl Tool for Bg {
 
             ExecResult::with_output(OutputData::text(format!("[{}] {} &\n", job_id, cmd)))
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::scheduler::JobManager;
+    use crate::vfs::{MemoryFs, VfsRouter};
+    use std::os::unix::process::CommandExt;
+    use std::sync::Arc;
+
+    fn make_ctx() -> ExecContext {
+        let mut vfs = VfsRouter::new();
+        vfs.mount("/", MemoryFs::new());
+        ExecContext::new(Arc::new(vfs))
+    }
+
+    /// GH #126 part B: a failed `SIGCONT` must not leave the job looking
+    /// `Running` with a dead process behind it. Spawn a real short-lived
+    /// process in its own process group (mirroring how a Ctrl-Z'd job is
+    /// registered — pgid == pid), register it as stopped, then actually kill
+    /// *and reap* it so its pid/pgid no longer exist in the process table:
+    /// `killpg(SIGCONT)` on that now-nonexistent group returns ESRCH,
+    /// exercising the exact failure path `bg` must handle without flipping
+    /// `stopped` to `false` first.
+    #[tokio::test]
+    async fn test_bg_failed_sigcont_does_not_mark_job_running() {
+        let mut child = std::process::Command::new("sleep")
+            .arg("5")
+            .process_group(0)
+            .spawn()
+            .expect("spawn sleep");
+        let pid = child.id();
+
+        let manager = Arc::new(JobManager::new());
+        let job_id = manager.register_stopped("sleep 5".to_string(), pid, pid).await;
+
+        child.kill().expect("kill sleep");
+        child.wait().expect("reap sleep");
+
+        let mut ctx = make_ctx();
+        ctx.set_job_manager(manager.clone());
+        let mut args = ToolArgs::new();
+        // A bare `Value::Int` job id, not the `%N` jobspec string form — this
+        // test targets the SIGCONT-ordering bug (part B) independent of the
+        // `%`-prefix parsing fix (part A), which lands on a separate branch.
+        args.positional.push(Value::Int(job_id.0 as i64));
+
+        let result = Bg.execute(args, &mut ctx).await;
+        assert!(!result.ok(), "SIGCONT to a dead process group should fail");
+        assert!(
+            result.err.contains("failed to continue job"),
+            "expected a SIGCONT failure, got: {}",
+            result.err
+        );
+
+        // Pre-fix: `resume_job()` ran before the (failing) `killpg`, so the
+        // job was left `stopped = false` (JobStatus::Running) with no live
+        // process and no reaper ever spawned to collect it. Post-fix: the
+        // job must still show as Stopped.
+        let info = manager.get(job_id).await.expect("job still tracked");
+        assert_eq!(
+            info.status,
+            kaish_types::JobStatus::Stopped,
+            "job must stay Stopped after a failed SIGCONT, not silently become Running"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Part B (the "medium" finding) of #126. `bg`'s `resume_job()` (which clears
the job's Stopped flag, marking it `JobStatus::Running`) ran *before*
`killpg(pgid, SIGCONT)`. If the signal failed — e.g. the process already
died (ESRCH) — the function returned failure immediately, before ever
reaching the reaper-spawn code further down. That left the job in the map
looking Running with no live process and no reaper task ever spawned to
collect it; only a manual `kill %N` could clean it up.

- Reordered so `resume_job()` only runs after a confirmed successful
  `SIGCONT`. On failure the job now simply stays in its prior Stopped state,
  with the exact same failure `ExecResult` as before.
- Added a unit test (`test_bg_failed_sigcont_does_not_mark_job_running`) that
  spawns a real short-lived process in its own process group, registers it as
  a stopped job, then kills *and reaps* it for real so its pid/pgid genuinely
  no longer exist in the process table — `killpg(SIGCONT)` then fails with a
  real ESRCH, exercising the exact failure path. Confirmed this fails pre-fix
  (job status flips to Running) and passes post-fix (stays Stopped).
- CHANGELOG bullet under `Fixed`.

**Scope note:** `fg.rs` (lines ~107-112) has the textually identical
`resume_job`-before-`SIGCONT` ordering bug. Deliberately left out of this
PR — GH #126 part B is scoped to `bg.rs`, and a proper `fg` fix also needs to
reconsider the terminal-handoff ordering (`give_terminal_to` runs before both
`resume_job` and `killpg` today, and a dead process group shouldn't get the
terminal either) — a mechanical reorder isn't quite enough there. Filed as a
separate follow-up: #161.

kaibo-reviewed (cast: deepseek) — walked every remaining state-transition
window (signal succeeds but process dies before `resume_job`/before the
reaper spawns; a concurrent `kill %N` racing the same job) and found no
leftover inconsistent-state path; confirmed the test reliably forces a real
`ESRCH` (via process-group semantics, not PID reuse, so it isn't racy); agreed
the `fg.rs` scope split is reasonable given the added terminal-handoff
complexity there. No changes requested.

**On #126's third finding (part C, the possible reaper/exit hang):** I
reproduced it (with process/thread-level evidence — a `tokio-runtime-w`
worker thread parked in `do_wait` while the driver blocks on `futex_do_wait`,
confirmed against a fast ~100ms control case with no backgrounded job), but
the fix needs a small design decision (what should happen to a backgrounded
job when the shell exits?) plus either a reaper rewrite or a `Repl`
restructure — more than this PR should carry, and not something to guess at.
Split out to its own tracked issue with full repro details: #162. Since C
won't land in this pass, this PR closes #126 (parts A and B are the
source-verified findings that are actually fixed; part C continues as #162).

Closes #126

## Test plan
- [x] New unit test fails on pre-fix code (asserts Stopped, observes Running), passes post-fix
- [x] `cargo test --all` — full workspace suite green, re-verified after rebase
- [x] `cargo clippy --all --all-targets` — zero warnings
- [x] kaibo review (cast: deepseek) — no changes requested

🤖 Generated with [Claude Code](https://claude.com/claude-code)
