### PR TITLE
fix(binary-sinks): close residual value_to_string binary-fallback sinks (GH #116)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,21 @@ breaking entries are marked **BREAKING**.
   Running in `jobs`/`wait` with no live process and no reaper ever spawned to
   clean it up. `bg` now only marks the job Running after a confirmed
   successful `SIGCONT`.
+- **`key=value` reassembly (`WordAssign`) now errors loudly on binary instead of
+  splicing the `[binary: N bytes]` placeholder.** `-v a=$BIN`-style value-flag
+  reassembly (`consume_flag_positionals`), `test`'s raw-argv binder, and the
+  general `key=value` → positional path (`dd if=$BIN`, `cat foo=$BIN`) all
+  fell outside the #93 item-1 sweep; the scheduler's sync `build_tool_args`
+  twin (the scatter/gather flag-value path) is fixed the same way (GH #116).
+- **`alias`, `unalias`, `unset`, and `kill --signal` now error loudly on a
+  binary operand** instead of silently treating the `[binary: N bytes]`
+  placeholder as a literal alias/variable/signal name (GH #116).
+- **A repeatable flag bound to binary (`grep --ftype=$BIN`, `glob
+  --include=$BIN`) now errors loudly.** Previously a single binary occurrence
+  silently vanished from the filter — the JSON-array reader skipped the
+  base64 byte envelope the binder had encoded it as — so the flag was
+  silently dropped rather than applied or refused, worse than the
+  placeholder pattern elsewhere (GH #116).
 - **`kaish-ignore` changes now persist past their own statement.** Every
   runtime ignore mutation (`add`/`clear`/`defaults`/`scope`) was silently
   dropped at the end of the statement that made it — the per-command context

--- a/crates/kaish-kernel/src/kernel.rs
+++ b/crates/kaish-kernel/src/kernel.rs
@@ -3383,7 +3383,15 @@ impl Kernel {
                     Arg::WordAssign { key, value } => {
                         let val = self.eval_expr_async(value).await?;
                         let val = apply_tilde_expansion(val, home.as_deref());
-                        let val_str = crate::interpreter::value_to_string(&val);
+                        // Loud on binary (GH #116): `-v a=$BIN` must not silently
+                        // reassemble the `[binary: N bytes]` placeholder into the
+                        // flag's value — same text-sink boundary as the primary
+                        // sinks fixed in #93 item 1.
+                        let val_str = crate::interpreter::value_to_text_sink_named(
+                            &val,
+                            "a key=value argument",
+                        )
+                        .map_err(|e| anyhow::anyhow!("{e}"))?;
                         collected.push(Value::String(format!("{key}={val_str}")));
                         consumed.insert(pos_idx);
                     }
@@ -3508,18 +3516,31 @@ impl Kernel {
                     Arg::Named { key, value } => {
                         let val = self.eval_expr_async(value).await?;
                         let val = apply_tilde_expansion(val, home.as_deref());
-                        tool_args.positional.push(Value::String(format!(
-                            "--{key}={}",
-                            crate::interpreter::value_to_string(&val)
-                        )));
+                        // Loud on binary (GH #116): `test --k=$BIN` must not
+                        // silently reassemble the placeholder into the raw-argv
+                        // positional stream `test` binds against.
+                        let val_str = crate::interpreter::value_to_text_sink_named(
+                            &val,
+                            "a --key=value argument",
+                        )
+                        .map_err(|e| anyhow::anyhow!("{e}"))?;
+                        tool_args
+                            .positional
+                            .push(Value::String(format!("--{key}={val_str}")));
                     }
                     Arg::WordAssign { key, value } => {
                         let val = self.eval_expr_async(value).await?;
                         let val = apply_tilde_expansion(val, home.as_deref());
-                        tool_args.positional.push(Value::String(format!(
-                            "{key}={}",
-                            crate::interpreter::value_to_string(&val)
-                        )));
+                        // Loud on binary (GH #116): same reasoning as the Named
+                        // arm above, for the bare `key=value` raw-argv form.
+                        let val_str = crate::interpreter::value_to_text_sink_named(
+                            &val,
+                            "a key=value argument",
+                        )
+                        .map_err(|e| anyhow::anyhow!("{e}"))?;
+                        tool_args
+                            .positional
+                            .push(Value::String(format!("{key}={val_str}")));
                     }
                     Arg::DoubleDash => {
                         tool_args.positional.push(Value::String("--".to_string()));
@@ -3645,7 +3666,14 @@ impl Kernel {
                     } else {
                         // Stringify "key=value" and pass as a positional.
                         // Matches bash: `cat foo=bar` opens a file named `foo=bar`.
-                        let val_str = crate::interpreter::value_to_string(&val);
+                        // Loud on binary (GH #116): `cat foo=$BIN`/`dd if=$BIN`
+                        // must not silently become a path/operand literally named
+                        // `foo=[binary: N bytes]`.
+                        let val_str = crate::interpreter::value_to_text_sink_named(
+                            &val,
+                            "a key=value argument",
+                        )
+                        .map_err(|e| anyhow::anyhow!("{e}"))?;
                         tool_args.positional.push(Value::String(format!("{key}={val_str}")));
                     }
                 }

--- a/crates/kaish-kernel/src/scheduler/pipeline.rs
+++ b/crates/kaish-kernel/src/scheduler/pipeline.rs
@@ -876,7 +876,13 @@ pub fn build_tool_args(
                     if accepts_word_assign {
                         tool_args.named.insert(key.clone(), val);
                     } else {
-                        let val_str = crate::interpreter::value_to_string(&val);
+                        // Loud on binary (GH #116) — sync twin of the async
+                        // binder's WordAssign fallback in kernel.rs.
+                        let val_str = crate::interpreter::value_to_text_sink_named(
+                            &val,
+                            "a key=value argument",
+                        )
+                        .map_err(|e| e.to_string())?;
                         tool_args.positional.push(Value::String(format!("{key}={val_str}")));
                     }
                 }
@@ -1988,6 +1994,28 @@ mod tests {
         assert_eq!(
             tool_args.positional,
             vec![Value::String("--this-is-data".to_string())]
+        );
+    }
+
+    /// GH #116: the sync twin of kernel.rs's async `build_args_async` WordAssign
+    /// fallback must also go loud on binary rather than silently reassembling
+    /// the `[binary: N bytes]` placeholder into `key=value` (e.g. `dd if=$BIN`
+    /// reached via a scatter/gather flag value, which routes through this sync
+    /// evaluator instead of the async binder).
+    #[test]
+    fn word_assign_binary_value_is_loud_not_placeholder() {
+        let args = vec![Arg::WordAssign {
+            key: "if".to_string(),
+            value: Expr::Literal(Value::Bytes(vec![0xff, 0x00, 0xfe])),
+        }];
+        let ctx = make_minimal_ctx();
+
+        // schema=None ⇒ accepts_word_assign is false ⇒ falls to the
+        // stringify-to-positional branch under test.
+        let err = build_tool_args(&args, &ctx, None).expect_err("binary WordAssign must error");
+        assert!(
+            err.contains("cannot be used as"),
+            "error should name the binary problem, got {err:?}"
         );
     }
 

--- a/crates/kaish-kernel/src/tools/builtin/alias.rs
+++ b/crates/kaish-kernel/src/tools/builtin/alias.rs
@@ -77,18 +77,31 @@ impl Tool for Alias {
 
         // Check named args first (name=value form, parsed by kernel as named args)
         for (name, value) in &args.named {
+            // Loud on binary (GH #116): `alias name=$BIN` must not silently
+            // define an alias body of `[binary: N bytes]`.
             let val = match value {
                 Value::String(s) => s.clone(),
-                other => crate::interpreter::value_to_string(other),
+                other => match crate::interpreter::value_to_text_sink_named(other, "an alias value") {
+                    Ok(s) => s,
+                    Err(e) => return ExecResult::failure(1, format!("alias: {e}")),
+                },
             };
             ctx.aliases.insert(name.clone(), val);
         }
 
         // Check positional args: either "name=value" strings or bare names to show
         for arg in &args.positional {
+            // Loud on binary (GH #116): `alias $BIN` must not silently treat the
+            // placeholder as an alias name/definition.
             let s = match arg {
                 Value::String(s) => s.clone(),
-                other => crate::interpreter::value_to_string(other),
+                other => match crate::interpreter::value_to_text_sink_named(
+                    other,
+                    "an alias name or definition",
+                ) {
+                    Ok(s) => s,
+                    Err(e) => return ExecResult::failure(1, format!("alias: {e}")),
+                },
             };
 
             if let Some((name, value)) = s.split_once('=') {
@@ -175,9 +188,14 @@ impl Tool for Unalias {
         }
 
         for arg in &args.positional {
+            // Loud on binary (GH #116): `unalias $BIN` must not silently try to
+            // remove an alias literally named `[binary: N bytes]`.
             let name = match arg {
                 Value::String(s) => s.clone(),
-                other => crate::interpreter::value_to_string(other),
+                other => match crate::interpreter::value_to_text_sink_named(other, "an alias name") {
+                    Ok(s) => s,
+                    Err(e) => return ExecResult::failure(1, format!("unalias: {e}")),
+                },
             };
             ctx.aliases.remove(&name);
         }

--- a/crates/kaish-kernel/src/tools/builtin/glob.rs
+++ b/crates/kaish-kernel/src/tools/builtin/glob.rs
@@ -126,8 +126,14 @@ impl Tool for Glob {
         // Build the rg-style file-type filter from `--ftype`/`--ftype-not`.
         // Repeatable value flags arrive as `Json(Array)`; read them off the raw
         // args (shared with grep). An unknown type name is loud (exit 2).
-        let ftype_select = read_repeatable_strings(&args, "ftype");
-        let ftype_negate = read_repeatable_strings(&args, "ftype-not");
+        let ftype_select = match read_repeatable_strings(&args, "ftype") {
+            Ok(v) => v,
+            Err(e) => return ExecResult::failure(2, format!("glob: {e}")),
+        };
+        let ftype_negate = match read_repeatable_strings(&args, "ftype-not") {
+            Ok(v) => v,
+            Err(e) => return ExecResult::failure(2, format!("glob: {e}")),
+        };
         let file_types = match build_file_types(&ftype_select, &ftype_negate) {
             Ok(t) => t,
             Err(e) => return ExecResult::failure(2, format!("glob: {e}")),
@@ -180,10 +186,18 @@ impl Tool for Glob {
         // Build the include/exclude filter. Repeatable value flags arrive as
         // `Json(Array)`; read them off the raw args like `--ftype` above.
         let mut filter = IncludeExclude::new();
-        for pattern in read_repeatable_strings(&args, "include") {
+        let includes = match read_repeatable_strings(&args, "include") {
+            Ok(v) => v,
+            Err(e) => return ExecResult::failure(2, format!("glob: {e}")),
+        };
+        let excludes = match read_repeatable_strings(&args, "exclude") {
+            Ok(v) => v,
+            Err(e) => return ExecResult::failure(2, format!("glob: {e}")),
+        };
+        for pattern in includes {
             filter.include(&pattern);
         }
-        for pattern in read_repeatable_strings(&args, "exclude") {
+        for pattern in excludes {
             filter.exclude(&pattern);
         }
 

--- a/crates/kaish-kernel/src/tools/builtin/grep.rs
+++ b/crates/kaish-kernel/src/tools/builtin/grep.rs
@@ -228,8 +228,14 @@ impl Tool for Grep {
         // unknown type name is loud (exit 2), never a silent empty match. The
         // filter only takes effect on the `-r` walk below, but we validate the
         // names here regardless so a typo is caught on any invocation.
-        let ftype_select = read_repeatable_strings(&args, "ftype");
-        let ftype_negate = read_repeatable_strings(&args, "ftype-not");
+        let ftype_select = match read_repeatable_strings(&args, "ftype") {
+            Ok(v) => v,
+            Err(e) => return ExecResult::failure(2, format!("grep: {e}")),
+        };
+        let ftype_negate = match read_repeatable_strings(&args, "ftype-not") {
+            Ok(v) => v,
+            Err(e) => return ExecResult::failure(2, format!("grep: {e}")),
+        };
         let file_types = match build_file_types(&ftype_select, &ftype_negate) {
             Ok(t) => t,
             Err(e) => return ExecResult::failure(2, format!("grep: {e}")),
@@ -421,10 +427,18 @@ impl Tool for Grep {
                     // them off the raw args like `--ftype`; the filter itself
                     // enforces include semantics (a file must match one).
                     let mut filter = IncludeExclude::new();
-                    for pattern in read_repeatable_strings(&args, "include") {
+                    let includes = match read_repeatable_strings(&args, "include") {
+                        Ok(v) => v,
+                        Err(e) => return ExecResult::failure(2, format!("grep: {e}")),
+                    };
+                    let excludes = match read_repeatable_strings(&args, "exclude") {
+                        Ok(v) => v,
+                        Err(e) => return ExecResult::failure(2, format!("grep: {e}")),
+                    };
+                    for pattern in includes {
                         filter.include(&pattern);
                     }
-                    for pattern in read_repeatable_strings(&args, "exclude") {
+                    for pattern in excludes {
                         filter.exclude(&pattern);
                     }
                     let glob = GlobPath::new("**/*").ok();

--- a/crates/kaish-kernel/src/tools/builtin/kill.rs
+++ b/crates/kaish-kernel/src/tools/builtin/kill.rs
@@ -74,15 +74,21 @@ impl Tool for Kill {
 
         // Signal from --signal / -s named param, or default to TERM. Prefer
         // args.named so an Int signal keeps its typing.
-        let signal_name = args
-            .named
-            .get("signal")
-            .map(|v| match v {
-                Value::String(s) => s.clone(),
-                Value::Int(i) => i.to_string(),
-                other => crate::interpreter::value_to_string(other),
-            })
-            .unwrap_or(parsed.signal);
+        //
+        // Loud on binary (GH #116): `--signal=$BIN` must not silently become
+        // the literal string `[binary: N bytes]` as the requested signal name
+        // (the positional target form below is already guarded separately).
+        let signal_name = match args.named.get("signal") {
+            Some(Value::String(s)) => s.clone(),
+            Some(Value::Int(i)) => i.to_string(),
+            Some(other) => {
+                match crate::interpreter::value_to_text_sink_named(other, "a signal name") {
+                    Ok(s) => s,
+                    Err(e) => return ExecResult::failure(1, format!("kill: {e}")),
+                }
+            }
+            None => parsed.signal,
+        };
 
         let target_str = match args.get_positional(0) {
             Some(Value::String(s)) => s.clone(),

--- a/crates/kaish-kernel/src/tools/builtin/mod.rs
+++ b/crates/kaish-kernel/src/tools/builtin/mod.rs
@@ -121,16 +121,51 @@ use super::ToolRegistry;
 /// the clap field isn't a reliable source — search builtins read the raw args
 /// here. Shared by grep/glob `--ftype`/`--ftype-not`; mirrors sed's
 /// `collect_expressions` (see the repeatable-flag gotcha in `arch_repeatable_flags`).
-pub(crate) fn read_repeatable_strings(args: &super::ToolArgs, key: &str) -> Vec<String> {
+///
+/// Loud on binary (GH #116): a single binary occurrence lands in the bare
+/// `Some(other)` arm; a *repeated* binary occurrence lands inside the
+/// `Json(Array)` as a base64 byte envelope (`push_repeatable_value` runs every
+/// value through `value_to_json`, which encodes `Value::Bytes` that way) — the
+/// array arm's `filter_map(v.as_str())` used to silently DROP that entry
+/// instead of erroring, which is worse than a placeholder: the filter/pattern
+/// just vanished and the caller ran unfiltered against real data. Both shapes
+/// now error instead of silently stringifying or dropping.
+pub(crate) fn read_repeatable_strings(
+    args: &super::ToolArgs,
+    key: &str,
+) -> Result<Vec<String>, String> {
     use crate::ast::Value;
     match args.named.get(key) {
-        Some(Value::Json(serde_json::Value::Array(items))) => items
-            .iter()
-            .filter_map(|v| v.as_str().map(|s| s.to_string()))
-            .collect(),
-        Some(Value::String(s)) => vec![s.clone()],
-        Some(other) => vec![crate::interpreter::value_to_string(other)],
-        None => Vec::new(),
+        Some(Value::Json(serde_json::Value::Array(items))) => {
+            let mut out = Vec::with_capacity(items.len());
+            for v in items {
+                match v.as_str() {
+                    Some(s) => out.push(s.to_string()),
+                    // Not a string: check for a binary envelope before
+                    // silently skipping (the pre-existing behavior, preserved
+                    // below for any other JSON shape — out of this sweep's
+                    // scope).
+                    None => {
+                        if let Some(bytes) = kaish_types::envelope_to_bytes(v) {
+                            return Err(format!(
+                                "binary data ({} bytes) cannot be used as a repeatable \
+                                 flag value — decode it (base64/xxd) or redirect to a file",
+                                bytes.len()
+                            ));
+                        }
+                    }
+                }
+            }
+            Ok(out)
+        }
+        Some(Value::String(s)) => Ok(vec![s.clone()]),
+        Some(other) => {
+            match crate::interpreter::value_to_text_sink_named(other, "a repeatable flag value") {
+                Ok(s) => Ok(vec![s]),
+                Err(e) => Err(e.to_string()),
+            }
+        }
+        None => Ok(Vec::new()),
     }
 }
 

--- a/crates/kaish-kernel/src/tools/builtin/test.rs
+++ b/crates/kaish-kernel/src/tools/builtin/test.rs
@@ -132,17 +132,26 @@ async fn eval_primary(ctx: &ExecContext, operands: &[Value]) -> Result<bool, Str
         0 => Err("test: missing expression".to_string()),
         1 => {
             let operand = &operands[0];
-            let s = value_to_string(operand);
-            // A lone operator is a forgotten operand — loud, not surprise-true.
-            if is_any_op(&s) {
-                return Err(format!("test: '{s}' needs an operand"));
-            }
             // A bare collection has no truth value here — loud Shape error.
             if is_collection(operand) {
                 return Err(format!(
                     "test: operand is a {}, not a string; a collection has no truth value",
                     collection_kind(operand)
                 ));
+            }
+            // Loud on binary: `test $BIN` must not silently treat the
+            // `[binary: N bytes]` placeholder as a truthy string (found via
+            // kaibo review of GH #116 — this raw-argv positional arm is the
+            // one sibling of the Named/WordAssign arms in kernel.rs's raw-argv
+            // fast path that isn't guarded there, since `test` itself needs
+            // the untouched typed value for its other operators; the guard
+            // belongs here instead, mirroring `-z`/`-n`/the path operators
+            // below).
+            let s = value_to_text_sink_named(operand, "a test operand")
+                .map_err(|e| format!("test: {e}"))?;
+            // A lone operator is a forgotten operand — loud, not surprise-true.
+            if is_any_op(&s) {
+                return Err(format!("test: '{s}' needs an operand"));
             }
             Ok(!s.is_empty())
         }
@@ -180,8 +189,16 @@ async fn apply_unary(ctx: &ExecContext, op: &str, operand: &Value) -> Result<boo
         return Err(msg);
     }
     match op {
-        "-z" => Ok(value_to_string(operand).is_empty()),
-        "-n" => Ok(!value_to_string(operand).is_empty()),
+        // Loud on binary (found via kaibo review of GH #116): `test -z $BIN`/
+        // `test -n $BIN` must not silently treat the `[binary: N bytes]`
+        // placeholder as a non-empty string — same class as the path operators
+        // below, just for the empty/non-empty-string test instead of a stat.
+        "-z" => Ok(value_to_text_sink_named(operand, "a test operand")
+            .map_err(|e| format!("test: {e}"))?
+            .is_empty()),
+        "-n" => Ok(!value_to_text_sink_named(operand, "a test operand")
+            .map_err(|e| format!("test: {e}"))?
+            .is_empty()),
         "-e" | "-f" | "-d" | "-r" | "-w" | "-x" => {
             // A binary operand goes loud rather than silently stat'ing a file
             // literally named `[binary: N bytes]` — mirrors `[[`'s `FileTest`

--- a/crates/kaish-kernel/src/tools/builtin/unset.rs
+++ b/crates/kaish-kernel/src/tools/builtin/unset.rs
@@ -56,9 +56,14 @@ impl Tool for Unset {
         }
 
         for arg in &args.positional {
+            // Loud on binary (GH #116): `unset $BIN` must not silently try to
+            // remove a variable literally named `[binary: N bytes]`.
             let name = match arg {
                 Value::String(s) => s.clone(),
-                other => value_to_string(other),
+                other => match crate::interpreter::value_to_text_sink_named(other, "a variable name") {
+                    Ok(s) => s,
+                    Err(e) => return ExecResult::failure(1, format!("unset: {e}")),
+                },
             };
 
             // POSIX: unsetting a nonexistent variable is not an error.
@@ -69,18 +74,6 @@ impl Tool for Unset {
         // `$()` captures and `--json` output with a stray number
         // (found by the --json sweep 2026-06-11).
         ExecResult::success("")
-    }
-}
-
-fn value_to_string(value: &Value) -> String {
-    match value {
-        Value::Null => "null".to_string(),
-        Value::Bool(b) => b.to_string(),
-        Value::Int(i) => i.to_string(),
-        Value::Float(f) => f.to_string(),
-        Value::String(s) => s.clone(),
-        Value::Json(json) => json.to_string(),
-        Value::Bytes(b) => format!("[binary: {} bytes]", b.len()),
     }
 }
 

--- a/crates/kaish-kernel/tests/binary_text_sink_tests.rs
+++ b/crates/kaish-kernel/tests/binary_text_sink_tests.rs
@@ -570,6 +570,31 @@ async fn test_builtin_raw_argv_word_assign_binary_is_loud() {
     assert_loud_binary("b=$(cat src.bin); test foo=$b").await;
 }
 
+/// `test $BIN` — the raw-argv fast path's `Arg::Positional` arm intentionally
+/// preserves every operand's real type (untouched Bytes included) since
+/// `test` needs it for typed comparisons elsewhere; the guard belongs in
+/// `test`'s own single-operand truthiness check instead. Found via kaibo
+/// review of the rest of this PR (GH #116) — the Named/WordAssign siblings in
+/// the same raw-argv arm were already guarded, but the bare-positional
+/// truthiness path used `value_to_string` unguarded.
+#[tokio::test]
+async fn test_builtin_bare_positional_truthiness_binary_is_loud() {
+    assert_loud_binary("b=$(cat src.bin); test $b").await;
+}
+
+/// `test -z $BIN` — same class as the bare-positional truthiness case above,
+/// for the explicit empty-string operator.
+#[tokio::test]
+async fn test_builtin_dash_z_binary_is_loud() {
+    assert_loud_binary("b=$(cat src.bin); test -z $b").await;
+}
+
+/// `test -n $BIN` — same class, for the non-empty-string operator.
+#[tokio::test]
+async fn test_builtin_dash_n_binary_is_loud() {
+    assert_loud_binary("b=$(cat src.bin); test -n $b").await;
+}
+
 /// `dd if=$BIN` — the main-loop `Arg::WordAssign` non-word-assign fallback
 /// (the general `key=value` → positional path any tool outside
 /// export/alias/unalias uses). This is issue #116's own headline example.

--- a/crates/kaish-kernel/tests/binary_text_sink_tests.rs
+++ b/crates/kaish-kernel/tests/binary_text_sink_tests.rs
@@ -541,3 +541,102 @@ async fn length_of_binary_is_byte_count_not_loud() {
     assert_eq!(result.code, 0, "err={}", result.err);
     assert_eq!(result.text_out().trim(), BIN.len().to_string());
 }
+
+// ── GH #116: residual `value_to_string` binary-fallback sinks ──
+//
+// The #93 item-1 PR closed the five primary text sinks (string interpolation,
+// echo, printf, path positionals, redirect targets, ==/in/case-glob). These
+// tests cover the sinks that fell outside that PR's scope: `key=value`
+// (WordAssign) reassembly in the argument binder (both the async kernel.rs
+// path and its sync scheduler/pipeline.rs twin — the twin has its own direct
+// unit test in pipeline.rs since scatter/gather is the only script-level route
+// to it), and a handful of builtins' own non-path scalar fallbacks.
+
+/// `awk -v x=$BIN` — `consume_flag_positionals`'s WordAssign reassembly arm.
+#[tokio::test]
+async fn awk_dash_v_binary_assignment_is_loud() {
+    assert_loud_binary("b=$(cat src.bin); awk -v x=$b 'BEGIN{}'").await;
+}
+
+/// `test --foo=$BIN` — `test`'s raw-argv fast path, the `Arg::Named` arm.
+#[tokio::test]
+async fn test_builtin_raw_argv_named_binary_is_loud() {
+    assert_loud_binary("b=$(cat src.bin); test --foo=$b").await;
+}
+
+/// `test foo=$BIN` — `test`'s raw-argv fast path, the `Arg::WordAssign` arm.
+#[tokio::test]
+async fn test_builtin_raw_argv_word_assign_binary_is_loud() {
+    assert_loud_binary("b=$(cat src.bin); test foo=$b").await;
+}
+
+/// `dd if=$BIN` — the main-loop `Arg::WordAssign` non-word-assign fallback
+/// (the general `key=value` → positional path any tool outside
+/// export/alias/unalias uses). This is issue #116's own headline example.
+#[tokio::test]
+async fn dd_word_assign_binary_is_loud() {
+    assert_loud_binary("b=$(cat src.bin); dd if=$b").await;
+}
+
+/// `alias name=$BIN` — the named-arg (`args.named`) half of alias's own
+/// value_to_string fallback.
+#[tokio::test]
+async fn alias_named_binary_value_is_loud() {
+    assert_loud_binary("b=$(cat src.bin); alias name=$b").await;
+}
+
+/// `alias $BIN` (bare positional) — the positional half of the same fallback.
+#[tokio::test]
+async fn alias_positional_binary_is_loud() {
+    assert_loud_binary("b=$(cat src.bin); alias $b").await;
+}
+
+/// `unalias $BIN`.
+#[tokio::test]
+async fn unalias_binary_is_loud() {
+    assert_loud_binary("b=$(cat src.bin); unalias $b").await;
+}
+
+/// `unset $BIN`.
+#[tokio::test]
+async fn unset_binary_is_loud() {
+    assert_loud_binary("b=$(cat src.bin); unset $b").await;
+}
+
+/// `kill --signal=$BIN %1` — the NAMED-flag `--signal` fallback only; the
+/// positional target form is guarded separately and untouched here.
+#[tokio::test]
+async fn kill_signal_named_binary_is_loud() {
+    assert_loud_binary("b=$(cat src.bin); kill --signal=$b %1").await;
+}
+
+/// `grep --ftype=$BIN pattern file` — `read_repeatable_strings`'s array arm.
+/// `--ftype` is repeatable, so even a single binary occurrence is JSON-encoded
+/// as a base64 byte envelope inside a `Json(Array)` by the binder
+/// (`push_repeatable_value` → `value_to_json`); the array arm used to silently
+/// DROP that entry (`filter_map(v.as_str())` skips non-string JSON) rather
+/// than erroring — worse than a placeholder, since the filter just vanished
+/// and grep ran unfiltered against the real data.
+///
+/// Searches a plain-text file (not `src.bin`) so the assertion isolates the
+/// `--ftype` guard: `src.bin` itself would trip grep's unrelated "refuses to
+/// search binary content" guard first and mask whether this fix fired at all
+/// (caught empirically — the pre-fix version of this test still failed, but
+/// for that unrelated reason, not the silently-dropped filter).
+#[tokio::test]
+async fn grep_ftype_binary_is_loud_not_silently_dropped() {
+    let dir = tempdir().unwrap();
+    fs::write(dir.path().join("src.bin"), BIN).unwrap();
+    fs::write(dir.path().join("plain.txt"), "hello world\n").unwrap();
+    let kernel = kernel_at(dir.path());
+    let result = kernel
+        .execute("b=$(cat src.bin); grep --ftype=$b pattern plain.txt")
+        .await
+        .unwrap();
+    assert_ne!(result.code, 0, "err={}", result.err);
+    assert!(
+        result.err.contains("cannot be used as"),
+        "error should name the binary problem, got err={:?}",
+        result.err
+    );
+}


### PR DESCRIPTION
## Summary

Closes #116.

The #93 item-1 pass closed the five primary text sinks (string interpolation, `echo`, `printf`, path positionals, redirect targets, `==`/`in`/case-glob) but explicitly scoped out a `key=value` (`WordAssign`) reassembly cluster and a few builtins' own scalar fallbacks — this PR closes those, all through the same existing `value_to_text_sink_named` guard so the error wording matches every other sink from #93.

## What's fixed

- **kernel.rs's async binder**: `consume_flag_positionals`'s `-v a=$BIN` reassembly, `test`'s raw-argv `Named`/`WordAssign` arms, and the general `key=value` → positional fallback (`dd if=$BIN`, `cat foo=$BIN`).
- **scheduler/pipeline.rs's sync twin** of the same `WordAssign` fallback (the scatter/gather flag-value path), with its own direct unit test since scatter/gather is the only script-level route to it.
- **`alias`/`unalias`** (name, value, and bare-positional forms), **`unset`**, and **`kill --signal`**'s named-flag fallback (the positional target form was already guarded before this PR).
- **`read_repeatable_strings`** (shared by `grep`/`glob` for `--ftype`/`--ftype-not`/`--include`/`--exclude`): changed to return `Result` and now guards both its scalar fallback *and* its `Json(Array)` arm. The array case turned up a second, worse bug along the way: a single binary `--ftype` occurrence is JSON-encoded as a base64 byte envelope by the binder, and the old `filter_map(v.as_str())` silently **dropped** that entry rather than erroring — the filter just vanished and the command ran unfiltered against real data.
- **`test` builtin's own bare-truthiness and `-z`/`-n` operators** — found via kaibo review of the rest of this diff. kernel.rs's raw-argv fast path intentionally leaves `test`'s bare-positional arm untouched (it needs the real type for other comparisons), so the guard belongs inside `test` itself, mirroring the guard its `-e`/`-f`/`-d`/... path operators already had two lines down.

## Deliberately left out of scope

- `dd.rs`'s own positional `value_to_string` fallback — already unreachable/loud via the binder fix above for the realistic `dd if=$BIN` case; a bare non-word-assign binary positional there only arises from directly-constructed `ToolArgs` in a unit test, not a real script.
- Internal `PATH`/`TMPDIR` scope-variable reads (`which.rs`, `spawn.rs`, `exec.rs`, `mktemp.rs`, `kernel.rs::try_execute_external`) — these read kernel-scope vars set only via `initial_vars`, never plausibly user-controlled `Value::Bytes`.

## Review

Reviewed via `mcp__kaibo__consult` (cast: deepseek), read-only over the actual current files (no diff handed over, so the review was holistic rather than diff-scoped). It confirmed the eight originally-changed sites were correct and that `read_repeatable_strings`'s new `Result` signature is handled by all 8 call sites, and it surfaced one real additional finding (the `test` builtin's bare-truthiness/`-z`/`-n` gap above), which is folded into this PR's second commit.

## Test plan

- [x] Every new test was checked against a temporarily hand-reverted version of its fix and confirmed to fail there, then confirmed to pass with the fix restored.
- [x] `cargo test --all` — clean, all real and doc tests pass.
- [x] `cargo clippy --all --all-targets` — zero warnings.
- [x] kaibo review (deepseek) — one finding, folded in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)