### PR TITLE
fix(spawn): kill_on_drop so a timed-out child is actually killed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -150,6 +150,12 @@ breaking entries are marked **BREAKING**.
   end-of-flags marker. Also broke `echo --=x` (→ `= x`), `echo --1` (→ `1`),
   and made `echo -- ---` a parse error (the spurious marker collided with the
   real `--`). All now lex as one literal word (#137).
+- **`spawn --timeout` no longer leaks the child process.** On timeout, the
+  `wait_with_output()` future (and the `Child` it owned) was dropped without
+  `kill_on_drop` set on the `Command`, so the OS process kept running past the
+  124 exit — a real leak for a long-lived agent that repeatedly times out
+  spawned commands. `kill_on_drop(true)` is now set at command construction,
+  mirroring the existing precedent in `dispatch.rs`/`kernel.rs`.
 
 ### Added
 - **The REPL announces finished background jobs at the next prompt and reaps

--- a/crates/kaish-kernel/src/tools/builtin/spawn.rs
+++ b/crates/kaish-kernel/src/tools/builtin/spawn.rs
@@ -181,6 +181,15 @@ impl Tool for Spawn {
         // Build command
         let mut cmd = Command::new(&command);
         cmd.args(&argv);
+        // Ensure the OS process is killed if this Command/Child is dropped
+        // before we've waited on it. This is exactly what happens on the
+        // timeout arm below: tokio::time::timeout drops the owned
+        // wait_with_output() future (and the Child inside it) when it fires,
+        // and without kill_on_drop the process was silently left running
+        // past the timeout — a real leak for a long-lived agent that
+        // repeatedly hits spawn timeouts. Mirrors the same call in
+        // dispatch.rs and the "backstop" kill_on_drop in kernel.rs.
+        cmd.kill_on_drop(true);
 
         // Set working directory if specified
         if let Some(ref dir) = cwd {
@@ -238,8 +247,9 @@ impl Tool for Spawn {
                 Ok(Ok(output)) => capture_to_result(output.status.code(), output.stdout, output.stderr),
                 Ok(Err(e)) => ExecResult::failure(1, format!("spawn: failed to wait: {}", e)),
                 Err(_) => {
-                    // Timeout - process is still running but we can't kill it
-                    // because wait_with_output took ownership. Return timeout error.
+                    // Timeout — dropping this future drops the owned Child;
+                    // kill_on_drop (set above) kills and reaps the process
+                    // as part of that drop, so it does not outlive us.
                     ExecResult::failure(124, format!("spawn: {}: timed out after {}ms", command, ms))
                 }
             }

--- a/crates/kaish-kernel/tests/spawn_timeout_kill_tests.rs
+++ b/crates/kaish-kernel/tests/spawn_timeout_kill_tests.rs
@@ -1,0 +1,52 @@
+//! `spawn --timeout` must actually kill the child process, not just report a
+//! 124 timeout while leaving the OS process running.
+//!
+//! Before this fix, the timeout arm in `Spawn::execute` wrapped
+//! `child.wait_with_output()` in `tokio::time::timeout` and, on expiry, simply
+//! dropped that future (and the `Child` it owned) without `kill_on_drop`
+//! having been set on the underlying `Command`. Tokio only kills a child on
+//! `Drop` if `kill_on_drop(true)` was set at construction, so the dropped
+//! future left the real OS process running past the timeout — a leak that
+//! accumulates indefinitely in a long-lived agent that repeatedly times out
+//! spawned commands.
+//!
+//! This proves the process itself is gone, not just that `spawn` returned
+//! exit code 124: it spawns a shell that sleeps longer than the timeout and
+//! then touches a marker file, and asserts the marker is never created even
+//! after waiting past the sleep duration.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+#![cfg(all(target_os = "linux", feature = "subprocess"))]
+
+use std::path::Path;
+
+use kaish_kernel::{Kernel, KernelConfig};
+
+fn kernel_at(dir: &Path) -> Kernel {
+    let config = KernelConfig::repl().with_cwd(dir.to_path_buf());
+    Kernel::new(config).expect("kernel")
+}
+
+#[tokio::test]
+async fn spawn_timeout_kills_child_process_does_not_leak() {
+    let tmp = tempfile::tempdir().unwrap();
+    let marker = tmp.path().join("marker");
+    let kernel = kernel_at(tmp.path());
+
+    // Sleep (0.3s) comfortably outlasts the timeout (50ms); if the child is
+    // genuinely killed, it never reaches the `touch`.
+    let script = format!(
+        r#"spawn --command sh --argv '["-c", "sleep 0.3; touch {}"]' --timeout 50"#,
+        marker.display()
+    );
+    let result = kernel.execute(&script).await.expect("kernel execute");
+    assert_eq!(result.code, 124, "expected timeout exit code: {:?}", result.err);
+
+    // Give the leaked-process window (the 0.3s sleep) time to elapse, then
+    // confirm the marker was never created — proof the child was actually
+    // killed, not left running in the background past the timeout.
+    tokio::time::sleep(std::time::Duration::from_millis(700)).await;
+    assert!(
+        !marker.exists(),
+        "child process kept running past the timeout — leaked"
+    );
+}


### PR DESCRIPTION
## Summary

`spawn --timeout` wrapped `child.wait_with_output()` in `tokio::time::timeout`. When the timeout fired, that future (and the `Child` it owned) was simply dropped — but the underlying `tokio::process::Command` never set `kill_on_drop(true)`, so tokio did not signal the process on drop. The OS process kept running in the background past the reported 124 exit code. For a long-lived agent process that repeatedly hits spawn timeouts, this is a real resource leak: orphaned children accumulate indefinitely, not just a cosmetic exit-code issue.

- Added `cmd.kill_on_drop(true);` right after building the `Command`, mirroring the existing precedent already in this codebase (`dispatch.rs` sets it the same way; `kernel.rs` has its own "backstop for kill on drop" comment doing the same on its capture-wait path). Deliberately did **not** wire `spawn` into the kernel's full `wait_or_kill`/`kill_with_grace` SIGTERM-then-grace-then-SIGKILL machinery (tied to the global `CancellationToken`) — that felt like scope creep for a local per-call timeout; `kill_on_drop(true)` alone is the documented minimal fix.
- Updated a stale comment on the timeout arm that had gone out of sync with the fix (caught by kaibo review, see below).

## Test plan

New test `crates/kaish-kernel/tests/spawn_timeout_kill_tests.rs` proves the OS process is actually killed, not just that `spawn` reports 124: it spawns a shell that sleeps (0.3s) longer than the timeout (50ms) and then touches a marker file, then asserts the marker is never created even after waiting well past the sleep window. Confirmed this fails against the pre-fix code (marker appears — the leak) and passes after the fix (marker absent).

- [x] `cargo test --all` clean (118 test binaries/doctests, 0 failed)
- [x] `cargo clippy --all --all-targets` clean (0 warnings, 0 errors)
- [x] Existing `test_spawn_with_timeout` unit test unaffected
- [x] Reviewed via kaibo (cast: deepseek) — confirmed `kill_on_drop` is sufficient (pipe-draining inside `wait_with_output` doesn't race with the kill/reap on drop) and flagged the stale comment noted above, which is now fixed

Closes #128