### PR TITLE
fix(seq,cut,awk): close ToolArgs::to_argv() ordering hazards found in the GH #120 audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,13 @@ breaking entries are marked **BREAKING**.
   (`transient`/`named`/`isolated`) keep the unfiltered default.
 
 ### Fixed
+- **`seq --separator` now errors loudly on a binary value instead of splicing
+  the `[binary: N bytes]` placeholder between the generated numbers** (GH
+  #120). `seq` read its own clap-parsed field before the untouched raw
+  `ToolArgs` value — `to_argv()`'s re-serialization had already stringified
+  the binary into the placeholder by the time clap saw it, so the guarded
+  fallback branch never ran. Reordered to check the raw value first, mirroring
+  the `checksum --check`/`patch --file` fix from the #93 item-1 PR.
 - **`scatter --timeout` no longer misclassifies a worker that completes right
   at the timeout boundary as timed out.** A worker whose command finished at
   (or a hair before) the deadline could read the timeout flag after the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,13 +31,18 @@ breaking entries are marked **BREAKING**.
   (`transient`/`named`/`isolated`) keep the unfiltered default.
 
 ### Fixed
-- **`seq --separator` now errors loudly on a binary value instead of splicing
-  the `[binary: N bytes]` placeholder between the generated numbers** (GH
-  #120). `seq` read its own clap-parsed field before the untouched raw
-  `ToolArgs` value — `to_argv()`'s re-serialization had already stringified
-  the binary into the placeholder by the time clap saw it, so the guarded
-  fallback branch never ran. Reordered to check the raw value first, mirroring
-  the `checksum --check`/`patch --file` fix from the #93 item-1 PR.
+- **`seq --separator`, `cut --fields`/`--characters`, and `awk
+  --field-separator` now error loudly on a binary value** instead of
+  silently misbehaving (GH #120). All three read their own clap-parsed field
+  before the untouched raw `ToolArgs` value — `to_argv()`'s re-serialization
+  had already stringified the binary into a `[binary: N bytes]` placeholder
+  by the time clap saw it, so a guard added only on the raw-value fallback
+  never ran. `seq` spliced the placeholder text between the generated
+  numbers; `cut` silently parsed it as zero valid field/character indices and
+  emitted one blank line per input line; `awk` set it as the literal `FS`,
+  so every line silently became a single field. Reordered all three to check
+  the raw value first, mirroring the `checksum --check`/`patch --file` fix
+  from the #93 item-1 PR.
 - **`scatter --timeout` no longer misclassifies a worker that completes right
   at the timeout boundary as timed out.** A worker whose command finished at
   (or a hair before) the deadline could read the timeout flag after the

--- a/crates/kaish-kernel/src/tools/builtin/awk.rs
+++ b/crates/kaish-kernel/src/tools/builtin/awk.rs
@@ -105,12 +105,39 @@ impl Tool for Awk {
             Err(e) => return ExecResult::failure(1, format!("awk: {}", e)),
         };
 
-        // Get field separator (clap value first, then legacy named fallback)
-        let field_sep = parsed
-            .field_separator
-            .clone()
-            .or_else(|| args.get_string("field_separator", usize::MAX))
-            .or_else(|| args.get_string("F", usize::MAX));
+        // Read the raw ToolArgs value FIRST, not `parsed.field_separator`
+        // (GH #120): `to_argv()` stringifies a `Value::Bytes` into the
+        // `[binary: N bytes]` placeholder before clap ever parses it, so
+        // checking the clap field first would hide a binary `-F`/
+        // `--field-separator` value entirely. There's no downstream
+        // validation to catch it either — the placeholder would just become
+        // awk's literal `FS`, which never matches real input, so every line
+        // silently becomes a single field instead of erroring (found via
+        // kaibo review of this PR). Mirrors the `seq --separator` fix.
+        //
+        // The raw `ToolArgs.named` key is whatever the user literally typed
+        // (kernel.rs's `Arg::Named` binder inserts under the token's own flag
+        // name, not a canonicalized one) — check every spelling the schema
+        // accepts (kebab long name, its `field_separator` visible_alias, and
+        // the short `-F`), not just the one the pre-existing legacy fallback
+        // below happened to check.
+        let field_sep = match args
+            .get("field-separator", usize::MAX)
+            .or_else(|| args.get("field_separator", usize::MAX))
+            .or_else(|| args.get("F", usize::MAX))
+        {
+            Some(v @ crate::ast::Value::Bytes(_)) => {
+                match crate::interpreter::value_to_text_sink_named(v, "a field separator") {
+                    Ok(s) => Some(s),
+                    Err(e) => return ExecResult::failure(1, format!("awk: {e}")),
+                }
+            }
+            _ => parsed
+                .field_separator
+                .clone()
+                .or_else(|| args.get_string("field_separator", usize::MAX))
+                .or_else(|| args.get_string("F", usize::MAX)),
+        };
 
         // Get input. A binary `path` operand goes loud rather than silently
         // falling through to the "no operand" branch (which reads stdin instead

--- a/crates/kaish-kernel/src/tools/builtin/cut.rs
+++ b/crates/kaish-kernel/src/tools/builtin/cut.rs
@@ -102,13 +102,38 @@ impl Tool for Cut {
             .or_else(|| args.get_string("d", usize::MAX))
             .unwrap_or_else(|| "\t".to_string());
 
-        let fields = parsed.fields.clone()
-            .or_else(|| args.get_string("fields", usize::MAX))
-            .or_else(|| args.get_string("f", usize::MAX));
+        // Read the raw ToolArgs value FIRST for `fields`/`characters`, not
+        // `parsed.fields`/`parsed.characters` (GH #120): `to_argv()` stringifies
+        // a `Value::Bytes` into the `[binary: N bytes]` placeholder before clap
+        // ever parses it, so checking the clap field first would hide a binary
+        // spec entirely. Unlike `delimiter` (guarded by the `chars().count() >
+        // 1` check below) a binary spec here has no downstream validation to
+        // catch it: `select_indices` silently parses "[binary: N bytes]" as
+        // zero valid indices (no digits, no `-`), so cut would silently emit
+        // one blank line per input line instead of erroring (found via kaibo
+        // review of this PR — my first pass wrongly classified this as
+        // already-loud like `delimiter`). Mirrors the `seq --separator` fix.
+        let fields = match args.get("fields", usize::MAX).or_else(|| args.get("f", usize::MAX)) {
+            Some(v @ Value::Bytes(_)) => match crate::interpreter::value_to_text_sink_named(v, "a fields spec") {
+                Ok(s) => Some(s),
+                Err(e) => return ExecResult::failure(1, format!("cut: {e}")),
+            },
+            _ => parsed.fields.clone()
+                .or_else(|| args.get_string("fields", usize::MAX))
+                .or_else(|| args.get_string("f", usize::MAX)),
+        };
 
-        let characters = parsed.characters.clone()
-            .or_else(|| args.get_string("characters", usize::MAX))
-            .or_else(|| args.get_string("c", usize::MAX));
+        // Same guard as `fields` above, same reasoning: `select_indices` on
+        // the placeholder silently yields zero character indices.
+        let characters = match args.get("characters", usize::MAX).or_else(|| args.get("c", usize::MAX)) {
+            Some(v @ Value::Bytes(_)) => match crate::interpreter::value_to_text_sink_named(v, "a characters spec") {
+                Ok(s) => Some(s),
+                Err(e) => return ExecResult::failure(1, format!("cut: {e}")),
+            },
+            _ => parsed.characters.clone()
+                .or_else(|| args.get_string("characters", usize::MAX))
+                .or_else(|| args.get_string("c", usize::MAX)),
+        };
 
         if delimiter.chars().count() > 1 {
             return ExecResult::failure(1, "cut: delimiter must be a single character");

--- a/crates/kaish-kernel/src/tools/builtin/seq.rs
+++ b/crates/kaish-kernel/src/tools/builtin/seq.rs
@@ -124,10 +124,28 @@ impl Tool for Seq {
             return ExecResult::failure(1, "seq: increment cannot be zero");
         }
 
-        let separator = parsed.separator.clone()
-            .or_else(|| args.get_string("separator", usize::MAX))
-            .or_else(|| args.get_string("s", usize::MAX))
-            .unwrap_or_else(|| "\n".to_string());
+        // Read the untouched raw value FIRST, not `parsed.separator` (GH #120):
+        // `parsed.separator` comes from `to_argv()`'s re-serialization, which
+        // stringifies a `Value::Bytes` into the `[binary: N bytes]` placeholder
+        // before clap ever sees it — checking the clap field first would let
+        // that placeholder silently win as the separator, spliced verbatim
+        // between the generated numbers with no validation to catch it
+        // (unlike e.g. `checksum --algo`, whose downstream allowlist check
+        // happens to make a placeholder loud-but-confusing rather than
+        // silent). Mirrors the `checksum --check`/`patch --file` reorder from
+        // the #93 item-1 PR.
+        let separator = match args.get("separator", usize::MAX).or_else(|| args.get("s", usize::MAX)) {
+            Some(v @ Value::Bytes(_)) => {
+                match crate::interpreter::value_to_text_sink_named(v, "a separator") {
+                    Ok(s) => s,
+                    Err(e) => return ExecResult::failure(1, format!("seq: {e}")),
+                }
+            }
+            _ => parsed.separator.clone()
+                .or_else(|| args.get_string("separator", usize::MAX))
+                .or_else(|| args.get_string("s", usize::MAX))
+                .unwrap_or_else(|| "\n".to_string()),
+        };
 
         let pad_width = parsed.width;
 

--- a/crates/kaish-kernel/tests/binary_text_sink_tests.rs
+++ b/crates/kaish-kernel/tests/binary_text_sink_tests.rs
@@ -477,6 +477,54 @@ async fn seq_separator_binary_is_loud() {
     assert_loud_binary("b=$(cat src.bin); seq --separator=$b 1 3").await;
 }
 
+/// `cut --fields=$BIN` (GH #120, found via kaibo review of this PR's own
+/// audit): my first pass wrongly classified `fields`/`characters` as
+/// already-loud like `delimiter` — in fact `select_indices` silently parses
+/// the `[binary: N bytes]` placeholder as zero valid indices (no digits, no
+/// `-`), so `cut` would silently emit one blank line per input line instead
+/// of erroring. Same clap-field-first ordering hazard as `seq --separator`.
+#[tokio::test]
+async fn cut_fields_binary_is_loud_not_blank_output() {
+    let dir = tempdir().unwrap();
+    fs::write(dir.path().join("src.bin"), BIN).unwrap();
+    let kernel = kernel_at(dir.path());
+    let result = kernel
+        .execute(r#"b=$(cat src.bin); echo "a,b,c" | cut --fields=$b -d,"#)
+        .await
+        .unwrap();
+    assert_ne!(result.code, 0, "err={}", result.err);
+    assert!(result.err.contains("cannot be used as"), "err={:?}", result.err);
+    assert!(
+        !result.text_out().contains('\n') || result.text_out().is_empty(),
+        "must not silently emit blank output lines: {:?}",
+        result.text_out()
+    );
+}
+
+/// `cut --characters=$BIN` — same class as `fields` above.
+#[tokio::test]
+async fn cut_characters_binary_is_loud_not_blank_output() {
+    let dir = tempdir().unwrap();
+    fs::write(dir.path().join("src.bin"), BIN).unwrap();
+    let kernel = kernel_at(dir.path());
+    let result = kernel
+        .execute("b=$(cat src.bin); echo abcdef | cut --characters=$b")
+        .await
+        .unwrap();
+    assert_ne!(result.code, 0, "err={}", result.err);
+    assert!(result.err.contains("cannot be used as"), "err={:?}", result.err);
+}
+
+/// `awk --field-separator=$BIN` (GH #120, missed in the original audit, found
+/// via kaibo review): the placeholder would silently become awk's literal
+/// `FS` — since it never matches real input, every line becomes a single
+/// field instead of erroring. Same clap-field-first ordering hazard.
+#[tokio::test]
+async fn awk_field_separator_binary_is_loud() {
+    assert_loud_binary(r#"b=$(cat src.bin); echo "a:b:c" | awk --field-separator=$b '{print $2}'"#)
+        .await;
+}
+
 /// `cmp`'s two file operands used to be read off `parsed.paths` (the
 /// clap-parsed, `to_argv()`-serialized field) instead of `args.positional` —
 /// found via a third kaibo pass over this PR. A binary first operand silently

--- a/crates/kaish-kernel/tests/binary_text_sink_tests.rs
+++ b/crates/kaish-kernel/tests/binary_text_sink_tests.rs
@@ -465,6 +465,18 @@ async fn checksum_binary_check_override_is_loud() {
     assert_loud_binary("b=$(cat src.bin); checksum --check=$b").await;
 }
 
+/// `seq --separator=$BIN` (GH #120): `parsed.separator` comes from clap's
+/// re-parse of `to_argv()`'s output, which already stringified the binary
+/// value into the `[binary: N bytes]` placeholder by the time clap sees it —
+/// checking the clap field before the untouched raw `ToolArgs` value hides a
+/// binary separator entirely, silently splicing the placeholder text between
+/// the generated numbers instead of erroring. Mirrors the checksum/patch
+/// reorder fix from the #93 item-1 PR.
+#[tokio::test]
+async fn seq_separator_binary_is_loud() {
+    assert_loud_binary("b=$(cat src.bin); seq --separator=$b 1 3").await;
+}
+
 /// `cmp`'s two file operands used to be read off `parsed.paths` (the
 /// clap-parsed, `to_argv()`-serialized field) instead of `args.positional` —
 /// found via a third kaibo pass over this PR. A binary first operand silently


### PR DESCRIPTION
## Summary

Closes #120.

`ToolArgs::to_argv()` (`crates/kaish-types/src/tool.rs`) stringifies a `Value::Bytes` argument into the `[binary: N bytes]` placeholder before clap ever parses it — a known, deliberately-deferred gap. The full fix would make `to_argv()` itself return `Result`, which ripples across every call site in the crate — too big and risky for this narrow audit, so that's filed separately as #164 and explicitly out of scope here.

The consequence for individual builtins: a tool using the common idiom `parsed.field.clone().or_else(|| args.get_string("field", ..))` sees the already-corrupted placeholder in `parsed.field` first, and never reaches a guard added only on the `args.get_string(...)` fallback branch (that branch only runs when the clap field is `None`, and the placeholder is very much `Some`).

## What's fixed

Audited every `Option<String>` named-flag using this exact clap-field-first idiom across `tools/builtin/*.rs`. Three sites turned out to be genuinely **silent** (a binary value produces a wrong-but-successful result, no error at all) — those are fixed here, each reordered to check the raw `ToolArgs` value first (mirroring the `checksum --check`/`patch --file` reorder from the #93 item-1 PR):

- **`seq --separator`** — the placeholder would be spliced verbatim between the generated numbers.
- **`cut --fields`/`--characters`** — `select_indices` silently parses the placeholder as zero valid indices (no digits, no `-`), so `cut` emits one blank line per input line instead of erroring.
- **`awk --field-separator`/`-F`** — the placeholder would silently become awk's literal `FS`; since it never matches real input, every line becomes a single field with no error.

The `awk` fix needed one extra wrinkle: kernel.rs's `Arg::Named` binder stores the raw `ToolArgs.named` key under whatever flag spelling the user actually typed, not a canonicalized name — so the raw-value check has to try every spelling the schema accepts (`field-separator`, its `field_separator` alias, and `-F`), not just the one spelling the pre-existing legacy fallback happened to check.

## Left as-is (loud-but-confusing, not silent)

- `checksum --algo` — an unrecognized value hits a strict allowlist check and errors.
- `cut --delimiter` — a multi-char value (the placeholder is 19 chars) is rejected by its own length check.
- `tokens --encoding` — same allowlist shape as `checksum --algo`.
- `mktemp --template`/`-t` — already reads the raw `ToolArgs` value first; not vulnerable to this ordering at all.

These all produce a real, nonzero-exit error today — just one that mentions the placeholder text rather than "binary data" by name. Fixing them for a cleaner message would mean either a shared helper or a broader reorder across more files, which is closer to the full `to_argv()` rework already deferred to #164 than this narrow audit.

## Note on scope

This PR grew from 1 fix to 3 over two rounds of kaibo review: the first round confirmed `seq`'s fix but flagged that my own classification of `cut --fields`/`--characters` as "already loud" was wrong, and separately surfaced `awk`'s `-F` as a missed site entirely. A second round of review (after fixing those two) confirmed both new fixes are correct and that no further site of this shape remains in `tools/builtin/*.rs`.

## Review

Reviewed via `mcp__kaibo__consult` (cast: deepseek), twice — once after the `seq` fix (surfaced the `cut`/`awk` misses, folded into a second commit), and again after that second commit specifically to check the two new fixes and confirm no third site remains.

## Test plan

- [x] Every new test was checked against a temporarily hand-reverted version of its fix and confirmed to fail there, then confirmed to pass with the fix restored.
- [x] `cargo test --all` — clean, all real and doc tests pass.
- [x] `cargo clippy --all --all-targets` — zero warnings.
- [x] kaibo review (deepseek), two rounds — both clean on the final diff.
- [x] Filed #164 for the deferred `to_argv() -> Result` root-cause fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)