### PR TITLE
chore: bump to v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ breaking entries are marked **BREAKING**.
 
 ## [Unreleased]
 
+## [0.12.0] - 2026-07-12
+
 ### Added
 - **`jobs --json` rows and scatter/gather rows carry the confirmation-latch
   object** for a `Latched` entry (nonce/paths/hint/ttl) — a caller can act on
@@ -173,6 +175,24 @@ breaking entries are marked **BREAKING**.
   `-s`/`--slurp` branch was ever consulted, so `jq -n -s '.'` produced `null`
   instead of real jq's `[null]` — `-s` unconditionally wraps its input, even
   the `-n` synthetic document (GH #111).
+- **`VirtualOverlayBackend` no longer reserves the whole `/v` tree — an
+  embedder can mount its own storage under it** (GH #118). `is_virtual_path`
+  matched any `/v`/`/v/…` path lexically before consulting the mount table, so
+  an embedder mounting under `/v` (e.g. kaijutsu's CAS at `/v/cas`) found its
+  own paths shadowed to `NotFound`, while surfaces that bypass the overlay saw
+  the real content — two different `/v/x` depending on the surface, silently.
+  Routing is now purely mount-coverage based: an unclaimed `/v/*` path
+  delegates to the embedder's backend and hits the embedder's own
+  read-only/write gate. A synthesized shared-ancestor directory (a path like
+  `/v` that sits above kaish's mounts but isn't itself one) is now handled
+  consistently everywhere — `stat`/`lstat`/`exists`/`list` all agree it's a
+  read-only union directory (a real kaish mount shadows a same-named embedder
+  entry), and any direct mutation (`rm`/`mkdir`/`touch`/write/rename/…) is
+  refused with a clear error instead of a misleading `NotFound` (closing a
+  `rm -rf /v` half-delete risk). Also fixes `ls /v` returning nothing, `ls /`
+  dropping `dev`, and a stale `is_trash_excluded` `/v` clause that would have
+  silently exempted an embedder's newly-reachable real content under `/v`
+  from trash/latch protection.
 
 ### Added
 - **The REPL announces finished background jobs at the next prompt and reaps
@@ -1355,7 +1375,8 @@ Initial public release of **kaish** (会sh) — a predictable Bourne-like shell 
 - **REPL** (`kaish-repl`) with multi-line input, completion, and history; **MCP server** (`kaish-mcp`) exposing `kaish_execute` with help resources and structured + plain-text content blocks.
 - **`KernelClient` trait** + `EmbeddedClient` for in-process embedding; topic-based help system; `kaish-wasi` `wasm32-wasip1` target.
 
-[Unreleased]: https://github.com/tobert/kaish/compare/v0.11.0...HEAD
+[Unreleased]: https://github.com/tobert/kaish/compare/v0.12.0...HEAD
+[0.12.0]: https://github.com/tobert/kaish/compare/v0.11.0...v0.12.0
 [0.11.0]: https://github.com/tobert/kaish/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/tobert/kaish/compare/v0.9.1...v0.10.0
 [0.9.1]: https://github.com/tobert/kaish/compare/v0.9.0...v0.9.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -965,7 +965,7 @@ dependencies = [
 
 [[package]]
 name = "kaish-client"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -979,7 +979,7 @@ dependencies = [
 
 [[package]]
 name = "kaish-glob"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "ignore",
@@ -991,14 +991,14 @@ dependencies = [
 
 [[package]]
 name = "kaish-help"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "kaish-types",
 ]
 
 [[package]]
 name = "kaish-kernel"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "ariadne",
@@ -1054,7 +1054,7 @@ dependencies = [
 
 [[package]]
 name = "kaish-repl"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1075,7 +1075,7 @@ dependencies = [
 
 [[package]]
 name = "kaish-tool-api"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "clap",
@@ -1085,7 +1085,7 @@ dependencies = [
 
 [[package]]
 name = "kaish-tools-host"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "clap",
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "kaish-types"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "base64",
  "schemars",
@@ -1108,7 +1108,7 @@ dependencies = [
 
 [[package]]
 name = "kaish-vfs"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "getrandom 0.3.4",
@@ -1119,7 +1119,7 @@ dependencies = [
 
 [[package]]
 name = "kaish-wasi"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "kaish-kernel",
  "kaish-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.11.0"
+version = "0.12.0"
 edition = "2024"
 rust-version = "1.85"
 authors = ["Amy Tobey <tobert@gmail.com>"]

--- a/crates/kaish-client/Cargo.toml
+++ b/crates/kaish-client/Cargo.toml
@@ -13,7 +13,7 @@ categories.workspace = true
 readme = "../../README.md"
 
 [dependencies]
-kaish-kernel = { path = "../kaish-kernel", version = "0.11.0" }
+kaish-kernel = { path = "../kaish-kernel", version = "0.12.0" }
 
 # Async runtime
 tokio = { workspace = true }

--- a/crates/kaish-help/Cargo.toml
+++ b/crates/kaish-help/Cargo.toml
@@ -13,7 +13,7 @@ categories.workspace = true
 readme = "../../README.md"
 
 [dependencies]
-kaish-types = { path = "../kaish-types", version = "0.11.0" }
+kaish-types = { path = "../kaish-types", version = "0.12.0" }
 
 [lints]
 workspace = true

--- a/crates/kaish-kernel/Cargo.toml
+++ b/crates/kaish-kernel/Cargo.toml
@@ -14,11 +14,11 @@ readme = "../../README.md"
 exclude = ["tests/snapshots/"]
 
 [dependencies]
-kaish-glob = { path = "../kaish-glob", version = "0.11.0" }
-kaish-types = { path = "../kaish-types", version = "0.11.0", features = [] }
-kaish-help = { path = "../kaish-help", version = "0.11.0" }
-kaish-tool-api = { path = "../kaish-tool-api", version = "0.11.0" }
-kaish-vfs = { path = "../kaish-vfs", version = "0.11.0", features = ["memory", "overlay"] }
+kaish-glob = { path = "../kaish-glob", version = "0.12.0" }
+kaish-types = { path = "../kaish-types", version = "0.12.0", features = [] }
+kaish-help = { path = "../kaish-help", version = "0.12.0" }
+kaish-tool-api = { path = "../kaish-tool-api", version = "0.12.0" }
+kaish-vfs = { path = "../kaish-vfs", version = "0.12.0", features = ["memory", "overlay"] }
 
 # Async runtime — minimal base; `localfs` adds tokio/fs, `subprocess` adds
 # tokio/process + tokio/rt-multi-thread (see [features]).
@@ -83,7 +83,7 @@ jaq-json = { workspace = true }
 # Optional deps, each pulled in by its capability feature:
 #   kaish-tools-host → host, trash/directories → os-integration,
 #   tiktoken-rs → tokens.
-kaish-tools-host = { path = "../kaish-tools-host", version = "0.11.0", optional = true }
+kaish-tools-host = { path = "../kaish-tools-host", version = "0.12.0", optional = true }
 trash = { workspace = true, optional = true }
 directories = { workspace = true, optional = true }
 tiktoken-rs = { workspace = true, optional = true }

--- a/crates/kaish-repl/Cargo.toml
+++ b/crates/kaish-repl/Cargo.toml
@@ -19,8 +19,8 @@ path = "src/main.rs"
 [dependencies]
 # The REPL is the full interactive human shell: it needs every capability
 # (external commands + job control, git, host introspection, tokens, trash).
-kaish-kernel = { path = "../kaish-kernel", version = "0.11.0", features = ["full"] }
-kaish-client = { path = "../kaish-client", version = "0.11.0" }
+kaish-kernel = { path = "../kaish-kernel", version = "0.12.0", features = ["full"] }
+kaish-client = { path = "../kaish-client", version = "0.12.0" }
 
 # Line editing
 rustyline = { workspace = true }

--- a/crates/kaish-tool-api/Cargo.toml
+++ b/crates/kaish-tool-api/Cargo.toml
@@ -12,7 +12,7 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-kaish-types = { path = "../kaish-types", version = "0.11.0", features = [] }
+kaish-types = { path = "../kaish-types", version = "0.12.0", features = [] }
 
 async-trait = { workspace = true }
 clap = { workspace = true }

--- a/crates/kaish-tools-host/Cargo.toml
+++ b/crates/kaish-tools-host/Cargo.toml
@@ -12,8 +12,8 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-kaish-types = { path = "../kaish-types", version = "0.11.0", features = [] }
-kaish-tool-api = { path = "../kaish-tool-api", version = "0.11.0" }
+kaish-types = { path = "../kaish-types", version = "0.12.0", features = [] }
+kaish-tool-api = { path = "../kaish-tool-api", version = "0.12.0" }
 
 async-trait = { workspace = true }
 clap = { workspace = true }

--- a/crates/kaish-vfs/Cargo.toml
+++ b/crates/kaish-vfs/Cargo.toml
@@ -12,7 +12,7 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-kaish-types = { path = "../kaish-types", version = "0.11.0", features = [] }
+kaish-types = { path = "../kaish-types", version = "0.12.0", features = [] }
 async-trait = { workspace = true }
 # DevFs's /dev/urandom pulls from the OS CSPRNG. Pure (no tokio); works on
 # Unix/macOS/WASI.

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -875,6 +875,27 @@ The `glob` builtin's `-a`/`--hidden` flag (and any hidden-inclusive walk) acts
 like `shopt -s dotglob`: bare wildcards then match dotfiles too. `find` includes
 hidden entries by default.
 
+### Ignore-aware filtering (`.gitignore`, `kaish-ignore`)
+
+The reference REPL is ignore-aware by default: interactive, `-c`, and script
+modes load `.gitignore` plus a default ignore list (`.git`, `node_modules`,
+`target`, `__pycache__`, `.venv`, `venv`, `dist`, `build`, `.next`) at
+**Advisory** scope. "Polite" file-walking tools (`glob`, `tree`, `grep -r`,
+`ls -R`) filter these out; `find` stays POSIX-unrestricted and always sees
+everything. A bare embedded kernel (`transient`/`named`/`isolated`) keeps the
+unfiltered default — only the reference REPL opts in.
+
+```sh
+glob '**/*.rs'                  # skips target/, .git/, etc. by default
+glob '**/*.rs' --no-ignore      # this call only: no filtering
+kaish-ignore clear              # this session: no filtering at all
+kaish-ignore                    # show current config
+```
+
+See `help ignore` for the full `kaish-ignore` builtin (`add`/`remove`/`clear`/
+`defaults`/`auto`/`scope`) and the Agent-mode Enforced scope, where `find`
+filters too.
+
 ## Error Handling
 
 ```sh
@@ -1225,6 +1246,7 @@ These are documented limitations of the current implementation:
 
 - **Scatter results in completion order** — The 散 (scatter) construct returns results in the order jobs complete, not input order. This is inherent to parallel execution—first done, first returned.
 - **Redirect targets are a single word** — Command substitution *works* in redirect targets and here-doc bodies (`cmd > $(gen-path)`, `cat < $(find-cfg)`). Because the target is one word and kaish doesn't paste adjacent tokens, quote any target that mixes literal text with an expansion: `> "/tmp/$(id -u).log"`, not the unquoted `> /tmp/$(id -u).log` (which is a parse error). See [Quoting](#quoting).
+- **Recursion is depth-guarded** — Command substitution (`$(...)`), shell-function calls, `.kai` script execution, and `source`/`.` all re-enter the interpreter on the native stack; a runaway or mutually recursive script (`f() { f; }; f`) hits a cap (`MAX_RECURSION_DEPTH`, 48 levels) and fails loudly with `maximum recursion depth exceeded` instead of overflowing the stack. See `docs/EMBEDDING.md` for the embedder-side stack-sizing contract.
 
 ### Performance
 


### PR DESCRIPTION
## Summary

Version bump + changelog stamp for the 0.12.0 release, covering everything merged since v0.11.0 (2026-07-04): 107 files, ~8300 insertions across the confirmation-latch surfacing pass (#96/#124), the recursion depth-guard + interpreter allocation/stack-shrink pass (#46/#47/#48), the `/v` overlay mount-coverage routing fix (#118), a large batch of silent-fallback binary-value fixes (#93/#116/#120/#121), REPL UX work (ignore-aware by default, CJK-correct tables, background-job auto-reap), and job-control fixes.

This is a **minor** bump, not a patch: the CHANGELOG's `## [0.12.0]` section carries an explicit `**BREAKING (embedders)**` entry (`ExecContext.tool_schemas` → `Arc<[ToolSchema]>`), new `#[non_exhaustive]` markers on `JobStatus`/`JobInfo`/`ToolResult`, a new `JobStatus::Latched` variant, and a default-behavior change (the reference REPL is now ignore-aware by default).

Independent kaibo review (deepseek) of everything since v0.11.0 found no release blockers — overlay routing and mutation-refusal semantics were verified correct, breaking changes are adequately called out, and test coverage is solid (one low-risk gap: scatter/gather latch rows are untested, tracked separately). It did surface a real changelog gap (the `/v` overlay fix, GH #118, had no bullet) and two documentation gaps (ignore-aware globbing and the recursion depth guard were undocumented in `docs/LANGUAGE.md`) — both fixed in this PR.

## Changes in this PR

- Bump workspace version + all 14 inter-crate `path + version` pins from 0.11.0 → 0.12.0
- Stamp `CHANGELOG.md`'s `Unreleased` section as `## [0.12.0] - 2026-07-12`, add a fresh empty `Unreleased`, update compare links
- Add a missing `CHANGELOG.md` bullet for the `/v` overlay mount-coverage fix (GH #118)
- Add `docs/LANGUAGE.md` coverage for ignore-aware globbing (`kaish-ignore`, GH #134) and the recursion depth guard (GH #46/#47)

## Test plan

- [x] `cargo test --all` — 118 test-result summaries, 0 failures
- [x] `cargo clippy --all --all-targets` — 0 warnings
- [x] `cargo insta test --check` — no pending snapshots
- [x] `cargo check --all` — version pins resolve at 0.12.0
- [x] kaibo (deepseek) release-readiness review — no blockers

🤖 Generated with [Claude Code](https://claude.com/claude-code)