### PR TITLE
docs: integrate CI into the contributor story

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,15 @@ cargo insta test --check                 # CI mode (fails on pending snapshots)
 cargo insta review                       # Interactive review of pending snapshots
 ```
 
+CI (`.github/workflows/ci.yml`) runs the gates on every PR and push to `main`:
+`cargo test --all --locked`, clippy with `-D warnings`, a committed-`.snap.new`
+tripwire, `cargo check -p kaish-kernel --no-default-features` (upgrading that
+leg to `cargo test` is GH #170), and the `kaish-wasi` wasm32-wasip1 build.
+When a gate changes, change ci.yml in the same PR. The runners track current
+stable Rust, which may be newer than local toolchains — CI clippy can fire
+lints local clippy doesn't have yet; fix the code rather than pinning the
+toolchain.
+
 The workspace denies `clippy::unwrap_used` and warns `clippy::expect_used` (see
 `[workspace.lints]` in the root `Cargo.toml`) to keep production code propagating
 errors. `clippy.toml` sets `allow-{unwrap,expect}-in-tests = true` so those
@@ -102,6 +111,8 @@ fixture IS the test failing). `cargo clippy --all` alone skips test targets — 
   - `cargo clippy --all --all-targets` — zero errors **and** zero warnings
     (`--all-targets` so test code is linted too; see Build Commands for the
     test-code allow convention)
+  CI enforces these (plus the sandbox and WASI legs) on the PR — run them
+  locally first anyway; the feedback loop is minutes faster.
 
 ### Commit messages
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # kaish (会sh)
 
+[![ci](https://github.com/tobert/kaish/actions/workflows/ci.yml/badge.svg)](https://github.com/tobert/kaish/actions/workflows/ci.yml)
+[![crates.io](https://img.shields.io/crates/v/kaish-kernel.svg)](https://crates.io/crates/kaish-kernel)
+
 <p align="center">
   <img src="docs/banner.svg" alt="Kai the hermit crab — kaish mascot — looking at kaish code" width="720">
 </p>
@@ -14,9 +17,9 @@ virtual filesystem that can pass through, stay in memory, or overlay the two.
 An embedded kaish gives an agent a complete scripting environment that can be
 constrained naturally.
 
-**Status:** 0.11, pre-1.0. The language has settled; what remains before 1.0 is
-ergonomics and correctness polish. Everything ships through
-[CHANGELOG.md](CHANGELOG.md).
+**Status:** pre-1.0 (current version on the badge above). The language has
+settled; what remains before 1.0 is ergonomics and correctness polish.
+Everything ships through [CHANGELOG.md](CHANGELOG.md).
 
 ## Why a shell for agents?
 
@@ -267,7 +270,14 @@ git clone https://github.com/tobert/kaish
 cd kaish
 cargo build --release
 cargo test --all
+cargo clippy --all --all-targets   # must be warning-free
 ```
+
+CI runs these same gates on every PR and push to `main` — plus a
+no-default-features check of the kernel (the capability-feature sandbox) and a
+`wasm32-wasip1` build of `kaish-wasi`. See
+[`.github/workflows/ci.yml`](.github/workflows/ci.yml); releases to crates.io
+are cut manually, so that one workflow is the whole CI story.
 
 ## Contributing
 
@@ -276,7 +286,9 @@ love seeing what other agents come up with. **All changes go through a PR** —
 branch, push, and open a PR rather than committing to `main` (releases are the
 exception). That said, please have your agent (or another model) review the PR
 before submitting — a few tokens on review goes a long way. Same goes for issues:
-agent-filed is fine, just make sure it makes sense.
+agent-filed is fine, just make sure it makes sense. CI must be green before a PR
+merges; note that the runners track current stable Rust, so clippy there may know
+lints your local toolchain doesn't yet.
 
 If you're working with AI coding agents, you might also be interested in
 [kaibo](https://github.com/tobert/kaibo), an assistant for you assistant with a

--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ cargo test --all
 cargo clippy --all --all-targets   # must be warning-free
 ```
 
-CI runs these same gates on every PR and push to `main` — plus a
+CI runs the test and clippy gates on every PR and push to `main` — plus a
 no-default-features check of the kernel (the capability-feature sandbox) and a
 `wasm32-wasip1` build of `kaish-wasi`. See
 [`.github/workflows/ci.yml`](.github/workflows/ci.yml); releases to crates.io

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -14,6 +14,49 @@ before it ships.
 
 ---
 
+## kaish gets CI, and CI immediately earns its keep (2026-07-13)
+
+Three years of shell projects say the first CI run never passes; kaish kept the
+streak. PR #169 added the repo's first GitHub Actions workflow — modeled on
+kaibo's (pinned-SHA actions, minimal permissions, per-ref concurrency) but
+encoding kaish's own CLAUDE.md gates: `cargo test --all --locked` + clippy
+`-D warnings` with `--all-targets`, the kernel's no-default-features leg, the
+`kaish-wasi` wasm32-wasip1 build, and a tripwire for committed `.snap.new`
+files. No release workflow on purpose: kaish ships crates, publishing stays the
+manual `/release` runbook, and kaibo's TLS-invariant guard didn't come along
+because kaish has no TLS surface.
+
+The first live run failed two of three jobs, and every failure was a
+pre-existing repo bug, not a workflow bug:
+
+- `non_interactive_stdin_is_dev_null` had been silently testing the wrong
+  process for who-knows-how-long. Its comment said "/bin/readlink to bypass the
+  builtin"; its code ran bare `readlink` — the kaish builtin — which resolves
+  the *test process's* fd/0. It only ever passed where the test runner itself
+  had stdin=/dev/null; GitHub's runner hands the step a pipe. Reproduced red
+  locally with `echo poke | cargo test …`, fixed by making code match comment.
+- The no-default-features leg was written as `cargo test`, which has **never
+  compiled** — `KernelConfig::repl()` is localfs-gated and ~25 test files call
+  it. The embarrassing part: local "verification" had piped cargo through
+  `tail`, reading tail's exit code. The documented invariant is "sandbox-mode
+  *compiles*", so the leg became `cargo check`; the test upgrade is GH #170.
+- Run two found a third class: CI's stable (1.97) out-lints local (1.96) —
+  `clippy::question_mark` got smarter and flagged a strip_prefix match in
+  ignore_config.rs. Fixed the code, didn't pin the toolchain; catching
+  toolchain drift is a feature, not a flake.
+
+A kaibo (deepseek) review of the workflow pre-push contributed the fourth fix:
+`.gitignore` had no `*.snap.new` entry, so the exact mistake the CI tripwire
+catches could still be staged locally by `git add .`.
+
+The doc sweep that followed (this PR) wired CI into the contributor story:
+README badge + gates in "Building from Source"/"Contributing" (and the stale
+"Status: 0.11" became badge-driven instead of hand-maintained), CLAUDE.md's
+gates section now names ci.yml as the enforcement point and warns about
+runner-vs-local clippy drift.
+
+---
+
 ## The REPL learns to read .gitignore — and kaish-ignore learns to persist (2026-07-06)
 
 Amy's call on #134: default to ignore-aware. The reference REPL had always run


### PR DESCRIPTION
Follow-up to #169: the workflow exists; this wires it into the docs contributors actually read, and serves as the final validation pass — this PR itself exercises the `pull_request` trigger on a fresh branch, and its merge will light the README badge from the `push`-to-main leg.

- **README**: ci badge + crates.io badge (kaish-kernel, the flagship embeddable crate). The `Status:` line stops hand-maintaining a version number — it had already drifted (said 0.11, we're on 0.12); the badge carries it now. "Building from Source" shows the clippy gate and points at `ci.yml`; "Contributing" notes CI must be green and warns that runners track current stable Rust, so CI clippy may know lints your local toolchain doesn't (this bit us live: 1.97's `question_mark` failed a run 1.96 passed).
- **CLAUDE.md**: Build Commands documents what CI runs, the keep-`ci.yml`-in-sync rule, and the fix-the-code-don't-pin-the-toolchain stance; the pre-commit gate list notes CI now enforces it.
- **docs/devlog.md**: the full arc of #169 — first run failed two of three jobs, every failure a pre-existing repo bug (builtin-shadowed `readlink` stdin test; a no-default-features test leg that never compiled → #170; toolchain-drift clippy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)