### PR TITLE
feat(clock): run the kernel in the browser (wasm32-unknown-unknown)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ breaking entries are marked **BREAKING**.
 
 ## [Unreleased]
 
+### Added
+- **The kernel runs in the browser** (`wasm32-unknown-unknown`) — clock
+  acquisition now routes through `kaish_types::clock` (`system_now()` plus
+  an `Instant` alias), which reads the JS clock via `web-time` on the
+  browser target and is exactly the std clock everywhere else (no new
+  dependency on native/WASI builds; types stay `std::time` in every
+  signature). Previously any wall-clock touch — including mounting a
+  `MemoryFs` — hit `std`'s unsupported-platform shim and panicked. Browser
+  embedders enable getrandom's `wasm_js` backend per its docs; the
+  kaish-extras `kaish-web` crate is a working embedding.
+
 ### Fixed
 - **Bare `${X:-${Y}}` works** (GH #173) — a nested braced reference in a
   default word outside quotes was a parse error (the `VarRef` token stopped at

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1104,6 +1104,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.17",
  "tokio-util",
+ "web-time",
 ]
 
 [[package]]

--- a/crates/kaish-kernel/Cargo.toml
+++ b/crates/kaish-kernel/Cargo.toml
@@ -153,3 +153,9 @@ tracing-subscriber = { workspace = true }
 
 [lints]
 workspace = true
+
+# Browser target: chrono's Local timezone math needs the JS environment
+# (wasmbind) on wasm32-unknown-unknown; every other target reads the OS
+# timezone as usual and never sees this.
+[target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dependencies]
+chrono = { workspace = true, features = ["wasmbind"] }

--- a/crates/kaish-kernel/src/lexer.rs
+++ b/crates/kaish-kernel/src/lexer.rs
@@ -36,7 +36,8 @@
 use logos::{Logos, Span};
 use std::fmt;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::UNIX_EPOCH;
+use kaish_types::clock::system_now;
 
 /// Global counter for generating unique markers across all tokenize calls.
 static MARKER_COUNTER: AtomicU64 = AtomicU64::new(0);
@@ -49,14 +50,16 @@ const MAX_PAREN_DEPTH: usize = 256;
 /// Generate a unique marker ID that's extremely unlikely to collide with user code.
 /// Uses a combination of timestamp, counter, and process ID.
 fn unique_marker_id() -> String {
-    let timestamp = SystemTime::now()
+    let timestamp = system_now()
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_nanos())
         .unwrap_or(0);
     let counter = MARKER_COUNTER.fetch_add(1, Ordering::Relaxed);
-    #[cfg(target_os = "wasi")]
+    // No process ids on any wasm target (WASI or the browser);
+    // std::process::id() is unsupported there and panics.
+    #[cfg(target_family = "wasm")]
     let pid = 0u32;
-    #[cfg(not(target_os = "wasi"))]
+    #[cfg(not(target_family = "wasm"))]
     let pid = std::process::id();
     format!("{:x}_{:x}_{:x}", timestamp, counter, pid)
 }

--- a/crates/kaish-kernel/src/nonce.rs
+++ b/crates/kaish-kernel/src/nonce.rs
@@ -11,7 +11,9 @@
 use std::collections::{BTreeSet, HashMap};
 use std::hash::{BuildHasher, Hasher};
 use std::sync::{Arc, Mutex};
-use std::time::{Duration, Instant, SystemTime};
+use std::time::{Duration, SystemTime};
+
+use kaish_types::clock::{system_now, Instant};
 
 /// What a nonce authorizes: a command and a set of paths.
 #[derive(Debug, Clone)]
@@ -174,7 +176,7 @@ fn generate_nonce() -> String {
     let mut hasher = hasher_state.build_hasher();
 
     // Mix in current time for uniqueness
-    let now = SystemTime::now()
+    let now = system_now()
         .duration_since(SystemTime::UNIX_EPOCH)
         .unwrap_or_default();
     hasher.write_u128(now.as_nanos());

--- a/crates/kaish-kernel/src/tools/builtin/date.rs
+++ b/crates/kaish-kernel/src/tools/builtin/date.rs
@@ -47,10 +47,14 @@ pub trait Clock: Send + Sync {
 }
 
 /// Production clock — reads the real system time.
+///
+/// Acquisition goes through `kaish_types::clock::system_now()` so this also
+/// works on `wasm32-unknown-unknown`, where `Utc::now()` reaches std's
+/// unsupported clock and panics; the conversion into chrono is pure math.
 struct SystemClock;
 impl Clock for SystemClock {
     fn now_utc(&self) -> DateTime<Utc> {
-        Utc::now()
+        DateTime::from(kaish_types::clock::system_now())
     }
 }
 

--- a/crates/kaish-kernel/src/tools/builtin/find.rs
+++ b/crates/kaish-kernel/src/tools/builtin/find.rs
@@ -19,6 +19,7 @@ use clap::{CommandFactory, Parser};
 use kaish_glob::glob_match;
 use std::path::Path;
 use std::time::SystemTime;
+use kaish_types::clock::system_now;
 
 use crate::ast::Value;
 use crate::backend_walker_fs::BackendWalkerFs;
@@ -319,7 +320,7 @@ impl Tool for Find {
                 Err(e) => return ExecResult::failure(1, format!("find: {}", e)),
             };
 
-            let _now_secs = SystemTime::now()
+            let _now_secs = system_now()
                 .duration_since(SystemTime::UNIX_EPOCH)
                 .map(|d| d.as_secs())
                 .unwrap_or(0);

--- a/crates/kaish-kernel/src/tools/builtin/sleep.rs
+++ b/crates/kaish-kernel/src/tools/builtin/sleep.rs
@@ -108,7 +108,7 @@ mod tests {
     use super::*;
     use crate::vfs::{MemoryFs, VfsRouter};
     use std::sync::Arc;
-    use std::time::Instant;
+    use kaish_types::clock::Instant;
 
     fn make_ctx() -> ExecContext {
         let mut vfs = VfsRouter::new();

--- a/crates/kaish-kernel/src/tools/builtin/touch.rs
+++ b/crates/kaish-kernel/src/tools/builtin/touch.rs
@@ -3,7 +3,7 @@
 use async_trait::async_trait;
 use clap::{CommandFactory, Parser};
 use std::path::Path;
-use std::time::SystemTime;
+use kaish_types::clock::system_now;
 
 use crate::backend::WriteMode;
 use crate::interpreter::ExecResult;
@@ -73,7 +73,7 @@ impl Tool for Touch {
             // (local + memory mounts) and rejects on read-only/virtual mounts
             // rather than silently reporting a success it didn't deliver.
             let result = if ctx.backend.exists(path).await {
-                ctx.backend.set_mtime(path, SystemTime::now()).await
+                ctx.backend.set_mtime(path, system_now()).await
             } else {
                 ctx.backend.write(path, &[], WriteMode::CreateNew).await
             };

--- a/crates/kaish-kernel/src/trash_system.rs
+++ b/crates/kaish-kernel/src/trash_system.rs
@@ -63,7 +63,7 @@ impl TrashBackend for SystemTrash {
         // process-global counter so two snapshots in the same nanosecond can't
         // race on the same staging path.
         static SEQ: AtomicU64 = AtomicU64::new(0);
-        let nanos = std::time::SystemTime::now()
+        let nanos = kaish_types::clock::system_now()
             .duration_since(std::time::UNIX_EPOCH)
             .map(|d| d.as_nanos())
             .unwrap_or(0);

--- a/crates/kaish-types/Cargo.toml
+++ b/crates/kaish-types/Cargo.toml
@@ -25,3 +25,9 @@ schema = ["dep:schemars"]
 
 [lints]
 workspace = true
+
+# Browser clock: std's SystemTime::now()/Instant::now() are unsupported
+# (panic) on wasm32-unknown-unknown; kaish_types::clock routes acquisition
+# through the JS clock there. Native and WASI builds never see this dep.
+[target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dependencies]
+web-time = "1"

--- a/crates/kaish-types/src/clock.rs
+++ b/crates/kaish-types/src/clock.rs
@@ -1,0 +1,66 @@
+//! Clock acquisition that works on every target kaish compiles for,
+//! including `wasm32-unknown-unknown` (the browser), where std's clock
+//! syscalls are unsupported and `SystemTime::now()`/`Instant::now()` panic.
+//!
+//! The types stay std everywhere they are stored or exposed —
+//! `std::time::SystemTime` is freely constructible on wasm
+//! (`UNIX_EPOCH + duration`); only *acquisition* needs the platform door.
+//! On the browser target that door is [`web-time`], which reads
+//! `Date.now()` / `performance.now()` through wasm-bindgen; on every other
+//! target these are exactly the std calls, with no extra dependency.
+//!
+//! [`web-time`]: https://docs.rs/web-time
+
+/// The monotonic clock for internal elapsed-time measurement.
+///
+/// On the browser target this is `web_time::Instant` (std's is
+/// unsupported there); everywhere else it is `std::time::Instant`.
+/// `std::time::Instant` has no public constructor, so call sites that
+/// measure durations use this alias as their type rather than converting.
+#[cfg(all(target_family = "wasm", target_os = "unknown"))]
+pub use web_time::Instant;
+#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
+pub use std::time::Instant;
+
+/// Wall-clock "now" as a plain `std::time::SystemTime`.
+///
+/// Identical to `SystemTime::now()` on native targets and WASI; on the
+/// browser target it reads the JS clock and rebases onto std's
+/// `UNIX_EPOCH` so stored types and signatures stay std everywhere.
+pub fn system_now() -> std::time::SystemTime {
+    #[cfg(all(target_family = "wasm", target_os = "unknown"))]
+    {
+        let since_epoch = web_time::SystemTime::now()
+            .duration_since(web_time::UNIX_EPOCH)
+            .unwrap_or_default();
+        std::time::UNIX_EPOCH + since_epoch
+    }
+    #[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
+    {
+        std::time::SystemTime::now()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn system_now_tracks_std() {
+        // On non-wasm targets system_now IS the std clock; prove they agree
+        // to within a generous slop so this can fail if the rebase math is
+        // ever wrong on a target where both clocks are live.
+        let a = std::time::SystemTime::now();
+        let b = system_now();
+        let skew = b
+            .duration_since(a)
+            .unwrap_or_else(|e| e.duration());
+        assert!(skew < std::time::Duration::from_secs(1), "skew {skew:?}");
+    }
+
+    #[test]
+    fn instant_measures_forward() {
+        let t0 = Instant::now();
+        assert!(t0.elapsed() < std::time::Duration::from_secs(60));
+    }
+}

--- a/crates/kaish-types/src/lib.rs
+++ b/crates/kaish-types/src/lib.rs
@@ -6,6 +6,7 @@
 
 pub mod backend;
 pub mod bytes;
+pub mod clock;
 pub mod command;
 pub mod dir_entry;
 pub mod job;

--- a/crates/kaish-vfs/src/memory.rs
+++ b/crates/kaish-vfs/src/memory.rs
@@ -11,6 +11,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::SystemTime;
+use kaish_types::clock::system_now;
 use tokio::sync::RwLock;
 
 /// Entry in the memory filesystem.
@@ -58,7 +59,7 @@ impl MemoryFs {
         entries.insert(
             PathBuf::from(""),
             Entry::Directory {
-                modified: SystemTime::now(),
+                modified: system_now(),
             },
         );
         Self {
@@ -208,7 +209,7 @@ impl MemoryFs {
                     name: String::new(),
                     kind: DirEntryKind::Directory,
                     size: 0,
-                    modified: Some(SystemTime::now()),
+                    modified: Some(system_now()),
                     permissions: None,
                     symlink_target: None,
                 });
@@ -294,7 +295,7 @@ impl MemoryFs {
                     }
                     std::collections::hash_map::Entry::Vacant(e) => {
                         e.insert(Entry::Directory {
-                            modified: SystemTime::now(),
+                            modified: system_now(),
                         });
                     }
                 }
@@ -369,7 +370,7 @@ impl Filesystem for MemoryFs {
             normalized,
             Entry::File {
                 data: data.to_vec(),
-                modified: SystemTime::now(),
+                modified: system_now(),
             },
         );
         self.settle(old_len, new_len);
@@ -483,7 +484,7 @@ impl Filesystem for MemoryFs {
                 name,
                 kind: DirEntryKind::Directory,
                 size: 0,
-                modified: Some(SystemTime::now()),
+                modified: Some(system_now()),
                 permissions: None,
                 symlink_target: None,
             });
@@ -558,7 +559,7 @@ impl Filesystem for MemoryFs {
             normalized,
             Entry::Symlink {
                 target: target.to_path_buf(),
-                modified: SystemTime::now(),
+                modified: system_now(),
             },
         );
         Ok(())
@@ -586,7 +587,7 @@ impl Filesystem for MemoryFs {
         entries.insert(
             normalized,
             Entry::Directory {
-                modified: SystemTime::now(),
+                modified: system_now(),
             },
         );
         Ok(())
@@ -755,7 +756,7 @@ mod tests {
     #[tokio::test]
     async fn test_set_mtime_missing_errors() {
         let fs = MemoryFs::new();
-        let result = fs.set_mtime(Path::new("nope.txt"), SystemTime::now()).await;
+        let result = fs.set_mtime(Path::new("nope.txt"), system_now()).await;
         assert_eq!(result.unwrap_err().kind(), io::ErrorKind::NotFound);
     }
 


### PR DESCRIPTION
## What

std's `SystemTime::now()`/`Instant::now()` (and `std::process::id()`) panic on `wasm32-unknown-unknown`, so the kernel died at `MemoryFs` mount time in a browser. This PR routes clock **acquisition** through a new `kaish_types::clock` module — `system_now()` plus an `Instant` alias — leaving every stored type and public signature on plain `std::time`.

## Decisions

- **Types stay std everywhere.** `std::time::SystemTime` is freely constructible on wasm (`UNIX_EPOCH + duration`); only acquisition needs a platform door. So `Filesystem::set_mtime`, `DirEntry` timestamps, and chrono interop are untouched — embedders see zero API change. `Instant` has no public constructor, so the internal elapsed-time sites (nonce TTLs, sleep tests) take the `clock::Instant` alias instead.
- **web-time exists only on the browser target.** The dependency is cfg'd to `(target_family = "wasm", target_os = "unknown")`; native and WASI builds get the literal std clock and no new dependency. On the browser it reads `Date.now()`/`performance.now()` through wasm-bindgen.
- **date builtin** (review follow-up): `SystemClock` now converts from `system_now()` — pure math, same value everywhere — with chrono's `wasmbind` target-cfg'd so `Local` renders the visitor's real timezone in a browser.
- **Deliberately not touched:** `output_limit.rs` spill naming (behind `localfs`, compiled out of browser builds), the bg-job spill path in `scheduler/job.rs` (unreachable without `subprocess`), and tokio::time in the watchdog/`sleep` builtin — the default `isolated()` config never arms the watchdog; a wasm-safe story for those is follow-up work.

## Verification

- 4612 native tests pass, clippy clean — on native this is bit-for-bit the std clock.
- Failing-first in a real browser: the kaish-extras `kaish-web` smoke page panicked in `std/sys/time/unsupported.rs` before this change; after it, headless chromium runs pipes/jq/loops/`date -u +%Y`/grep over a 526-file seeded tree, green.
- Cross-family review (kaibo `oneshot`, deepseek-v4-pro): mergeable; its demanded workspace clock audit ran and drove the date-builtin fix above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017iutoShYRUYwdv94ZwBmPj