### PR TITLE
fix(uname): report kai as the operating system, not Kaijutsu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ breaking entries are marked **BREAKING**.
 
 ## [Unreleased]
 
+### Changed
+- **`uname -o` (and the tail of `uname -a`) now reports `kai`** instead of
+  `Kaijutsu` — the shell's identity belongs to kaish itself, not to one
+  embedder. Scripts detecting the platform should match `kai` (sysname is
+  still `kaish`, unchanged).
+
 ### Fixed
 - **Bare `${X:-${Y}}` works** (GH #173) — a nested braced reference in a
   default word outside quotes was a parse error (the `VarRef` token stopped at

--- a/crates/kaish-kernel/src/tools/builtin/uname.rs
+++ b/crates/kaish-kernel/src/tools/builtin/uname.rs
@@ -18,7 +18,7 @@
 //!
 //! ```kaish
 //! uname                          # → kaish
-//! uname -a                       # → kaish myhost 0.1.0 ... x86_64 Kaijutsu
+//! uname -a                       # → kaish myhost 0.1.0 ... x86_64 kai
 //! uname -snm                     # → kaish myhost x86_64
 //! uname --host                   # → Linux (native build only)
 //! uname --host -a                # → Linux myhost 6.x.y ... x86_64 GNU/Linux
@@ -113,7 +113,7 @@ impl UnameInfo {
             release: version.to_string(),
             version: format!("kaish {version} ({git_hash} {build_date})"),
             machine: std::env::consts::ARCH.to_string(),
-            os: "Kaijutsu".to_string(),
+            os: "kai".to_string(),
         }
     }
 
@@ -339,7 +339,7 @@ mod tests {
         args.flags.insert("o".to_string());
         let result = Uname.execute(args, &mut ctx).await;
         assert!(result.ok());
-        assert_eq!(&*result.text_out(), "Kaijutsu");
+        assert_eq!(&*result.text_out(), "kai");
     }
 
     #[tokio::test]
@@ -379,7 +379,7 @@ mod tests {
         // At minimum 6 whitespace-separated tokens (version has parens with spaces)
         assert!(fields.len() >= 6, "expected ≥6 fields, got: {:?}", fields);
         assert_eq!(fields[0], "kaish");
-        assert_eq!(*fields.last().unwrap(), "Kaijutsu");
+        assert_eq!(*fields.last().unwrap(), "kai");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What

`uname -o` (and the tail of `uname -a`) reported `Kaijutsu`. Amy spotted it in the try-kaish browser playground: the shell's identity belongs to kaish itself, not to one embedder.

## Decision

The OS field becomes `kai` while sysname stays `kaish`, so `uname -a` reads as shell-on-platform (`kaish … x86_64 kai`) rather than repeating one string — "kaish or kai" per Amy; trivial to flip if `kaish` is preferred for both. Doc comments that describe kaijutsu *as an embedder* are untouched — those are about the project, not the platform identity.

Changelog entry included (scripts detecting the platform should match `kai`). Note: the Unreleased section may trivially conflict with #205's changelog hunk — merge either first and the other rebases in seconds.

## Verification

12 uname tests updated and passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017iutoShYRUYwdv94ZwBmPj