### PR TITLE
test: feature-gate integration tests so --no-default-features compiles and runs (#170)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,11 +56,12 @@ jobs:
           fi
 
   # Capability features are opt-in axes (localfs, subprocess, host, os-integration,
-  # tokens); a no-default-features build must compile without touching the OS. This
-  # is the gate that catches OS-touching code landing outside its axis. `check`, not
-  # `test`: the integration-test crates call feature-gated constructors like
-  # `KernelConfig::repl()` (localfs) and have never compiled without default
-  # features — upgrading this leg to `cargo test` is GH #170.
+  # tokens); a no-default-features build must compile AND pass without touching the
+  # OS. This is the gate that catches OS-touching code landing outside its axis.
+  # `cargo test`, not `check` (GH #170 fixed): the integration-test files that need
+  # a real filesystem are gated `#![cfg(feature = "localfs")]` (or narrower,
+  # test-fn-level cfg where only part of a file needs it), so this leg both compiles
+  # and runs the tests that are genuinely feature-independent.
   sandbox:
     name: no-default-features
     runs-on: ubuntu-latest
@@ -77,8 +78,8 @@ jobs:
         with:
           key: no-default-features
 
-      - name: Check (kernel, no default features)
-        run: cargo check -p kaish-kernel --no-default-features --locked
+      - name: Test (kernel, no default features)
+        run: cargo test -p kaish-kernel --no-default-features --locked
 
   # The WASI target only builds (no test runner); it exists to keep the kernel
   # compiling for wasm32-wasip1 so embedders on that target don't discover breakage

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,9 +52,9 @@ cargo insta review                       # Interactive review of pending snapsho
 
 CI (`.github/workflows/ci.yml`) runs the gates on every PR and push to `main`:
 `cargo test --all --locked`, clippy with `-D warnings`, a committed-`.snap.new`
-tripwire, `cargo check -p kaish-kernel --no-default-features` (upgrading that
-leg to `cargo test` is GH #170), and the `kaish-wasi` wasm32-wasip1 build.
-When a gate changes, change ci.yml in the same PR. The runners track current
+tripwire, `cargo test -p kaish-kernel --no-default-features --locked` (see the
+integration-test feature-gating convention below), and the `kaish-wasi`
+wasm32-wasip1 build. When a gate changes, change ci.yml in the same PR. The runners track current
 stable Rust, which may be newer than local toolchains — CI clippy can fire
 lints local clippy doesn't have yet; fix the code rather than pinning the
 toolchain.
@@ -247,5 +247,19 @@ Hard-won rules that aren't obvious from the code. Violating these silently break
   not spawn subprocesses. `full`/`native` are aliases for all five. New OS-touching
   code must sit behind the right axis and compile out cleanly without it (the
   `--no-default-features` gates in Build Commands enforce this).
+- **Feature-gate integration-test files that need a capability, not just the
+  production code.** A test file that constructs a kernel via `KernelConfig::repl()`,
+  touches a real host path (`tempfile`, `common::kernel_at`), or mounts `LocalFs`
+  directly needs `#![cfg(feature = "localfs")]` at the top (the `external_command_tests.rs`
+  pattern: `#![cfg(feature = "subprocess")]`, or `#![cfg(all(feature = "localfs",
+  feature = "subprocess"))]` when both apply). Prefer the narrowest gate that
+  compiles+passes: if only a few tests in an otherwise-featureless file need it,
+  gate just those `#[cfg(feature = "localfs")] #[tokio::test]` functions instead of
+  the whole file (`vfs_budget_tests.rs`, `validation_tests.rs` do this). Watch for
+  tests that *compile* featureless but *fail at runtime* — e.g. `Kernel::transient()`
+  falls back to `KernelConfig::isolated()` (`NoLocal`, cwd `"/"`, no real
+  filesystem) without `localfs`, so a test asserting cwd-isolation against a non-`/`
+  starting cwd, or reading a real tempfile path, needs the same gate even though
+  nothing failed to compile.
 
 

--- a/crates/kaish-kernel/tests/and_or_precedence_tests.rs
+++ b/crates/kaish-kernel/tests/and_or_precedence_tests.rs
@@ -2,6 +2,7 @@
 //! `&&`-binds-tighter. Regression for the statement-list path (`parser.rs`); the
 //! `[[ ]]` compound path was already correct.
 
+#![cfg(feature = "localfs")]
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
 use kaish_kernel::{Kernel, KernelConfig};

--- a/crates/kaish-kernel/tests/awk_numeric_compare_tests.rs
+++ b/crates/kaish-kernel/tests/awk_numeric_compare_tests.rs
@@ -10,6 +10,7 @@
 //! and `$1 == 0` (with input "0") to compare strings ("0" == "0" = EQ only
 //! accidentally, but "0.0" != "0" would be NE instead of the correct EQ).
 
+#![cfg(feature = "localfs")]
 // Test-fixture code: unwrap/expect on known-good setup is the idiom here.
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 

--- a/crates/kaish-kernel/tests/background_execution_tests.rs
+++ b/crates/kaish-kernel/tests/background_execution_tests.rs
@@ -55,7 +55,9 @@ async fn wait_for_job(kernel: &Kernel, job_id: u64, timeout: Duration) -> String
 /// A kernel that owns no host filesystem must not persist job output to a host
 /// temp file — that write goes through `std::fs`, bypassing the VFS and any
 /// read-only mount. Holds for `NoLocal` (mounts nothing) and `with_backend`
-/// (the embedder owns the VFS). A host-owning kernel still persists.
+/// (the embedder owns the VFS). The host-owning counterpart lives in
+/// `test_job_output_persistence_enabled_for_host_owning_kernel` below (localfs
+/// only — see that test's doc comment for why).
 #[tokio::test]
 async fn test_job_output_persistence_disabled_for_hostless_kernels() {
     use kaish_kernel::vfs::{MemoryFs, VfsRouter};
@@ -78,8 +80,18 @@ async fn test_job_output_persistence_disabled_for_hostless_kernels() {
         !embedded.jobs().persist_output_files(),
         "with_backend kernel must not write job output to host disk"
     );
+}
 
-    // A host-owning kernel (Sandboxed) keeps the default persistence.
+/// A host-owning kernel (`Sandboxed` vfs_mode) keeps the default persistence.
+///
+/// `KernelConfig::transient()` only builds a `Sandboxed` (real host cwd)
+/// config behind the `localfs` feature; without it, `transient()` falls back
+/// to `Self::isolated()` (`NoLocal`) per `kernel.rs`, so this kernel would be
+/// hostless too and the assertion below would not hold — hence the gate,
+/// rather than folding this into the hostless test above.
+#[cfg(feature = "localfs")]
+#[tokio::test]
+async fn test_job_output_persistence_enabled_for_host_owning_kernel() {
     let host_owning = Kernel::new(KernelConfig::transient()).expect("transient kernel");
     assert!(
         host_owning.jobs().persist_output_files(),

--- a/crates/kaish-kernel/tests/env_filter_tests.rs
+++ b/crates/kaish-kernel/tests/env_filter_tests.rs
@@ -7,6 +7,7 @@
 //! Both flags must apply when there is NO positional command, not only when a
 //! command is specified.
 
+#![cfg(feature = "localfs")]
 // Test-fixture code: unwrap/expect on known-good setup is the idiom here.
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 

--- a/crates/kaish-kernel/tests/for_newline_split_tests.rs
+++ b/crates/kaish-kernel/tests/for_newline_split_tests.rs
@@ -47,6 +47,14 @@ async fn for_subst_printf_multiline_iterates_per_line() {
     assert!(text.contains("count=3"), "expected 3 iterations:\n{text}");
 }
 
+// The only test in this file that touches a real host path (via
+// `tempfile::NamedTempFile` + `cat`) — `Kernel::transient()` only mounts a
+// real filesystem under the `localfs` feature; without it, `transient()`
+// falls back to `KernelConfig::isolated()` (NoLocal, in-memory `/`), so the
+// absolute tempfile path would resolve to nothing. Every other test in this
+// file only touches virtual builtins (echo/printf/seq/jq/split) and runs
+// featureless.
+#[cfg(feature = "localfs")]
 #[tokio::test]
 async fn for_subst_cat_file_iterates_per_line() {
     let kernel = Kernel::transient().unwrap();

--- a/crates/kaish-kernel/tests/pipeline_structured_data_tests.rs
+++ b/crates/kaish-kernel/tests/pipeline_structured_data_tests.rs
@@ -9,6 +9,7 @@
 //! current-thread runtime the producer (spawned first) always wins and hides
 //! the bug. Pre-fix this failed ~197/200; the fix makes it deterministic.
 
+#![cfg(feature = "localfs")]
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
 use kaish_kernel::{Kernel, KernelConfig};

--- a/crates/kaish-kernel/tests/quoted_cmdsubst_error_tests.rs
+++ b/crates/kaish-kernel/tests/quoted_cmdsubst_error_tests.rs
@@ -2,6 +2,7 @@
 //! not silently turned into literal text. Regression for `parser.rs`
 //! (`parse_interpolated_string` used to fall back to literal on parse failure).
 
+#![cfg(feature = "localfs")]
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
 use kaish_kernel::{Kernel, KernelConfig};

--- a/crates/kaish-kernel/tests/redirect_in_cmdsubst_tests.rs
+++ b/crates/kaish-kernel/tests/redirect_in_cmdsubst_tests.rs
@@ -19,6 +19,7 @@
 //!
 //! Real-FS via `tempfile::tempdir()` per the no-hardcoded-system-paths rule.
 
+#![cfg(feature = "localfs")]
 // Test-fixture code: unwrap/expect on known-good setup is the idiom here.
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 

--- a/crates/kaish-kernel/tests/scatter_single_json_tests.rs
+++ b/crates/kaish-kernel/tests/scatter_single_json_tests.rs
@@ -10,6 +10,7 @@
 //! path directly via the kernel dispatch chain (not via `Scatter::execute`
 //! directly — per the no-direct-builtin-call convention).
 
+#![cfg(feature = "localfs")]
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
 use kaish_kernel::{Kernel, KernelConfig};

--- a/crates/kaish-kernel/tests/shell_bugs_tests.rs
+++ b/crates/kaish-kernel/tests/shell_bugs_tests.rs
@@ -422,6 +422,12 @@ async fn test_short_flag_with_value_tail() {
 // Command-substitution cwd isolation — depends on host process cwd
 // ============================================================================
 
+// Without `localfs`, `Kernel::transient()` falls back to `KernelConfig::isolated()`
+// (NoLocal), whose cwd is always literally "/" — the "pwd should not leak back to
+// the subshell's cd /" assertion below is structurally unsatisfiable there since
+// the kernel's own starting cwd already is "/". Needs a real (non-"/") starting
+// cwd, which only `localfs`'s sandbox root provides.
+#[cfg(feature = "localfs")]
 #[tokio::test]
 async fn test_cmd_subst_cwd_isolation() {
     let kernel = Kernel::transient().unwrap();
@@ -448,6 +454,8 @@ pwd
     );
 }
 
+// Same NoLocal-cwd-is-always-"/" reasoning as `test_cmd_subst_cwd_isolation` above.
+#[cfg(feature = "localfs")]
 #[tokio::test]
 async fn test_cmd_subst_in_string_cwd_isolation() {
     let kernel = Kernel::transient().unwrap();

--- a/crates/kaish-kernel/tests/with_backend_dev_tests.rs
+++ b/crates/kaish-kernel/tests/with_backend_dev_tests.rs
@@ -4,6 +4,7 @@
 //! instead of silently discarding the write, because `/dev` was never
 //! kernel-owned in the `with_backend` path.
 
+#![cfg(feature = "localfs")]
 // Test-fixture code: unwrap/expect on known-good setup is the idiom here.
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 

--- a/crates/kaish-kernel/tests/with_backend_v_overlay_tests.rs
+++ b/crates/kaish-kernel/tests/with_backend_v_overlay_tests.rs
@@ -6,6 +6,7 @@
 //! its virtual filesystems under `/v`. It also fixes the pre-existing papercuts
 //! where `ls /v` returned nothing and `ls /` dropped `dev`.
 
+#![cfg(feature = "localfs")]
 // Test-fixture code: unwrap/expect on known-good setup is the idiom here.
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 


### PR DESCRIPTION
## Summary

PR #169 downgraded the `no-default-features` CI leg to `cargo check` because the
integration-test crates called feature-gated constructors (`KernelConfig::repl()`)
and had never compiled without default features. This PR gates the remaining
files so `cargo test -p kaish-kernel --no-default-features` both compiles and
passes, and upgrades the CI leg from `check` to `test`.

## What was gated

A `cargo check --tests -p kaish-kernel --no-default-features --keep-going` sweep
(the only way to see every compile error in one pass instead of the first
handful) showed most integration-test files were **already** correctly gated
from earlier capability-feature work — only 9 of ~94 test files needed a new
gate:

**Whole-file `#![cfg(feature = "localfs")]`** (all tests in the file are
localfs-dependent, no mixed content):
- `and_or_precedence_tests.rs`, `awk_numeric_compare_tests.rs`,
  `env_filter_tests.rs`, `pipeline_structured_data_tests.rs`,
  `quoted_cmdsubst_error_tests.rs`, `scatter_single_json_tests.rs` — all call
  `KernelConfig::repl()` directly
- `redirect_in_cmdsubst_tests.rs` — imports the localfs-gated
  `common::kernel_at` helper
- `with_backend_dev_tests.rs`, `with_backend_v_overlay_tests.rs` — construct
  `LocalFs` directly for a `with_backend` embedder shape

Compiling clean surfaced three more failures **at runtime**, not build time,
because `Kernel::transient()` silently falls back to `KernelConfig::isolated()`
(`NoLocal`, cwd `"/"`) without the `localfs` feature — the CLAUDE.md-warned
"compiles featureless but fails at runtime" class, not actual bugs:

**Test-fn-level `#[cfg(feature = "localfs")]`** (narrowest gate, rest of the
file stays featureless):
- `background_execution_tests.rs` — one of three assertions in
  `test_job_output_persistence_disabled_for_hostless_kernels` asserted a
  `transient()` kernel still persists job output, true only when `transient()`
  is actually host-owning. Split that assertion into its own
  `test_job_output_persistence_enabled_for_host_owning_kernel`, gated; the
  other two (genuinely feature-independent) assertions stay ungated.
- `for_newline_split_tests.rs` — one of ten tests reads a real
  `tempfile::NamedTempFile` path; gated just that test.
- `shell_bugs_tests.rs` — two cwd-isolation tests assume the kernel's starting
  cwd isn't `"/"` (the file's own doc comment already flagged this as
  host-cwd-dependent); gated both.

`vfs_budget_tests.rs` and `validation_tests.rs` were already doing test-fn-level
gating correctly and needed no changes — they served as the reference pattern
for splitting rather than blanket-gating the files above.

## Verification

- `cargo test -p kaish-kernel --no-default-features --locked` — compiles and
  passes, **3053 tests**.
- `cargo test -p kaish-kernel --no-default-features --features subprocess --locked`
  — also compiles and passes (localfs-less-but-subprocess is a legal
  combination), **4015 tests**.
- `cargo test --all --locked` stays green: **4643 -> 4644** tests (net +1, from
  the `background_execution_tests.rs` split into two test functions — accounted
  for, not a regression).
- `cargo clippy --all --all-targets --locked -- -D warnings` — clean.

## CI / docs

- `.github/workflows/ci.yml`: sandbox leg `cargo check` -> `cargo test`, comment
  rewritten (no longer references #170 as open work).
- `CLAUDE.md`: Build Commands blurb updated; added a contributor-conventions
  bullet documenting the gating pattern (whole-file vs. test-fn-level, and the
  `Kernel::transient()` NoLocal-fallback runtime gotcha) for the next person
  adding a test file.

No CHANGELOG bullet — this is test/CI infrastructure churn, not
user/embedder-facing behavior.

## Test plan

- [x] `cargo test --all --locked`
- [x] `cargo test -p kaish-kernel --no-default-features --locked`
- [x] `cargo test -p kaish-kernel --no-default-features --features subprocess --locked`
- [x] `cargo clippy --all --all-targets --locked -- -D warnings`

Closes #170

🤖 Generated with [Claude Code](https://claude.com/claude-code)