### PR TITLE
feat(client): flag-completion helpers — current_command + flag_candidates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,21 @@ breaking entries are marked **BREAKING**.
 ## [Unreleased]
 
 ### Added
+- **Flag completion helpers in `kaish_client::completion`** —
+  `current_command(line, pos)` (which command word governs the statement
+  under the cursor) and `flag_candidates(params, word)` (canonical `--long`
+  and `-x` spellings from a tool's `ParamSchema`s; snake-case field-id
+  aliases stay reachable but aren't offered). First consumer: the
+  kaish-extras browser playground; the native REPL can adopt the same pair
+  (GH #202).
+
+### Fixed
+- `cargo test -p kaish-client` alone no longer fails the cwd test: the
+  tests assert localfs-flavored behavior and now declare `localfs` as a
+  dev-dependency feature instead of inheriting it from whichever workspace
+  sibling happened to build.
+
+### Added
 - **`kaish_client::completion`** — completion context detection
   (`CompletionContext`, `detect_completion_context`, `word_start`) extracted
   from the REPL into the client crate, so every frontend answering Tab (the

--- a/crates/kaish-client/Cargo.toml
+++ b/crates/kaish-client/Cargo.toml
@@ -34,6 +34,12 @@ serde_json = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]
+# The runtime dep above is feature-neutral; tests assert localfs-flavored
+# behavior (transient() cwd=$HOME) and must say so themselves — without
+# this, `cargo test -p kaish-client` alone sees a no-localfs kernel while a
+# whole-workspace run gets localfs unified in by the REPL, and outcomes
+# depend on which crates happened to build.
+kaish-kernel = { path = "../kaish-kernel", version = "0.12.0", features = ["localfs"] }
 proptest = { workspace = true }
 # Tests drive the async client API; the library itself needs no runtime —
 # and must not pull one in: wasm builds (kaish-extras) break on tokio/net.

--- a/crates/kaish-client/src/completion.rs
+++ b/crates/kaish-client/src/completion.rs
@@ -157,3 +157,127 @@ mod tests {
         assert_eq!(word_start("a | gr", 6), 4);
     }
 }
+
+// ── Flag completion ─────────────────────────────────────────────────
+
+/// Byte range of the command word governing the statement that contains
+/// `pos`, or `None` when the cursor is still inside (or before) that word —
+/// in which case command-name completion applies, not argument completion.
+///
+/// Scans back to the nearest statement boundary (`|`, `;`, `&`, `(`,
+/// newline), then walks forward past leading `VAR=…` assignments and the
+/// shell keywords that prefix a command position.
+pub fn current_command(line: &str, pos: usize) -> Option<(usize, usize)> {
+    const KEYWORDS: [&str; 7] = ["if", "then", "elif", "else", "while", "until", "do"];
+
+    let before = &line[..pos];
+    let stmt_start = before
+        .rfind(|c: char| matches!(c, '|' | ';' | '&' | '(' | '\n'))
+        .map(|i| i + 1)
+        .unwrap_or(0);
+
+    let mut word_from = stmt_start;
+    loop {
+        // Skip whitespace to the next word.
+        let rest = &line[word_from..pos];
+        let skip = rest.len() - rest.trim_start().len();
+        let start = word_from + skip;
+        if start >= pos {
+            return None; // nothing but whitespace before the cursor
+        }
+        let end = line[start..pos]
+            .find(char::is_whitespace)
+            .map(|i| start + i)
+            .unwrap_or(pos);
+        let word = &line[start..end];
+
+        // `FOO=bar cmd` and `if cmd` — the command is still ahead.
+        if word.contains('=') || KEYWORDS.contains(&word) {
+            word_from = end;
+            continue;
+        }
+        // The cursor sitting in the command word itself is command
+        // completion's business.
+        if end >= pos {
+            return None;
+        }
+        return Some((start, end));
+    }
+}
+
+/// Flag spellings from a tool's params that extend `word` (which starts
+/// with `-`): the canonical `--long` for every non-positional param, `-x`
+/// for single-char aliases, `--alias` for visible long aliases. Snake-case
+/// field-id aliases (they contain `_`) are reachable in scripts but not
+/// offered — completion promotes canonical spellings. Sorted, deduped;
+/// display and replacement are the same string.
+pub fn flag_candidates(
+    params: &[kaish_types::tool::ParamSchema],
+    word: &str,
+) -> Vec<String> {
+    let mut out = Vec::new();
+    for p in params.iter().filter(|p| !p.positional) {
+        let long = format!("--{}", p.name);
+        if long.starts_with(word) {
+            out.push(long);
+        }
+        for alias in &p.aliases {
+            if alias.contains('_') {
+                continue;
+            }
+            let spelled = if alias.chars().count() == 1 {
+                format!("-{alias}")
+            } else {
+                format!("--{alias}")
+            };
+            if spelled.starts_with(word) {
+                out.push(spelled);
+            }
+        }
+    }
+    out.sort();
+    out.dedup();
+    out
+}
+
+#[cfg(test)]
+mod flag_tests {
+    use super::*;
+    use kaish_types::tool::ParamSchema;
+
+    fn param(name: &str, aliases: &[&str], positional: bool) -> ParamSchema {
+        let mut p = ParamSchema::new(name.to_string(), "bool".to_string());
+        p.aliases = aliases.iter().map(|s| s.to_string()).collect();
+        p.positional = positional;
+        p
+    }
+
+    #[test]
+    fn test_current_command_basics() {
+        assert_eq!(current_command("uname -", 7), Some((0, 5)));
+        assert_eq!(current_command("echo hi | grep -i", 17), Some((10, 14)));
+        // Cursor still inside the command word → command completion's turf.
+        assert_eq!(current_command("unam", 4), None);
+        assert_eq!(current_command("", 0), None);
+    }
+
+    #[test]
+    fn test_current_command_skips_assignments_and_keywords() {
+        assert_eq!(current_command("FOO=1 grep -", 12), Some((6, 10)));
+        assert_eq!(current_command("if grep -q x", 12), Some((3, 7)));
+        // Nothing after the keyword/assignment yet.
+        assert_eq!(current_command("FOO=1 ", 6), None);
+    }
+
+    #[test]
+    fn test_flag_candidates_spellings() {
+        let params = vec![
+            param("no-newline", &["n", "no_newline"], false),
+            param("paths", &[], true),
+        ];
+        // Long + short offered; snake alias and positionals never.
+        assert_eq!(flag_candidates(&params, "-"), vec!["--no-newline", "-n"]);
+        assert_eq!(flag_candidates(&params, "--no"), vec!["--no-newline"]);
+        assert_eq!(flag_candidates(&params, "--x"), Vec::<String>::new());
+    }
+}

--- a/crates/kaish-client/src/completion.rs
+++ b/crates/kaish-client/src/completion.rs
@@ -172,7 +172,7 @@ pub fn current_command(line: &str, pos: usize) -> Option<(usize, usize)> {
 
     let before = &line[..pos];
     let stmt_start = before
-        .rfind(|c: char| matches!(c, '|' | ';' | '&' | '(' | '\n'))
+        .rfind(['|', ';', '&', '(', '\n'])
         .map(|i| i + 1)
         .unwrap_or(0);
 


### PR DESCRIPTION
## What

Two more frontend-neutral helpers in `kaish_client::completion`, enabling flag completion (`grep --i⇥`) in the kaish-extras playground — and ready for the native REPL (GH #202):

- `current_command(line, pos)` — byte range of the command word governing the statement under the cursor (statement-boundary scan back, then forward past `VAR=…` assignments and command-prefix keywords; `None` while the cursor is still in the command word).
- `flag_candidates(params, word)` — flag spellings from a tool's `ParamSchema`s: canonical `--long` per non-positional param, `-x` for single-char aliases, `--alias` for visible long aliases. Snake-case field-id aliases stay reachable but aren't offered.

## Also fixes

A unification-dependent test: `cargo test -p kaish-client` *alone* failed the cwd test after #213 made the kernel dep feature-neutral — the test asserts localfs behavior (`transient()` cwd=`$HOME`) that used to arrive via the REPL's kernel dep in whole-workspace builds. Tests now declare `localfs` themselves in dev-dependencies.

## Verification

22 kaish-client tests green solo (the failure mode was solo runs), clippy clean. Consumer wiring in kaish-extras builds against this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017iutoShYRUYwdv94ZwBmPj