### PR TITLE
feat(types): ToolArgs::to_argv_excluding for raw-read named params (#218)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ breaking entries are marked **BREAKING**.
   rustyline REPL, the kaish-extras browser playground, embedders) shares one
   detector; the REPL now consumes it. `EmbeddedClient` is also browser-safe:
   its blob-id timestamp goes through `kaish_types::clock`.
+- **`ToolArgs::to_argv_excluding`** — like `to_argv()` but skips given named
+  keys entirely, so a builtin that deliberately reads one of its own named
+  params raw (to preserve a `Value::Bytes` payload past the argv/text
+  boundary) doesn't need a bespoke clone-and-remove dance. `to_argv()` now
+  delegates to it with an empty exclude list. `write`'s `content` param
+  adopts it (GH #218, a follow-up from the GH #164/#215 review).
 ### Removed
 - **BREAKING:** `output_limit::spill_aware_collect` and its private helpers
   (`collect_stderr`, `collect_stdout_with_spill`, `handle_overflow`,

--- a/crates/kaish-kernel/src/tools/builtin/write.rs
+++ b/crates/kaish-kernel/src/tools/builtin/write.rs
@@ -63,14 +63,13 @@ impl Tool for Write {
         // makes it the same "clap sink nobody reads" case as `push`'s hidden
         // positional (CLAUDE.md's clap-builtin convention), just on a named
         // flag instead: `to_argv()`'s loud named-Bytes guard (GH #164) exists
-        // for keys a builtin *does* read via the clap-parsed field, so drop
-        // `content` before computing argv for clap — every other flag
-        // (`path`/`confirm`/global) still gets the full guard, and
-        // `parsed.content` simply stays `None`, which is fine since nothing
-        // reads it.
-        let mut argv_source = args.clone();
-        argv_source.named.remove("content");
-        let argv = match argv_source.to_argv() {
+        // for keys a builtin *does* read via the clap-parsed field, so
+        // exclude `content` from argv (GH #218's `to_argv_excluding` — a
+        // first-class alternative to hand-cloning `ToolArgs` and removing the
+        // key). Every other flag (`path`/`confirm`/global) still gets the
+        // full guard, and `parsed.content` simply stays `None`, which is fine
+        // since nothing reads it.
+        let argv = match args.to_argv_excluding(&["content"]) {
             Ok(v) => v,
             Err(e) => return ExecResult::failure(2, format!("write: {e}")),
         };

--- a/crates/kaish-kernel/tests/binary_text_sink_tests.rs
+++ b/crates/kaish-kernel/tests/binary_text_sink_tests.rs
@@ -767,6 +767,31 @@ async fn write_binary_content_positional_round_trips_byte_for_byte() {
     );
 }
 
+/// `write dest.bin --content=$(cat src.bin)`: the *named* `content` flag
+/// carries real `Value::Bytes` (GH #218). This is the scenario
+/// `ToolArgs::to_argv_excluding(&["content"])` exists for — a named
+/// `Value::Bytes` would otherwise trip `to_argv()`'s loud `BinaryNamedValue`
+/// guard (GH #164) before `write` ever got a chance to read it raw. Proves
+/// the exclusion actually reaches the kernel-routed named path, not just the
+/// positional one covered above.
+#[tokio::test]
+async fn write_binary_content_named_flag_round_trips_byte_for_byte() {
+    let dir = tempdir().unwrap();
+    fs::write(dir.path().join("src.bin"), BIN).unwrap();
+    let kernel = kernel_at(dir.path());
+    let result = kernel
+        .execute("b=$(cat src.bin); write dest.bin --content=$b")
+        .await
+        .unwrap();
+    assert!(result.ok(), "err={}", result.err);
+    let written = fs::read(dir.path().join("dest.bin")).unwrap();
+    assert_eq!(
+        written, BIN,
+        "binary content must round-trip byte-for-byte through the named --content flag, \
+         not error at the to_argv() boundary nor leak the `[binary: N bytes]` placeholder"
+    );
+}
+
 /// `push xs $(cat src.bin)`: `push`'s value positional must not be rejected
 /// by `to_argv()` just because it carries binary content. Checks list length
 /// (not byte content) — kaish's native lists are backed internally by

--- a/crates/kaish-types/src/tool.rs
+++ b/crates/kaish-types/src/tool.rs
@@ -498,7 +498,42 @@ impl ToolArgs {
     /// NOT error here; see [`value_to_argv_token`]'s doc comment for why.
     ///
     /// See the clap builtin pattern in CLAUDE.md (Contributor conventions).
+    ///
+    /// Equivalent to [`to_argv_excluding`](Self::to_argv_excluding)`(&[])` —
+    /// same rendering path, nothing excluded.
     pub fn to_argv(&self) -> Result<Vec<String>, ToolArgvError> {
+        self.to_argv_excluding(&[])
+    }
+
+    /// Like [`to_argv`](Self::to_argv), but skips the given **named** keys
+    /// entirely — neither the key's flag token nor its value appears in the
+    /// rendered argv, and (crucially) a `Value::Bytes` under an excluded key
+    /// is never passed to [`render_named_value`], so it can never trip
+    /// [`ToolArgvError::BinaryNamedValue`].
+    ///
+    /// Use this when a builtin deliberately reads one of its own named
+    /// parameters raw off `ToolArgs` (e.g. `args.named.get("content")`)
+    /// instead of the clap-parsed field, specifically to preserve a
+    /// typed/binary value that must not cross the argv/text stringification
+    /// boundary — while still wanting the *rest* of its arguments bound
+    /// through the normal clap path. `write`'s `content` param is the
+    /// motivating case (GH #218, a follow-up from the GH #164 / #215
+    /// review): before this helper, the builtin cloned the whole `ToolArgs`
+    /// and called `named.remove("content")` by hand, which silently stops
+    /// covering a *second* Bytes-capable named param the moment one is added.
+    /// Naming the excluded keys here instead makes the exemption a
+    /// greppable, drift-resistant idiom.
+    ///
+    /// Only **named** keys are excludable — not flags or positionals, by
+    /// design. A bool flag carries no value to protect, so there is nothing
+    /// to exempt. A positional's clap-reflected field is already a
+    /// validation-only sink nobody reads (see CLAUDE.md's clap-builtin
+    /// convention), so a positional `Value::Bytes` never needed an
+    /// exemption in the first place — [`value_to_argv_token`] renders it as
+    /// an inert placeholder rather than erroring. If a future case needs to
+    /// exclude a flag or positional too, that is new design, not an
+    /// extension of this helper.
+    pub fn to_argv_excluding(&self, exclude: &[&str]) -> Result<Vec<String>, ToolArgvError> {
         let mut argv = Vec::with_capacity(
             self.flags.len() + self.named.len() * 2 + self.positional.len() + 1,
         );
@@ -517,7 +552,12 @@ impl ToolArgs {
         // for multi-char keys. `=` form keeps parsing unambiguous when the
         // value begins with `-`. Multi-value (`consumes > 1`) params are
         // stored as Value::Json(Array(Array(...))) — one entry per occurrence.
+        // An excluded key is skipped before its value is ever inspected, so a
+        // Value::Bytes there can't reach render_named_value's Bytes guard.
         for (key, value) in &self.named {
+            if exclude.contains(&key.as_str()) {
+                continue;
+            }
             for rendered in render_named_value(key, value)? {
                 argv.push(format!("{}={}", flag_token(key), rendered));
             }
@@ -869,6 +909,84 @@ mod to_argv_tests {
         let err = args.to_argv().expect_err("named Bytes must still error");
         let ToolArgvError::BinaryNamedValue { key, .. } = err;
         assert_eq!(key, "check");
+    }
+
+    // ── GH #218: ToolArgs::to_argv_excluding ────────────────────────────
+    //
+    // write.rs reads its own `content` named param raw off `ToolArgs` to
+    // preserve `Value::Bytes`, then needs the *rest* of its args through the
+    // normal clap/to_argv path — these tests pin the helper that replaces the
+    // ad hoc "clone ToolArgs, remove the key, call to_argv()" dance.
+
+    /// A named `Value::Bytes` under an excluded key must not error and must
+    /// not appear anywhere in the rendered argv — this is the whole point:
+    /// `write`'s `content` carries real binary and must never reach argv.
+    #[test]
+    fn to_argv_excluding_skips_excluded_named_bytes_without_error() {
+        let mut args = ToolArgs::new();
+        args.named.insert("content".into(), Value::Bytes(vec![0xff, 0x00, 0xfe]));
+        args.named.insert("path".into(), Value::String("dest.bin".into()));
+
+        let argv = args
+            .to_argv_excluding(&["content"])
+            .expect("excluded named Bytes must not error");
+        assert_eq!(argv, vec!["--path=dest.bin"]);
+        assert!(
+            argv.iter().all(|tok| !tok.contains("content")),
+            "excluded key must not appear in argv at all: {argv:?}"
+        );
+    }
+
+    /// A named `Value::Bytes` under a key that is NOT excluded still errors
+    /// loudly, same as plain `to_argv()` — excluding one key must not blanket
+    /// the whole named map.
+    #[test]
+    fn to_argv_excluding_still_errors_on_non_excluded_named_bytes() {
+        let mut args = ToolArgs::new();
+        args.named.insert("content".into(), Value::Bytes(vec![1, 2, 3]));
+        args.named.insert("separator".into(), Value::Bytes(vec![9, 9]));
+
+        let err = args
+            .to_argv_excluding(&["content"])
+            .expect_err("non-excluded named Bytes must still error");
+        let ToolArgvError::BinaryNamedValue { key, .. } = err;
+        assert_eq!(key, "separator");
+    }
+
+    /// Excluding a key that isn't a `Value::Bytes` at all (the common case —
+    /// most invocations of `write` carry plain string content) still drops it
+    /// from argv. The exclusion is unconditional on the key, not conditional
+    /// on the value being binary.
+    #[test]
+    fn to_argv_excluding_drops_excluded_key_regardless_of_value_type() {
+        let mut args = ToolArgs::new();
+        args.named.insert("content".into(), Value::String("hello".into()));
+        args.named.insert("path".into(), Value::String("dest.txt".into()));
+
+        let argv = args.to_argv_excluding(&["content"]).expect("no error expected");
+        assert_eq!(argv, vec!["--path=dest.txt"]);
+    }
+
+    /// An empty exclude list must behave *exactly* like `to_argv()` — same
+    /// tokens, same order — across flags, named values, and positionals, on
+    /// args that don't touch the Bytes edge case at all. `to_argv()` itself
+    /// delegates to this with an empty slice, so this is also the guard that
+    /// the delegation didn't change plain `to_argv()` behavior.
+    #[test]
+    fn to_argv_excluding_empty_list_matches_to_argv() {
+        let mut args = ToolArgs::new();
+        args.flags.insert("verbose".into());
+        args.flags.insert("n".into());
+        args.named.insert("limit".into(), Value::Int(10));
+        args.named.insert("name".into(), Value::String("foo".into()));
+        args.positional.push(Value::String("file.txt".into()));
+        args.positional.push(Value::String("-weird".into()));
+
+        assert_eq!(
+            args.to_argv_excluding(&[]).unwrap(),
+            args.to_argv().unwrap(),
+            "empty exclude list must be indistinguishable from to_argv()"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

A follow-up from kaibo's (deepseek) review of PR #215 (GH #164): `write.rs` cloned its `ToolArgs`, removed the `content` named value, and called `to_argv()` on the remainder — because `content` is deliberately read raw off `ToolArgs` to preserve `Value::Bytes`, and a named `Value::Bytes` trips `to_argv()`'s loud `BinaryNamedValue` guard. The clone dance worked but was bespoke: it only covers `content` by construction, so a second Bytes-capable named param (on `write` or any other builtin adopting the same raw-read idiom) would silently stop being covered.

- Adds `ToolArgs::to_argv_excluding(&self, exclude: &[&str])` in `kaish-types`: skips the given **named** keys before their values are ever handed to the renderer, so an excluded key's `Value::Bytes` can't reach the `BinaryNamedValue` guard — without cloning the whole `ToolArgs`.
- `to_argv()` now delegates to `to_argv_excluding(&[])` — one rendering path, no parallel old/new representations (per the project's no-dual-representations rule).
- **Named-only exclusion is deliberate.** A bool flag carries no value to protect. A positional's clap-reflected field is already a validation-only sink nobody reads (CLAUDE.md's clap-builtin convention), so positional `Value::Bytes` never needed an exemption — `value_to_argv_token` already renders it as an inert placeholder. If a future case needs to exclude a flag or positional too, that's new design, not an extension of this helper.
- Adopted in `write.rs`: `args.to_argv_excluding(&["content"])` replaces the clone-and-remove.
- **Survey:** grepped the workspace for other clone-then-remove-then-`to_argv` sites — `write.rs` was the only one. No other adoption needed right now.

## Test plan

- [x] TDD: new unit tests in `kaish-types` (`crates/kaish-types/src/tool.rs`) written first against the not-yet-existing method (confirmed compile failure), then made to pass: excluded named `Bytes` doesn't error and doesn't appear in argv; non-excluded named `Bytes` still errors; excluding a non-`Bytes` key still drops it; empty exclude list produces byte-identical output to `to_argv()`.
- [x] Existing `write` unit tests pass unchanged (`test_write_simple`, `test_write_named`, `test_write_nested`, `test_write_no_path`).
- [x] Existing kernel-routed binary round-trip test still passes: `write_binary_content_positional_round_trips_byte_for_byte`.
- [x] Added a kernel-routed test for the **named** form, which had zero prior coverage even though it's the exact scenario this helper exists for: `write_binary_content_named_flag_round_trips_byte_for_byte` (`write dest.bin --content=$b`).
- [x] `cargo test --all --locked` — clean.
- [x] `cargo clippy --all --all-targets` — zero warnings.
- [x] `cargo check -p kaish-kernel --no-default-features` — clean.
- [x] `CHANGELOG.md` bullet under `Unreleased` → `Added` (purely additive kaish-types API, not BREAKING).

Closes #218