### PR TITLE
feat(kernel): ExecuteOptions::interrupt — polled interrupt check for blocked-thread embedders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ breaking entries are marked **BREAKING**.
 ## [Unreleased]
 
 ### Added
+- **`ExecuteOptions::interrupt`** — a polled interrupt check for embedders
+  whose thread cannot fire `cancel_token` while execution runs (the browser:
+  single-threaded wasm reading a SharedArrayBuffer flag the page's main
+  thread flips). The kernel polls at its existing cancellation checkpoints
+  and maps a firing check to the same exit-130 path as `Kernel::cancel()`;
+  session state survives the interrupt. Per-call and cleared on every exit
+  path. First consumer: state-preserving Ctrl-C in the kaish-extras
+  browser playground.
+
+### Added
 - **Flag completion helpers in `kaish_client::completion`** —
   `current_command(line, pos)` (which command word governs the statement
   under the cursor) and `flag_candidates(params, word)` (canonical `--long`

--- a/crates/kaish-kernel/src/kernel.rs
+++ b/crates/kaish-kernel/src/kernel.rs
@@ -766,6 +766,12 @@ pub struct Kernel {
     /// needs sync access. Each `execute()` call gets a fresh child token;
     /// `cancel()` cancels the current token and replaces it.
     cancel_token: std::sync::Mutex<tokio_util::sync::CancellationToken>,
+    /// Per-call polled interrupt check (`ExecuteOptions::interrupt`),
+    /// installed for the duration of an `execute_with_options` call and
+    /// cleared on exit. Consulted by `is_cancelled()` so every existing
+    /// cancellation checkpoint gains interrupt awareness without new wiring.
+    /// std Mutex for the same sync-access reason as `cancel_token`.
+    interrupt: std::sync::Mutex<Option<std::sync::Arc<dyn Fn() -> bool + Send + Sync>>>,
     /// Terminal state for job control (interactive mode only, Unix only).
     #[cfg(all(unix, feature = "subprocess"))]
     terminal_state: Option<Arc<crate::terminal::TerminalState>>,
@@ -1215,6 +1221,7 @@ impl Kernel {
             kill_grace,
             stderr_receiver: tokio::sync::Mutex::new(stderr_receiver),
             cancel_token: std::sync::Mutex::new(tokio_util::sync::CancellationToken::new()),
+            interrupt: std::sync::Mutex::new(None),
             #[cfg(all(unix, feature = "subprocess"))]
             terminal_state: None,
             self_weak: std::sync::OnceLock::new(),
@@ -1358,6 +1365,7 @@ impl Kernel {
             kill_grace: self.kill_grace,
             stderr_receiver: tokio::sync::Mutex::new(stderr_receiver),
             cancel_token: std::sync::Mutex::new(cancel),
+            interrupt: std::sync::Mutex::new(None),
             #[cfg(all(unix, feature = "subprocess"))]
             terminal_state: None,
             self_weak: std::sync::OnceLock::new(),
@@ -1433,7 +1441,19 @@ impl Kernel {
     }
 
     /// Check if the current execution has been cancelled.
+    ///
+    /// Also the polling point for `ExecuteOptions::interrupt`: when the
+    /// embedder's check reports true, the internal token fires here, so every
+    /// call site of this method is an interrupt checkpoint for free.
     pub fn is_cancelled(&self) -> bool {
+        let interrupted = {
+            #[allow(clippy::expect_used)]
+            let check = self.interrupt.lock().expect("interrupt poisoned");
+            check.as_ref().is_some_and(|f| f())
+        };
+        if interrupted {
+            self.cancel();
+        }
         #[allow(clippy::expect_used)]
         let token = self.cancel_token.lock().expect("cancel_token poisoned");
         token.is_cancelled()
@@ -1814,6 +1834,25 @@ impl Kernel {
         // (b) re-route a later `Kernel::cancel()` into the embedder's token,
         // (c) extend the token's lifetime via the kernel's strong clone.
         let internal = self.reset_cancel();
+
+        // Install the per-call polled interrupt for `is_cancelled()` to
+        // consult. The guard clears it on every exit path — a stale check
+        // must not outlive its call and fire into a later one.
+        struct ClearInterrupt<'a>(&'a Kernel);
+        impl Drop for ClearInterrupt<'_> {
+            fn drop(&mut self) {
+                if let Ok(mut slot) = self.0.interrupt.lock() {
+                    *slot = None;
+                }
+            }
+        }
+        {
+            #[allow(clippy::expect_used)]
+            let mut slot = self.interrupt.lock().expect("interrupt poisoned");
+            *slot = opts.interrupt.clone();
+        }
+        let _interrupt_guard = ClearInterrupt(self);
+
         // Race the embedder token against the kernel's internal token via a
         // tracked watcher task. We hold the JoinHandle so we can abort the
         // task at function exit — otherwise it would wait forever for either

--- a/crates/kaish-kernel/tests/interrupt.rs
+++ b/crates/kaish-kernel/tests/interrupt.rs
@@ -1,0 +1,76 @@
+//! `ExecuteOptions::interrupt` — the polled interrupt check for embedders
+//! whose thread cannot fire a cancel token while execution runs (the
+//! browser: single-threaded wasm polling a SharedArrayBuffer flag).
+//!
+//! The contract under test: the kernel polls the check at its cancellation
+//! checkpoints, an interrupt maps to the same exit-130 path as
+//! `Kernel::cancel()`, session state survives, and the check never leaks
+//! past its own call.
+
+
+#![allow(clippy::expect_used)]
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::Arc;
+
+use kaish_kernel::{ExecuteOptions, Kernel, KernelConfig};
+
+fn kernel() -> Arc<Kernel> {
+    Kernel::new(KernelConfig::isolated())
+        .expect("kernel")
+        .into_arc()
+}
+
+/// A runaway `while true` loop stops with exit 130 when the check fires,
+/// and everything the session did before and during the loop survives.
+#[tokio::test]
+async fn interrupt_stops_loop_preserving_state() {
+    let k = kernel();
+    k.execute("BEFORE=kept").await.expect("set var");
+
+    let polls = Arc::new(AtomicU32::new(0));
+    let seen = polls.clone();
+    let opts = ExecuteOptions::new()
+        .with_interrupt(Arc::new(move || seen.fetch_add(1, Ordering::Relaxed) >= 3));
+
+    let r = k
+        .execute_with_options("while true; do DURING=also-kept; done", opts)
+        .await
+        .expect("interrupted execute returns a result, not an error");
+    assert_eq!(r.code, 130, "interrupt maps to SIGINT-style exit 130");
+    assert!(polls.load(Ordering::Relaxed) >= 3, "check was actually polled");
+
+    // The point of tier-2 interrupt: the session survives.
+    let r = k.execute("echo \"$BEFORE/$DURING\"").await.expect("echo");
+    assert_eq!(r.text_out().trim(), "kept/also-kept");
+}
+
+/// A check that never fires changes nothing.
+#[tokio::test]
+async fn inert_interrupt_is_invisible() {
+    let k = kernel();
+    let opts = ExecuteOptions::new().with_interrupt(Arc::new(|| false));
+    let r = k.execute_with_options("echo hello", opts).await.expect("echo");
+    assert_eq!(r.code, 0);
+    assert_eq!(r.text_out().trim(), "hello");
+}
+
+/// The check is per-call: it must not leak into the next execute.
+#[tokio::test]
+async fn interrupt_does_not_leak_into_later_calls() {
+    let k = kernel();
+    let opts = ExecuteOptions::new().with_interrupt(Arc::new(|| true));
+    let r = k
+        .execute_with_options("while true; do true; done", opts)
+        .await
+        .expect("interrupted");
+    assert_eq!(r.code, 130);
+
+    // Same kernel, plain execute: an interrupt stuck in the slot would kill
+    // this loop too. Three iterations then exit cleanly proves it's gone.
+    let r = k
+        .execute("N=0; while test $N -lt 3; do N=$((N + 1)); done; echo $N")
+        .await
+        .expect("clean run");
+    assert_eq!(r.code, 0, "stale interrupt leaked: {}", r.err);
+    assert_eq!(r.text_out().trim(), "3");
+}

--- a/crates/kaish-types/src/kernel.rs
+++ b/crates/kaish-types/src/kernel.rs
@@ -76,6 +76,15 @@ pub struct ExecuteOptions {
     /// `String`-typed to match `ExecContext::set_stdin`; binary stdin is fed
     /// through files/VFS, not this knob.
     pub stdin: Option<String>,
+    /// Polled interrupt check, for embedders whose thread cannot fire
+    /// `cancel_token` while execution runs — the motivating case is
+    /// single-threaded wasm, where the browser's main thread flips a
+    /// SharedArrayBuffer flag and this closure reads it. The kernel polls at
+    /// its cancellation checkpoints (each loop iteration, among others) and,
+    /// on `true`, fires its internal cancel — the same exit-130 path as
+    /// `Kernel::cancel()`. Keep the closure cheap: it runs on the hot path.
+    /// `None` (the default) polls nothing.
+    pub interrupt: Option<std::sync::Arc<dyn Fn() -> bool + Send + Sync>>,
 }
 
 impl ExecuteOptions {
@@ -92,6 +101,15 @@ impl ExecuteOptions {
     /// Add a single variable to the overlay (extending; last write wins).
     pub fn with_var(mut self, name: impl Into<String>, value: Value) -> Self {
         self.vars.insert(name.into(), value);
+        self
+    }
+
+    /// Install a polled interrupt check (see the `interrupt` field).
+    pub fn with_interrupt(
+        mut self,
+        check: std::sync::Arc<dyn Fn() -> bool + Send + Sync>,
+    ) -> Self {
+        self.interrupt = Some(check);
         self
     }
 


### PR DESCRIPTION
## What

`ExecuteOptions::interrupt: Option<Arc<dyn Fn() -> bool + Send + Sync>>` — a per-call polled interrupt check, enabling **state-preserving Ctrl-C** in the kaish-extras browser playground (tier 2 of the design discussed with Amy).

## Why this shape

The cancellation plumbing already existed end-to-end: `cancel_token` races the internal token, loops checkpoint per iteration via `Kernel::is_cancelled()`, and cancellation maps to exit 130. The only gap is on single-threaded wasm: nothing can *fire* a token while the worker thread is blocked inside `execute()` — the sole cross-thread signal a blocked worker can observe is a SharedArrayBuffer read through JS Atomics, which is a *poll*, not an event.

So the seam is a polled check, consulted inside `is_cancelled()` itself — every existing checkpoint becomes an interrupt checkpoint with one wiring point, and a firing check takes exactly the `Kernel::cancel()` path. It's installed per-call behind a drop guard so no closure outlives its call.

## Verification

Failing-first tests in `tests/interrupt.rs`: a runaway `while true` stops with 130 **and both prior and mid-loop variables survive** (the point of tier 2); an inert check is invisible; the check does not leak into later executes. Full kernel suite green, clippy clean.

Consumer wiring (SAB flag + coi-serviceworker for Pages, tier-1 terminate fallback when SAB is unavailable) lands in kaish-extras next, pinned to this branch until merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017iutoShYRUYwdv94ZwBmPj