### PR TITLE
fix(awk,env): repeatable flags fail loudly on binary values instead of silently skipping (#217)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,17 @@ breaking entries are marked **BREAKING**.
   kaish-extras `kaish-web` crate is a working embedding.
 
 ### Fixed
+- **`awk -v` and `env -u` fail loudly on a binary occurrence instead of
+  silently dropping it** (GH #217) — found by a kaibo review of PR #215.
+  Both flags are repeatable-value flags, so the kernel accumulates every
+  occurrence (even the first) into a `Value::Json(Array)`; a binary
+  occurrence lands in that array as a base64 envelope, and each builtin's own
+  hand-rolled collector (`awk::collect_vars`, `env::collect_unset_vars`)
+  filtered for strings and silently skipped anything else — the assignment
+  or unset just vanished and the builtin ran as if the flag had never been
+  given. Both now delegate to the shared `read_repeatable_strings` helper
+  that `grep`/`glob` already use for `--ftype`/`--include`/`--exclude`, so a
+  binary occurrence errors instead of disappearing.
 - **Case patterns accept dash/plus bare words** (GH #144) — `---`, `-`, `--`,
   `-x`, `+foo`, and alternations like `-h|--help) ...` are now valid case
   patterns; they previously failed to parse (`pattern_part` had no arm for

--- a/crates/kaish-kernel/src/tools/builtin/awk.rs
+++ b/crates/kaish-kernel/src/tools/builtin/awk.rs
@@ -15,6 +15,7 @@ use std::path::Path;
 use crate::ast::Value;
 use crate::interpreter::{ExecResult, OutputData};
 use crate::tools::builtin::get_path_string;
+use crate::tools::builtin::read_repeatable_strings;
 use crate::tools::builtin::regex_dialect::{append_dialect_hint, bre_metas_to_ere};
 use crate::tools::{schema_from_clap, ExecContext, ToolCtx, GlobalFlags, Tool, ToolArgs, ToolSchema};
 
@@ -158,7 +159,11 @@ impl Tool for Awk {
         // `ToolArgs::to_argv()` collapses to one JSON token (it can't tell a
         // repeatable scalar array from a single array value) — same gotcha as
         // sed's `-e`. Each assignment is applied in order; later wins.
-        for var_assign in collect_vars(&args) {
+        let var_assigns = match collect_vars(&args) {
+            Ok(v) => v,
+            Err(e) => return ExecResult::failure(2, format!("awk: -v: {e}")),
+        };
+        for var_assign in var_assigns {
             if let Some((name, value)) = var_assign.split_once('=') {
                 // Command-line assignments are numeric strings (POSIX strnum).
                 runtime.set_var(name.trim(), AwkValue::StrNum(value.to_string()));
@@ -186,24 +191,25 @@ impl Tool for Awk {
 /// under the canonical `var` key; a single value may arrive as a bare
 /// `Value::String`. Mirrors sed's `collect_expressions` — see the repeatable
 /// gotcha in `[[arch_repeatable_flags]]`.
-fn collect_vars(args: &ToolArgs) -> Vec<String> {
-    let mut vars = Vec::new();
+///
+/// Delegates to [`read_repeatable_strings`] (GH #217) rather than a hand-rolled
+/// `filter_map`: a `-v` value that reaches here is either the `key=value`
+/// string produced by `consume_flag_positionals`'s WordAssign reassembly (see
+/// `awk_dash_v_binary_assignment_is_loud`), or a *bare* substitution with no
+/// literal `=` in the source (`-v $x`) — which skips that guard and can still
+/// carry a binary envelope. The old `if let Value::String(s) = item` filter
+/// silently dropped that entry instead of erroring, so the assignment just
+/// vanished and awk ran as if `-v` had never been given.
+fn collect_vars(args: &ToolArgs) -> Result<Vec<String>, String> {
     // Both `-v` and `--var` canonicalize to the long name `var`; `v` is
     // defensive insurance in case a future change binds under the short alias.
-    for key in ["var", "v"] {
-        match args.named.get(key) {
-            Some(crate::ast::Value::Json(serde_json::Value::Array(items))) => {
-                for item in items {
-                    if let serde_json::Value::String(s) = item {
-                        vars.push(s.clone());
-                    }
-                }
-            }
-            Some(crate::ast::Value::String(s)) => vars.push(s.clone()),
-            _ => {}
-        }
+    // Only one key is ever actually populated, so trying `var` first and
+    // falling back to `v` only when it's empty can't double-count or reorder.
+    let vars = read_repeatable_strings(args, "var")?;
+    if !vars.is_empty() {
+        return Ok(vars);
     }
-    vars
+    read_repeatable_strings(args, "v")
 }
 
 // ============================================================================

--- a/crates/kaish-kernel/src/tools/builtin/env.rs
+++ b/crates/kaish-kernel/src/tools/builtin/env.rs
@@ -15,6 +15,7 @@ use clap::{CommandFactory, Parser};
 
 use crate::ast::Value;
 use crate::interpreter::{ExecResult, OutputData};
+use crate::tools::builtin::read_repeatable_strings;
 use crate::tools::{schema_from_clap, ExecContext, ToolCtx, GlobalFlags, Tool, ToolArgs, ToolSchema};
 
 /// Env tool: print environment or run command with modified environment.
@@ -95,7 +96,10 @@ impl Tool for Env {
         // named["u"], but `to_argv()` re-renders that as a single JSON token
         // that clap can't split back into individual strings. Read the raw map
         // directly (same approach sed uses for repeatable `-e`).
-        let unset_vars = collect_unset_vars(&args);
+        let unset_vars = match collect_unset_vars(&args) {
+            Ok(v) => v,
+            Err(e) => return ExecResult::failure(2, format!("env: -u: {e}")),
+        };
 
         // No positional arguments: print environment with -u/-i applied.
         // -u and -i must filter the listing even when no command is given.
@@ -185,28 +189,17 @@ impl Tool for Env {
 /// split that array back into individual `-u=NAME` tokens, so we must read the
 /// raw `ToolArgs::named` map directly — the same pattern sed uses for its
 /// repeatable `-e` expressions.
-fn collect_unset_vars(args: &ToolArgs) -> Vec<String> {
-    // The kernel canonicalises the flag to the long name; "u" is a defensive
-    // fallback in case a future change binds under the short alias.
-    for key in ["u"] {
-        match args.named.get(key) {
-            Some(Value::Json(serde_json::Value::Array(items))) => {
-                return items
-                    .iter()
-                    .filter_map(|v| {
-                        if let serde_json::Value::String(s) = v {
-                            Some(s.clone())
-                        } else {
-                            None
-                        }
-                    })
-                    .collect();
-            }
-            Some(Value::String(s)) => return vec![s.clone()],
-            _ => {}
-        }
-    }
-    Vec::new()
+///
+/// Delegates to [`read_repeatable_strings`] (GH #217): `-u` never takes a
+/// `key=value` form, so every occurrence — even the first — is a bare
+/// positional that `push_repeatable_value` wraps into the array regardless of
+/// occurrence count. The old hand-rolled `filter_map` silently dropped a
+/// binary occurrence instead of erroring, so `env -u $BIN` would run as if
+/// `-u` had never been given rather than failing loudly.
+fn collect_unset_vars(args: &ToolArgs) -> Result<Vec<String>, String> {
+    // The kernel canonicalises the flag to the long name; "u" is the only key
+    // ever actually populated.
+    read_repeatable_strings(args, "u")
 }
 
 /// Print environment with overrides applied.

--- a/crates/kaish-kernel/tests/binary_text_sink_tests.rs
+++ b/crates/kaish-kernel/tests/binary_text_sink_tests.rs
@@ -735,6 +735,94 @@ async fn grep_ftype_binary_is_loud_not_silently_dropped() {
     );
 }
 
+// ── GH #217: awk `-v` / env `-u` had their own silent-skip copy of the same
+// bug `read_repeatable_strings` fixed for grep's `--ftype` above. Found by
+// kaibo review of PR #215. `awk -v x=$BIN` (the WordAssign `key=value` form)
+// was already loud — `consume_flag_positionals`'s WordAssign arm reassembles
+// via `value_to_text_sink_named` before the value ever reaches the
+// repeatable-flag accumulator (see `awk_dash_v_binary_assignment_is_loud`
+// above). But a *bare* `-v $BIN` (no literal `=` in the source, so it's an
+// `Arg::Positional`, not a `WordAssign`) skips that guard entirely and lands
+// straight in `push_repeatable_value`, same as `env -u $BIN` always does
+// (`-u` never takes `key=value` form). Both `awk::collect_vars` and
+// `env::collect_unset_vars` had their own hand-rolled `if let
+// serde_json::Value::String(s) = item` filters that silently dropped a
+// non-string array entry instead of checking for the binary envelope first —
+// unlike `read_repeatable_strings`, which both builtins now delegate to.
+
+/// `awk -v $BIN 'BEGIN{}'` — a single *bare* occurrence (no `=` in the source)
+/// used to vanish silently rather than error.
+#[tokio::test]
+async fn awk_v_bare_single_binary_occurrence_is_loud_not_silently_dropped() {
+    let dir = tempdir().unwrap();
+    fs::write(dir.path().join("src.bin"), BIN).unwrap();
+    let kernel = kernel_at(dir.path());
+    let result = kernel
+        .execute("b=$(cat src.bin); awk -v $b 'BEGIN{}'")
+        .await
+        .unwrap();
+    assert_ne!(result.code, 0, "err={}", result.err);
+    assert!(
+        result.err.contains("cannot be used as"),
+        "error should name the binary problem, got err={:?}",
+        result.err
+    );
+}
+
+/// Two `-v` flags, only the SECOND binary: must fail loudly naming the
+/// problem, not silently drop the binary occurrence and apply only the first.
+#[tokio::test]
+async fn awk_v_multi_occurrence_binary_is_loud_not_silently_dropped() {
+    let dir = tempdir().unwrap();
+    fs::write(dir.path().join("src.bin"), BIN).unwrap();
+    let kernel = kernel_at(dir.path());
+    let result = kernel
+        .execute("b=$(cat src.bin); awk -v x=1 -v $b 'BEGIN{print x}'")
+        .await
+        .unwrap();
+    assert_ne!(result.code, 0, "err={}", result.err);
+    assert!(
+        result.err.contains("cannot be used as"),
+        "error should name the binary problem, got err={:?}",
+        result.err
+    );
+}
+
+/// `env -u $BIN` — `-u` never takes a `key=value` form, so even a single
+/// occurrence is a bare positional; it used to vanish silently.
+#[tokio::test]
+async fn env_u_single_binary_occurrence_is_loud_not_silently_dropped() {
+    let dir = tempdir().unwrap();
+    fs::write(dir.path().join("src.bin"), BIN).unwrap();
+    let kernel = kernel_at(dir.path());
+    let result = kernel.execute("b=$(cat src.bin); env -u $b").await.unwrap();
+    assert_ne!(result.code, 0, "err={}", result.err);
+    assert!(
+        result.err.contains("cannot be used as"),
+        "error should name the binary problem, got err={:?}",
+        result.err
+    );
+}
+
+/// Two `-u` flags, only the SECOND binary: must fail loudly, not silently
+/// unset FOO and drop the binary occurrence.
+#[tokio::test]
+async fn env_u_multi_occurrence_binary_is_loud_not_silently_dropped() {
+    let dir = tempdir().unwrap();
+    fs::write(dir.path().join("src.bin"), BIN).unwrap();
+    let kernel = kernel_at(dir.path());
+    let result = kernel
+        .execute("b=$(cat src.bin); env -u FOO -u $b")
+        .await
+        .unwrap();
+    assert_ne!(result.code, 0, "err={}", result.err);
+    assert!(
+        result.err.contains("cannot be used as"),
+        "error should name the binary problem, got err={:?}",
+        result.err
+    );
+}
+
 // ── GH #164: ToolArgs::to_argv() closes the root cause behind the #120 bug
 // class (a named/flag Value::Bytes silently stringifying to the `[binary: N
 // bytes]` placeholder before a builtin's clap layer ever sees it) — named/flag


### PR DESCRIPTION
## Summary

A kaibo review of PR #215 (the `ToolArgs::to_argv()` binary guard) flagged an
asymmetry: `awk -v` and `env -u` were the only two repeatable-value flags in
the tree that still silently dropped a binary occurrence instead of erroring.
`grep`/`glob`'s `--ftype`/`--include`/`--exclude` already go loud via the
shared `read_repeatable_strings` helper, and `sed -e` goes loud via its own
hand-rolled `collect_expressions`. `awk::collect_vars` and
`env::collect_unset_vars` had their own hand-rolled collectors that filtered
array items for `Value::String` and silently skipped anything else —
including a base64 binary envelope.

- Migrated both `collect_vars` (awk) and `collect_unset_vars` (env) to the
  shared `read_repeatable_strings` helper instead of a second hand-rolled loud
  path. Its shape — a flat `Vec<String>`, checking for the binary envelope
  before giving up on a non-string item — fits both call sites with no loss:
  awk only ever needs the assignment text back, env only ever needs the
  variable name back.
- Turns out the bug wasn't limited to the *repeated*-flag case. Every
  occurrence of a repeatable flag — even the very first — is wrapped into a
  `Value::Json(Array)` by `push_repeatable_value` (there's no special case for
  "only one occurrence so far"), so a lone `env -u $BIN` or a bare `awk -v
  $BIN` (no literal `=` in the source, so it skips the WordAssign
  `key=value` reassembly guard that already made `awk -v x=$BIN` loud)
  silently vanished today too, not just the two-flags-one-binary case. Pinned
  both the single-bare-occurrence and multi-occurrence shapes with failing
  tests before touching the fix; both flipped green after the migration.

## Survey

Grepped `crates/kaish-kernel/src/tools/builtin/` for the
accumulate-then-filter-strings pattern (`fn collect_...` reading
`args.named` and filtering a `Json(Array)` for strings). The only other
match was jq's `collect_bindings` (`--arg`/`--argjson`), and it turned out to
be a structurally different bug, not a sibling of this one:

- `--arg`/`--argjson` are `consumes=2` pair flags (`NAME VALUE`), a different
  binding shape than awk/env's single-value flags.
- Its `value_as_string` helper doesn't filter-and-drop; it *always* returns
  `Some(...)`, stringifying any non-string/number/bool JSON value (including
  a binary envelope) into the bound `$var` rather than erroring.
- Confirmed empirically: `jq -n --arg x $BIN '$x'` exits 0 today, with `$x`
  bound to the literal JSON text of the base64 envelope object, not a loud
  error and not the real bytes.

That's silent data corruption rather than silent-drop, and fixing it means
deciding what `--arg`/`--argjson` *should* do with binary (error? decode?) —
a real design question, not a copy-paste of this fix. Left out of this PR;
flagging here so it doesn't get lost.

## Test plan

- [x] Failing tests added first (`binary_text_sink_tests.rs`): single-bare-
      occurrence and multi-occurrence binary `-v`/`-u`, confirmed RED against
      the pre-fix code (exit 0, silently dropped) before implementing the fix.
- [x] Existing happy-path regressions still pass: `awk_multiple_v_assignments_all_apply`
      (`builtin_fidelity_tests.rs`), `env_u_multiple_removes_all_named` /
      `env_u_removes_var_from_listing` (`env_filter_tests.rs`).
- [x] `cargo test --all --locked` — all green.
- [x] `cargo clippy --all --all-targets` — zero warnings.
- [x] `cargo check -p kaish-kernel --no-default-features` — clean.
- [x] CHANGELOG.md bullet under `## [Unreleased]` → `### Fixed`.

Closes #217