### PR TITLE
fix(output-limit): principled spill-mode defaults for host-backed kernels (#177)

### DIFF
--- a/crates/kaish-kernel/src/output_limit.rs
+++ b/crates/kaish-kernel/src/output_limit.rs
@@ -715,6 +715,34 @@ mod tests {
         assert!(result.text_out().starts_with("1\n"));
     }
 
+    /// GH #177: every other Disk-mode test in this module re-specifies
+    /// `spill_mode: SpillMode::Disk` explicitly, so none of them actually pin
+    /// that a host-backed (`Sandboxed`) kernel's *untouched* default — no
+    /// `.with_output_limit()` override at all — is `Disk`. This is the literal
+    /// "`Kernel::new` without `.in_memory()`" scenario the issue names. The
+    /// forcing logic in `Kernel::assemble` (`no_host_side_channel`) must leave
+    /// a `Sandboxed` kernel's config alone; only `NoLocal`/`with_backend`
+    /// override it to `Memory`.
+    #[tokio::test]
+    async fn test_agent_kernel_unmodified_default_spills_to_disk() {
+        use crate::kernel::{Kernel, KernelConfig};
+
+        // Untouched: OutputLimitConfig::agent() — 8K limit, SpillMode::Disk.
+        let config = KernelConfig::agent();
+        assert_eq!(config.output_limit.spill_mode(), SpillMode::Disk);
+        let kernel = Kernel::new(config).expect("kernel creation");
+
+        let big = "x".repeat(8 * 1024 + 200);
+        let result = kernel.execute(&format!("echo '{}'", big)).await.expect("execute");
+        assert_eq!(result.code, 3, "default 8K agent limit should trip the spill");
+        assert!(
+            result.text_out().contains("full output at"),
+            "an unmodified agent() default must spill to a real file, not truncate in \
+             memory: {}",
+            result.text_out()
+        );
+    }
+
     #[tokio::test]
     async fn test_spill_exits_3() {
         use crate::kernel::{Kernel, KernelConfig};

--- a/docs/EMBEDDING.md
+++ b/docs/EMBEDDING.md
@@ -334,6 +334,49 @@ vfs.mount("/", MemoryFs::with_budget(budget.clone()));
 // budget.used() / budget.remaining() are observable at any time.
 ```
 
+### Output Limits and Spill Mode (`OutputLimitConfig`)
+
+`KernelConfig::output_limit` caps how much a single command's output can grow
+before it's truncated (exit code 3 — see [the result contract](#the-result-contract)).
+Independent of the byte cap, `SpillMode` decides *where* the overflow goes:
+
+- **`SpillMode::Disk`** (the default): the full output is written to a spill
+  file under `paths::spill_dir()` — `$XDG_RUNTIME_DIR/kaish/spill` (tmpfs on
+  systemd systems, cleared on reboot) — and the result carries a head+tail
+  preview pointing at it (`cat` it to read the rest).
+- **`SpillMode::Memory`**: head+tail truncation only — no disk I/O, no
+  recoverable file. Memory stays bounded regardless of how much the command
+  produced.
+
+| Construction | `SpillMode` |
+|---|---|
+| `KernelConfig::agent()` / `.agent_with_root()` / `.named()` / `.transient()` (`Sandboxed`, real host mount) | `Disk` |
+| `KernelConfig::repl()` (`Passthrough`, real host mount) | `Disk` in principle, but moot — `repl()`'s `output_limit` is `none()` (unlimited) |
+| `KernelConfig::isolated()`, or any config `.with_vfs_mode(VfsMountMode::NoLocal)` | `Memory` — forced at construction, no host mount to spill to |
+| `Kernel::with_backend(..)` | `Memory` — forced at construction, the embedder owns the VFS and a kernel-side `std::fs` write would bypass it (see the Warning above) |
+
+Forcing beats an explicit request: setting `SpillMode::Disk` on a config that's
+`NoLocal` or headed for `with_backend` is silently overridden to `Memory` in
+`Kernel::assemble` — neither kernel shape owns a host mount to write to, so an
+explicit `Disk` request there would be nonsensical, not honored.
+
+A **host-backed** kernel (`Sandboxed`/`Passthrough`, built with `Kernel::new`)
+defaults to `Disk` because it already has a real filesystem — spilling there is
+no different from any other write it does. If you want a host-backed kernel
+that nonetheless never touches disk (e.g. the output may hold data you don't
+want recoverable from a temp file even though the kernel has host access),
+opt in explicitly:
+
+```rust
+use kaish_kernel::OutputLimitConfig;
+
+let config = KernelConfig::agent()
+    .with_output_limit(OutputLimitConfig::agent().in_memory());
+```
+
+There's no equivalent flag to force `Disk` on a `NoLocal`/`with_backend`
+kernel — by design, since neither owns a host mount to spill to.
+
 ## Initial Variables and Hermetic Subprocess Env
 
 The kernel is **hermetic by default** — it never reads `std::env::vars()`,


### PR DESCRIPTION
## Summary

GH #177 flagged a residual from the SpillMode work: `NoLocal`/no-host-fs
kernels are auto-forced to `SpillMode::Memory` at construction (`kernel.rs`
`Kernel::assemble`, `no_host_side_channel` logic), but a host-backed
(`Sandboxed`/`Passthrough`) kernel built via `Kernel::new` without
`.in_memory()` still defaults to `SpillMode::Disk`. The issue asked whether
that's an actual bug or already-correct behavior — "none known in the wild."

## Scope decision

**Disk-by-default for host-backed kernels is correct, not a bug — no
production behavior change in this PR.**

- `Kernel::assemble`'s forcing logic is `no_host_side_channel =
  no_host_filesystem || matches!(config.vfs_mode, VfsMountMode::NoLocal)`.
  A `Sandboxed`/`Passthrough` kernel already mounts a real host filesystem —
  even `/tmp` and the XDG runtime dir stay real `LocalFs` regardless of the
  `overlay` flag — so a spill file landing there is no different from any
  other host write the kernel already does.
- Both real embedders construct their kernels exclusively via
  `Kernel::with_backend` (kaibo's `src/sandbox.rs`, kaijutsu's
  `crates/kaijutsu-kernel/src/runtime/embedded_kaish.rs`), which is already
  forced to `Memory` (`no_host_filesystem = true`) — neither is affected in
  practice, matching the issue's own "none known in the wild."
- There is no "read-only Sandboxed via `Kernel::new`" construction path in
  the codebase — the only read-only host-backed kernels are built via
  `with_backend` (kaibo's `LocalFs::read_only` + `LocalBackend`), already
  covered by the forced-Memory branch.
- Got a second opinion via kaibo (cast `deepseek`) on this conclusion —
  no host-backed construction path found where the Disk default is actually
  dangerous.

## Forcing matrix (as implemented, unchanged — now pinned by test + docs)

| Construction | `SpillMode` |
|---|---|
| `KernelConfig::agent()` / `.agent_with_root()` / `.named()` / `.transient()` (`Sandboxed`) | `Disk` |
| `KernelConfig::repl()` (`Passthrough`) | `Disk` in principle, moot — `repl()`'s limit is `none()` |
| `KernelConfig::isolated()` / any `.with_vfs_mode(VfsMountMode::NoLocal)` | `Memory` (forced) |
| `Kernel::with_backend(..)` | `Memory` (forced) |

An explicit `SpillMode::Disk` request is silently overridden to `Memory` for
the last two rows — already tested (`test_nolocal_kernel_forces_memory_spill`,
`test_with_backend_forces_in_memory_spill_not_host_disk`). The one real gap:
every existing Disk-mode test re-specified `spill_mode: SpillMode::Disk`
explicitly, so none pinned that the *untouched* default (no
`.with_output_limit()` override at all) is Disk for a host-backed kernel —
closed by the new `test_agent_kernel_unmodified_default_spills_to_disk`.

## What changed

- **Test** (`crates/kaish-kernel/src/output_limit.rs`): new
  `test_agent_kernel_unmodified_default_spills_to_disk`, built from a
  completely untouched `KernelConfig::agent()`. Verified it fails when the
  forcing logic is broken (temporarily forced `no_host_side_channel = true`
  locally, confirmed the new test panics, reverted).
- **Docs** (`docs/EMBEDDING.md`): new "Output Limits and Spill Mode" section
  under Kernel Construction — the forcing matrix table above, and the
  `.in_memory()` opt-out for embedders who want a host-backed kernel that
  still never touches disk. The actual residual here was discoverability,
  not behavior.
- **CHANGELOG**: no bullet — docs/tests only, no observable behavior changed.

## Parked (not this PR)

The issue's second bullet — `host` feature's `/proc`/`/etc` reads bypassing
the VFS by design — is a separate documentation/positioning question ("is
read-only ever marketed as no host observation") not a code change here.
Left parked per the issue; a future PR should gate it at runtime if that
marketing claim is ever made.

Refs #177 (the SpillMode-default half is resolved as "working as intended,
now documented and tested"; the `/proc`/`/etc` positioning half remains open
for a separate PR/issue if the marketing question above is ever raised —
recommend leaving #177 open or filing a narrower follow-up issue for that
half only, maintainer's call).

## Test plan

- [x] `cargo test --all --locked` — clean
- [x] `cargo clippy --all --all-targets` — zero warnings
- [x] `cargo check -p kaish-kernel --no-default-features` — clean
- [x] Manually confirmed the new test fails when the forcing logic is broken

🤖 Generated with [Claude Code](https://claude.com/claude-code)