### PR TITLE
fix(overlay): friendly error when external commands hit VFS-only paths (#181)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,15 @@ breaking entries are marked **BREAKING**.
   (GH #202).
 
 ### Fixed
+- **Friendlier error when an external command can't be spawned under a
+  virtual working directory** (CoW overlay, in-memory VFS mount, `/dev`, …):
+  a resolvable command used to fall all the way through to the generic
+  `command not found` (127), which blamed the wrong thing. Now it names the
+  real cause and suggests a fix (a kaish builtin, `cd` to a real path, or
+  `kaish-vfs commit` to materialize a CoW overlay) — exit code is unchanged.
+  A command that genuinely isn't in PATH still gets the plain
+  `command not found` (GH #181; cross-layer symlink/whiteout/mtime
+  semantics remain parked, tracked in the same issue).
 - `cargo test -p kaish-client` alone no longer fails the cwd test: the
   tests assert localfs-flavored behavior and now declare `localfs` as a
   dev-dependency feature instead of inheriting it from whichever workspace

--- a/crates/kaish-help/content/en/overlay.md
+++ b/crates/kaish-help/content/en/overlay.md
@@ -76,8 +76,11 @@ External commands (those resolved via PATH) are **unavailable** while cwd is
 inside an overlay mount. `OverlayFs::real_path` returns `None` by design —
 returning the lower's real path would hand tools a host path that bypasses
 the overlay (git and friends write through real paths). The kernel cannot
-resolve a cwd with no real path, so external commands fail with exit 127
-("command not found: git") from inside an overlay mount.
+spawn a child process with nowhere real to run it, so external commands fail
+with exit 127 from inside an overlay mount — the message names the actual
+cause (no real filesystem location for the cwd) and suggests a fix (a kaish
+builtin, `cd` to a real path, or `kaish-vfs commit`), rather than the plain
+"command not found" a missing command gets.
 
 Under Sandboxed+overlay, `cd /tmp` moves cwd to a real LocalFs mount — from
 there, external commands work and see (and write) the real filesystem directly.

--- a/crates/kaish-kernel/src/dispatch.rs
+++ b/crates/kaish-kernel/src/dispatch.rs
@@ -42,7 +42,7 @@ use crate::scheduler::build_tool_args;
 #[cfg(test)]
 use crate::tools::{GlobalFlags, ToolRegistry};
 #[cfg(all(test, feature = "subprocess"))]
-use crate::tools::resolve_in_path;
+use crate::tools::{resolve_in_path, virtual_cwd_error};
 
 /// Position of a command within a pipeline.
 ///
@@ -161,12 +161,15 @@ impl BackendDispatcher {
             return None;
         }
 
-        // Get real working directory (needed for relative path resolution and child cwd).
-        // If the CWD is virtual (no real path), skip external execution entirely.
-        let real_cwd = match ctx.backend.resolve_real_path(&ctx.cwd) {
-            Some(p) => p,
-            None => return None,
-        };
+        // Real filesystem location of the shell's cwd, if any. A `None` real
+        // path means the cwd is virtual (a CoW overlay, an in-memory VFS
+        // mount, …) — there's nowhere for a child OS process to run. Don't
+        // bail out here: a bare command name that isn't in PATH at all is a
+        // genuine "not found" regardless of cwd. Once the command actually
+        // resolves, `real_cwd` is checked again below and the honest reason
+        // is given then — kept in sync with kernel.rs::try_execute_external
+        // (issue #181).
+        let real_cwd = ctx.backend.resolve_real_path(&ctx.cwd);
 
         // Resolve command: absolute/relative path or PATH lookup
         let executable = if name.contains('/') {
@@ -174,7 +177,13 @@ impl BackendDispatcher {
             let resolved = if std::path::Path::new(name).is_absolute() {
                 std::path::PathBuf::from(name)
             } else {
-                real_cwd.join(name)
+                match &real_cwd {
+                    Some(real_cwd) => real_cwd.join(name),
+                    // Can't resolve a relative path without a real cwd to
+                    // join against, so we can't even tell whether it would
+                    // exist — name the actual blocker.
+                    None => return Some(virtual_cwd_error(name, &ctx.cwd)),
+                }
             };
             if resolved.exists() {
                 resolved.to_string_lossy().into_owned()
@@ -188,6 +197,13 @@ impl BackendDispatcher {
                 .map(crate::interpreter::value_to_string)
                 .unwrap_or_default();
             resolve_in_path(name, &path_var)?
+        };
+
+        // The executable resolved — found in PATH, or a path that exists —
+        // but there's still nowhere to run it without a real cwd.
+        let real_cwd = match real_cwd {
+            Some(p) => p,
+            None => return Some(virtual_cwd_error(name, &ctx.cwd)),
         };
 
         // Build flat argv from args. A for-loop (not filter_map) so the

--- a/crates/kaish-kernel/src/kernel.rs
+++ b/crates/kaish-kernel/src/kernel.rs
@@ -107,7 +107,7 @@ use crate::scheduler::{is_bool_type, schema_param_lookup, select_leaf, stderr_st
 use crate::scheduler::{drain_to_stream, DEFAULT_STREAM_MAX_SIZE};
 use crate::tools::{register_builtins, ExecContext, GlobalFlags, ToolArgs, ToolRegistry};
 #[cfg(feature = "subprocess")]
-use crate::tools::resolve_in_path;
+use crate::tools::{resolve_in_path, virtual_cwd_error};
 use crate::validator::{Severity, Validator};
 #[cfg(feature = "localfs")]
 use crate::vfs::LocalFs;
@@ -5122,16 +5122,17 @@ impl Kernel {
             return Ok(None);
         }
 
-        // Get real working directory for relative path resolution and child cwd.
-        // If the CWD is virtual (no real filesystem path), skip external command
-        // execution entirely — return None so the dispatch can fall through to
-        // backend-registered tools.
-        let real_cwd = {
+        // Get the shell's cwd and its real filesystem location, if any. A
+        // `None` real path means the cwd is virtual (a CoW overlay, an
+        // in-memory VFS mount, `/dev`, …) — there's nowhere for a child OS
+        // process to run. Don't bail out here: a bare command name that isn't
+        // in PATH at all is a genuine "not found" regardless of cwd, and the
+        // virtual-cwd error would blame the wrong thing for that case. Once
+        // the command actually resolves, `real_cwd` is checked again below
+        // and the honest reason is given then (issue #181).
+        let (cwd, real_cwd) = {
             let ctx = self.exec_ctx.read().await;
-            match ctx.backend.resolve_real_path(&ctx.cwd) {
-                Some(p) => p,
-                None => return Ok(None),
-            }
+            (ctx.cwd.clone(), ctx.backend.resolve_real_path(&ctx.cwd))
         };
 
         let executable = if name.contains('/') {
@@ -5139,7 +5140,14 @@ impl Kernel {
             let resolved = if std::path::Path::new(name).is_absolute() {
                 std::path::PathBuf::from(name)
             } else {
-                real_cwd.join(name)
+                match &real_cwd {
+                    Some(real_cwd) => real_cwd.join(name),
+                    // A relative path can't be resolved without a real cwd to
+                    // join against, so we can't even tell whether it would
+                    // exist — name the actual blocker instead of a
+                    // misleading "No such file or directory".
+                    None => return Ok(Some(virtual_cwd_error(name, &cwd))),
+                }
             };
             if !resolved.exists() {
                 return Ok(Some(ExecResult::failure(
@@ -5181,6 +5189,14 @@ impl Kernel {
                 Some(path) => path,
                 None => return Ok(None), // Not found - let caller handle error
             }
+        };
+
+        // The executable resolved — found in PATH, or a path that exists and
+        // is executable — but there's still nowhere to run it without a real
+        // cwd to spawn the child process in.
+        let real_cwd = match real_cwd {
+            Some(p) => p,
+            None => return Ok(Some(virtual_cwd_error(name, &cwd))),
         };
 
         tracing::debug!(executable = %executable, "resolved external command");

--- a/crates/kaish-kernel/src/tools/builtin/mod.rs
+++ b/crates/kaish-kernel/src/tools/builtin/mod.rs
@@ -27,7 +27,7 @@ mod exec;
 #[cfg(feature = "subprocess")]
 mod spawn;
 #[cfg(feature = "subprocess")]
-pub use spawn::resolve_in_path;
+pub use spawn::{resolve_in_path, virtual_cwd_error};
 mod export;
 #[cfg(feature = "subprocess")]
 mod fg;

--- a/crates/kaish-kernel/src/tools/builtin/spawn.rs
+++ b/crates/kaish-kernel/src/tools/builtin/spawn.rs
@@ -274,6 +274,30 @@ fn capture_to_result(code: Option<i32>, stdout: Vec<u8>, stderr: Vec<u8>) -> Exe
     result
 }
 
+/// Friendly, actionable error for the "nowhere to spawn" case: the shell's
+/// cwd has no location on the real filesystem (a CoW overlay, an in-memory
+/// VFS mount, `/dev`, etc.), so an external process has no real directory to
+/// run in. Shared by both external-command spawn sites
+/// (`kernel.rs::try_execute_external`, the production path, and
+/// `dispatch.rs::BackendDispatcher::try_external`, its test-only twin) so the
+/// wording can't drift between them — see CLAUDE.md's two-spawn-sites gotcha.
+///
+/// Deliberately hedges "if this is a CoW overlay" rather than asserting it:
+/// this same guard fires for any virtual cwd (a plain in-memory VFS mount
+/// too), and this call site has no way to tell which one it is.
+pub fn virtual_cwd_error(name: &str, cwd: &Path) -> ExecResult {
+    ExecResult::failure(
+        127,
+        format!(
+            "{name}: can't run external commands here — \"{}\" has no location on \
+             the real filesystem, so there's nowhere to spawn a child process. Use a \
+             kaish builtin instead, or `cd` to a real directory first; if this is a \
+             CoW overlay, `kaish-vfs commit` writes it to disk.",
+            cwd.display()
+        ),
+    )
+}
+
 /// Resolve a command name in PATH.
 ///
 /// Searches each directory in `path_var` (colon-separated) for an executable

--- a/crates/kaish-kernel/src/tools/mod.rs
+++ b/crates/kaish-kernel/src/tools/mod.rs
@@ -21,7 +21,7 @@ mod traits;
 
 pub use builtin::register_builtins;
 #[cfg(feature = "subprocess")]
-pub use builtin::resolve_in_path;
+pub use builtin::{resolve_in_path, virtual_cwd_error};
 pub use clap_schema::{params_from_clap, schema_from_clap, schema_tree_from_clap};
 pub use context::{ExecContext, OutputContext};
 pub(crate) use context::{cas_overwrite, is_trash_excluded};

--- a/crates/kaish-kernel/tests/external_command_tests.rs
+++ b/crates/kaish-kernel/tests/external_command_tests.rs
@@ -819,3 +819,98 @@ async fn external_stdout_within_limit_is_unaffected() {
         result.err
     );
 }
+
+// ============================================================================
+// #181: friendly error when an external command hits a virtual (overlay/VFS)
+// working directory — the cwd has no location on the real filesystem, so
+// there's nowhere for a child OS process to run.
+// ============================================================================
+
+#[cfg(feature = "overlay")]
+#[tokio::test]
+async fn external_command_under_overlay_gives_friendly_virtual_cwd_error() {
+    // `OverlayFs::real_path` always returns `None` (it's a CoW view, never a
+    // real filesystem location), so an overlay-backed kernel's cwd trips the
+    // "nowhere to spawn" guard in `try_execute_external` unconditionally —
+    // even for `true`, a command that unquestionably exists in PATH. Before
+    // the #181 fix this fell all the way through the dispatch chain to the
+    // generic "command not found" 127, which is actively misleading: the
+    // command was never the problem, the virtual cwd was.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path();
+
+    let mut vars = HashMap::new();
+    vars.insert(
+        "PATH".to_string(),
+        Value::String(std::env::var("PATH").unwrap_or_default()),
+    );
+    let config = KernelConfig::agent_with_root(root.to_path_buf())
+        .with_overlay(true)
+        .with_latch(false)
+        .with_trash(false)
+        .with_allow_external_commands(true)
+        .with_initial_vars(vars);
+    let kernel = Kernel::new(config).expect("overlay kernel");
+
+    // `printenv` is a real external (not a kaish builtin, unlike `true` —
+    // see `external_resolution_is_hermetic_no_os_path_fallback` above), so
+    // this actually exercises `try_execute_external` rather than resolving
+    // to a builtin before the guard is ever reached.
+    let result = kernel.execute("printenv").await.expect("execute");
+
+    // Exit code is unchanged (127, same class as the old "not found") — only
+    // the wording changes; scripts checking `$?` see no behavior difference.
+    assert_eq!(
+        result.code, 127,
+        "exit code stays 127 — this is a wording-only fix: {result:?}"
+    );
+    let msg = format!("{}{}", result.text_out(), result.err);
+    assert!(msg.contains("printenv"), "error should name the command: {msg}");
+    assert!(
+        msg.contains("real filesystem"),
+        "error should explain the actual cause (no real filesystem location \
+         for the cwd), not a generic not-found: {msg}"
+    );
+    assert!(
+        !msg.contains("command not found"),
+        "must not fall back to the generic 'command not found' message \
+         anymore — `printenv` really is on PATH: {msg}"
+    );
+}
+
+#[cfg(feature = "overlay")]
+#[tokio::test]
+async fn external_command_not_in_path_under_overlay_stays_generic_not_found() {
+    // The reordering that lets a *resolvable* command get the friendly
+    // virtual-cwd error must NOT reclassify a genuinely missing command: a
+    // bare name that isn't in PATH at all is "not found" regardless of cwd,
+    // and blaming the virtual cwd for that would point at the wrong cause.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path();
+
+    let mut vars = HashMap::new();
+    vars.insert(
+        "PATH".to_string(),
+        Value::String(std::env::var("PATH").unwrap_or_default()),
+    );
+    let config = KernelConfig::agent_with_root(root.to_path_buf())
+        .with_overlay(true)
+        .with_latch(false)
+        .with_trash(false)
+        .with_allow_external_commands(true)
+        .with_initial_vars(vars);
+    let kernel = Kernel::new(config).expect("overlay kernel");
+
+    let result = kernel
+        .execute("definitely-not-a-real-command-181")
+        .await
+        .expect("execute");
+
+    assert_eq!(result.code, 127, "unresolvable command should still be 127: {result:?}");
+    let msg = format!("{}{}", result.text_out(), result.err);
+    assert!(
+        msg.contains("command not found"),
+        "a command that isn't in PATH at all must keep the generic \
+         not-found message, not the virtual-cwd one: {msg}"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes the "friendlier ext-command error" half of #181. The other half of that
issue — punted cross-layer semantics (layer-local symlink resolution,
per-file-only directory whiteout, `commit_into` not propagating mtimes) — is
explicitly **not** touched by this PR and stays parked.

## Before

Verified empirically first (kernel-routed, via `kernel.execute(...)`): an
overlay-backed kernel's cwd always has `resolve_real_path() == None` —
`OverlayFs::real_path` is unconditionally `None` by design (returning the
lower's real path would hand tools a host path that bypasses the CoW
transaction). `try_execute_external`'s real-cwd guard used that fact to bail
out immediately with `Ok(None)`, which falls all the way through the dispatch
chain to the generic fallback. Concretely, for `printenv` (a real external
command, definitely on PATH) run from inside an overlay-backed kernel:

```
exit code: 127
message:   command not found: printenv
```

That's actively misleading — `printenv` was never the problem; the virtual
cwd was.

## After

The real-cwd check is now deferred until *after* the command actually
resolves (found in PATH, or an absolute/relative path that exists) — so a
genuinely missing command still gets the plain "command not found" — and
only a command that would otherwise run gets the new message naming the real
cause and a suggested fix:

```
exit code: 127
message:   printenv: can't run external commands here — "<cwd>" has no location on
           the real filesystem, so there's nowhere to spawn a child process. Use a
           kaish builtin instead, or `cd` to a real directory first; if this is a
           CoW overlay, `kaish-vfs commit` writes it to disk.
```

Exit code is unchanged (127) — only the wording changes, so scripts checking
`$?` see no behavior difference.

## What changed

- `try_execute_external` (kernel.rs, the production spawn site) and
  `BackendDispatcher::try_external` (dispatch.rs, its test-only twin, kept in
  sync per the CLAUDE.md two-spawn-sites convention) both reorder: resolve
  the executable first, then check for a real cwd to spawn it in. A bare
  name that never resolves in PATH still returns `Ok(None)`/`None` untouched
  (genuine not-found, regardless of cwd) — the reordering only affects
  commands that *would* run.
- New shared helper `virtual_cwd_error` (`tools/builtin/spawn.rs`, re-exported
  through `tools/mod.rs`) builds the message once so wording can't drift
  between the two spawn sites.
- The message deliberately hedges "if this is a CoW overlay" rather than
  asserting it — the same guard fires for any virtual cwd (e.g. `cd
  /v/blobs` on a plain in-memory VFS mount), and this call site has no way
  to distinguish which one triggered it. This was the "can't reliably
  distinguish" case called out in the task: for a *relative* path command
  (`./script`) under a virtual cwd there's no real cwd to resolve against at
  all, so existence can't be checked either — that case gets the same honest
  "nowhere to spawn" message rather than a fabricated "No such file or
  directory".

## Tests (TDD)

Added to `crates/kaish-kernel/tests/external_command_tests.rs`
(subprocess-feature-gated file, `#[cfg(feature = "overlay")]` on the two new
fns per the narrowest-gate convention):

- `external_command_under_overlay_gives_friendly_virtual_cwd_error` — pins
  the new message for a command (`printenv`) that genuinely resolves in
  PATH. Verified this fails against the pre-fix code (temporarily reverted
  kernel.rs/dispatch.rs locally, confirmed the old `command not found:
  printenv` / exit 127, then restored) before confirming it passes with the
  fix.
- `external_command_not_in_path_under_overlay_stays_generic_not_found` —
  locks in that a command that isn't in PATH at all keeps the plain
  "command not found", proving the reordering doesn't misclassify a real
  typo as "blocked by the overlay".

Also updated `crates/kaish-help/content/en/overlay.md` (the `help overlay`
content), which quoted the old exact wording verbatim.

## Gates (all clean)

- `cargo test --all --locked`
- `cargo clippy --all --all-targets` — zero warnings
- `cargo check -p kaish-kernel --no-default-features`
- `cargo test -p kaish-kernel --no-default-features --locked` (this
  worktree's CI leg)

## Scope note

Refs #181, not Closes — the issue bundles this fix with the punted
cross-layer semantics (symlink resolution, directory whiteout, `commit_into`
mtimes), which this PR intentionally does not attempt. #181 should stay open
to track that remaining half.