### PR TITLE
fix(binary): stdin keeps Bytes typing; wc -m explicit on binary (#176)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,24 @@ breaking entries are marked **BREAKING**.
 
 ## [Unreleased]
 
+### Fixed
+- **BREAKING:** buffered stdin is bytes-typed, not `String` (GH #176) —
+  `ExecContext::stdin` and `ExecuteOptions::stdin` now carry `Vec<u8>` instead
+  of `String` (`set_stdin`/`with_stdin` accept `impl Into<Vec<u8>>`, so
+  existing `&str`/`String` call sites keep compiling unchanged). A `< binfile`
+  redirect over non-UTF-8 content — or an embedder's pre-read
+  `ExecuteOptions::with_stdin(Vec<u8>)` — now feeds a byte-aware builtin
+  (`wc -c`, `cat`, `cmp`, …) the raw bytes intact instead of erroring at
+  redirect setup; a text-only builtin (`grep`, `sed`, …) still refuses binary
+  loudly, just at the point it actually asks for text (`read_stdin_to_text`),
+  not before the command even runs.
+- **`wc -m`/`-w`/default now refuse invalid UTF-8 loudly** (GH #176) instead
+  of lossy-decoding it — `String::from_utf8_lossy`'s `U+FFFD` expansion used to
+  over-count a binary stream's/file's chars and words. `wc -c`/`wc -l` are
+  pure byte-level counts (exact length, raw `\n` scan) and are unaffected,
+  bringing `wc` in line with the rest of the fleet's binary stance
+  (`grep`/`sed`/`head`'s line mode/…).
+
 ### Added
 - **Flag completion helpers in `kaish_client::completion`** —
   `current_command(line, pos)` (which command word governs the statement

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,13 +20,23 @@ breaking entries are marked **BREAKING**.
   (`wc -c`, `cat`, `cmp`, …) the raw bytes intact instead of erroring at
   redirect setup; a text-only builtin (`grep`, `sed`, …) still refuses binary
   loudly, just at the point it actually asks for text (`read_stdin_to_text`),
-  not before the command even runs.
+  not before the command even runs. **`ExecContext::read_stdin_to_string`
+  removed** (embedder-facing) — it was a lossy `U+FFFD`-mangling counterpart
+  to `read_stdin_to_bytes`/`read_stdin_to_text` with zero remaining callers
+  once stdin itself carries bytes; use `read_stdin_to_text` (loud on binary)
+  or `read_stdin_to_bytes` (byte-clean) instead.
 - **`wc -m`/`-w`/default now refuse invalid UTF-8 loudly** (GH #176) instead
   of lossy-decoding it — `String::from_utf8_lossy`'s `U+FFFD` expansion used to
   over-count a binary stream's/file's chars and words. `wc -c`/`wc -l` are
   pure byte-level counts (exact length, raw `\n` scan) and are unaffected,
   bringing `wc` in line with the rest of the fleet's binary stance
   (`grep`/`sed`/`head`'s line mode/…).
+- **`xxd -r` refuses invalid UTF-8 loudly instead of lossy-decoding it into
+  corrupt bytes** — found via a second review pass on the stdin fix above,
+  which newly let a `< binfile` redirect reach `xxd -r`'s existing
+  `String::from_utf8_lossy` call; a `U+FFFD`-mangled "hex" string silently
+  decoded into wrong (or truncated) bytes rather than erroring. Fixed for
+  both the stdin and file-path input sources, which share the same read path.
 
 ### Added
 - **Flag completion helpers in `kaish_client::completion`** —

--- a/crates/kaish-client/src/embedded.rs
+++ b/crates/kaish-client/src/embedded.rs
@@ -131,7 +131,7 @@ impl EmbeddedClient {
     /// Execute with options + per-statement callback, feeding a **lazy** process
     /// stdin as a [`kaish_kernel::PipeReader`].
     ///
-    /// Unlike [`ExecuteOptions::with_stdin`] (a pre-read `String`), the reader is
+    /// Unlike [`ExecuteOptions::with_stdin`] (a pre-read buffer), the reader is
     /// drained only if a command actually reads stdin — so `kaish -c 'echo hi'`
     /// with an open, never-EOF pipe returns immediately instead of hanging. The
     /// non-interactive REPL frontend uses this for `-c`/script mode.

--- a/crates/kaish-kernel/src/dispatch.rs
+++ b/crates/kaish-kernel/src/dispatch.rs
@@ -275,7 +275,7 @@ impl BackendDispatcher {
             }
         }
 
-        // Stdin: pipe_stdin or buffered string or inherit (interactive) or null
+        // Stdin: pipe_stdin or buffered bytes or inherit (interactive) or null
         cmd.stdin(if has_pipe_stdin || has_buffered_stdin {
             std::process::Stdio::piped()
         } else if ctx.interactive && matches!(ctx.pipeline_position, PipelinePosition::First | PipelinePosition::Only) {

--- a/crates/kaish-kernel/src/dispatch.rs
+++ b/crates/kaish-kernel/src/dispatch.rs
@@ -336,14 +336,14 @@ impl BackendDispatcher {
                 })
             })
         } else if let Some(data) = ctx.stdin.take() {
-            // Buffered string stdin written from a DETACHED task, not inline:
+            // Buffered stdin bytes written from a DETACHED task, not inline:
             // an inline write deadlocks once the stdin pipe fills before the
             // output drain below has spawned (mirrors the kernel.rs fix; keeps
             // the two spawn sites in sync). Drop signals EOF; a broken pipe
             // (child closed stdin early) is fine.
             child.stdin.take().map(|mut child_stdin| {
                 tokio::spawn(async move {
-                    let _ = child_stdin.write_all(data.as_bytes()).await;
+                    let _ = child_stdin.write_all(&data).await;
                 })
             })
         } else {

--- a/crates/kaish-kernel/src/kernel.rs
+++ b/crates/kaish-kernel/src/kernel.rs
@@ -1914,7 +1914,7 @@ impl Kernel {
         // from bleeding into the next call. Same RAII pattern as CwdGuard.
         struct StdinGuard<'a> {
             kernel: &'a Kernel,
-            saved: Option<String>,
+            saved: Option<Vec<u8>>,
         }
         impl Drop for StdinGuard<'_> {
             fn drop(&mut self) {
@@ -5190,17 +5190,17 @@ impl Kernel {
 
         // Get stdin sources: a streaming `pipe_stdin` (an inter-stage pipeline
         // pipe, or a frontend-seeded process-stdin pipe) and/or a buffered
-        // `String`. Take both out under the lock but do NOT drain here — a pipe
-        // read can block on its producer (a still-running upstream stage), so
-        // draining before spawn would serialize the pipeline (deadlocking
+        // byte vector. Take both out under the lock but do NOT drain here — a
+        // pipe read can block on its producer (a still-running upstream stage),
+        // so draining before spawn would serialize the pipeline (deadlocking
         // `sleep 60 | extern`). The pipe is streamed to the child *after* spawn.
-        // `set_stdin` clears `pipe_stdin`, so a redirect-set String and a pipe
+        // `set_stdin` clears `pipe_stdin`, so a redirect-set buffer and a pipe
         // are mutually exclusive in practice; prefer the pipe.
-        let (pipe_stdin, stdin_string) = {
+        let (pipe_stdin, stdin_bytes) = {
             let mut ctx = self.exec_ctx.write().await;
             (ctx.pipe_stdin.take(), ctx.take_stdin())
         };
-        let has_stdin = pipe_stdin.is_some() || stdin_string.is_some();
+        let has_stdin = pipe_stdin.is_some() || stdin_bytes.is_some();
 
         // Build and spawn the command
         use tokio::process::Command;
@@ -5338,9 +5338,8 @@ impl Kernel {
         // Feed stdin. A streaming `pipe_stdin` is copied to the child by a
         // detached task (bounded memory, no pre-drain) so an upstream stage and
         // this child run concurrently — and a child that never reads stdin (or
-        // is killed) just breaks the copy, which stops. A buffered `String` is
-        // written inline and stdin dropped to signal EOF. Bytes are copied
-        // verbatim, so binary stdin survives.
+        // is killed) just breaks the copy, which stops. A buffered byte vector
+        // is written verbatim (no text detour), so binary stdin survives.
         let stdin_task: Option<tokio::task::JoinHandle<()>> = if let Some(mut pipe_in) = pipe_stdin {
             child.stdin.take().map(|mut child_stdin| {
                 tokio::spawn(async move {
@@ -5360,8 +5359,8 @@ impl Kernel {
                     // Dropping child_stdin signals EOF to the child.
                 })
             })
-        } else if let Some(data) = stdin_string {
-            // Write the buffered String from a detached task too — NOT inline.
+        } else if let Some(data) = stdin_bytes {
+            // Write the buffered bytes from a detached task too — NOT inline.
             // An inline write blocks once the stdin pipe fills, and the output
             // drain hasn't spawned yet, so a child that emits a lot before
             // consuming all its input (every pipe buffer full) deadlocks. A
@@ -5371,7 +5370,7 @@ impl Kernel {
             child.stdin.take().map(|mut child_stdin| {
                 tokio::spawn(async move {
                     use tokio::io::AsyncWriteExt;
-                    let _ = child_stdin.write_all(data.as_bytes()).await;
+                    let _ = child_stdin.write_all(&data).await;
                 })
             })
         } else {

--- a/crates/kaish-kernel/src/kernel.rs
+++ b/crates/kaish-kernel/src/kernel.rs
@@ -1698,15 +1698,15 @@ impl Kernel {
 
     /// Execute with a **lazy** standard input fed as a [`PipeReader`].
     ///
-    /// Unlike [`ExecuteOptions::with_stdin`] (a pre-read `String`), this never
+    /// Unlike [`ExecuteOptions::with_stdin`] (a pre-read buffer), this never
     /// forces the input to be drained before execution: the reader seeds the
     /// first top-level command's `pipe_stdin`, and a command that does not read
     /// stdin (`echo`) returns without touching it. This is the seam a
     /// non-interactive frontend uses to forward an *open* process stdin without
     /// hanging on a pipe that never sends EOF (`sleep 10 | kaish -c 'echo hi'`).
     ///
-    /// Embedders that already hold a complete buffer should prefer the simpler
-    /// [`ExecuteOptions::with_stdin`] String path.
+    /// Embedders that already hold a complete buffer (text or binary) should
+    /// prefer the simpler [`ExecuteOptions::with_stdin`] path instead.
     pub async fn execute_with_pipe_stdin(
         &self,
         input: &str,

--- a/crates/kaish-kernel/src/scheduler/pipeline.rs
+++ b/crates/kaish-kernel/src/scheduler/pipeline.rs
@@ -229,8 +229,13 @@ async fn redirect_append(ctx: &ExecContext, path: &str, data: &[u8]) -> Result<(
 ///
 /// `< file` reads through the VFS backend (not the host filesystem) with the
 /// target resolved against `ctx.cwd`, mirroring how `cat` and the output
-/// redirects resolve their operands. A missing/unreadable file or non-UTF-8
-/// content is a hard error — we never silently feed the command empty stdin.
+/// redirects resolve their operands. A missing/unreadable file is a hard
+/// error — we never silently feed the command empty stdin. Non-UTF-8 content
+/// is NOT rejected here (GH #176): `ctx.stdin` is bytes-typed, so the raw
+/// bytes flow through to whatever the command actually does with them — a
+/// byte-aware builtin (`wc -c`, `cat`, `cmp`, …) consumes them intact, and a
+/// text-only builtin refuses loudly at the point it asks for text
+/// (`read_stdin_to_text`), not before the command even runs.
 async fn setup_stdin_redirects(
     cmd: &Command,
     ctx: &mut ExecContext,
@@ -247,9 +252,7 @@ async fn setup_stdin_redirects(
                     .read(Path::new(&resolved), None)
                     .await
                     .map_err(|e| format!("redirect: {path}: {e}"))?;
-                let content = String::from_utf8(data)
-                    .map_err(|_| format!("redirect: {path}: invalid UTF-8"))?;
-                ctx.set_stdin(content);
+                ctx.set_stdin(data);
             }
             RedirectKind::HereDoc => {
                 match &redir.target {
@@ -408,7 +411,7 @@ impl PipelineRunner {
         &self,
         cmd: &Command,
         ctx: &mut ExecContext,
-        stdin: Option<String>,
+        stdin: Option<Vec<u8>>,
         dispatcher: &dyn CommandDispatcher,
     ) -> ExecResult {
         // Set up stdin from redirects (< file, <<heredoc)

--- a/crates/kaish-kernel/src/scheduler/scatter.rs
+++ b/crates/kaish-kernel/src/scheduler/scatter.rs
@@ -161,9 +161,10 @@ impl ScatterGatherRunner {
         // Run pre-scatter commands to get input.
         // Uses run_sequential to avoid async recursion (scatter → run → scatter).
         let (text, data) = if pre_scatter.is_empty() {
-            // Use existing stdin — structured data, a String buffer, or a lazy
-            // `pipe_stdin` (a frontend-seeded process-stdin pipe). `take_stdin`
-            // alone would miss the pipe; `read_stdin_to_text` prefers it.
+            // Use existing stdin — structured data, a buffered byte vector, or
+            // a lazy `pipe_stdin` (a frontend-seeded process-stdin pipe).
+            // `take_stdin` alone would miss the pipe; `read_stdin_to_text`
+            // prefers it.
             let data = ctx.take_stdin_data();
             let text = match ctx.read_stdin_to_text().await {
                 Ok(s) => s.unwrap_or_default(),

--- a/crates/kaish-kernel/src/tools/builtin/patch.rs
+++ b/crates/kaish-kernel/src/tools/builtin/patch.rs
@@ -712,7 +712,7 @@ mod tests {
     #[tokio::test]
     async fn test_patch_apply() {
         let mut ctx = make_test_ctx().await;
-        ctx.stdin = Some(simple_patch());
+        ctx.set_stdin(simple_patch());
 
         let mut args = ToolArgs::new();
         // Strip 'b/' prefix from target path
@@ -738,7 +738,7 @@ mod tests {
     #[tokio::test]
     async fn test_patch_dry_run() {
         let mut ctx = make_test_ctx().await;
-        ctx.stdin = Some(simple_patch());
+        ctx.set_stdin(simple_patch());
 
         let mut args = ToolArgs::new();
         args.named.insert("p".to_string(), Value::Int(1));
@@ -764,13 +764,13 @@ mod tests {
         let mut ctx = make_test_ctx().await;
 
         // First apply the patch
-        ctx.stdin = Some(simple_patch());
+        ctx.set_stdin(simple_patch());
         let mut args = ToolArgs::new();
         args.named.insert("p".to_string(), Value::Int(1));
         Patch.execute(args, &mut ctx).await;
 
         // Then reverse it
-        ctx.stdin = Some(simple_patch());
+        ctx.set_stdin(simple_patch());
         let mut args = ToolArgs::new();
         args.named.insert("p".to_string(), Value::Int(1));
         args.flags.insert("R".to_string());
@@ -989,7 +989,7 @@ mod tests {
             .unwrap();
         vfs.mount("/", mem);
         let mut ctx = ExecContext::new(Arc::new(vfs));
-        ctx.stdin = Some(simple_patch());
+        ctx.set_stdin(simple_patch());
 
         let mut args = ToolArgs::new();
         args.named.insert("p".to_string(), Value::Int(1));
@@ -1020,7 +1020,7 @@ mod tests {
             "+changed\n",
             " nope3\n",
         );
-        ctx.stdin = Some(bad.to_string());
+        ctx.set_stdin(bad.to_string());
         let mut args = ToolArgs::new();
         args.named.insert("p".to_string(), Value::Int(1));
         let result = Patch.execute(args, &mut ctx).await;

--- a/crates/kaish-kernel/src/tools/builtin/wc.rs
+++ b/crates/kaish-kernel/src/tools/builtin/wc.rs
@@ -89,7 +89,10 @@ impl Tool for Wc {
         // If no files, read from stdin
         if paths.is_empty() {
             let input = ctx.read_stdin_to_bytes().await.unwrap_or_default();
-            let (lc, wc, cc, bc) = count_content(&input);
+            let (lc, wc, cc, bc, invalid_utf8) = count_content(&input);
+            if invalid_utf8 && (chars_only || words_only || show_all) {
+                return ExecResult::failure(1, format!("wc: {INVALID_UTF8_HINT}"));
+            }
             let cells = build_cells(lc, wc, cc, bc, lines_only, words_only, chars_only, bytes_only, show_all);
             let text = format_counts_text(&[("".to_string(), cells.clone())]);
             let node = OutputNode::new("").with_cells(cells);
@@ -107,11 +110,15 @@ impl Tool for Wc {
         let mut had_error = false;
         let mut error_messages = Vec::new();
 
+        let needs_text = chars_only || words_only || show_all;
+
         for path in &paths {
             let resolved = ctx.resolve_path(path);
             // Stream the file through a bounded chunk window rather than reading
-            // it whole. Counts come from raw bytes — `wc -c` is exact on binary,
-            // and there is no UTF-8 gate to reject a binary file.
+            // it whole. Byte/line counts come from raw bytes regardless of
+            // encoding (`wc -c`/`-l` are exact on binary); char/word counts need
+            // a text view, so an invalid-UTF-8 file is a loud per-file error
+            // when they're actually requested — never a lossy U+FFFD mangle.
             let mut counter = WcCounter::default();
             match ctx
                 .read_file_chunked(&resolved, ExecContext::STREAM_CHUNK_SIZE, |chunk| {
@@ -121,7 +128,13 @@ impl Tool for Wc {
                 .await
             {
                 Ok(()) => {
-                    let (lc, wc, cc, bc) = counter.finish();
+                    let (lc, wc, cc, bc, invalid_utf8) = counter.finish();
+
+                    if invalid_utf8 && needs_text {
+                        error_messages.push(format!("wc: {}: {INVALID_UTF8_HINT}", path));
+                        had_error = true;
+                        continue;
+                    }
 
                     total_lines += lc;
                     total_words += wc;
@@ -164,16 +177,27 @@ impl Tool for Wc {
     }
 }
 
+/// Shared tail of the loud error `wc` emits when `-m`/`-w`/default (any count
+/// that needs a text view) meets invalid UTF-8. `-c`/`-l` are pure byte-level
+/// operations (exact length, raw `\n` scan) and are unaffected — this only
+/// fires when a char/word count was actually requested. Mirrors the rest of
+/// the fleet's stance (`grep`/`sed`/`head`'s line mode/…): a loud error, never
+/// a lossy `U+FFFD` mangle. See `docs/binary-data.md`.
+const INVALID_UTF8_HINT: &str =
+    "invalid UTF-8 — char/word counts require text; use -c/-l for byte/line counts, \
+     or pipe through base64/xxd";
+
 /// Incremental, line-buffered counter for streaming `wc`.
 ///
 /// Fed arbitrary byte chunks via [`push`](WcCounter::push), it produces the
-/// same `(lines, words, chars, bytes)` tuple as [`count_content`] over the
-/// concatenation — without ever holding the whole input. The trick is to carry
-/// the trailing partial line (the bytes after the last `\n`) between chunks, so
-/// complete lines are only counted once their bytes are all present. Because
-/// `\n` is a word/line separator and never part of a multibyte UTF-8 sequence,
-/// splitting on it lets each line decode cleanly and keeps words, chars, and
-/// UTF-8 boundaries from ever straddling a chunk edge.
+/// same `(lines, words, chars, bytes, invalid_utf8)` tuple as
+/// [`count_content`] over the concatenation — without ever holding the whole
+/// input. The trick is to carry the trailing partial line (the bytes after the
+/// last `\n`) between chunks, so complete lines are only counted once their
+/// bytes are all present. Because `\n` is a word/line separator and never part
+/// of a multibyte UTF-8 sequence, splitting on it lets each line decode
+/// cleanly and keeps words, chars, and UTF-8 boundaries from ever straddling a
+/// chunk edge.
 #[derive(Default)]
 struct WcCounter {
     /// Bytes seen since the last newline — the in-progress line.
@@ -184,6 +208,12 @@ struct WcCounter {
     /// are added back in `finish`).
     chars: usize,
     bytes: usize,
+    /// Set once a line failed strict UTF-8 decode. Byte/line counts (`bytes`,
+    /// `newlines`) stay exact regardless; `words`/`chars` under-count once this
+    /// is set (that line's contribution is skipped), so callers that need
+    /// char/word counts must check this flag and refuse rather than trust
+    /// them.
+    invalid_utf8: bool,
 }
 
 impl WcCounter {
@@ -206,12 +236,19 @@ impl WcCounter {
     }
 
     fn count_line(&mut self, lo: usize, hi: usize) {
-        let line = String::from_utf8_lossy(&self.carry[lo..hi]);
-        self.words += line.split_whitespace().count();
-        self.chars += line.chars().count();
+        // Strict decode, not lossy: a line that isn't valid UTF-8 marks
+        // `invalid_utf8` and contributes nothing to words/chars rather than
+        // expanding each bad byte run into a counted `U+FFFD`.
+        match std::str::from_utf8(&self.carry[lo..hi]) {
+            Ok(line) => {
+                self.words += line.split_whitespace().count();
+                self.chars += line.chars().count();
+            }
+            Err(_) => self.invalid_utf8 = true,
+        }
     }
 
-    fn finish(mut self) -> (usize, usize, usize, usize) {
+    fn finish(mut self) -> (usize, usize, usize, usize, bool) {
         // The final remainder (bytes after the last `\n`) still contributes its
         // words and chars, so count it — but it is NOT a line. `wc -l` counts
         // newline characters (like GNU): an unterminated final line is not
@@ -222,23 +259,29 @@ impl WcCounter {
         let lines = self.newlines;
         // Every consumed `\n` is one character that line-splitting removed.
         let chars = self.chars + self.newlines;
-        (lines, self.words, chars, self.bytes)
+        (lines, self.words, chars, self.bytes, self.invalid_utf8)
     }
 }
 
-/// Count lines, words, chars, and bytes in content.
-fn count_content(input: &[u8]) -> (usize, usize, usize, usize) {
-    // Byte count is the raw length — exact for binary too. Lines/words/chars
-    // use a lossy text view: identical to before for valid UTF-8 (borrowed, no
-    // copy), best-effort for binary. This keeps `wc -c` honest on binary input.
+/// Count lines, words, chars, and bytes in content, plus whether the content
+/// failed strict UTF-8 decode.
+fn count_content(input: &[u8]) -> (usize, usize, usize, usize, bool) {
+    // Byte and line counts are pure byte-level operations — exact for binary
+    // too, regardless of UTF-8 validity. `wc -l` counts newline characters
+    // (GNU semantics): an unterminated final line is not a line.
     let bytes = input.len();
-    let text = String::from_utf8_lossy(input);
-    // `wc -l` counts newline characters (GNU semantics): an unterminated final
-    // line is not a line. `str::lines()` would over-count it.
     let lines = input.iter().filter(|&&b| b == b'\n').count();
-    let words = text.split_whitespace().count();
-    let chars = text.chars().count();
-    (lines, words, chars, bytes)
+    // Char/word counts need a text view: strict decode, not lossy — invalid
+    // UTF-8 is reported to the caller instead of being expanded into counted
+    // `U+FFFD` replacement characters.
+    match std::str::from_utf8(input) {
+        Ok(text) => {
+            let words = text.split_whitespace().count();
+            let chars = text.chars().count();
+            (lines, words, chars, bytes, false)
+        }
+        Err(_) => (lines, 0, 0, bytes, true),
+    }
 }
 
 /// Render wc's text output: each row is the count fields right-justified to a
@@ -554,7 +597,14 @@ mod tests {
         // split at *every* byte boundary, and compared to the whole-buffer
         // reference. The multibyte and mid-word splits are the seam this guards:
         // a 2-byte kanji or a word straddling the chunk edge must still count
-        // exactly once.
+        // exactly once. Every fixture here is valid UTF-8 by construction —
+        // see `wc_counter_invalid_utf8_flag_is_split_independent` below for the
+        // binary-input counterpart. (A mixed-validity buffer would legitimately
+        // diverge between the two paths on the *word/char* counts — whole-buffer
+        // `count_content` bails to `(0, 0)` the moment any byte is invalid,
+        // while the chunked counter still tallies the valid lines before the
+        // bad one — but both agree on the `invalid_utf8` flag that gates
+        // display, so the divergence is never user-visible.)
         let inputs: &[&[u8]] = &[
             b"hello world\nfoo bar baz\n",
             b"word",
@@ -577,6 +627,38 @@ mod tests {
                     String::from_utf8_lossy(input),
                     split
                 );
+            }
+        }
+    }
+
+    #[test]
+    fn wc_counter_invalid_utf8_flag_is_split_independent() {
+        // The `invalid_utf8` flag is what gates wc -m/-w's loud refusal
+        // (GH #176) — if it depended on *where* the streaming reader happened
+        // to split the input, `wc -m` could silently succeed on binary
+        // depending on chunk size, exactly the class of chunk-boundary bug the
+        // line-buffering scheme must not have. Byte and line counts (pure
+        // byte-level operations) must also stay exact regardless of split
+        // point or validity.
+        let inputs: &[&[u8]] = &[
+            b"\xff\x00\xfe\x80\x01\xc0kaish\xf5",   // invalid, no newline at all
+            b"good line\n\xff\xfe bad line\nmore\n", // invalid line in the middle
+            b"\xff\xfestart\ngood\n\xc0end",         // invalid at both ends
+        ];
+        for input in inputs {
+            let (want_lines, _, _, want_bytes, want_invalid) = count_content(input);
+            assert!(want_invalid, "fixture must actually be invalid UTF-8: {input:?}");
+            for split in 0..=input.len() {
+                let mut c = WcCounter::default();
+                c.push(&input[..split]);
+                c.push(&input[split..]);
+                let (lines, _, _, bytes, invalid_utf8) = c.finish();
+                assert!(
+                    invalid_utf8,
+                    "invalid_utf8 must be true regardless of split point: input={input:?} split={split}"
+                );
+                assert_eq!(bytes, want_bytes, "byte count must stay exact: split={split}");
+                assert_eq!(lines, want_lines, "line count must stay exact: split={split}");
             }
         }
     }

--- a/crates/kaish-kernel/src/tools/builtin/xxd.rs
+++ b/crates/kaish-kernel/src/tools/builtin/xxd.rs
@@ -119,8 +119,23 @@ impl Tool for Xxd {
         };
 
         if reverse {
-            // Hex input is ASCII; a lossy view is lossless here. Output is bytes.
-            return reverse_hex(&String::from_utf8_lossy(&data), plain);
+            // Reverse mode consumes hex TEXT, not raw bytes: a loud error on
+            // invalid UTF-8, never a lossy decode. `String::from_utf8_lossy`
+            // here would turn an invalid byte run into `U+FFFD`, which
+            // `reverse_hex` then silently drops as non-hex filler — real
+            // binary fed to `-r` (a `< binfile` redirect, or a binary file
+            // path) would corrupt or truncate the decoded bytes without ever
+            // raising an error. This applies uniformly to both input sources
+            // above (file path and stdin), since both funnel into the same
+            // `data: Vec<u8>` before this check.
+            return match std::str::from_utf8(&data) {
+                Ok(s) => reverse_hex(s, plain),
+                Err(_) => ExecResult::failure(
+                    2,
+                    "xxd: -r input is not valid UTF-8 (binary data, not a hex dump?) \
+                     — -r expects hex text, not raw bytes",
+                ),
+            };
         }
 
         // Forward: produce hex dump from the raw bytes.

--- a/crates/kaish-kernel/src/tools/context.rs
+++ b/crates/kaish-kernel/src/tools/context.rs
@@ -59,8 +59,12 @@ pub struct ExecContext {
     pub cwd: PathBuf,
     /// Previous working directory (for `cd -`).
     pub prev_cwd: Option<PathBuf>,
-    /// Standard input for the tool (from pipeline).
-    pub stdin: Option<String>,
+    /// Standard input for the tool (from a redirect, heredoc, here-string, or
+    /// `ExecuteOptions::stdin`). Bytes-typed (GH #176) so a `< binfile`
+    /// redirect over non-UTF-8 content reaches a byte-aware builtin intact
+    /// instead of erroring at redirect setup; a text-only builtin still
+    /// refuses it loudly when it calls `read_stdin_to_text`.
+    pub stdin: Option<Vec<u8>>,
     /// Structured data from pipeline (pre-parsed JSON from previous command).
     /// Tools can check this before parsing stdin to avoid redundant JSON parsing.
     pub stdin_data: Option<Value>,
@@ -548,26 +552,30 @@ impl ExecContext {
 
     /// Set stdin for this execution.
     ///
-    /// An explicit stdin string (`< file`, heredoc, here-string, or a pipeline
+    /// An explicit stdin buffer (`< file`, heredoc, here-string, or a pipeline
     /// hand-off) supersedes any inherited lazy `pipe_stdin`. Since `read_stdin_*`
     /// prefers `pipe_stdin`, clear it here so redirect precedence holds — a
-    /// `< file` must beat a frontend-seeded piped stdin.
-    pub fn set_stdin(&mut self, stdin: String) {
-        self.stdin = Some(stdin);
+    /// `< file` must beat a frontend-seeded piped stdin. Accepts anything
+    /// `Into<Vec<u8>>` — a `String`/`&str` (heredocs, here-strings, most
+    /// callers) or a raw `Vec<u8>` (a `< binfile` redirect, GH #176) both work.
+    pub fn set_stdin(&mut self, stdin: impl Into<Vec<u8>>) {
+        self.stdin = Some(stdin.into());
         self.pipe_stdin = None;
     }
 
     /// Get stdin, consuming it.
-    pub fn take_stdin(&mut self) -> Option<String> {
+    pub fn take_stdin(&mut self) -> Option<Vec<u8>> {
         self.stdin.take()
     }
 
     /// Set both text stdin and structured data.
     ///
     /// Use this when passing output through a pipeline where the previous
-    /// command produced structured data (e.g., JSON from MCP tools).
+    /// command produced structured data (e.g., JSON from MCP tools). The text
+    /// side is always a genuine `String` here (structured-data hand-off is a
+    /// JSON-producing pipeline stage, never binary).
     pub fn set_stdin_with_data(&mut self, text: String, data: Option<Value>) {
-        self.stdin = Some(text);
+        self.stdin = Some(text.into_bytes());
         self.stdin_data = data;
     }
 
@@ -632,10 +640,13 @@ impl ExecContext {
         self.prev_cwd.as_ref()
     }
 
-    /// Read all stdin (pipe or buffered string) into a String.
+    /// Read all stdin (pipe or buffered bytes) into a String, lossily
+    /// decoding invalid UTF-8 with `U+FFFD` rather than erroring.
     ///
     /// Prefers pipe_stdin if set (streaming pipeline), otherwise falls back
-    /// to the buffered stdin string. Consumes the source.
+    /// to the buffered stdin bytes. Consumes the source. Most text-only
+    /// builtins should prefer [`Self::read_stdin_to_text`] instead, which
+    /// refuses binary loudly rather than mangling it.
     pub async fn read_stdin_to_string(&mut self) -> Option<String> {
         if let Some(mut reader) = self.pipe_stdin.take() {
             use tokio::io::AsyncReadExt;
@@ -643,7 +654,7 @@ impl ExecContext {
             reader.read_to_end(&mut buf).await.ok()?;
             Some(String::from_utf8_lossy(&buf).into_owned())
         } else {
-            self.stdin.take()
+            self.stdin.take().map(|b| String::from_utf8_lossy(&b).into_owned())
         }
     }
 
@@ -671,8 +682,9 @@ impl ExecContext {
     /// The byte-clean counterpart to [`Self::read_stdin_to_string`], for
     /// binary-aware builtins (`base64`, `xxd`, `checksum`, `wc -c`, `cmp`, …).
     /// Returns `None` when there is no stdin at all (no pipe and no buffer);
-    /// an empty pipe yields `Some(vec![])`. A buffered text stdin is returned
-    /// as its UTF-8 bytes. See `docs/binary-data.md`.
+    /// an empty pipe yields `Some(vec![])`. The buffered source is already
+    /// bytes-typed (GH #176), so this is a plain move, never a re-encode.
+    /// See `docs/binary-data.md`.
     pub async fn read_stdin_to_bytes(&mut self) -> Option<Vec<u8>> {
         if let Some(mut reader) = self.pipe_stdin.take() {
             use tokio::io::AsyncReadExt;
@@ -680,7 +692,7 @@ impl ExecContext {
             reader.read_to_end(&mut buf).await.ok()?;
             Some(buf)
         } else {
-            self.stdin.take().map(String::into_bytes)
+            self.stdin.take()
         }
     }
 

--- a/crates/kaish-kernel/src/tools/context.rs
+++ b/crates/kaish-kernel/src/tools/context.rs
@@ -640,28 +640,10 @@ impl ExecContext {
         self.prev_cwd.as_ref()
     }
 
-    /// Read all stdin (pipe or buffered bytes) into a String, lossily
-    /// decoding invalid UTF-8 with `U+FFFD` rather than erroring.
-    ///
-    /// Prefers pipe_stdin if set (streaming pipeline), otherwise falls back
-    /// to the buffered stdin bytes. Consumes the source. Most text-only
-    /// builtins should prefer [`Self::read_stdin_to_text`] instead, which
-    /// refuses binary loudly rather than mangling it.
-    pub async fn read_stdin_to_string(&mut self) -> Option<String> {
-        if let Some(mut reader) = self.pipe_stdin.take() {
-            use tokio::io::AsyncReadExt;
-            let mut buf = Vec::new();
-            reader.read_to_end(&mut buf).await.ok()?;
-            Some(String::from_utf8_lossy(&buf).into_owned())
-        } else {
-            self.stdin.take().map(|b| String::from_utf8_lossy(&b).into_owned())
-        }
-    }
-
     /// Read stdin as text, erroring on non-UTF-8 instead of silently
     /// lossy-decoding it (which corrupts binary with `U+FFFD`).
     ///
-    /// The strict counterpart to [`Self::read_stdin_to_string`], for text-only
+    /// The strict counterpart to [`Self::read_stdin_to_bytes`], for text-only
     /// builtins (`grep`, `sed`, `awk`, `cut`, `sort`, `jq`, …): a binary stream
     /// is a loud error, not a mangle. Returns `Ok(None)` when there is no stdin
     /// at all. The `Err` is a ready-to-use message; callers prefix their name.
@@ -679,7 +661,7 @@ impl ExecContext {
 
     /// Read all of stdin as raw bytes, preserving binary intact.
     ///
-    /// The byte-clean counterpart to [`Self::read_stdin_to_string`], for
+    /// The byte-clean counterpart to [`Self::read_stdin_to_text`], for
     /// binary-aware builtins (`base64`, `xxd`, `checksum`, `wc -c`, `cmp`, …).
     /// Returns `None` when there is no stdin at all (no pipe and no buffer);
     /// an empty pipe yields `Some(vec![])`. The buffered source is already

--- a/crates/kaish-kernel/tests/binary_stdin_tests.rs
+++ b/crates/kaish-kernel/tests/binary_stdin_tests.rs
@@ -152,3 +152,56 @@ async fn execute_options_with_stdin_text_str_is_unaffected() {
     assert!(result.ok(), "err={}", result.err);
     assert_eq!(result.text_out(), "hello\n");
 }
+
+// ── `xxd -r` regression: a `< file` redirect newly reaches binary content
+// (see above), and `xxd -r` must refuse it loudly rather than lossy-decoding
+// it — found via a second review pass over this PR. ──
+
+#[tokio::test]
+async fn redirect_stdin_binary_file_xxd_reverse_errors_loud_not_lossy() {
+    // `xxd -r` consumes hex TEXT. Before this PR's stdin fix, a `< file`
+    // redirect over binary content couldn't even reach `xxd` (redirect setup
+    // itself rejected non-UTF-8, so this exact bug was unreachable). Now that
+    // redirects carry bytes through intact, `xxd -r` must refuse loud on its
+    // own instead of `String::from_utf8_lossy`-ing BIN into `U+FFFD` and
+    // silently mis-decoding the (wrong) "hex".
+    let dir = tempdir().unwrap();
+    fs::write(dir.path().join("src.bin"), BIN).unwrap();
+    let kernel = kernel_at(dir.path());
+
+    let result = kernel.execute("xxd -r -p < src.bin").await.unwrap();
+    assert!(!result.ok(), "xxd -r on binary input must fail loud, not lossy-decode it");
+    assert!(
+        result.err.contains("not valid UTF-8"),
+        "error should name the binary problem, got err={:?}",
+        result.err
+    );
+}
+
+#[tokio::test]
+async fn xxd_reverse_file_path_binary_input_errors_loud() {
+    // Same guard, exercised via a binary *file path* operand rather than
+    // stdin — both sources funnel through the same `data: Vec<u8>` read in
+    // `xxd.rs` before the reverse-mode decode, so this was an equally live
+    // (pre-existing, not GH #176-introduced) lossy-decode hazard.
+    let dir = tempdir().unwrap();
+    fs::write(dir.path().join("src.bin"), BIN).unwrap();
+    let kernel = kernel_at(dir.path());
+
+    let result = kernel.execute("xxd -r -p src.bin").await.unwrap();
+    assert!(!result.ok(), "xxd -r on a binary file must fail loud, not lossy-decode it");
+    assert!(result.err.contains("not valid UTF-8"), "err={:?}", result.err);
+}
+
+#[tokio::test]
+async fn xxd_forward_reverse_round_trip_is_unaffected() {
+    // Happy-path pin: an ordinary forward-then-reverse round trip through a
+    // pipeline (valid hex text, not a binary source) must keep working
+    // exactly as before the strict-decode guard was added.
+    let dir = tempdir().unwrap();
+    let kernel = kernel_at(dir.path());
+
+    let result = kernel.execute("echo -n hello | xxd -p | xxd -r -p").await.unwrap();
+    assert!(result.ok(), "err={}", result.err);
+    assert_eq!(result.text_out(), "hello");
+}

--- a/crates/kaish-kernel/tests/binary_stdin_tests.rs
+++ b/crates/kaish-kernel/tests/binary_stdin_tests.rs
@@ -1,0 +1,154 @@
+//! Kernel-routed regression tests for GH #176 item 1: buffered stdin must
+//! carry raw bytes, not stringify (or refuse) binary content.
+//!
+//! Before this fix, `ExecContext::stdin` / `ExecuteOptions::stdin` were
+//! `Option<String>`, so a `< file` redirect over non-UTF-8 content failed at
+//! *redirect setup* (`String::from_utf8` error) before any builtin ever ran,
+//! and an embedder feeding pre-read binary via `ExecuteOptions::with_stdin` had
+//! no way to hand over anything but valid UTF-8 text. Byte-aware builtins
+//! (`wc -c`, `cat`, `cmp`, `checksum`, …) should consume that content exactly
+//! as they already do over a streamed pipe; text-only builtins (`grep`,
+//! `sed`, …) must still refuse it loudly — just at the point of
+//! *consumption* (`read_stdin_to_text`), not at redirect setup.
+//!
+//! All tests route through `kernel.execute()` / `kernel.execute_with_options()`
+//! so the full dispatch chain runs.
+
+// Test-fixture code: unwrap/expect on known-good setup is the idiom.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+#![cfg(feature = "localfs")]
+
+mod common;
+
+use common::kernel_at;
+use kaish_kernel::ExecuteOptions;
+use std::fs;
+use tempfile::tempdir;
+
+/// Invalid-UTF-8 octets — same fixture idiom as `binary_text_sink_tests.rs` —
+/// so a redirect/`with_stdin` source is genuinely binary, not just "not ASCII".
+const BIN: &[u8] = b"\xff\x00\xfe\x80\x01\xc0kaish\xf5";
+
+#[tokio::test]
+async fn redirect_stdin_binary_file_feeds_exact_byte_count() {
+    let dir = tempdir().unwrap();
+    fs::write(dir.path().join("src.bin"), BIN).unwrap();
+    let kernel = kernel_at(dir.path());
+
+    let result = kernel.execute("wc -c < src.bin").await.unwrap();
+    assert!(result.ok(), "err={}", result.err);
+    assert_eq!(
+        result.text_out().trim(),
+        BIN.len().to_string(),
+        "wc -c over a `< file` redirect must see the exact byte count instead \
+         of erroring on invalid UTF-8 at redirect setup: out={:?}",
+        result.text_out()
+    );
+}
+
+#[tokio::test]
+async fn redirect_stdin_binary_file_cat_round_trips_bytes() {
+    let dir = tempdir().unwrap();
+    fs::write(dir.path().join("src.bin"), BIN).unwrap();
+    let kernel = kernel_at(dir.path());
+
+    let result = kernel.execute("cat < src.bin").await.unwrap();
+    assert!(result.ok(), "err={}", result.err);
+    assert_eq!(
+        result.out_bytes(),
+        Some(BIN),
+        "cat over a `< file` redirect must round-trip the raw bytes byte-for-byte"
+    );
+}
+
+#[tokio::test]
+async fn redirect_stdin_binary_file_text_tool_still_errors_loud() {
+    // grep is a text-only consumer: it must still refuse binary — just at the
+    // point it calls `read_stdin_to_text`, not at redirect setup (which no
+    // longer requires UTF-8 up front).
+    let dir = tempdir().unwrap();
+    fs::write(dir.path().join("src.bin"), BIN).unwrap();
+    let kernel = kernel_at(dir.path());
+
+    let result = kernel.execute("grep x < src.bin").await.unwrap();
+    assert!(!result.ok(), "grep over binary stdin must fail, not match garbage");
+    assert!(
+        result.err.contains("not valid UTF-8"),
+        "error should name the binary problem, got err={:?}",
+        result.err
+    );
+}
+
+#[tokio::test]
+async fn redirect_stdin_text_file_is_unaffected() {
+    // Control: an ordinary text `< file` redirect keeps working exactly as
+    // before (this is the overwhelmingly common case).
+    let dir = tempdir().unwrap();
+    fs::write(dir.path().join("plain.txt"), "b\na\nc\n").unwrap();
+    let kernel = kernel_at(dir.path());
+
+    let result = kernel.execute("sort < plain.txt").await.unwrap();
+    assert!(result.ok(), "err={}", result.err);
+    assert_eq!(result.text_out(), "a\nb\nc\n");
+}
+
+#[tokio::test]
+async fn redirect_stdin_missing_file_is_still_a_loud_error() {
+    // Control: a missing redirect target must still error (not silently empty
+    // stdin) — the read failure path is untouched by the UTF-8-gate removal.
+    let dir = tempdir().unwrap();
+    let kernel = kernel_at(dir.path());
+
+    let result = kernel.execute("cat < does-not-exist.txt").await.unwrap();
+    assert!(!result.ok(), "a missing redirect target must be a loud error");
+}
+
+#[tokio::test]
+async fn execute_options_with_stdin_bytes_feeds_byte_aware_builtin() {
+    let dir = tempdir().unwrap();
+    let kernel = kernel_at(dir.path());
+
+    let result = kernel
+        .execute_with_options("wc -c", ExecuteOptions::new().with_stdin(BIN.to_vec()))
+        .await
+        .unwrap();
+    assert!(result.ok(), "err={}", result.err);
+    assert_eq!(
+        result.text_out().trim(),
+        BIN.len().to_string(),
+        "ExecuteOptions::with_stdin(Vec<u8>) must feed raw bytes to a byte-aware builtin"
+    );
+}
+
+#[tokio::test]
+async fn execute_options_with_stdin_bytes_text_tool_errors_loud() {
+    let dir = tempdir().unwrap();
+    let kernel = kernel_at(dir.path());
+
+    let result = kernel
+        .execute_with_options("grep x", ExecuteOptions::new().with_stdin(BIN.to_vec()))
+        .await
+        .unwrap();
+    assert!(!result.ok());
+    assert!(
+        result.err.contains("not valid UTF-8"),
+        "err={:?}",
+        result.err
+    );
+}
+
+#[tokio::test]
+async fn execute_options_with_stdin_text_str_is_unaffected() {
+    // Control: the common `&str` embedder call site must keep compiling and
+    // working now that `with_stdin` takes `impl Into<Vec<u8>>` instead of
+    // `impl Into<String>`.
+    let dir = tempdir().unwrap();
+    let kernel = kernel_at(dir.path());
+
+    let result = kernel
+        .execute_with_options("cat", ExecuteOptions::new().with_stdin("hello\n"))
+        .await
+        .unwrap();
+    assert!(result.ok(), "err={}", result.err);
+    assert_eq!(result.text_out(), "hello\n");
+}

--- a/crates/kaish-kernel/tests/binary_wc_tests.rs
+++ b/crates/kaish-kernel/tests/binary_wc_tests.rs
@@ -1,0 +1,155 @@
+//! Kernel-routed regression tests for GH #176 item 2: `wc -m`/`-w`/default must
+//! refuse invalid UTF-8 loudly instead of silently lossy-decoding it
+//! (`String::from_utf8_lossy` expands every invalid byte run into `U+FFFD`,
+//! over-counting chars/words on binary input). `wc -c`/`wc -l` are pure
+//! byte-level operations (exact length, raw `\n` scan) and must keep working on
+//! binary — only the counts that require a text view refuse.
+//!
+//! This mirrors the rest of the fleet: `grep`/`sed`/`awk`/`cut`/`sort` already
+//! error loud on non-UTF-8 stdin/file input (`read_stdin_to_text`,
+//! `String::from_utf8`) rather than mangling it — `wc`'s char/word counts are
+//! brought in line with that stance. See `docs/binary-data.md`.
+//!
+//! All tests route through `kernel.execute()` so the full dispatch chain runs.
+
+// Test-fixture code: unwrap/expect on known-good setup is the idiom.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+#![cfg(feature = "localfs")]
+
+mod common;
+
+use common::kernel_at;
+use std::fs;
+use tempfile::tempdir;
+
+/// Invalid-UTF-8 octets — same fixture idiom as `binary_text_sink_tests.rs`.
+const BIN: &[u8] = b"\xff\x00\xfe\x80\x01\xc0kaish\xf5";
+
+// ── stdin (redirect) path ──
+
+#[tokio::test]
+async fn wc_dash_c_still_works_on_binary_stdin() {
+    let dir = tempdir().unwrap();
+    fs::write(dir.path().join("src.bin"), BIN).unwrap();
+    let kernel = kernel_at(dir.path());
+
+    let result = kernel.execute("wc -c < src.bin").await.unwrap();
+    assert!(result.ok(), "err={}", result.err);
+    assert_eq!(result.text_out().trim(), BIN.len().to_string());
+}
+
+#[tokio::test]
+async fn wc_dash_l_still_works_on_binary_stdin() {
+    let dir = tempdir().unwrap();
+    fs::write(dir.path().join("src.bin"), BIN).unwrap();
+    let kernel = kernel_at(dir.path());
+
+    let result = kernel.execute("wc -l < src.bin").await.unwrap();
+    assert!(result.ok(), "err={}", result.err);
+    // BIN has no `\n` byte in it.
+    assert_eq!(result.text_out().trim(), "0");
+}
+
+#[tokio::test]
+async fn wc_dash_m_errors_loud_on_binary_stdin() {
+    let dir = tempdir().unwrap();
+    fs::write(dir.path().join("src.bin"), BIN).unwrap();
+    let kernel = kernel_at(dir.path());
+
+    let result = kernel.execute("wc -m < src.bin").await.unwrap();
+    assert!(!result.ok(), "wc -m on binary must fail loud, not lossy-decode it");
+    assert!(
+        result.err.contains("invalid UTF-8"),
+        "error should name the binary problem, got err={:?}",
+        result.err
+    );
+    assert!(
+        result.text_out().trim().is_empty(),
+        "no lossy char count should be emitted: {:?}",
+        result.text_out()
+    );
+}
+
+#[tokio::test]
+async fn wc_dash_w_errors_loud_on_binary_stdin() {
+    let dir = tempdir().unwrap();
+    fs::write(dir.path().join("src.bin"), BIN).unwrap();
+    let kernel = kernel_at(dir.path());
+
+    let result = kernel.execute("wc -w < src.bin").await.unwrap();
+    assert!(!result.ok(), "wc -w on binary must fail loud");
+    assert!(result.err.contains("invalid UTF-8"), "err={:?}", result.err);
+}
+
+#[tokio::test]
+async fn wc_default_all_counts_errors_loud_on_binary_stdin() {
+    let dir = tempdir().unwrap();
+    fs::write(dir.path().join("src.bin"), BIN).unwrap();
+    let kernel = kernel_at(dir.path());
+
+    let result = kernel.execute("wc < src.bin").await.unwrap();
+    assert!(!result.ok(), "plain wc (all counts) on binary must fail loud");
+    assert!(result.err.contains("invalid UTF-8"), "err={:?}", result.err);
+}
+
+// ── file path (chunked read) ──
+
+#[tokio::test]
+async fn wc_dash_c_still_works_on_binary_file() {
+    let dir = tempdir().unwrap();
+    fs::write(dir.path().join("src.bin"), BIN).unwrap();
+    let kernel = kernel_at(dir.path());
+
+    let result = kernel.execute("wc -c src.bin").await.unwrap();
+    assert!(result.ok(), "err={}", result.err);
+    assert!(
+        result.text_out().contains(&BIN.len().to_string()),
+        "out={:?}",
+        result.text_out()
+    );
+}
+
+#[tokio::test]
+async fn wc_dash_m_errors_loud_on_binary_file() {
+    let dir = tempdir().unwrap();
+    fs::write(dir.path().join("src.bin"), BIN).unwrap();
+    let kernel = kernel_at(dir.path());
+
+    let result = kernel.execute("wc -m src.bin").await.unwrap();
+    assert!(!result.ok(), "wc -m on a binary file must fail loud");
+    assert!(
+        result.err.contains("invalid UTF-8"),
+        "error should name the file and the binary problem, got err={:?}",
+        result.err
+    );
+}
+
+#[tokio::test]
+async fn wc_dash_m_multi_file_reports_the_binary_one_but_still_counts_the_text_one() {
+    let dir = tempdir().unwrap();
+    fs::write(dir.path().join("src.bin"), BIN).unwrap();
+    fs::write(dir.path().join("plain.txt"), "hi\n").unwrap();
+    let kernel = kernel_at(dir.path());
+
+    let result = kernel.execute("wc -m plain.txt src.bin").await.unwrap();
+    assert!(!result.ok(), "one binary file among many must still fail loud overall");
+    assert!(result.err.contains("src.bin"), "err={:?}", result.err);
+    assert!(
+        result.text_out().contains("plain.txt"),
+        "the valid file's row should still be reported: {:?}",
+        result.text_out()
+    );
+}
+
+// ── control: valid UTF-8 is unaffected ──
+
+#[tokio::test]
+async fn wc_dash_m_counts_multibyte_utf8_as_one_char_each() {
+    let dir = tempdir().unwrap();
+    let kernel = kernel_at(dir.path());
+
+    // "héllo" is 6 bytes (é is 2 bytes) but 5 chars.
+    let result = kernel.execute(r#"echo -n "héllo" | wc -m"#).await.unwrap();
+    assert!(result.ok(), "err={}", result.err);
+    assert_eq!(result.text_out().trim(), "5");
+}

--- a/crates/kaish-kernel/tests/execute_pipe_stdin_tests.rs
+++ b/crates/kaish-kernel/tests/execute_pipe_stdin_tests.rs
@@ -1,9 +1,10 @@
 //! Kernel-routed coverage for the *lazy* stdin seam — `Kernel::execute_with_
 //! pipe_stdin(_streaming)`, which hands the kernel a `PipeReader` instead of a
-//! pre-read `String`.
+//! pre-read buffer.
 //!
 //! This is the fix for the P1.0 regression: the original `ExecuteOptions::stdin`
-//! (String) path forced the frontend to `read_to_end` process stdin *before*
+//! (a pre-read buffer, `String` at the time) path forced the frontend to
+//! `read_to_end` process stdin *before*
 //! executing, which **hangs** `kaish -c 'echo hi'` when stdin is an open pipe
 //! that never sends EOF (the subprocess-with-idle-stdin case). A lazy pipe lets
 //! a command that never reads stdin (`echo`) return immediately while the writer
@@ -117,7 +118,7 @@ async fn lazy_stdin_feeds_an_external_command() {
 #[tokio::test]
 async fn lazy_stdin_feeds_scatter_with_no_pre_scatter_command() {
     // The scatter/gather runner's no-pre-scatter branch reads stdin directly;
-    // it must see a seeded lazy pipe, not just the String buffer.
+    // it must see a seeded lazy pipe, not just the buffered bytes.
     let kernel = kernel();
     let (writer, reader) = pipe_stream_default();
     writer.write_bytes(b"a\nb\nc\n").await.unwrap();
@@ -132,8 +133,8 @@ async fn lazy_stdin_feeds_scatter_with_no_pre_scatter_command() {
         .await
         .expect("kernel execute");
     // Each line is scattered to a worker (item bound to `$ITEM`) and gathered.
-    // Before the fix the runner read only the String buffer, so scatter saw no
-    // items and returned empty.
+    // Before the fix the runner read only the buffered bytes, so scatter saw
+    // no items and returned empty.
     assert!(result.ok(), "scatter failed: {}", result.err);
     let out = result.text_out();
     assert!(out.contains("loud-a"), "missing loud-a: {out:?}");

--- a/crates/kaish-types/src/kernel.rs
+++ b/crates/kaish-types/src/kernel.rs
@@ -72,10 +72,15 @@ pub struct ExecuteOptions {
     ///
     /// Lets a non-interactive frontend feed piped input, e.g.
     /// `printf '…' | kaish -c 'sort'`. Without it a bare top-level builtin
-    /// reading stdin has no input source and silently produces nothing. It is
-    /// `String`-typed to match `ExecContext::set_stdin`; binary stdin is fed
-    /// through files/VFS, not this knob.
-    pub stdin: Option<String>,
+    /// reading stdin has no input source and silently produces nothing.
+    /// Bytes-typed (GH #176) to match `ExecContext::set_stdin`: a byte-aware
+    /// builtin (`wc -c`, `cat`, `cmp`, `checksum`, …) sees binary content
+    /// exactly, while a text-only builtin (`grep`, `sed`, …) still refuses it
+    /// loudly at the point it asks for text (`read_stdin_to_text`), not here.
+    /// Embedders that already hold a complete buffer use this; one that wants
+    /// to avoid pre-draining an open process stdin should prefer
+    /// `Kernel::execute_with_pipe_stdin` instead.
+    pub stdin: Option<Vec<u8>>,
 }
 
 impl ExecuteOptions {
@@ -138,7 +143,10 @@ impl ExecuteOptions {
     }
 
     /// Set the standard input fed to this call's first stdin-reading command.
-    pub fn with_stdin(mut self, stdin: impl Into<String>) -> Self {
+    ///
+    /// Accepts anything `Into<Vec<u8>>` — a `&str`/`String` (the common text
+    /// case) or a raw `Vec<u8>` (binary, GH #176) both work.
+    pub fn with_stdin(mut self, stdin: impl Into<Vec<u8>>) -> Self {
         self.stdin = Some(stdin.into());
         self
     }

--- a/docs/EMBEDDING.md
+++ b/docs/EMBEDDING.md
@@ -413,16 +413,19 @@ Fields:
   cascades to forks and external children (SIGTERM → grace → SIGKILL on
   the process group).
 - **`cwd`** — per-call working directory override.
-- **`stdin`** — standard input for this call as a ready `String` buffer,
+- **`stdin`** — standard input for this call as a ready, bytes-typed buffer
+  (`impl Into<Vec<u8>>` — a `&str`/`String` or a raw `Vec<u8>` both work),
   consumed by the first top-level command that reads stdin (shell draining
   semantics — a later reader sees nothing). Lets an embedder feed piped input,
-  e.g. `printf '…' | kaish -c 'sort'`. A redirect (`< file`/heredoc) on the
-  command still takes precedence. Eager: the whole buffer must exist before the
-  call. For a **lazy or binary** stream — fed only if a command reads stdin,
-  byte-clean — use `Kernel::execute_with_pipe_stdin(_streaming)` with a
+  e.g. `printf '…' | kaish -c 'sort'`, binary included — a byte-aware builtin
+  (`wc -c`, `cat`, `cmp`, …) sees it intact, while a text-only builtin still
+  refuses non-UTF-8 loudly when it asks for text. A redirect (`< file`/heredoc)
+  on the command still takes precedence. Eager: the whole buffer must exist
+  before the call. For a **lazy** stream — fed only if a command reads stdin,
+  so an open process stdin that never sends EOF doesn't block a command that
+  never reads it — use `Kernel::execute_with_pipe_stdin(_streaming)` with a
   `PipeReader` instead (this is how the non-interactive `kaish` CLI forwards its
-  open process stdin without blocking a command that never reads it, e.g.
-  `sleep 10 | kaish -c 'echo hi'`).
+  own process stdin, e.g. `sleep 10 | kaish -c 'echo hi'`).
 - **`traceparent` / `tracestate` / `baggage`** — W3C trace context;
   kaish's execution span parents onto your trace, and baggage merges back
   out through `ExecResult.baggage`.

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -1173,9 +1173,14 @@ output), so binary never garbles a terminal or a JSON channel.
 **Text builtins refuse binary.** `grep`, `sed`, `awk`, `sort`, `cut`, `tr`, `jq`,
 and the other text tools **error** on non-UTF-8 input instead of silently
 replacing bytes with `U+FFFD`. The byte-aware movers (`cat`, `dd`, `base64`,
-`xxd`, `checksum`, `wc`, `tee`, `head -c`, `tail -c`, `cmp`, `file`) consume
-binary directly. External commands keep binary intact in both directions, so
-`curl url > out.bin` and `... | gzip` round-trip.
+`xxd`, `checksum`, `tee`, `head -c`, `tail -c`, `cmp`, `file`) consume binary
+directly. `wc -c`/`wc -l` are pure byte-level counts (exact length, raw `\n`
+scan) and consume binary directly too; `wc -m`/`-w`/default need a text view
+and **error** on non-UTF-8 input like the other text tools rather than
+over-counting via `U+FFFD`. External commands keep binary intact in both
+directions, so `curl url > out.bin` and `... | gzip` round-trip. A `< file`
+redirect (or an embedder's `ExecuteOptions::with_stdin`) forwards binary intact
+too — only the command actually reading it decides whether that's fine.
 
 ## What's Intentionally Missing
 

--- a/docs/binary-data.md
+++ b/docs/binary-data.md
@@ -10,8 +10,14 @@ generic `encode`/`decode` was **dropped** — `base64` and `xxd` (`-p`/`-r`) alr
 bridge text↔bytes, so a generic pair would only duplicate them and invite a
 basenc-style "tons of formats × weird flags" surface that's easy for an agent to
 misuse. The one real gap is URL/percent encoding; add a focused
-`urlencode`/`urldecode` only if web work needs it. Residual: buffered-String stdin
-(`take_stdin`) for the rare binary-heredoc case.
+`urlencode`/`urldecode` only if web work needs it. GH #176 (2026-07-17) closed
+the last two residuals: `ExecContext::stdin`/`ExecuteOptions::stdin` are
+bytes-typed, so a `< binfile` redirect (or an embedder's pre-read
+`with_stdin(Vec<u8>)`) feeds binary through intact rather than erroring at
+redirect setup; `wc -m`/`-w`/default now refuse invalid UTF-8 loudly instead of
+lossy-decoding it (see below). A heredoc/here-string body interpolating a
+binary value is unaffected and unchanged — that's text-sink territory
+(`value_to_text_sink`), correctly loud already, not a stdin-typing residual.
 
 ### Producer coercion is content-sniffing — an accepted tradeoff
 
@@ -23,8 +29,10 @@ on binary, so a tool's `--json` shape varies with content (`"out":"hi"` vs
 — always-`Bytes` — forces every `cat`/`head` through the binary envelope and breaks
 the common text path. It differs from the banned JSON *value* sniffing: content is
 never mutated, only its text-vs-binary tag is detected losslessly. Known minor
-edges: `cat` multi-file / `-n` still rejects binary with `invalid UTF-8` (single-file
-is byte-aware); `wc -m` on binary over-counts via `U+FFFD` expansion (use `-c`).
+edge: `cat` multi-file / `-n` still rejects binary with `invalid UTF-8`
+(single-file is byte-aware). `wc -m`/`-w`/default used to over-count binary via
+`U+FFFD` expansion; fixed in GH #176 (2026-07-17) to refuse invalid UTF-8
+loudly instead — `-c`/`-l` are pure byte-level counts and are unaffected.
 Author: design notes from a 2026-06-13 session (out of the synthetic-`/dev` work)
 Related: [LANGUAGE.md](LANGUAGE.md), [issues.md](issues.md), `docs/help/vfs.md`,
 `project_dev_fs.md` (auto-memory), `arch_no_json_sniffing.md` (auto-memory)


### PR DESCRIPTION
## Summary

GH #176 listed two P2 residuals left over after the 0.12.0 `Value::Bytes` silent-fallback sweep. Both were re-verified against current `main` (post #215/#219/#221, which hardened the argv boundary but didn't touch these) before any change was made — neither was already resolved.

### 1. Buffered stdin was `String`-typed

`ExecContext::stdin` and `ExecuteOptions::stdin` were `Option<String>`. A `< binfile` redirect over non-UTF-8 content failed at *redirect setup* (`String::from_utf8` in `setup_stdin_redirects`) before any builtin ever ran, and an embedder with pre-read binary had no way to hand it to `ExecuteOptions::with_stdin`.

Fix: both fields are now `Option<Vec<u8>>`. `set_stdin`/`with_stdin` accept `impl Into<Vec<u8>>`, so every existing `&str`/`String` call site (heredocs, here-strings, the ~90 existing `set_stdin("...".to_string())` test call sites, embedder code) keeps compiling unchanged — `Vec<u8>: From<String>` and `From<&str>` both exist. The redirect no longer gates on UTF-8 validity: a byte-aware builtin (`wc -c`, `cat`, `cmp`, `checksum`, …) now sees the raw bytes; a text-only builtin (`grep`, `sed`, …) still refuses binary loudly — just later, at the point it actually asks for text (`read_stdin_to_text`), not before the command even runs. Both external-command spawn sites (`kernel.rs::try_execute_external`, and its test-only mirror `dispatch.rs::BackendDispatcher::try_external`) were updated in lockstep per the project's two-spawn-sites-must-match convention.

Heredoc/here-string bodies are unaffected by design: interpolating a binary value into one is text-sink territory (`value_to_text_sink`) and correctly stays loud — that was never the residual this issue described.

### 2. `wc -m`/`-w`/default lossy-decoded binary

Both the stdin path (`count_content`) and the streamed file path (`WcCounter`) built their char/word text view with `String::from_utf8_lossy`, silently expanding invalid UTF-8 into `U+FFFD` and over-counting binary input.

**Decision:** bring `wc` in line with the rest of the fleet's existing stance — `grep`/`sed`/`head`'s line mode already refuse binary loudly (`read_stdin_to_text`'s strict decode) rather than mangle it; `wc -m`/`-w`/default (any count needing a text view) now do the same: strict `std::str::from_utf8`, loud `ExecResult::failure` naming the problem when char/word counts are actually requested. `wc -c`/`-l` are pure byte-level operations (exact length, raw `\n` scan) that never need decode, so they're untouched and keep working on binary exactly as before — this was true before the fix and stays true after.

The per-line strict-decode approach in the streaming `WcCounter` is safe across chunk boundaries because `\n` (0x0A) is never a valid UTF-8 continuation byte, so a line's bytes are never split mid-codepoint by the chunking; a kaibo review independently traced this and confirmed no chunk-boundary bug, and a new test (`wc_counter_invalid_utf8_flag_is_split_independent`) locks in that the `invalid_utf8` flag — the thing gating the loud refusal — can't silently flip based on where the streaming reader happens to split the input.

## Test plan

- [x] TDD: `crates/kaish-kernel/tests/binary_stdin_tests.rs` and `binary_wc_tests.rs` (new, kernel-routed via `kernel.execute()`/`execute_with_options()`) — written first, confirmed failing against pre-fix code, now pass. Cover both fixes and their controls (text stdin unaffected, `wc -c`/`-l` unaffected, multi-file `wc -m` still reports the good file, `ExecuteOptions::with_stdin("&str")` still compiles/works).
- [x] `cargo test --all --locked` — clean
- [x] `cargo clippy --all --all-targets` — zero warnings
- [x] `cargo check -p kaish-kernel --no-default-features` — clean
- [x] kaibo (deepseek) review of the full diff against current `main` — traced every stdin call site (both spawns, pipeline hand-off, `snapshot_exec_ctx`/`child_for_pipeline`, RAII guards) end to end; no bugs found. Its one note (the existing chunk-seam unit test only covers valid-UTF-8 fixtures) is addressed by the new split-independence test above.
- [x] `docs/binary-data.md` and `docs/LANGUAGE.md`/`docs/EMBEDDING.md` updated to drop the now-stale "residual" callouts.
- [x] `CHANGELOG.md` — `### Fixed` under `[Unreleased]`, `with_stdin`/field type change marked **BREAKING** per the embedder-API rule.

Closes #176