### PR TITLE
refactor(kernel): eliminate the sync build_tool_args twin (#188)

### DIFF
--- a/crates/kaish-kernel/src/dispatch.rs
+++ b/crates/kaish-kernel/src/dispatch.rs
@@ -494,12 +494,14 @@ impl CommandDispatcher for BackendDispatcher {
             _ => {}
         }
 
-        // Build tool args with schema-aware parsing (sync — no command substitution).
+        // Build tool args through the reduced sync evaluator (no command
+        // substitution) — see `SyncEvalSource` in `scheduler::pipeline`.
         // A bad/subscripted collection access is a genuine PathError here too —
         // propagate it via `?` rather than swallowing, same as the production
         // Kernel::dispatch_command's `execute_command(..).await?`.
         let schema = self.tools.get(&cmd.name).map(|t| t.schema());
         let tool_args = build_tool_args(&cmd.args, ctx, schema.as_ref())
+            .await
             .map_err(|e| anyhow::anyhow!(e))?;
 
         // Honor --json before the tool runs so a parse failure inside the

--- a/crates/kaish-kernel/src/kernel.rs
+++ b/crates/kaish-kernel/src/kernel.rs
@@ -3333,593 +3333,22 @@ impl Kernel {
         }
     }
 
-    // (see `push_repeatable_value` below for the repeatable-flag accumulation.)
-
-    /// Pull `consumes` positional args after a non-bool flag and stash them
-    /// on `tool_args.named` under the canonical param name.
-    ///
-    /// - `consumes == 1` (non-repeatable) keeps the historical contract: a
-    ///   single scalar value (last write wins on the rare duplicate).
-    /// - `consumes == 1` + `repeatable` accumulates each occurrence as a scalar
-    ///   inside `named[canonical] = Value::Json(Array(...))`, preserving
-    ///   invocation order. This is the shape sed's `-e EXPR -e EXPR` lands in —
-    ///   a repeated single-value flag must keep every value, not silently drop
-    ///   all but the last (a "no silent corruption" violation).
-    /// - `consumes > 1` accumulates each occurrence as an inner
-    ///   `serde_json::Value::Array` inside `named[canonical] =
-    ///   Value::Json(Array(...))`, preserving invocation order. This is the
-    ///   shape jq's `--arg NAME VAL` / `--argjson NAME VAL` land in.
-    ///
-    /// Errors loudly if the flag is missing required positionals — matches
-    /// kaish's "no silent fallback" posture and mirrors real jq, which
-    /// errors on `--arg NAME` with no value.
-    #[allow(clippy::too_many_arguments)]
-    async fn consume_flag_positionals(
-        &self,
-        args: &[Arg],
-        flag_name: &str,
-        canonical: &str,
-        consumes: usize,
-        repeatable: bool,
-        positional_indices: &[usize],
-        consumed: &mut std::collections::HashSet<usize>,
-        current_idx: usize,
-        tool_args: &mut ToolArgs,
-    ) -> Result<()> {
-        let home = self.scope_home().await;
-        let mut collected: Vec<Value> = Vec::with_capacity(consumes.max(1));
-        for _ in 0..consumes.max(1) {
-            // A `key=value` (WordAssign) token is consumable only by a
-            // single-value flag (`-v a=1`). For a multi-value flag (`jq --arg
-            // NAME VAL`, consumes>1) it is NOT eligible — otherwise `--arg x=1
-            // filter` would reassemble `x=1` into the first slot and steal the
-            // filter into the second. Multi-value flags take plain positionals.
-            let allow_word_assign = consumes <= 1;
-            let next_pos = positional_indices
-                .iter()
-                .find(|idx| {
-                    **idx > current_idx
-                        && !consumed.contains(idx)
-                        && (allow_word_assign || matches!(args[**idx], Arg::Positional(_)))
-                })
-                .copied();
-            match next_pos {
-                Some(pos_idx) => match &args[pos_idx] {
-                    Arg::Positional(expr) => {
-                        let value = self.eval_expr_async(expr).await?;
-                        let value = apply_tilde_expansion(value, home.as_deref());
-                        collected.push(value);
-                        consumed.insert(pos_idx);
-                    }
-                    // `-v a=1`: reassemble the `key=value` token as the flag's
-                    // scalar value (see `positional_indices` construction).
-                    Arg::WordAssign { key, value } => {
-                        let val = self.eval_expr_async(value).await?;
-                        let val = apply_tilde_expansion(val, home.as_deref());
-                        // Loud on binary (GH #116): `-v a=$BIN` must not silently
-                        // reassemble the `[binary: N bytes]` placeholder into the
-                        // flag's value — same text-sink boundary as the primary
-                        // sinks fixed in #93 item 1.
-                        let val_str = crate::interpreter::value_to_text_sink_named(
-                            &val,
-                            "a key=value argument",
-                        )
-                        .map_err(|e| anyhow::anyhow!("{e}"))?;
-                        collected.push(Value::String(format!("{key}={val_str}")));
-                        consumed.insert(pos_idx);
-                    }
-                    _ => {}
-                },
-                None => {
-                    if consumes <= 1 && collected.is_empty() {
-                        // Back-compat: a flag with no follow-up positional
-                        // becomes a bare flag. `--path` with nothing after
-                        // lands in `flags`, same as before this refactor.
-                        tool_args.flags.insert(flag_name.to_string());
-                        return Ok(());
-                    }
-                    anyhow::bail!(
-                        "--{flag_name} requires {consumes} argument{}, got {}",
-                        if consumes == 1 { "" } else { "s" },
-                        collected.len()
-                    );
-                }
-            }
-        }
-
-        if consumes <= 1 {
-            if let Some(v) = collected.pop() {
-                if repeatable {
-                    push_repeatable_value(tool_args, flag_name, canonical, v)?;
-                } else {
-                    tool_args.named.insert(canonical.to_string(), v);
-                }
-            }
-            return Ok(());
-        }
-
-        // Multi-consume: accumulate under named[canonical] as array-of-arrays.
-        let occ: Vec<serde_json::Value> = collected
-            .into_iter()
-            .map(|v| crate::interpreter::value_to_json(&v))
-            .collect();
-        let entry = tool_args
-            .named
-            .entry(canonical.to_string())
-            .or_insert_with(|| Value::Json(serde_json::Value::Array(Vec::new())));
-        if let Value::Json(serde_json::Value::Array(outer)) = entry {
-            outer.push(serde_json::Value::Array(occ));
-        } else {
-            anyhow::bail!(
-                "--{flag_name}: named[{canonical}] already holds a non-array value"
-            );
-        }
-        Ok(())
-    }
-
     /// Build tool arguments from AST args.
     ///
     /// Uses async evaluation to support command substitution in arguments.
+    /// Delegates to the shared `bind_tool_args` core (GH #188): this method
+    /// now only supplies the evaluator — `self` implements `ArgValueSource`
+    /// against the kernel's own session state (full recursion through the
+    /// async pipeline, real glob expansion, tilde expansion). Before this,
+    /// `bind_tool_args`'s flag/positional-binding logic was duplicated by a
+    /// reduced sync twin (`scheduler::pipeline::build_tool_args`, used by
+    /// scatter/gather's own option parsing and the `#[cfg(test)]`
+    /// `BackendDispatcher`) that could — and did — drift from this method,
+    /// the same drift-class GH #133 fixed for the external-command spawn
+    /// sites. Now both paths call the one `bind_tool_args` core, differing
+    /// only in which `ArgValueSource` they hand it.
     async fn build_args_async(&self, args: &[Arg], schema: Option<&crate::tools::ToolSchema>) -> Result<ToolArgs> {
-        let mut tool_args = ToolArgs::new();
-        let home = self.scope_home().await;
-
-        // A glob-passthrough tool (`glob`) consumes patterns as data: skip
-        // argv glob expansion so the pattern reaches the tool as written —
-        // otherwise `glob **/*.rs` binds the first *matching path* as its
-        // pattern. The eval fallback turns `Expr::GlobPattern` into its
-        // literal string.
-        let glob_passthrough = schema.is_some_and(|s| s.glob_passthrough);
-
-        // Raw-argv fast path (POSIX `test`): bind every argument to `positional`
-        // in source order with types preserved — operators (`-f`, `=`, `!`) as
-        // strings, operands keeping their `Value` — leaving `flags`/`named`
-        // empty. A position-sensitive command needs the *true* argv: an operand
-        // that looks like a flag (`test $x = -n`, `test 0 -gt -5`) must not be
-        // hoisted into the unordered flag set the normal binder splits into.
-        // Globs still expand and `~` still resolves, matching normal positional
-        // binding — so `test -f *.rs` errors on too many args, not a literal
-        // pattern stat.
-        if schema.is_some_and(|s| s.raw_argv) {
-            for arg in args {
-                match arg {
-                    Arg::Positional(expr) => {
-                        let glob = if let Expr::GlobPattern(p) = expr {
-                            (!glob_passthrough && self.scope.read().await.glob_enabled())
-                                .then(|| p.clone())
-                        } else {
-                            None
-                        };
-                        if let Some(pattern) = glob {
-                            let (paths, cwd) = {
-                                let ctx = self.exec_ctx.read().await;
-                                let paths = ctx
-                                    .expand_glob(&pattern)
-                                    .await
-                                    .map_err(|e| anyhow::anyhow!("glob: {}", e))?;
-                                let cwd = ctx.resolve_path(".");
-                                (paths, cwd)
-                            };
-                            if paths.is_empty() {
-                                return Err(anyhow::anyhow!("no matches: {}", pattern));
-                            }
-                            for path in paths {
-                                let display = if !pattern.starts_with('/') {
-                                    path.strip_prefix(&cwd)
-                                        .unwrap_or(&path)
-                                        .to_string_lossy()
-                                        .into_owned()
-                                } else {
-                                    path.to_string_lossy().into_owned()
-                                };
-                                tool_args.positional.push(Value::String(display));
-                            }
-                        } else {
-                            let value = self.eval_expr_async(expr).await?;
-                            let value = apply_tilde_expansion(value, home.as_deref());
-                            tool_args.positional.push(value);
-                        }
-                    }
-                    Arg::ShortFlag(name) => {
-                        tool_args.positional.push(Value::String(format!("-{name}")));
-                    }
-                    Arg::LongFlag(name) => {
-                        tool_args.positional.push(Value::String(format!("--{name}")));
-                    }
-                    Arg::Named { key, value } => {
-                        let val = self.eval_expr_async(value).await?;
-                        let val = apply_tilde_expansion(val, home.as_deref());
-                        // Loud on binary (GH #116): `test --k=$BIN` must not
-                        // silently reassemble the placeholder into the raw-argv
-                        // positional stream `test` binds against.
-                        let val_str = crate::interpreter::value_to_text_sink_named(
-                            &val,
-                            "a --key=value argument",
-                        )
-                        .map_err(|e| anyhow::anyhow!("{e}"))?;
-                        tool_args
-                            .positional
-                            .push(Value::String(format!("--{key}={val_str}")));
-                    }
-                    Arg::WordAssign { key, value } => {
-                        let val = self.eval_expr_async(value).await?;
-                        let val = apply_tilde_expansion(val, home.as_deref());
-                        // Loud on binary (GH #116): same reasoning as the Named
-                        // arm above, for the bare `key=value` raw-argv form.
-                        let val_str = crate::interpreter::value_to_text_sink_named(
-                            &val,
-                            "a key=value argument",
-                        )
-                        .map_err(|e| anyhow::anyhow!("{e}"))?;
-                        tool_args
-                            .positional
-                            .push(Value::String(format!("{key}={val_str}")));
-                    }
-                    Arg::DoubleDash => {
-                        tool_args.positional.push(Value::String("--".to_string()));
-                    }
-                }
-            }
-            return Ok(tool_args);
-        }
-
-        // Subcommand-aware tools (e.g. `kj context list`) expose a tree of
-        // schemas; pick the leaf the leading positionals route to and bind
-        // flags against *its* params. Flat tools return the root. select_leaf
-        // errors (fail loud) if a computed positional sits where a subcommand
-        // selector is required.
-        let leaf = match schema {
-            Some(s) => Some(select_leaf(s, args)?),
-            None => None,
-        };
-        // Bind against the leaf's params, but MERGE the root schema's params on
-        // top as "global" flags: a value-flag declared at the tool's top level
-        // (e.g. kj's `--confirm <nonce>`) must bind at every leaf, including when
-        // it trails the subcommand path (`kj context retag a b --confirm <n>`).
-        // The leaf wins on name conflicts. For a flat tool, leaf == root, so the
-        // merge is a harmless no-op.
-        let mut param_lookup = schema.map(schema_param_lookup).unwrap_or_default();
-        if let Some(l) = leaf {
-            param_lookup.extend(schema_param_lookup(l));
-        }
-        // accepts_word_assign keys off the root tool name (the WORD_ASSIGN list),
-        // not the leaf — it's a property of the command, not the subcommand.
-        let accepts_word_assign = schema
-            .map(|s| crate::tools::accepts_word_assign(s.name.as_str()))
-            .unwrap_or(false);
-
-        // Track which positional indices have been consumed as flag values
-        let mut consumed: std::collections::HashSet<usize> = std::collections::HashSet::new();
-        let mut past_double_dash = false;
-
-        // Indices a value-flag may consume as its value. Positionals always
-        // qualify. A `WordAssign` (`a=1`) also qualifies when the tool does not
-        // itself treat `key=value` as an assignment (everything but
-        // export/alias/unalias) — getopt semantics: `awk -v a=1` binds `a=1` to
-        // `-v`, rather than skipping it and grabbing the next positional (the
-        // program). Without this, the natural `-F`/`-v NAME=VALUE` form silently
-        // mis-binds. The main-loop `WordAssign` arm skips consumed indices.
-        let positional_indices: Vec<usize> = args.iter().enumerate()
-            .filter_map(|(i, a)| {
-                let consumable = matches!(a, Arg::Positional(_))
-                    || (!accepts_word_assign && matches!(a, Arg::WordAssign { .. }));
-                consumable.then_some(i)
-            })
-            .collect();
-
-        let mut i = 0;
-        while i < args.len() {
-            match &args[i] {
-                Arg::DoubleDash => {
-                    past_double_dash = true;
-                }
-                Arg::Positional(expr) => {
-                    if !consumed.contains(&i) {
-                        // Glob expansion: bare glob patterns expand to matching files
-                        if let Expr::GlobPattern(pattern) = expr {
-                            let glob_enabled = {
-                                let scope = self.scope.read().await;
-                                scope.glob_enabled()
-                            };
-                            if glob_enabled && !glob_passthrough {
-                                let (paths, cwd) = {
-                                    let ctx = self.exec_ctx.read().await;
-                                    let paths = ctx.expand_glob(pattern).await
-                                        .map_err(|e| anyhow::anyhow!("glob: {}", e))?;
-                                    let cwd = ctx.resolve_path(".");
-                                    (paths, cwd)
-                                };
-                                if paths.is_empty() {
-                                    return Err(anyhow::anyhow!("no matches: {}", pattern));
-                                }
-                                for path in paths {
-                                    let display = if !pattern.starts_with('/') {
-                                        path.strip_prefix(&cwd)
-                                            .unwrap_or(&path)
-                                            .to_string_lossy().into_owned()
-                                    } else {
-                                        path.to_string_lossy().into_owned()
-                                    };
-                                    tool_args.positional.push(Value::String(display));
-                                }
-                                i += 1;
-                                continue;
-                            }
-                        }
-                        let value = self.eval_expr_async(expr).await?;
-                        let value = apply_tilde_expansion(value, home.as_deref());
-                        tool_args.positional.push(value);
-                    }
-                }
-                Arg::Named { key, value } => {
-                    let val = self.eval_expr_async(value).await?;
-                    let val = apply_tilde_expansion(val, home.as_deref());
-                    // A repeatable flag in `--flag=value` form must accumulate too,
-                    // not overwrite — otherwise `--expression=A --expression=B`
-                    // would silently keep only B, and mixing with the `-e` space
-                    // form would clobber the array. Route it through the same
-                    // accumulator the space form uses.
-                    if let Some(&(canonical, _, _, true)) = param_lookup.get(key.as_str()) {
-                        push_repeatable_value(&mut tool_args, key, canonical, val)?;
-                    } else {
-                        tool_args.named.insert(key.clone(), val);
-                    }
-                }
-                Arg::WordAssign { key, value } => {
-                    // Already pulled in as a preceding value-flag's argument
-                    // (`awk -v a=1`); don't also emit it as a positional.
-                    if consumed.contains(&i) {
-                        i += 1;
-                        continue;
-                    }
-                    let val = self.eval_expr_async(value).await?;
-                    let val = apply_tilde_expansion(val, home.as_deref());
-                    if accepts_word_assign {
-                        tool_args.named.insert(key.clone(), val);
-                    } else {
-                        // Stringify "key=value" and pass as a positional.
-                        // Matches bash: `cat foo=bar` opens a file named `foo=bar`.
-                        // Loud on binary (GH #116): `cat foo=$BIN`/`dd if=$BIN`
-                        // must not silently become a path/operand literally named
-                        // `foo=[binary: N bytes]`.
-                        let val_str = crate::interpreter::value_to_text_sink_named(
-                            &val,
-                            "a key=value argument",
-                        )
-                        .map_err(|e| anyhow::anyhow!("{e}"))?;
-                        tool_args.positional.push(Value::String(format!("{key}={val_str}")));
-                    }
-                }
-                Arg::ShortFlag(name) => {
-                    if past_double_dash {
-                        tool_args.positional.push(Value::String(format!("-{name}")));
-                    } else if name.len() == 1 {
-                        let flag_name = name.as_str();
-                        let lookup = param_lookup.get(flag_name);
-                        let is_bool = lookup.map(|(_, typ, ..)| is_bool_type(typ)).unwrap_or(true);
-
-                        if is_bool {
-                            tool_args.flags.insert(flag_name.to_string());
-                        } else {
-                            // Non-bool: consume `consumes` positionals as value(s)
-                            let canonical = lookup.map(|(n, ..)| *n).unwrap_or(flag_name);
-                            let consumes = lookup.map(|(_, _, c, _)| *c).unwrap_or(1);
-                            let repeatable = lookup.map(|(_, _, _, r)| *r).unwrap_or(false);
-                            self.consume_flag_positionals(
-                                args,
-                                name,
-                                canonical,
-                                consumes,
-                                repeatable,
-                                &positional_indices,
-                                &mut consumed,
-                                i,
-                                &mut tool_args,
-                            )
-                            .await?;
-                        }
-                    } else if let Some(&(canonical, typ, consumes, repeatable)) = param_lookup.get(name.as_str()) {
-                        // Multi-char short flag matches a schema param (POSIX style: -name value)
-                        if is_bool_type(typ) {
-                            tool_args.flags.insert(canonical.to_string());
-                        } else {
-                            self.consume_flag_positionals(
-                                args,
-                                name,
-                                canonical,
-                                consumes,
-                                repeatable,
-                                &positional_indices,
-                                &mut consumed,
-                                i,
-                                &mut tool_args,
-                            )
-                            .await?;
-                        }
-                    } else if let Some(&(canonical, _, consumes, repeatable)) = param_lookup
-                        .get(&name[..1])
-                        .filter(|(_, typ, ..)| !is_bool_type(typ))
-                    {
-                        // Glued short-flag value: `cut -f1`, `head -c5`, `cut -f1-3`,
-                        // `grep -A1`, `sed -e1d`. The first char is a declared
-                        // value-taking short flag, so the rest of the token is its
-                        // value — the coreutils idiom. The lexer's flag char class is
-                        // `[a-zA-Z][a-zA-Z0-9-]*`, so the first byte is always ASCII
-                        // (safe to slice) and the tail is a plain literal.
-                        bind_glued_short_value(
-                            &mut tool_args,
-                            &name[..1],
-                            canonical,
-                            consumes,
-                            repeatable,
-                            name[1..].to_string(),
-                        )?;
-                    } else {
-                        // Multi-char combined short flags. Bool flags stack
-                        // (`-la`), but the FIRST value-taking flag reached
-                        // consumes the rest of the token as its glued value
-                        // (`-ivC3` → C=3) or, if it is the last char, the next
-                        // positional (`grep -ivC 3` → C=3). Before this, a
-                        // trailing value-flag was silently treated as a bool,
-                        // stranding its argument as a stray positional (arity
-                        // error). Undeclared/bool chars stay bare flags, so a
-                        // schemaless tool keeps the old all-boolean behavior.
-                        // The first char being value-taking is handled by the
-                        // glued arm above, so it never reaches here. The flag
-                        // char class is ASCII, so byte indexing is char indexing
-                        // (no `Vec<char>` allocation needed).
-                        let bytes = name.as_bytes();
-                        let mut p = 0;
-                        while p < bytes.len() {
-                            let key = &name[p..p + 1];
-                            match param_lookup.get(key) {
-                                Some(&(canonical, typ, consumes, repeatable))
-                                    if !is_bool_type(typ) =>
-                                {
-                                    let glued = name[p + 1..].to_string();
-                                    if glued.is_empty() {
-                                        // Value flag is the last char: take the
-                                        // next positional. `consume_flag_positionals`
-                                        // respects `consumes`.
-                                        self.consume_flag_positionals(
-                                            args,
-                                            key,
-                                            canonical,
-                                            consumes,
-                                            repeatable,
-                                            &positional_indices,
-                                            &mut consumed,
-                                            i,
-                                            &mut tool_args,
-                                        )
-                                        .await?;
-                                    } else {
-                                        bind_glued_short_value(
-                                            &mut tool_args,
-                                            key,
-                                            canonical,
-                                            consumes,
-                                            repeatable,
-                                            glued,
-                                        )?;
-                                    }
-                                    break;
-                                }
-                                _ => {
-                                    tool_args.flags.insert(key.to_string());
-                                    p += 1;
-                                }
-                            }
-                        }
-                    }
-                }
-                Arg::LongFlag(name) => {
-                    if past_double_dash {
-                        tool_args.positional.push(Value::String(format!("--{name}")));
-                    } else {
-                        let lookup = param_lookup.get(name.as_str());
-                        // An *undeclared* long flag under a `map_positionals`
-                        // (backend/MCP) schema that is immediately followed by an
-                        // unconsumed positional is ambiguous: kaish can't tell the
-                        // space-form value (`--type explorer`) from a bool flag
-                        // before a real positional (`--force file.txt`). Defaulting
-                        // to bool here silently divorces the value and misroutes it
-                        // — a privilege-escalation-by-typo against deny-by-default
-                        // embedders (docs/issues.md). Fail loud instead of guessing.
-                        let ambiguous_value = (lookup.is_none()
-                            && leaf.is_some_and(|s| s.map_positionals)
-                            && !consumed.contains(&(i + 1)))
-                            .then(|| match args.get(i + 1) {
-                                // Echo a concrete value for a copy-pasteable fix
-                                // when it's a plain literal; fall back to VALUE.
-                                Some(Arg::Positional(Expr::Literal(Value::String(s)))) => {
-                                    Some(s.clone())
-                                }
-                                Some(Arg::Positional(_)) => Some("VALUE".to_string()),
-                                _ => None,
-                            })
-                            .flatten();
-                        if let Some(val) = ambiguous_value {
-                            let tool = leaf.map(|s| s.name.as_str()).unwrap_or("command");
-                            anyhow::bail!(
-                                "{tool}: --{name} is not a declared flag, so the \
-                                 space-separated value would be silently dropped. \
-                                 Use --{name}={val}, or have {tool} declare --{name} \
-                                 in its schema."
-                            );
-                        }
-                        let is_bool = lookup.map(|(_, typ, ..)| is_bool_type(typ)).unwrap_or(true);
-
-                        if is_bool {
-                            tool_args.flags.insert(name.clone());
-                        } else {
-                            let canonical = lookup.map(|(n, ..)| *n).unwrap_or(name.as_str());
-                            let consumes = lookup.map(|(_, _, c, _)| *c).unwrap_or(1);
-                            let repeatable = lookup.map(|(_, _, _, r)| *r).unwrap_or(false);
-                            self.consume_flag_positionals(
-                                args,
-                                name,
-                                canonical,
-                                consumes,
-                                repeatable,
-                                &positional_indices,
-                                &mut consumed,
-                                i,
-                                &mut tool_args,
-                            )
-                            .await?;
-                        }
-                    }
-                }
-            }
-            i += 1;
-        }
-
-        // Map remaining positionals to unfilled non-bool schema params (in order).
-        // This enables `drift_push "abc" "hello"` → named["target_ctx"] = "abc", named["content"] = "hello"
-        // Positionals that appeared after `--` are never mapped (they're raw data).
-        // Only for backend/external tools (map_positionals=true). Builtins handle their own positionals.
-        // Keyed off the routed leaf so a subcommand tool maps against the active
-        // leaf's params (kj leaves keep map_positionals=false → block skipped).
-        if let Some(schema) = leaf.filter(|s| s.map_positionals) {
-            let pre_dash_count = if past_double_dash {
-                let dash_pos = args.iter().position(|a| matches!(a, Arg::DoubleDash)).unwrap_or(args.len());
-                positional_indices.iter()
-                    .filter(|idx| **idx < dash_pos && !consumed.contains(idx))
-                    .count()
-            } else {
-                tool_args.positional.len()
-            };
-
-            let mut remaining = Vec::new();
-            let mut positional_iter = tool_args.positional.drain(..).enumerate();
-
-            for param in &schema.params {
-                if tool_args.named.contains_key(&param.name) || tool_args.flags.contains(&param.name) {
-                    continue;
-                }
-                if is_bool_type(&param.param_type) {
-                    continue;
-                }
-                loop {
-                    match positional_iter.next() {
-                        Some((idx, val)) if idx < pre_dash_count => {
-                            tool_args.named.insert(param.name.clone(), val);
-                            break;
-                        }
-                        Some((_, val)) => {
-                            remaining.push(val);
-                        }
-                        None => break,
-                    }
-                }
-            }
-
-            remaining.extend(positional_iter.map(|(_, v)| v));
-            tool_args.positional = remaining;
-        }
-
-        Ok(tool_args)
+        bind_tool_args(args, schema, self).await
     }
 
     /// Build arguments as flat string list for external commands.
@@ -5918,6 +5347,711 @@ impl Kernel {
 
         Ok(result)
     }
+}
+
+/// Evaluates a single AST expression on behalf of [`bind_tool_args`], the one
+/// shared arg-binding core behind both `Kernel::build_args_async`
+/// (production: full recursion through the async pipeline, command
+/// substitution, real glob expansion) and the reduced sync evaluator behind
+/// scatter/gather's own option parsing and the `#[cfg(test)]`
+/// `BackendDispatcher` (`scheduler::pipeline::build_tool_args`'s
+/// `SyncEvalSource`). GH #188 closes the drift class between those two
+/// callers: the flag/positional-binding logic (this file's `bind_tool_args`)
+/// is now the ONLY implementation; only expression evaluation, which is
+/// capability-bound (recursing into command substitution needs a live async
+/// pipeline the reduced context doesn't have), still has two providers.
+#[async_trait]
+pub(crate) trait ArgValueSource: Send + Sync {
+    /// Evaluate `expr` to a `Value`. `Ok(None)` means "not representable by
+    /// this evaluator" — the reduced sync evaluator's bash-compatible
+    /// "coalesce" convention for an unset bare variable, or an expression
+    /// form it doesn't support (a binary op) — and the caller drops the
+    /// argument the same way an unset bare variable always has. The real
+    /// (Kernel) evaluator never returns `Ok(None)`: it can always fully
+    /// evaluate.
+    async fn eval(&self, expr: &Expr) -> Result<Option<Value>>;
+
+    /// Expand a bare glob-pattern positional to display strings, or `None`
+    /// if this evaluator doesn't expand globs here (disabled, or the reduced
+    /// sync context, which never has — matching its documented "no
+    /// filesystem walk before worker forks" limit). `bind_tool_args` falls
+    /// back to `eval` (which hands back the pattern text as a literal
+    /// string) when this returns `None`. An enabled expansion that matches
+    /// nothing is a genuine error, not `Ok(None)`.
+    async fn expand_glob(&self, pattern: &str) -> Result<Option<Vec<String>>>;
+
+    /// Session `HOME`, for tilde expansion. `None` disables tilde expansion
+    /// — the reduced sync evaluator's existing behavior (it never expanded
+    /// `~`).
+    async fn home(&self) -> Option<String>;
+}
+
+#[async_trait]
+impl ArgValueSource for Kernel {
+    async fn eval(&self, expr: &Expr) -> Result<Option<Value>> {
+        Ok(Some(self.eval_expr_async(expr).await?))
+    }
+
+    async fn expand_glob(&self, pattern: &str) -> Result<Option<Vec<String>>> {
+        let glob_enabled = self.scope.read().await.glob_enabled();
+        if !glob_enabled {
+            return Ok(None);
+        }
+        let (paths, cwd) = {
+            let ctx = self.exec_ctx.read().await;
+            let paths = ctx
+                .expand_glob(pattern)
+                .await
+                .map_err(|e| anyhow::anyhow!("glob: {}", e))?;
+            let cwd = ctx.resolve_path(".");
+            (paths, cwd)
+        };
+        if paths.is_empty() {
+            anyhow::bail!("no matches: {}", pattern);
+        }
+        let display = paths
+            .into_iter()
+            .map(|path| {
+                if !pattern.starts_with('/') {
+                    path.strip_prefix(&cwd)
+                        .unwrap_or(&path)
+                        .to_string_lossy()
+                        .into_owned()
+                } else {
+                    path.to_string_lossy().into_owned()
+                }
+            })
+            .collect();
+        Ok(Some(display))
+    }
+
+    async fn home(&self) -> Option<String> {
+        self.scope_home().await
+    }
+}
+
+/// Pull `consumes` positional args after a non-bool flag and stash them on
+/// `tool_args.named` under the canonical param name. Shared core behind
+/// [`bind_tool_args`]'s `ShortFlag`/`LongFlag` value-flag arms — see that
+/// function's doc comment for the unification story (GH #188).
+///
+/// - `consumes == 1` (non-repeatable) keeps the historical contract: a
+///   single scalar value (last write wins on the rare duplicate).
+/// - `consumes == 1` + `repeatable` accumulates each occurrence as a scalar
+///   inside `named[canonical] = Value::Json(Array(...))`, preserving
+///   invocation order. This is the shape sed's `-e EXPR -e EXPR` lands in —
+///   a repeated single-value flag must keep every value, not silently drop
+///   all but the last (a "no silent corruption" violation).
+/// - `consumes > 1` accumulates each occurrence as an inner
+///   `serde_json::Value::Array` inside `named[canonical] =
+///   Value::Json(Array(...))`, preserving invocation order. This is the
+///   shape jq's `--arg NAME VAL` / `--argjson NAME VAL` land in.
+///
+/// Errors loudly if the flag is missing required positionals — matches
+/// kaish's "no silent fallback" posture and mirrors real jq, which errors on
+/// `--arg NAME` with no value. A reduced evaluator's `Ok(None)` (a value it
+/// can't represent — Kernel's evaluator never returns this) falls back to a
+/// bare flag on the FIRST occurrence, matching the pre-#188 sync twin's
+/// unset-bare-var "coalesce" convention; mid-accumulation it's a genuine
+/// error rather than a silently-partial array.
+#[allow(clippy::too_many_arguments)]
+async fn consume_flag_positionals(
+    source: &dyn ArgValueSource,
+    home: Option<&str>,
+    args: &[Arg],
+    flag_name: &str,
+    canonical: &str,
+    consumes: usize,
+    repeatable: bool,
+    positional_indices: &[usize],
+    consumed: &mut std::collections::HashSet<usize>,
+    current_idx: usize,
+    tool_args: &mut ToolArgs,
+) -> Result<()> {
+    let mut collected: Vec<Value> = Vec::with_capacity(consumes.max(1));
+    for _ in 0..consumes.max(1) {
+        // A `key=value` (WordAssign) token is consumable only by a
+        // single-value flag (`-v a=1`). For a multi-value flag (`jq --arg
+        // NAME VAL`, consumes>1) it is NOT eligible — otherwise `--arg x=1
+        // filter` would reassemble `x=1` into the first slot and steal the
+        // filter into the second. Multi-value flags take plain positionals.
+        let allow_word_assign = consumes <= 1;
+        let next_pos = positional_indices
+            .iter()
+            .find(|idx| {
+                **idx > current_idx
+                    && !consumed.contains(idx)
+                    && (allow_word_assign || matches!(args[**idx], Arg::Positional(_)))
+            })
+            .copied();
+        match next_pos {
+            Some(pos_idx) => match &args[pos_idx] {
+                Arg::Positional(expr) => match source.eval(expr).await? {
+                    Some(value) => {
+                        let value = apply_tilde_expansion(value, home);
+                        collected.push(value);
+                        consumed.insert(pos_idx);
+                    }
+                    None if collected.is_empty() => {
+                        tool_args.flags.insert(flag_name.to_string());
+                        return Ok(());
+                    }
+                    None => anyhow::bail!(
+                        "--{flag_name}: could not evaluate argument {} in this context",
+                        collected.len() + 1
+                    ),
+                },
+                // `-v a=1`: reassemble the `key=value` token as the flag's
+                // scalar value (see `positional_indices` construction).
+                Arg::WordAssign { key, value } => match source.eval(value).await? {
+                    Some(val) => {
+                        let val = apply_tilde_expansion(val, home);
+                        // Loud on binary (GH #116): `-v a=$BIN` must not silently
+                        // reassemble the `[binary: N bytes]` placeholder into the
+                        // flag's value — same text-sink boundary as the primary
+                        // sinks fixed in #93 item 1.
+                        let val_str = crate::interpreter::value_to_text_sink_named(
+                            &val,
+                            "a key=value argument",
+                        )
+                        .map_err(|e| anyhow::anyhow!("{e}"))?;
+                        collected.push(Value::String(format!("{key}={val_str}")));
+                        consumed.insert(pos_idx);
+                    }
+                    None if collected.is_empty() => {
+                        tool_args.flags.insert(flag_name.to_string());
+                        return Ok(());
+                    }
+                    None => anyhow::bail!(
+                        "--{flag_name}: could not evaluate argument {} in this context",
+                        collected.len() + 1
+                    ),
+                },
+                _ => {}
+            },
+            None => {
+                if consumes <= 1 && collected.is_empty() {
+                    // Back-compat: a flag with no follow-up positional
+                    // becomes a bare flag. `--path` with nothing after
+                    // lands in `flags`, same as before this refactor.
+                    tool_args.flags.insert(flag_name.to_string());
+                    return Ok(());
+                }
+                anyhow::bail!(
+                    "--{flag_name} requires {consumes} argument{}, got {}",
+                    if consumes == 1 { "" } else { "s" },
+                    collected.len()
+                );
+            }
+        }
+    }
+
+    if consumes <= 1 {
+        if let Some(v) = collected.pop() {
+            if repeatable {
+                push_repeatable_value(tool_args, flag_name, canonical, v)?;
+            } else {
+                tool_args.named.insert(canonical.to_string(), v);
+            }
+        }
+        return Ok(());
+    }
+
+    // Multi-consume: accumulate under named[canonical] as array-of-arrays.
+    let occ: Vec<serde_json::Value> = collected
+        .into_iter()
+        .map(|v| crate::interpreter::value_to_json(&v))
+        .collect();
+    let entry = tool_args
+        .named
+        .entry(canonical.to_string())
+        .or_insert_with(|| Value::Json(serde_json::Value::Array(Vec::new())));
+    if let Value::Json(serde_json::Value::Array(outer)) = entry {
+        outer.push(serde_json::Value::Array(occ));
+    } else {
+        anyhow::bail!(
+            "--{flag_name}: named[{canonical}] already holds a non-array value"
+        );
+    }
+    Ok(())
+}
+
+/// Build `ToolArgs` from AST `Arg`s — the single arg-binding implementation
+/// (GH #188) shared by `Kernel::build_args_async` (production) and the
+/// reduced sync path (`scheduler::pipeline::build_tool_args`, used by
+/// scatter/gather's own option parsing and the `#[cfg(test)]`
+/// `BackendDispatcher`). The two differ only in the [`ArgValueSource`] they
+/// pass: Kernel's evaluates full expressions (including `$(...)` command
+/// substitution) and expands real globs/tilde; the reduced one can't recurse
+/// into the async pipeline this early (scatter/gather's own flags bind
+/// before any worker forks) so it evaluates a smaller expression subset and
+/// never expands globs/tilde — see `SyncEvalSource` in `scheduler::pipeline`.
+///
+/// If a schema is provided, uses it to determine argument types:
+/// - For `--flag` where schema says type is non-bool: consume next
+///   positional(s) as value(s) (`consumes`/`repeatable`-aware).
+/// - For `--flag` where schema says type is bool (or unknown): treat as a
+///   boolean flag.
+///
+/// This enables natural shell syntax like `mcp_tool --query "test" --limit 10`.
+pub(crate) async fn bind_tool_args(
+    args: &[Arg],
+    schema: Option<&crate::tools::ToolSchema>,
+    source: &dyn ArgValueSource,
+) -> Result<ToolArgs> {
+    let mut tool_args = ToolArgs::new();
+    let home = source.home().await;
+
+    // A glob-passthrough tool (`glob`) consumes patterns as data: skip
+    // argv glob expansion so the pattern reaches the tool as written —
+    // otherwise `glob **/*.rs` binds the first *matching path* as its
+    // pattern. The eval fallback turns `Expr::GlobPattern` into its
+    // literal string.
+    let glob_passthrough = schema.is_some_and(|s| s.glob_passthrough);
+
+    // Raw-argv fast path (POSIX `test`): bind every argument to `positional`
+    // in source order with types preserved — operators (`-f`, `=`, `!`) as
+    // strings, operands keeping their `Value` — leaving `flags`/`named`
+    // empty. A position-sensitive command needs the *true* argv: an operand
+    // that looks like a flag (`test $x = -n`, `test 0 -gt -5`) must not be
+    // hoisted into the unordered flag set the normal binder splits into.
+    // Globs still expand and `~` still resolves, matching normal positional
+    // binding — so `test -f *.rs` errors on too many args, not a literal
+    // pattern stat.
+    if schema.is_some_and(|s| s.raw_argv) {
+        for arg in args {
+            match arg {
+                Arg::Positional(expr) => {
+                    let glob = if let Expr::GlobPattern(p) = expr {
+                        (!glob_passthrough).then(|| p.clone())
+                    } else {
+                        None
+                    };
+                    if let Some(pattern) = glob {
+                        match source.expand_glob(&pattern).await? {
+                            Some(paths) => {
+                                for path in paths {
+                                    tool_args.positional.push(Value::String(path));
+                                }
+                            }
+                            None => {
+                                let value = source.eval(expr).await?.ok_or_else(|| {
+                                    anyhow::anyhow!(
+                                        "raw-argv positional could not be evaluated in this context"
+                                    )
+                                })?;
+                                let value = apply_tilde_expansion(value, home.as_deref());
+                                tool_args.positional.push(value);
+                            }
+                        }
+                    } else {
+                        let value = source.eval(expr).await?.ok_or_else(|| {
+                            anyhow::anyhow!(
+                                "raw-argv positional could not be evaluated in this context"
+                            )
+                        })?;
+                        let value = apply_tilde_expansion(value, home.as_deref());
+                        tool_args.positional.push(value);
+                    }
+                }
+                Arg::ShortFlag(name) => {
+                    tool_args.positional.push(Value::String(format!("-{name}")));
+                }
+                Arg::LongFlag(name) => {
+                    tool_args.positional.push(Value::String(format!("--{name}")));
+                }
+                Arg::Named { key, value } => {
+                    let val = source.eval(value).await?.ok_or_else(|| {
+                        anyhow::anyhow!("raw-argv --key=value could not be evaluated in this context")
+                    })?;
+                    let val = apply_tilde_expansion(val, home.as_deref());
+                    // Loud on binary (GH #116): `test --k=$BIN` must not
+                    // silently reassemble the placeholder into the raw-argv
+                    // positional stream `test` binds against.
+                    let val_str = crate::interpreter::value_to_text_sink_named(
+                        &val,
+                        "a --key=value argument",
+                    )
+                    .map_err(|e| anyhow::anyhow!("{e}"))?;
+                    tool_args
+                        .positional
+                        .push(Value::String(format!("--{key}={val_str}")));
+                }
+                Arg::WordAssign { key, value } => {
+                    let val = source.eval(value).await?.ok_or_else(|| {
+                        anyhow::anyhow!("raw-argv key=value could not be evaluated in this context")
+                    })?;
+                    let val = apply_tilde_expansion(val, home.as_deref());
+                    // Loud on binary (GH #116): same reasoning as the Named
+                    // arm above, for the bare `key=value` raw-argv form.
+                    let val_str = crate::interpreter::value_to_text_sink_named(
+                        &val,
+                        "a key=value argument",
+                    )
+                    .map_err(|e| anyhow::anyhow!("{e}"))?;
+                    tool_args
+                        .positional
+                        .push(Value::String(format!("{key}={val_str}")));
+                }
+                Arg::DoubleDash => {
+                    tool_args.positional.push(Value::String("--".to_string()));
+                }
+            }
+        }
+        return Ok(tool_args);
+    }
+
+    // Subcommand-aware tools (e.g. `kj context list`) expose a tree of
+    // schemas; pick the leaf the leading positionals route to and bind
+    // flags against *its* params. Flat tools return the root. select_leaf
+    // errors (fail loud) if a computed positional sits where a subcommand
+    // selector is required.
+    let leaf = match schema {
+        Some(s) => Some(select_leaf(s, args)?),
+        None => None,
+    };
+    // Bind against the leaf's params, but MERGE the root schema's params on
+    // top as "global" flags: a value-flag declared at the tool's top level
+    // (e.g. kj's `--confirm <nonce>`) must bind at every leaf, including when
+    // it trails the subcommand path (`kj context retag a b --confirm <n>`).
+    // The leaf wins on name conflicts. For a flat tool, leaf == root, so the
+    // merge is a harmless no-op.
+    let mut param_lookup = schema.map(schema_param_lookup).unwrap_or_default();
+    if let Some(l) = leaf {
+        param_lookup.extend(schema_param_lookup(l));
+    }
+    // accepts_word_assign keys off the root tool name (the WORD_ASSIGN list),
+    // not the leaf — it's a property of the command, not the subcommand.
+    let accepts_word_assign = schema
+        .map(|s| crate::tools::accepts_word_assign(s.name.as_str()))
+        .unwrap_or(false);
+
+    // Track which positional indices have been consumed as flag values
+    let mut consumed: std::collections::HashSet<usize> = std::collections::HashSet::new();
+    let mut past_double_dash = false;
+
+    // Indices a value-flag may consume as its value. Positionals always
+    // qualify. A `WordAssign` (`a=1`) also qualifies when the tool does not
+    // itself treat `key=value` as an assignment (everything but
+    // export/alias/unalias) — getopt semantics: `awk -v a=1` binds `a=1` to
+    // `-v`, rather than skipping it and grabbing the next positional (the
+    // program). Without this, the natural `-F`/`-v NAME=VALUE` form silently
+    // mis-binds. The main-loop `WordAssign` arm skips consumed indices.
+    let positional_indices: Vec<usize> = args
+        .iter()
+        .enumerate()
+        .filter_map(|(i, a)| {
+            let consumable = matches!(a, Arg::Positional(_))
+                || (!accepts_word_assign && matches!(a, Arg::WordAssign { .. }));
+            consumable.then_some(i)
+        })
+        .collect();
+
+    let mut i = 0;
+    while i < args.len() {
+        match &args[i] {
+            Arg::DoubleDash => {
+                past_double_dash = true;
+            }
+            Arg::Positional(expr) => {
+                if !consumed.contains(&i) {
+                    // Glob expansion: bare glob patterns expand to matching files
+                    if let Expr::GlobPattern(pattern) = expr {
+                        if !glob_passthrough {
+                            if let Some(paths) = source.expand_glob(pattern).await? {
+                                for path in paths {
+                                    tool_args.positional.push(Value::String(path));
+                                }
+                                i += 1;
+                                continue;
+                            }
+                        }
+                    }
+                    if let Some(value) = source.eval(expr).await? {
+                        let value = apply_tilde_expansion(value, home.as_deref());
+                        tool_args.positional.push(value);
+                    }
+                }
+            }
+            Arg::Named { key, value } => {
+                if let Some(val) = source.eval(value).await? {
+                    let val = apply_tilde_expansion(val, home.as_deref());
+                    // A repeatable flag in `--flag=value` form must accumulate too,
+                    // not overwrite — otherwise `--expression=A --expression=B`
+                    // would silently keep only B, and mixing with the `-e` space
+                    // form would clobber the array. Route it through the same
+                    // accumulator the space form uses.
+                    if let Some(&(canonical, _, _, true)) = param_lookup.get(key.as_str()) {
+                        push_repeatable_value(&mut tool_args, key, canonical, val)?;
+                    } else {
+                        tool_args.named.insert(key.clone(), val);
+                    }
+                }
+            }
+            Arg::WordAssign { key, value } => {
+                // Already pulled in as a preceding value-flag's argument
+                // (`awk -v a=1`); don't also emit it as a positional.
+                if consumed.contains(&i) {
+                    i += 1;
+                    continue;
+                }
+                if let Some(val) = source.eval(value).await? {
+                    let val = apply_tilde_expansion(val, home.as_deref());
+                    if accepts_word_assign {
+                        tool_args.named.insert(key.clone(), val);
+                    } else {
+                        // Stringify "key=value" and pass as a positional.
+                        // Matches bash: `cat foo=bar` opens a file named `foo=bar`.
+                        // Loud on binary (GH #116): `cat foo=$BIN`/`dd if=$BIN`
+                        // must not silently become a path/operand literally named
+                        // `foo=[binary: N bytes]`.
+                        let val_str = crate::interpreter::value_to_text_sink_named(
+                            &val,
+                            "a key=value argument",
+                        )
+                        .map_err(|e| anyhow::anyhow!("{e}"))?;
+                        tool_args.positional.push(Value::String(format!("{key}={val_str}")));
+                    }
+                }
+            }
+            Arg::ShortFlag(name) => {
+                if past_double_dash {
+                    tool_args.positional.push(Value::String(format!("-{name}")));
+                } else if name.len() == 1 {
+                    let flag_name = name.as_str();
+                    let lookup = param_lookup.get(flag_name);
+                    let is_bool = lookup.map(|(_, typ, ..)| is_bool_type(typ)).unwrap_or(true);
+
+                    if is_bool {
+                        tool_args.flags.insert(flag_name.to_string());
+                    } else {
+                        // Non-bool: consume `consumes` positionals as value(s)
+                        let canonical = lookup.map(|(n, ..)| *n).unwrap_or(flag_name);
+                        let consumes = lookup.map(|(_, _, c, _)| *c).unwrap_or(1);
+                        let repeatable = lookup.map(|(_, _, _, r)| *r).unwrap_or(false);
+                        consume_flag_positionals(
+                            source,
+                            home.as_deref(),
+                            args,
+                            name,
+                            canonical,
+                            consumes,
+                            repeatable,
+                            &positional_indices,
+                            &mut consumed,
+                            i,
+                            &mut tool_args,
+                        )
+                        .await?;
+                    }
+                } else if let Some(&(canonical, typ, consumes, repeatable)) = param_lookup.get(name.as_str()) {
+                    // Multi-char short flag matches a schema param (POSIX style: -name value)
+                    if is_bool_type(typ) {
+                        tool_args.flags.insert(canonical.to_string());
+                    } else {
+                        consume_flag_positionals(
+                            source,
+                            home.as_deref(),
+                            args,
+                            name,
+                            canonical,
+                            consumes,
+                            repeatable,
+                            &positional_indices,
+                            &mut consumed,
+                            i,
+                            &mut tool_args,
+                        )
+                        .await?;
+                    }
+                } else if let Some(&(canonical, _, consumes, repeatable)) = param_lookup
+                    .get(&name[..1])
+                    .filter(|(_, typ, ..)| !is_bool_type(typ))
+                {
+                    // Glued short-flag value: `cut -f1`, `head -c5`, `cut -f1-3`,
+                    // `grep -A1`, `sed -e1d`. The first char is a declared
+                    // value-taking short flag, so the rest of the token is its
+                    // value — the coreutils idiom. The lexer's flag char class is
+                    // `[a-zA-Z][a-zA-Z0-9-]*`, so the first byte is always ASCII
+                    // (safe to slice) and the tail is a plain literal.
+                    bind_glued_short_value(
+                        &mut tool_args,
+                        &name[..1],
+                        canonical,
+                        consumes,
+                        repeatable,
+                        name[1..].to_string(),
+                    )?;
+                } else {
+                    // Multi-char combined short flags. Bool flags stack
+                    // (`-la`), but the FIRST value-taking flag reached
+                    // consumes the rest of the token as its glued value
+                    // (`-ivC3` → C=3) or, if it is the last char, the next
+                    // positional (`grep -ivC 3` → C=3). Before this, a
+                    // trailing value-flag was silently treated as a bool,
+                    // stranding its argument as a stray positional (arity
+                    // error). Undeclared/bool chars stay bare flags, so a
+                    // schemaless tool keeps the old all-boolean behavior.
+                    // The first char being value-taking is handled by the
+                    // glued arm above, so it never reaches here. The flag
+                    // char class is ASCII, so byte indexing is char indexing
+                    // (no `Vec<char>` allocation needed).
+                    let bytes = name.as_bytes();
+                    let mut p = 0;
+                    while p < bytes.len() {
+                        let key = &name[p..p + 1];
+                        match param_lookup.get(key) {
+                            Some(&(canonical, typ, consumes, repeatable))
+                                if !is_bool_type(typ) =>
+                            {
+                                let glued = name[p + 1..].to_string();
+                                if glued.is_empty() {
+                                    // Value flag is the last char: take the
+                                    // next positional. `consume_flag_positionals`
+                                    // respects `consumes`.
+                                    consume_flag_positionals(
+                                        source,
+                                        home.as_deref(),
+                                        args,
+                                        key,
+                                        canonical,
+                                        consumes,
+                                        repeatable,
+                                        &positional_indices,
+                                        &mut consumed,
+                                        i,
+                                        &mut tool_args,
+                                    )
+                                    .await?;
+                                } else {
+                                    bind_glued_short_value(
+                                        &mut tool_args,
+                                        key,
+                                        canonical,
+                                        consumes,
+                                        repeatable,
+                                        glued,
+                                    )?;
+                                }
+                                break;
+                            }
+                            _ => {
+                                tool_args.flags.insert(key.to_string());
+                                p += 1;
+                            }
+                        }
+                    }
+                }
+            }
+            Arg::LongFlag(name) => {
+                if past_double_dash {
+                    tool_args.positional.push(Value::String(format!("--{name}")));
+                } else {
+                    let lookup = param_lookup.get(name.as_str());
+                    // An *undeclared* long flag under a `map_positionals`
+                    // (backend/MCP) schema that is immediately followed by an
+                    // unconsumed positional is ambiguous: kaish can't tell the
+                    // space-form value (`--type explorer`) from a bool flag
+                    // before a real positional (`--force file.txt`). Defaulting
+                    // to bool here silently divorces the value and misroutes it
+                    // — a privilege-escalation-by-typo against deny-by-default
+                    // embedders (docs/issues.md). Fail loud instead of guessing.
+                    let ambiguous_value = (lookup.is_none()
+                        && leaf.is_some_and(|s| s.map_positionals)
+                        && !consumed.contains(&(i + 1)))
+                        .then(|| match args.get(i + 1) {
+                            // Echo a concrete value for a copy-pasteable fix
+                            // when it's a plain literal; fall back to VALUE.
+                            Some(Arg::Positional(Expr::Literal(Value::String(s)))) => {
+                                Some(s.clone())
+                            }
+                            Some(Arg::Positional(_)) => Some("VALUE".to_string()),
+                            _ => None,
+                        })
+                        .flatten();
+                    if let Some(val) = ambiguous_value {
+                        let tool = leaf.map(|s| s.name.as_str()).unwrap_or("command");
+                        anyhow::bail!(
+                            "{tool}: --{name} is not a declared flag, so the \
+                             space-separated value would be silently dropped. \
+                             Use --{name}={val}, or have {tool} declare --{name} \
+                             in its schema."
+                        );
+                    }
+                    let is_bool = lookup.map(|(_, typ, ..)| is_bool_type(typ)).unwrap_or(true);
+
+                    if is_bool {
+                        tool_args.flags.insert(name.clone());
+                    } else {
+                        let canonical = lookup.map(|(n, ..)| *n).unwrap_or(name.as_str());
+                        let consumes = lookup.map(|(_, _, c, _)| *c).unwrap_or(1);
+                        let repeatable = lookup.map(|(_, _, _, r)| *r).unwrap_or(false);
+                        consume_flag_positionals(
+                            source,
+                            home.as_deref(),
+                            args,
+                            name,
+                            canonical,
+                            consumes,
+                            repeatable,
+                            &positional_indices,
+                            &mut consumed,
+                            i,
+                            &mut tool_args,
+                        )
+                        .await?;
+                    }
+                }
+            }
+        }
+        i += 1;
+    }
+
+    // Map remaining positionals to unfilled non-bool schema params (in order).
+    // This enables `drift_push "abc" "hello"` → named["target_ctx"] = "abc", named["content"] = "hello"
+    // Positionals that appeared after `--` are never mapped (they're raw data).
+    // Only for backend/external tools (map_positionals=true). Builtins handle their own positionals.
+    // Keyed off the routed leaf so a subcommand tool maps against the active
+    // leaf's params (kj leaves keep map_positionals=false → block skipped).
+    if let Some(schema) = leaf.filter(|s| s.map_positionals) {
+        let pre_dash_count = if past_double_dash {
+            let dash_pos = args.iter().position(|a| matches!(a, Arg::DoubleDash)).unwrap_or(args.len());
+            positional_indices.iter()
+                .filter(|idx| **idx < dash_pos && !consumed.contains(idx))
+                .count()
+        } else {
+            tool_args.positional.len()
+        };
+
+        let mut remaining = Vec::new();
+        let mut positional_iter = tool_args.positional.drain(..).enumerate();
+
+        for param in &schema.params {
+            if tool_args.named.contains_key(&param.name) || tool_args.flags.contains(&param.name) {
+                continue;
+            }
+            if is_bool_type(&param.param_type) {
+                continue;
+            }
+            loop {
+                match positional_iter.next() {
+                    Some((idx, val)) if idx < pre_dash_count => {
+                        tool_args.named.insert(param.name.clone(), val);
+                        break;
+                    }
+                    Some((_, val)) => {
+                        remaining.push(val);
+                    }
+                    None => break,
+                }
+            }
+        }
+
+        remaining.extend(positional_iter.map(|(_, v)| v));
+        tool_args.positional = remaining;
+    }
+
+    Ok(tool_args)
 }
 
 #[async_trait]

--- a/crates/kaish-kernel/src/scheduler/pipeline.rs
+++ b/crates/kaish-kernel/src/scheduler/pipeline.rs
@@ -363,11 +363,11 @@ impl PipelineRunner {
         // "reduced sync path" entry). Mirrors run_single's dispatch-error handling.
         let scatter_schema = self.tools.get("scatter").map(|t| t.schema());
         let gather_schema = self.tools.get("gather").map(|t| t.schema());
-        let scatter_args = match build_tool_args(&scatter_cmd.args, ctx, scatter_schema.as_ref()) {
+        let scatter_args = match build_tool_args(&scatter_cmd.args, ctx, scatter_schema.as_ref()).await {
             Ok(args) => args,
             Err(e) => return ExecResult::failure(1, format!("scatter: {e}")),
         };
-        let gather_args = match build_tool_args(&gather_cmd.args, ctx, gather_schema.as_ref()) {
+        let gather_args = match build_tool_args(&gather_cmd.args, ctx, gather_schema.as_ref()).await {
             Ok(args) => args,
             Err(e) => return ExecResult::failure(1, format!("gather: {e}")),
         };
@@ -814,228 +814,60 @@ pub fn is_bool_type(param_type: &str) -> bool {
     matches!(param_type.to_lowercase().as_str(), "bool" | "boolean")
 }
 
-/// Build ToolArgs from AST Args, evaluating expressions.
+/// Reduced [`crate::kernel::ArgValueSource`] for `build_tool_args` below:
+/// evaluates via this module's own synchronous `eval_simple_expr` (no
+/// recursion into the async pipeline, so no command substitution) and never
+/// expands globs or tilde — `build_tool_args`'s historical "reduced sync"
+/// contract (see its doc comment), preserved exactly. Only the STRUCTURAL
+/// flag/positional binding now comes from the one shared
+/// `crate::kernel::bind_tool_args` core (GH #188).
+struct SyncEvalSource<'a> {
+    ctx: &'a ExecContext,
+}
+
+#[async_trait::async_trait]
+impl crate::kernel::ArgValueSource for SyncEvalSource<'_> {
+    async fn eval(&self, expr: &Expr) -> anyhow::Result<Option<Value>> {
+        eval_simple_expr(expr, self.ctx).map_err(|e| anyhow::anyhow!(e))
+    }
+
+    async fn expand_glob(&self, _pattern: &str) -> anyhow::Result<Option<Vec<String>>> {
+        // This reduced context has never expanded globs (bare patterns bind
+        // as literal text via `eval_simple_expr`'s `GlobPattern` arm) —
+        // scatter/gather's own flag values (`--as`, `--limit`, `--timeout`)
+        // are never file globs, so there's nothing to fix here (GH #188
+        // scoped this out; see the PR description).
+        Ok(None)
+    }
+
+    async fn home(&self) -> Option<String> {
+        // No tilde expansion in this reduced context — unchanged from
+        // before GH #188 (scatter/gather's own flag values are never paths).
+        None
+    }
+}
+
+/// Build ToolArgs from AST Args, evaluating expressions — the reduced sync
+/// wrapper around the shared [`crate::kernel::bind_tool_args`] core. Used by
+/// scatter/gather's own option parsing (`run_scatter_gather`, below —
+/// before any worker forks, so it can't recurse back into
+/// `PipelineRunner::run` for command substitution) and the `#[cfg(test)]`
+/// `BackendDispatcher` (`dispatch.rs`).
 ///
-/// If a schema is provided, uses it to determine argument types:
-/// - For `--flag` where schema says type is non-bool: consume next positional as value
-/// - For `--flag` where schema says type is bool (or unknown): treat as boolean flag
-///
-/// This enables natural shell syntax like `mcp_tool --query "test" --limit 10`.
-///
-/// Fallible: a bad/subscripted collection access (`${u[nope]}` on a record
-/// without that key, a subscript on a scalar, `${#u[tags]}` on an undefined
-/// subscripted root) must fail loud here too, matching the four primary eval
-/// sites (`echo`, assignment, `$(( ))`, `"${…}"`) — see [`eval_simple_expr`].
-pub fn build_tool_args(
+/// GH #188: this used to be a hand-rolled twin of `Kernel::build_args_async`'s
+/// flag/positional-binding logic that could — and did — drift from it (no
+/// undeclared-space-flag guard, no glued-short-flag handling, no
+/// `consumes`/`repeatable` accumulation). Now it's a thin wrapper: the
+/// binding logic itself is shared via [`SyncEvalSource`], and only
+/// expression evaluation differs (this context can't run `$(...)`).
+pub async fn build_tool_args(
     args: &[Arg],
     ctx: &ExecContext,
     schema: Option<&ToolSchema>,
 ) -> Result<ToolArgs, String> {
-    let mut tool_args = ToolArgs::new();
-    let param_lookup = schema.map(schema_param_lookup).unwrap_or_default();
-    let accepts_word_assign = schema
-        .map(|s| crate::tools::accepts_word_assign(s.name.as_str()))
-        .unwrap_or(false);
-
-    // Track which positional indices have been consumed as flag values
-    let mut consumed_positionals: std::collections::HashSet<usize> = std::collections::HashSet::new();
-    let mut past_double_dash = false;
-
-    // First pass: find positional args and their indices
-    let mut positional_indices: Vec<(usize, &Expr)> = Vec::new();
-    for (i, arg) in args.iter().enumerate() {
-        if let Arg::Positional(expr) = arg {
-            positional_indices.push((i, expr));
-        }
-    }
-
-    // Second pass: process all args
-    let mut i = 0;
-    while i < args.len() {
-        let arg = &args[i];
-
-        match arg {
-            Arg::DoubleDash => {
-                past_double_dash = true;
-            }
-            Arg::Positional(expr) => {
-                // Check if this positional was consumed by a preceding flag
-                if !consumed_positionals.contains(&i)
-                    && let Some(value) = eval_simple_expr(expr, ctx)?
-                {
-                    tool_args.positional.push(value);
-                }
-            }
-            Arg::Named { key, value } => {
-                if let Some(val) = eval_simple_expr(value, ctx)? {
-                    tool_args.named.insert(key.clone(), val);
-                }
-            }
-            Arg::WordAssign { key, value } => {
-                if let Some(val) = eval_simple_expr(value, ctx)? {
-                    if accepts_word_assign {
-                        tool_args.named.insert(key.clone(), val);
-                    } else {
-                        // Loud on binary (GH #116) — sync twin of the async
-                        // binder's WordAssign fallback in kernel.rs.
-                        let val_str = crate::interpreter::value_to_text_sink_named(
-                            &val,
-                            "a key=value argument",
-                        )
-                        .map_err(|e| e.to_string())?;
-                        tool_args.positional.push(Value::String(format!("{key}={val_str}")));
-                    }
-                }
-            }
-            Arg::ShortFlag(name) => {
-                if past_double_dash {
-                    tool_args.positional.push(Value::String(format!("-{name}")));
-                } else if name.len() == 1 {
-                    // Single-char short flag: look up schema to check if it takes a value.
-                    // e.g., `-n 5` where `-n` is an alias for `lines` (type: int)
-                    let flag_name = name.as_str();
-                    let lookup = param_lookup.get(flag_name);
-                    let is_bool = lookup
-                        .map(|(_, typ, ..)| is_bool_type(typ))
-                        .unwrap_or(true);
-
-                    if is_bool {
-                        tool_args.flags.insert(flag_name.to_string());
-                    } else {
-                        // Non-bool: consume next positional as value, insert under canonical name
-                        let canonical = lookup.map(|(n, ..)| *n).unwrap_or(flag_name);
-                        let next_positional = positional_indices
-                            .iter()
-                            .find(|(idx, _)| *idx > i && !consumed_positionals.contains(idx));
-
-                        if let Some((pos_idx, expr)) = next_positional {
-                            if let Some(value) = eval_simple_expr(expr, ctx)? {
-                                tool_args.named.insert(canonical.to_string(), value);
-                                consumed_positionals.insert(*pos_idx);
-                            } else {
-                                tool_args.flags.insert(flag_name.to_string());
-                            }
-                        } else {
-                            tool_args.flags.insert(flag_name.to_string());
-                        }
-                    }
-                } else if let Some(&(canonical, typ, ..)) = param_lookup.get(name.as_str()) {
-                    // Multi-char short flag matches a schema param (POSIX style: -name value)
-                    if is_bool_type(typ) {
-                        tool_args.flags.insert(canonical.to_string());
-                    } else {
-                        let next_positional = positional_indices
-                            .iter()
-                            .find(|(idx, _)| *idx > i && !consumed_positionals.contains(idx));
-                        if let Some((pos_idx, expr)) = next_positional {
-                            if let Some(value) = eval_simple_expr(expr, ctx)? {
-                                tool_args.named.insert(canonical.to_string(), value);
-                                consumed_positionals.insert(*pos_idx);
-                            } else {
-                                tool_args.flags.insert(name.clone());
-                            }
-                        } else {
-                            tool_args.flags.insert(name.clone());
-                        }
-                    }
-                } else {
-                    // Multi-char combined flags like -la: always boolean
-                    for c in name.chars() {
-                        tool_args.flags.insert(c.to_string());
-                    }
-                }
-            }
-            Arg::LongFlag(name) => {
-                if past_double_dash {
-                    tool_args.positional.push(Value::String(format!("--{name}")));
-                } else {
-                    // Look up type in schema (checks name and aliases)
-                    let lookup = param_lookup.get(name.as_str());
-                    let is_bool = lookup
-                        .map(|(_, typ, ..)| is_bool_type(typ))
-                        .unwrap_or(true); // Unknown params default to bool
-
-                    if is_bool {
-                        tool_args.flags.insert(name.clone());
-                    } else {
-                        // Non-bool: consume next positional as value, insert under canonical name
-                        // Note: the sync build_tool_args does NOT honor `consumes > 1` OR
-                        // `repeatable` (it overwrites on a repeated flag). The async
-                        // build_args_async in kernel.rs is the only path that supports multi-consume
-                        // and repeatable accumulation. Sync callers — scatter/gather option parsing
-                        // (scalar flags only) and the test-only BackendDispatcher — don't carry such
-                        // flags, so this is safe today; if they ever do, lift the logic via a shared
-                        // helper. Tracked in docs/issues.md.
-                        let canonical = lookup.map(|(n, ..)| *n).unwrap_or(name.as_str());
-                        let next_positional = positional_indices
-                            .iter()
-                            .find(|(idx, _)| *idx > i && !consumed_positionals.contains(idx));
-
-                        if let Some((pos_idx, expr)) = next_positional {
-                            if let Some(value) = eval_simple_expr(expr, ctx)? {
-                                tool_args.named.insert(canonical.to_string(), value);
-                                consumed_positionals.insert(*pos_idx);
-                            } else {
-                                tool_args.flags.insert(name.clone());
-                            }
-                        } else {
-                            tool_args.flags.insert(name.clone());
-                        }
-                    }
-                }
-            }
-        }
-        i += 1;
-    }
-
-    // Map remaining positionals to unfilled non-bool schema params (in order).
-    // This enables `drift_push "abc" "hello"` → named["target_ctx"] = "abc", named["content"] = "hello"
-    // Positionals that appeared after `--` are never mapped (they're raw data).
-    // Only for backend/external tools (map_positionals=true). Builtins handle their own positionals.
-    if let Some(schema) = schema.filter(|s| s.map_positionals) {
-        // Count how many positionals were added before `--`
-        let pre_dash_count = if past_double_dash {
-            // Find where the double-dash was in the original args to count pre-dash positionals
-            let dash_pos = args.iter().position(|a| matches!(a, Arg::DoubleDash)).unwrap_or(args.len());
-            // Count unconsumed positionals before the double-dash
-            positional_indices.iter()
-                .filter(|(idx, _)| *idx < dash_pos && !consumed_positionals.contains(idx))
-                .count()
-        } else {
-            tool_args.positional.len()
-        };
-
-        let mut remaining = Vec::new();
-        let mut positional_iter = tool_args.positional.drain(..).enumerate();
-
-        for param in &schema.params {
-            if tool_args.named.contains_key(&param.name) || tool_args.flags.contains(&param.name) {
-                continue; // Already filled by a flag or named arg
-            }
-            if is_bool_type(&param.param_type) {
-                continue; // Bool params should only be set by flags
-            }
-            // Take from pre-dash positionals only
-            loop {
-                match positional_iter.next() {
-                    Some((idx, val)) if idx < pre_dash_count => {
-                        tool_args.named.insert(param.name.clone(), val);
-                        break;
-                    }
-                    Some((_, val)) => {
-                        remaining.push(val); // Post-dash or past limit, keep as positional
-                    }
-                    None => break,
-                }
-            }
-        }
-
-        // Any leftover positionals stay positional (e.g. `cat file1 file2`)
-        remaining.extend(positional_iter.map(|(_, v)| v));
-        tool_args.positional = remaining;
-    }
-
-    Ok(tool_args)
+    crate::kernel::bind_tool_args(args, schema, &SyncEvalSource { ctx })
+        .await
+        .map_err(|e| e.to_string())
 }
 
 /// Simple expression evaluation for args (without full scope access).
@@ -1874,8 +1706,8 @@ mod tests {
         BackendDispatcher::new(Arc::new(ToolRegistry::new()))
     }
 
-    #[test]
-    fn test_schema_aware_string_arg() {
+    #[tokio::test]
+    async fn test_schema_aware_string_arg() {
         // --query "test" should become named: {"query": "test"}
         let args = vec![
             Arg::LongFlag("query".to_string()),
@@ -1884,7 +1716,7 @@ mod tests {
         let schema = make_test_schema();
         let ctx = make_minimal_ctx();
 
-        let tool_args = build_tool_args(&args, &ctx, Some(&schema)).expect("build_tool_args");
+        let tool_args = build_tool_args(&args, &ctx, Some(&schema)).await.expect("build_tool_args");
 
         assert!(tool_args.flags.is_empty(), "No flags should be set");
         assert!(tool_args.positional.is_empty(), "No positionals - consumed by --query");
@@ -1895,8 +1727,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_schema_aware_bool_flag() {
+    #[tokio::test]
+    async fn test_schema_aware_bool_flag() {
         // --verbose should remain a flag since schema says bool
         let args = vec![
             Arg::LongFlag("verbose".to_string()),
@@ -1904,15 +1736,15 @@ mod tests {
         let schema = make_test_schema();
         let ctx = make_minimal_ctx();
 
-        let tool_args = build_tool_args(&args, &ctx, Some(&schema)).expect("build_tool_args");
+        let tool_args = build_tool_args(&args, &ctx, Some(&schema)).await.expect("build_tool_args");
 
         assert!(tool_args.flags.contains("verbose"), "--verbose should be a flag");
         assert!(tool_args.named.is_empty(), "No named args");
         assert!(tool_args.positional.is_empty(), "No positionals");
     }
 
-    #[test]
-    fn test_schema_aware_mixed() {
+    #[tokio::test]
+    async fn test_schema_aware_mixed() {
         // mcp_tool file.txt --output out.txt --verbose
         // file.txt maps to "query" (first unfilled non-bool schema param)
         let args = vec![
@@ -1924,7 +1756,7 @@ mod tests {
         let schema = make_test_schema();
         let ctx = make_minimal_ctx();
 
-        let tool_args = build_tool_args(&args, &ctx, Some(&schema)).expect("build_tool_args");
+        let tool_args = build_tool_args(&args, &ctx, Some(&schema)).await.expect("build_tool_args");
 
         assert!(tool_args.positional.is_empty(), "file.txt consumed as query param");
         assert_eq!(
@@ -1938,8 +1770,8 @@ mod tests {
         assert!(tool_args.flags.contains("verbose"));
     }
 
-    #[test]
-    fn test_schema_aware_multiple_string_args() {
+    #[tokio::test]
+    async fn test_schema_aware_multiple_string_args() {
         // --query "test" --output "result.json" --verbose --limit 5
         let args = vec![
             Arg::LongFlag("query".to_string()),
@@ -1953,7 +1785,7 @@ mod tests {
         let schema = make_test_schema();
         let ctx = make_minimal_ctx();
 
-        let tool_args = build_tool_args(&args, &ctx, Some(&schema)).expect("build_tool_args");
+        let tool_args = build_tool_args(&args, &ctx, Some(&schema)).await.expect("build_tool_args");
 
         assert!(tool_args.positional.is_empty(), "All positionals consumed");
         assert_eq!(
@@ -1971,8 +1803,8 @@ mod tests {
         assert!(tool_args.flags.contains("verbose"));
     }
 
-    #[test]
-    fn test_schema_aware_double_dash() {
+    #[tokio::test]
+    async fn test_schema_aware_double_dash() {
         // --output out.txt -- --this-is-data
         // After --, everything is positional
         let args = vec![
@@ -1984,7 +1816,7 @@ mod tests {
         let schema = make_test_schema();
         let ctx = make_minimal_ctx();
 
-        let tool_args = build_tool_args(&args, &ctx, Some(&schema)).expect("build_tool_args");
+        let tool_args = build_tool_args(&args, &ctx, Some(&schema)).await.expect("build_tool_args");
 
         assert_eq!(
             tool_args.named.get("output"),
@@ -2002,8 +1834,8 @@ mod tests {
     /// the `[binary: N bytes]` placeholder into `key=value` (e.g. `dd if=$BIN`
     /// reached via a scatter/gather flag value, which routes through this sync
     /// evaluator instead of the async binder).
-    #[test]
-    fn word_assign_binary_value_is_loud_not_placeholder() {
+    #[tokio::test]
+    async fn word_assign_binary_value_is_loud_not_placeholder() {
         let args = vec![Arg::WordAssign {
             key: "if".to_string(),
             value: Expr::Literal(Value::Bytes(vec![0xff, 0x00, 0xfe])),
@@ -2012,15 +1844,15 @@ mod tests {
 
         // schema=None ⇒ accepts_word_assign is false ⇒ falls to the
         // stringify-to-positional branch under test.
-        let err = build_tool_args(&args, &ctx, None).expect_err("binary WordAssign must error");
+        let err = build_tool_args(&args, &ctx, None).await.expect_err("binary WordAssign must error");
         assert!(
             err.contains("cannot be used as"),
             "error should name the binary problem, got {err:?}"
         );
     }
 
-    #[test]
-    fn test_no_schema_fallback() {
+    #[tokio::test]
+    async fn test_no_schema_fallback() {
         // Without schema, all --flags are treated as bool flags
         let args = vec![
             Arg::LongFlag("query".to_string()),
@@ -2028,7 +1860,7 @@ mod tests {
         ];
         let ctx = make_minimal_ctx();
 
-        let tool_args = build_tool_args(&args, &ctx, None).expect("build_tool_args");
+        let tool_args = build_tool_args(&args, &ctx, None).await.expect("build_tool_args");
 
         // Without schema, --query is a flag and "test" is a positional
         assert!(tool_args.flags.contains("query"), "--query should be a flag");
@@ -2039,9 +1871,17 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_unknown_flag_in_schema() {
-        // --unknown-flag value: --unknown is bool (not in schema), "value" maps to query
+    /// GH #188: `--unknown value` under a `map_positionals` schema (real
+    /// MCP/backend tools) is ambiguous — kaish can't tell an undeclared
+    /// flag's space-form value from a bool flag sitting before a genuine
+    /// positional. The pre-#188 reduced sync twin silently defaulted
+    /// `--unknown` to a bool flag and mapped "value" onto the first unfilled
+    /// param (`query`) instead — exactly the "no undeclared-space-flag
+    /// guard" divergence from `Kernel::build_args_async`'s real behavior
+    /// that unifying the two binders closes. Production's ambiguous-value
+    /// guard (`kernel::bind_tool_args`) now fires here too.
+    #[tokio::test]
+    async fn test_unknown_flag_ambiguous_space_value_now_errors_loud() {
         let args = vec![
             Arg::LongFlag("unknown".to_string()),
             Arg::Positional(Expr::Literal(Value::String("value".to_string()))),
@@ -2049,7 +1889,28 @@ mod tests {
         let schema = make_test_schema();
         let ctx = make_minimal_ctx();
 
-        let tool_args = build_tool_args(&args, &ctx, Some(&schema)).expect("build_tool_args");
+        let err = build_tool_args(&args, &ctx, Some(&schema))
+            .await
+            .expect_err("an undeclared flag immediately before a positional must be ambiguous, not silently bool");
+        assert!(
+            err.contains("--unknown is not a declared flag"),
+            "got: {err}"
+        );
+    }
+
+    /// The unambiguous half of the same guard: an undeclared flag with
+    /// nothing after it can't be silently swallowing a positional, so it
+    /// still defaults to a bare bool flag — unchanged by GH #188.
+    #[tokio::test]
+    async fn test_unknown_bool_flag_with_no_following_positional_is_fine() {
+        let args = vec![
+            Arg::Positional(Expr::Literal(Value::String("value".to_string()))),
+            Arg::LongFlag("unknown".to_string()),
+        ];
+        let schema = make_test_schema();
+        let ctx = make_minimal_ctx();
+
+        let tool_args = build_tool_args(&args, &ctx, Some(&schema)).await.expect("build_tool_args");
 
         assert!(tool_args.flags.contains("unknown"));
         assert!(tool_args.positional.is_empty(), "value consumed as query param");
@@ -2059,8 +1920,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_named_args_unchanged() {
+    #[tokio::test]
+    async fn test_named_args_unchanged() {
         // key=value syntax should work regardless of schema
         let args = vec![
             Arg::Named {
@@ -2072,7 +1933,7 @@ mod tests {
         let schema = make_test_schema();
         let ctx = make_minimal_ctx();
 
-        let tool_args = build_tool_args(&args, &ctx, Some(&schema)).expect("build_tool_args");
+        let tool_args = build_tool_args(&args, &ctx, Some(&schema)).await.expect("build_tool_args");
 
         assert_eq!(
             tool_args.named.get("query"),
@@ -2081,8 +1942,8 @@ mod tests {
         assert!(tool_args.flags.contains("verbose"));
     }
 
-    #[test]
-    fn test_short_flags_unchanged() {
+    #[tokio::test]
+    async fn test_short_flags_unchanged() {
         // Short flags -la should expand regardless of schema; file.txt maps to query
         let args = vec![
             Arg::ShortFlag("la".to_string()),
@@ -2091,7 +1952,7 @@ mod tests {
         let schema = make_test_schema();
         let ctx = make_minimal_ctx();
 
-        let tool_args = build_tool_args(&args, &ctx, Some(&schema)).expect("build_tool_args");
+        let tool_args = build_tool_args(&args, &ctx, Some(&schema)).await.expect("build_tool_args");
 
         assert!(tool_args.flags.contains("l"));
         assert!(tool_args.flags.contains("a"));
@@ -2102,8 +1963,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_flag_at_end_no_value() {
+    #[tokio::test]
+    async fn test_flag_at_end_no_value() {
         // --output at end with no value available - treat as flag (lenient)
         // file.txt maps to query (first unfilled non-bool param)
         let args = vec![
@@ -2113,7 +1974,7 @@ mod tests {
         let schema = make_test_schema();
         let ctx = make_minimal_ctx();
 
-        let tool_args = build_tool_args(&args, &ctx, Some(&schema)).expect("build_tool_args");
+        let tool_args = build_tool_args(&args, &ctx, Some(&schema)).await.expect("build_tool_args");
 
         // output expects a value but none available after it, so it becomes a flag
         assert!(tool_args.flags.contains("output"));
@@ -2124,8 +1985,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_positional_skips_bool_params() {
+    #[tokio::test]
+    async fn test_positional_skips_bool_params() {
         // Schema: [query: string, verbose: bool, output: string]
         // Args: "val1" "val2"
         // Expected: query="val1", verbose unset, output="val2"
@@ -2150,7 +2011,7 @@ mod tests {
         ];
         let ctx = make_minimal_ctx();
 
-        let tool_args = build_tool_args(&args, &ctx, Some(&schema)).expect("build_tool_args");
+        let tool_args = build_tool_args(&args, &ctx, Some(&schema)).await.expect("build_tool_args");
 
         assert_eq!(
             tool_args.named.get("query"),
@@ -2164,8 +2025,8 @@ mod tests {
         assert!(tool_args.positional.is_empty());
     }
 
-    #[test]
-    fn test_positionals_fill_available_slots() {
+    #[tokio::test]
+    async fn test_positionals_fill_available_slots() {
         // Schema has query (string), limit (int), verbose (bool), output (string).
         // Three positionals fill the 3 non-bool slots.
         let args = vec![
@@ -2176,7 +2037,7 @@ mod tests {
         let schema = make_test_schema(); // query, limit(int), verbose(bool), output
         let ctx = make_minimal_ctx();
 
-        let tool_args = build_tool_args(&args, &ctx, Some(&schema)).expect("build_tool_args");
+        let tool_args = build_tool_args(&args, &ctx, Some(&schema)).await.expect("build_tool_args");
 
         // val1 → query, val2 → limit (int param but receives string — tool decides),
         // val3 → output
@@ -2195,8 +2056,8 @@ mod tests {
         assert!(tool_args.positional.is_empty());
     }
 
-    #[test]
-    fn test_truly_excess_positionals() {
+    #[tokio::test]
+    async fn test_truly_excess_positionals() {
         // More positionals than non-bool schema params — leftovers stay positional
         let schema = ToolSchema::new("test", "")
             .param(ParamSchema::required("name", "string", ""))
@@ -2208,7 +2069,7 @@ mod tests {
         ];
         let ctx = make_minimal_ctx();
 
-        let tool_args = build_tool_args(&args, &ctx, Some(&schema)).expect("build_tool_args");
+        let tool_args = build_tool_args(&args, &ctx, Some(&schema)).await.expect("build_tool_args");
 
         assert_eq!(
             tool_args.named.get("name"),
@@ -2223,8 +2084,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_double_dash_positional_not_mapped() {
+    #[tokio::test]
+    async fn test_double_dash_positional_not_mapped() {
         // `tool val1 -- val2` — val1 maps to query, val2 stays positional (post-dash)
         let args = vec![
             Arg::Positional(Expr::Literal(Value::String("val1".to_string()))),
@@ -2234,7 +2095,7 @@ mod tests {
         let schema = make_test_schema();
         let ctx = make_minimal_ctx();
 
-        let tool_args = build_tool_args(&args, &ctx, Some(&schema)).expect("build_tool_args");
+        let tool_args = build_tool_args(&args, &ctx, Some(&schema)).await.expect("build_tool_args");
 
         assert_eq!(
             tool_args.named.get("query"),
@@ -2247,8 +2108,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_all_params_filled_by_flags() {
+    #[tokio::test]
+    async fn test_all_params_filled_by_flags() {
         // All schema params satisfied by explicit flags — no positional mapping needed
         let args = vec![
             Arg::LongFlag("query".to_string()),
@@ -2260,7 +2121,7 @@ mod tests {
         let schema = make_test_schema();
         let ctx = make_minimal_ctx();
 
-        let tool_args = build_tool_args(&args, &ctx, Some(&schema)).expect("build_tool_args");
+        let tool_args = build_tool_args(&args, &ctx, Some(&schema)).await.expect("build_tool_args");
 
         assert_eq!(
             tool_args.named.get("query"),
@@ -2274,8 +2135,8 @@ mod tests {
         assert!(tool_args.positional.is_empty());
     }
 
-    #[test]
-    fn test_mixed_flags_and_positional_fill() {
+    #[tokio::test]
+    async fn test_mixed_flags_and_positional_fill() {
         // --output foo val1 — output is explicit, val1 maps to query
         let args = vec![
             Arg::LongFlag("output".to_string()),
@@ -2285,7 +2146,7 @@ mod tests {
         let schema = make_test_schema();
         let ctx = make_minimal_ctx();
 
-        let tool_args = build_tool_args(&args, &ctx, Some(&schema)).expect("build_tool_args");
+        let tool_args = build_tool_args(&args, &ctx, Some(&schema)).await.expect("build_tool_args");
 
         assert_eq!(
             tool_args.named.get("output"),
@@ -2298,8 +2159,8 @@ mod tests {
         assert!(tool_args.positional.is_empty());
     }
 
-    #[test]
-    fn test_alias_flag_prevents_mapping_overwrite() {
+    #[tokio::test]
+    async fn test_alias_flag_prevents_mapping_overwrite() {
         // -q "search" "out.txt" — -q is alias for query, so out.txt should map to output
         let schema = ToolSchema::new("test", "")
             .param(ParamSchema::required("query", "string", "").with_aliases(["-q"]))
@@ -2312,7 +2173,7 @@ mod tests {
         ];
         let ctx = make_minimal_ctx();
 
-        let tool_args = build_tool_args(&args, &ctx, Some(&schema)).expect("build_tool_args");
+        let tool_args = build_tool_args(&args, &ctx, Some(&schema)).await.expect("build_tool_args");
 
         assert_eq!(
             tool_args.named.get("query"),
@@ -2325,8 +2186,8 @@ mod tests {
         assert!(tool_args.positional.is_empty());
     }
 
-    #[test]
-    fn test_builtin_schema_no_positional_mapping() {
+    #[tokio::test]
+    async fn test_builtin_schema_no_positional_mapping() {
         // Builtins have map_positionals=false — positionals stay positional
         let schema = ToolSchema::new("echo", "")
             .param(ParamSchema::optional("args", "any", Value::Null, ""))
@@ -2338,7 +2199,7 @@ mod tests {
         ];
         let ctx = make_minimal_ctx();
 
-        let tool_args = build_tool_args(&args, &ctx, Some(&schema)).expect("build_tool_args");
+        let tool_args = build_tool_args(&args, &ctx, Some(&schema)).await.expect("build_tool_args");
 
         // Positionals should NOT be consumed as named params
         assert_eq!(
@@ -2351,8 +2212,8 @@ mod tests {
         assert!(!tool_args.named.contains_key("args"));
     }
 
-    #[test]
-    fn test_short_flag_with_alias_consumes_value() {
+    #[tokio::test]
+    async fn test_short_flag_with_alias_consumes_value() {
         // `-n 5` where `-n` is aliased to `lines` (type: int)
         // Should produce named: {"lines": 5}, not flags: {"n"} + positional: [5]
         let schema = ToolSchema::new("head", "Output first part of files")
@@ -2365,11 +2226,92 @@ mod tests {
         ];
         let ctx = make_minimal_ctx();
 
-        let tool_args = build_tool_args(&args, &ctx, Some(&schema)).expect("build_tool_args");
+        let tool_args = build_tool_args(&args, &ctx, Some(&schema)).await.expect("build_tool_args");
 
         assert!(tool_args.flags.is_empty(), "no boolean flags: {:?}", tool_args.flags);
         assert_eq!(tool_args.named.get("lines"), Some(&Value::Int(5)), "should resolve alias to canonical name");
         assert_eq!(tool_args.positional, vec![Value::String("/tmp/file.txt".to_string())]);
+    }
+
+    // === GH #188: divergences the pre-unification sync twin couldn't handle ===
+    //
+    // The old `scheduler::pipeline::build_tool_args` hand-rolled its own
+    // flag/positional binder that never supported glued short-flag values or
+    // `consumes`/`repeatable` accumulation (see the removed comment that used
+    // to sit on the `LongFlag` arm). Scatter/gather's own schemas never
+    // exercised these (scalar flags only), so the gap was real but
+    // un-triggerable in production — these tests pin the now-shared
+    // `kernel::bind_tool_args` behavior through the reduced sync entry point
+    // so the two binders can't quietly drift apart on it again.
+
+    #[tokio::test]
+    async fn test_glued_short_flag_value_now_binds() {
+        // `-f1` (`cut -f1`-shaped): before #188 this fell to the "combined
+        // short flags" arm and produced two bogus bool flags ("f", "1")
+        // instead of resolving the declared value-flag's glued value.
+        let schema = ToolSchema::new("cut", "")
+            .param(ParamSchema::optional("fields", "string", Value::Null, "").with_aliases(["-f"]));
+        let args = vec![Arg::ShortFlag("f1".to_string())];
+        let ctx = make_minimal_ctx();
+
+        let tool_args = build_tool_args(&args, &ctx, Some(&schema)).await.expect("build_tool_args");
+
+        assert!(tool_args.flags.is_empty(), "no bogus bool flags: {:?}", tool_args.flags);
+        assert_eq!(tool_args.named.get("fields"), Some(&Value::String("1".to_string())));
+    }
+
+    #[tokio::test]
+    async fn test_repeatable_flag_now_accumulates() {
+        // `-e A -e B`: before #188 the sync twin's value-flag path always
+        // overwrote `named[canonical]`, silently keeping only the last
+        // occurrence ("B"). The shared core accumulates both, matching
+        // `Kernel::build_args_async`.
+        let schema = ToolSchema::new("sed", "")
+            .param(ParamSchema::optional("expression", "string", Value::Null, "")
+                .with_aliases(["-e"])
+                .with_repeatable(true));
+        let args = vec![
+            Arg::ShortFlag("e".to_string()),
+            Arg::Positional(Expr::Literal(Value::String("A".to_string()))),
+            Arg::ShortFlag("e".to_string()),
+            Arg::Positional(Expr::Literal(Value::String("B".to_string()))),
+        ];
+        let ctx = make_minimal_ctx();
+
+        let tool_args = build_tool_args(&args, &ctx, Some(&schema)).await.expect("build_tool_args");
+
+        assert_eq!(
+            tool_args.named.get("expression"),
+            Some(&Value::Json(serde_json::json!(["A", "B"]))),
+            "both occurrences must survive, not just the last: {:?}",
+            tool_args.named
+        );
+    }
+
+    #[tokio::test]
+    async fn test_multi_consume_flag_now_accumulates() {
+        // `--arg NAME VAL` (jq-shaped, `consumes == 2`): before #188 the sync
+        // twin only ever consumed a single positional per flag occurrence,
+        // so a `consumes: 2` param was unsupported. The shared core
+        // recognizes it and accumulates array-of-arrays occurrences.
+        let schema = ToolSchema::new("jq", "")
+            .param(ParamSchema::optional("arg", "any", Value::Null, "").consumes(2));
+        let args = vec![
+            Arg::LongFlag("arg".to_string()),
+            Arg::Positional(Expr::Literal(Value::String("name".to_string()))),
+            Arg::Positional(Expr::Literal(Value::String("val".to_string()))),
+        ];
+        let ctx = make_minimal_ctx();
+
+        let tool_args = build_tool_args(&args, &ctx, Some(&schema)).await.expect("build_tool_args");
+
+        assert_eq!(
+            tool_args.named.get("arg"),
+            Some(&Value::Json(serde_json::json!([["name", "val"]]))),
+            "got: {:?}",
+            tool_args.named
+        );
+        assert!(tool_args.positional.is_empty());
     }
 
     // === Redirect Execution Tests ===

--- a/crates/kaish-kernel/tests/scatter_gather_jsonl_tests.rs
+++ b/crates/kaish-kernel/tests/scatter_gather_jsonl_tests.rs
@@ -522,3 +522,23 @@ async fn scatter_flag_value_command_substitution_is_loud_not_silently_dropped() 
         "a $(...) scatter flag value must fail loud, not silently coalesce to the default limit: {r:?}"
     );
 }
+
+// ═══════════════════════════════════════════════════════════════════════
+// GH #188: `scatter`/`gather`'s own option parsing used to bind through a
+// hand-rolled sync twin (`scheduler::pipeline::build_tool_args`) of the real
+// binder (`Kernel::build_args_async`). It's now a thin wrapper over the same
+// shared `kernel::bind_tool_args` core — these round-trips through
+// `kernel.execute()` pin that the unification didn't change scatter/gather's
+// own observable option-binding behavior.
+// ═══════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn scatter_as_and_limit_options_still_bind_through_the_shared_core() {
+    let k = kernel_at(tempdir().unwrap().path());
+    let r = run_full(&k, "seq 1 3 | scatter --as N --limit 2 | echo $N | gather").await;
+    assert_eq!(r.code, 0, "{:?}", r.err);
+    let got = rows(&r.text_out());
+    let mut outs: Vec<_> = got.iter().map(|row| row["out"].as_str().unwrap().to_string()).collect();
+    outs.sort();
+    assert_eq!(outs, vec!["1", "2", "3"], "--as N must bind the item to $N: {got:?}");
+}

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -15,6 +15,48 @@ before it ships.
 
 ---
 
+## Eliminating the sync `build_tool_args` twin (2026-07-17, GH #188)
+
+The scheduler had a second, hand-rolled arg binder living next to the real
+one: `Kernel::build_args_async` (kernel.rs) is the production flag/positional
+binder — schema-aware, subcommand routing (`select_leaf`), glued short-flag
+values, `consumes`/`repeatable` accumulation, real glob/tilde expansion,
+command substitution via full async recursion. `scheduler::pipeline::build_tool_args`
+was a *reduced* sync twin of the same logic, needed because scatter/gather's
+own option parsing (`--as`, `--limit`, `--timeout`) has to bind before any
+worker forks — too early to recurse back into the async pipeline — and the
+`#[cfg(test)]` `BackendDispatcher` used it too, so pipeline/runner unit tests
+could exercise schema-aware binding without spinning up a full `Kernel`. Two
+implementations of the same flag-binding rules is exactly the drift class GH
+#133 named for the external-command spawn sites; this was its sibling in the
+arg-binding seam, and the code already carried three comments admitting the
+gap (no undeclared-space-flag guard, no glued short-flag handling, no
+`consumes`/`repeatable` accumulation) — all "currently un-triggerable" only
+because scatter/gather's own schema happens to be scalar-only.
+
+The fix extracts the structural binding logic — everything except "how do I
+evaluate one expression" — into a single `bind_tool_args` core (kernel.rs),
+parameterized over a new `ArgValueSource` trait (`eval`/`expand_glob`/`home`).
+`Kernel` implements it with its real capabilities; `build_args_async` is now
+a one-line call into the shared core. The reduced sync path gets its own
+`SyncEvalSource`, wrapping the same `eval_simple_expr` it always used (still
+no command substitution — that capability boundary is real, not laziness),
+and `scheduler::pipeline::build_tool_args` becomes a thin `async fn` wrapper
+around the shared core instead of a parallel implementation. Both the
+scatter/gather call site and the test-only `BackendDispatcher` converge on
+it unchanged in call shape (still `Result<ToolArgs, String>`), so the ~30
+direct unit tests of the old twin only needed a mechanical `#[test]` →
+`#[tokio::test]` conversion, not a rewrite. One test (`test_unknown_flag_in_schema`)
+turned out to be pinning the exact undeclared-space-flag bug the issue named —
+split into a loud-error pin and a separate unambiguous-case test, plus new
+tests proving glued short-flag values and `repeatable`/`consumes>1`
+accumulation now bind correctly through the reduced path too. No CHANGELOG
+bullet: scatter/gather's real schema is still scalar-only, so nothing
+user-observable changed today — the fix is that the next flag which needs
+any of this can't silently misbind through the reduced path anymore.
+
+---
+
 ## The lexer becomes one machine (2026-07-16)
 
 GH #95 sat locked since 2026-07-04: two cross-model batch reviews (gemini-pro,


### PR DESCRIPTION
## Summary

GH #133 named the drift-class hazard for the external-command spawn sites ("two spawn sites must stay in sync"). The arg-binding seam had the same disease: `Kernel::build_args_async` (kernel.rs) is the real, schema-aware flag/positional binder; `scheduler::pipeline::build_tool_args` was a hand-rolled sync twin needed because scatter/gather's own option parsing (`--as`/`--limit`/`--timeout`) has to bind *before any worker forks* — too early to recurse back into the async pipeline. The `#[cfg(test)]` `BackendDispatcher` used the same twin so pipeline/runner unit tests could exercise schema-aware binding without a full `Kernel`.

The twin's own comments already admitted three gaps: no undeclared-space-flag guard, no glued short-flag handling, no `consumes`/`repeatable` accumulation — all "currently un-triggerable" only because scatter/gather's own schema (`--as`, `--limit`, `--timeout`, `--lines`) happens to be scalar-only today. This PR closes the drift class by making the binding logic itself the single implementation.

## Seam chosen

Extract the *structural* binding logic — schema/param lookup, subcommand routing (`select_leaf`), flag/positional classification, glued short-flag values, `consumes`/`repeatable` accumulation, the undeclared-long-flag ambiguity guard, `map_positionals` mapping — into one `bind_tool_args` core in `kernel.rs`, parameterized over a new `ArgValueSource` trait covering only the parts that genuinely differ by capability:

- `eval(&self, expr) -> Result<Option<Value>>` — evaluate one expression (`Ok(None)` = "not representable here," the reduced context's bash-compatible coalesce for an unset bare variable)
- `expand_glob(&self, pattern) -> Result<Option<Vec<String>>>` — expand a bare glob positional, or `None` to fall back to literal text
- `home(&self) -> Option<String>` — session `HOME` for tilde expansion

`Kernel` implements it with its real capabilities (full async recursion incl. command substitution, real glob/tilde expansion); `build_args_async` is now a one-line call into the shared core. The reduced sync path gets a `SyncEvalSource` wrapping the same `eval_simple_expr` it always used (still no command substitution — a real capability boundary, not laziness, since it runs before any worker fork exists to recurse through). `scheduler::pipeline::build_tool_args` becomes a thin `async fn` wrapper instead of a parallel implementation.

I verified what actually needs `.await` in the async path (three things: evaluate-an-expr, expand-a-glob, resolve-HOME) and confined the trait to exactly those — the rest of the ~500-line binder is pure/sync logic shared verbatim, so the "prefer extracting the shared core over making callers async" guidance meant keeping `run_scatter_gather` and `BackendDispatcher::dispatch` at their existing async call sites (just adding `.await`) rather than growing new async surface.

## Caller inventory

- `scheduler/pipeline.rs::run_scatter_gather` — scatter/gather's own option parsing (2 call sites: scatter args, gather args)
- `dispatch.rs::BackendDispatcher::dispatch` (`#[cfg(test)]`) — test-only dispatcher used by pipeline/runner unit tests
- ~30 direct unit tests of `build_tool_args` in `scheduler/pipeline.rs` (mechanical `#[test]` → `#[tokio::test]` conversion, since the wrapper is now `async fn`)

`Kernel::build_args_async`'s own callers (all of production command dispatch) are unaffected — same method, same signature, now backed by the shared core.

## Divergences found and closed

All three were real but currently un-triggerable in production (scatter/gather's schema is scalar-only), so no CHANGELOG bullet (internal refactor, no observable behavior change today):

1. **No undeclared-space-flag guard.** `--unknown value` under a `map_positionals` schema silently defaulted `--unknown` to bool and mapped `value` onto an unrelated param instead of erroring on the ambiguity. Found via an *existing* test (`test_unknown_flag_in_schema`) that was unknowingly pinning this exact bug — split into `test_unknown_flag_ambiguous_space_value_now_errors_loud` (pins the fix) and `test_unknown_bool_flag_with_no_following_positional_is_fine` (pins the still-valid unambiguous case).
2. **No glued short-flag handling.** `-f1` (`cut -f1`-shaped) fell through to "combined bool flags," producing bogus `f`/`1` bool flags instead of binding `fields=1`. Pinned by `test_glued_short_flag_value_now_binds`.
3. **No `consumes`/`repeatable` accumulation.** A repeated flag (`-e A -e B`) silently kept only the last value; a `consumes: 2` flag (jq's `--arg NAME VAL` shape) wasn't supported at all. Pinned by `test_repeatable_flag_now_accumulates` and `test_multi_consume_flag_now_accumulates`.

Also added an end-to-end `kernel.execute()` round-trip (`scatter_as_and_limit_options_still_bind_through_the_shared_core`) as a durable regression pin on the seam itself, alongside the existing `scatter_gather_jsonl_tests.rs` suite (unchanged assertions — including `scatter_flag_value_command_substitution_is_loud_not_silently_dropped`, which still correctly fails loud since the reduced evaluator's capability boundary is unchanged by design).

## Deliberately out of scope

- **Command substitution in scatter/gather's own flag values** (`scatter --limit $(echo 2)`) still fails loud. The issue's "unblocks actually evaluating a `$()`-valued scatter/gather option" is accurate — `run_scatter_gather` already holds a `&dyn CommandDispatcher` whose `eval_expr` *can* run command substitution for `Kernel` — but wiring it through would need `SyncEvalSource` to route via `dispatcher.eval_expr` instead of `eval_simple_expr`, and `BackendDispatcher::eval_expr` maps its own "not representable" case to a hard `Err` rather than `eval_simple_expr`'s `Ok(None)` coalesce, which would change the reduced-context's unset-bare-variable behavior for every other `BackendDispatcher`-routed test, not just scatter/gather. That's a real, separable design question, not a drift-class bug — noted here rather than folded into this PR's scope; happy to open a follow-up issue if wanted.
- **`validator::walker.rs::build_tool_args_for_validation`** — a third, structurally different "arg builder" (no `ExecContext`, placeholder values instead of real evaluation, infallible/warning-tolerant contract for static analysis) that the issue suggested folding in. It already shares the low-level primitives (`bind_glued_short_value`, `push_repeatable_value`, `schema_param_lookup`, `is_bool_type`) with `kernel.rs`. Forcing it onto the same `ArgValueSource`/`bind_tool_args` core would mean giving it a fallible contract and the ambiguous-long-flag guard it never had, which changes validator (warning-only) semantics — a different, separable change I didn't make here.
- **`scatter.rs:167-168`'s inline `take_stdin_data()`/`read_stdin_to_text()`** instead of `resolve_stdin()` — flagged in the issue as a "related small refactor in the same seam" but unrelated to arg binding; left alone.

## Test plan

- [x] `cargo test --all --locked` — clean
- [x] `cargo clippy --all --all-targets` — zero warnings
- [x] `cargo check -p kaish-kernel --no-default-features` — clean
- [x] `cargo build -p kaish-wasi --target wasm32-wasip1` — clean
- [x] New/updated tests pass: `scheduler::pipeline::tests::*` (glued short flag, repeatable, multi-consume, ambiguous-flag guard) and `scatter_gather_jsonl_tests.rs`

Closes #188