### PR TITLE
fix(collections): residuals punch list — push bracket-path target, quoted ], record error text, loud arithmetic errors (#183)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,24 @@ breaking entries are marked **BREAKING**.
 
 ## [Unreleased]
 
+### Fixed
+- **`push` accepts a bracket-path target** (`push services[web][tags] item`),
+  not just a top-level bareword — the lexer now recognizes `push`'s target
+  with its own trigger and fuses it verbatim into a path instead of
+  glob-expanding it (GH #183).
+- **A `]` inside a quoted subscript key no longer breaks the subscript**
+  (`${r["weird]key"]}`) — the bracket collector consumes a quoted key
+  verbatim to its own closing quote before looking for the terminator (GH #183).
+- **An unquoted multi-word record value gets an actionable error** instead of
+  a generic parse-error message — `{msg: hello world}` now names the mistake
+  and shows the quoted fix (GH #183).
+- **A bad `$((...))` arithmetic expansion no longer fails silently** — this
+  used to swallow the error and splice in an empty string/drop the value in
+  three places: string interpolation (`"$((1/0))"` in ordinary command
+  execution), and a scatter/gather flag value's bare and quoted forms
+  (`scatter --limit $((1/0))`, `scatter --limit "$((1/0))"`); all three now
+  propagate the real arithmetic error (GH #183).
+
 ### Added
 - **Flag completion helpers in `kaish_client::completion`** —
   `current_command(line, pos)` (which command word governs the statement

--- a/crates/kaish-help/content/en/syntax.md
+++ b/crates/kaish-help/content/en/syntax.md
@@ -104,17 +104,12 @@ xs[9]=x                   # error — index out of bounds (push grows lists)
 s[api][port]=1            # error — no `api` key (no autoviv; init it first)
 user.email=x              # error — brackets only, use `user[email]=x`
 
-# push appends to a top-level LIST in place — takes the NAME (like read/unset)
+# push appends to a LIST in place — takes the NAME (like read/unset), a
+# top-level name or a bracket path; same lvalue rules as assignment (no
+# autoviv on intermediates, leaf must already be a list)
 push xs date               # xs is now [...,"date"]
 push xs $rec               # values push as typed Values, not stringified text
-
-# KNOWN LIMITATION — push only takes a top-level bareword target; a bracket
-# path target fuses into a glob and fails loudly ("no matches") instead of
-# pushing. Read the nested list out, push, assign it back:
-push services[web][tags] item   # ERROR — no matches: services[web][tags]
-tmp=${services[web][tags]}      # workaround
-push tmp item
-services[web][tags]=$tmp
+push services[web][tags] canary   # bracket-path target
 ```
 
 ## Paths

--- a/crates/kaish-help/src/fragments.rs
+++ b/crates/kaish-help/src/fragments.rs
@@ -359,17 +359,12 @@ xs[9]=x                   # error — index out of bounds (push grows lists)
 s[api][port]=1            # error — no `api` key (no autoviv; init it first)
 user.email=x              # error — brackets only, use `user[email]=x`
 
-# push appends to a top-level LIST in place — takes the NAME (like read/unset)
+# push appends to a LIST in place — takes the NAME (like read/unset), a
+# top-level name or a bracket path; same lvalue rules as assignment (no
+# autoviv on intermediates, leaf must already be a list)
 push xs date               # xs is now [...,"date"]
 push xs $rec               # values push as typed Values, not stringified text
-
-# KNOWN LIMITATION — push only takes a top-level bareword target; a bracket
-# path target fuses into a glob and fails loudly ("no matches") instead of
-# pushing. Read the nested list out, push, assign it back:
-push services[web][tags] item   # ERROR — no matches: services[web][tags]
-tmp=${services[web][tags]}      # workaround
-push tmp item
-services[web][tags]=$tmp
+push services[web][tags] canary   # bracket-path target
 ```"#,
     ),
     syntax_section(

--- a/crates/kaish-kernel/src/interpreter/scope.rs
+++ b/crates/kaish-kernel/src/interpreter/scope.rs
@@ -356,6 +356,22 @@ fn apply_leaf_write(
     }
 }
 
+/// Render a mid-walk `PathError` for `push`'s error text. `Absence`/`Shape`
+/// already carry a ready-to-display `${…}` message from `resolve_step`/
+/// `descend_mut` (shared with `walk_write`); only `UndefinedRoot` needs
+/// `push`-flavored wording here — it fires for an unset `$k` dynamic
+/// subscript mid-path, not the root itself (`walk_append` checks the root
+/// exists before ever starting the walk).
+fn push_path_error_message(err: PathError, root_name: &str) -> String {
+    match err {
+        PathError::UndefinedRoot(msg) if msg.is_empty() => {
+            format!("push: {root_name} is not defined")
+        }
+        PathError::UndefinedRoot(msg) => format!("push: {msg}"),
+        PathError::Absence(msg) | PathError::Shape(msg) => msg,
+    }
+}
+
 /// Variable scope with nested frames and last-result tracking.
 ///
 /// Variables are looked up from innermost to outermost frame.
@@ -840,25 +856,70 @@ impl Scope {
         Ok(())
     }
 
-    /// Append value(s) to a top-level list variable, in place (`push xs val`).
+    /// Append value(s) to a list variable, in place: a top-level bareword
+    /// target (`push xs val`) or a bracket-path target
+    /// (`push services[web][tags] item`).
     ///
-    /// The target must already exist and be a list — an undefined or
-    /// non-list target is a loud error, never a silent create (see
-    /// `docs/arrays-and-hashes.md`, "Append — push"). Bracket-path push
-    /// (`push services[web][tags] item`) is deferred (see `docs/issues.md`);
-    /// this only handles a top-level bareword name.
-    pub fn walk_append(&mut self, name: &str, values: Vec<Value>) -> Result<(), String> {
+    /// The target must already exist and be a list — an undefined root, a
+    /// non-list leaf, or a missing intermediate hop is a loud error, never a
+    /// silent create or autoviv (see `docs/arrays-and-hashes.md`, "Append —
+    /// push"). Intermediate hops share `walk_write`'s `resolve_step`/
+    /// `descend_mut` (no autoviv, same bounds/shape classification); the
+    /// final hop diverges — it appends instead of replacing.
+    pub fn walk_append(&mut self, path: &VarPath, values: Vec<Value>) -> Result<(), String> {
+        let Some(VarSegment::Field(root_name)) = path.segments.first() else {
+            return Err("push: target has no root".to_string());
+        };
+        let root_name = root_name.clone();
         let current = self
-            .get(name)
-            .ok_or_else(|| format!("push: {name} is not defined"))?;
-        if !matches!(current, Value::Json(serde_json::Value::Array(_))) {
-            return Err(format!("push: {name} is not a list ({})", type_name(current)));
+            .get(&root_name)
+            .ok_or_else(|| format!("push: {root_name} is not defined"))?
+            .clone();
+
+        let subscripts = &path.segments[1..];
+        if subscripts.is_empty() {
+            if !matches!(current, Value::Json(serde_json::Value::Array(_))) {
+                return Err(format!("push: {root_name} is not a list ({})", type_name(&current)));
+            }
+            let Value::Json(serde_json::Value::Array(mut arr)) = current else {
+                unreachable!("checked above")
+            };
+            arr.extend(values.iter().map(value_to_json));
+            self.set_global(root_name, Value::Json(serde_json::Value::Array(arr)));
+            return Ok(());
         }
-        let Value::Json(serde_json::Value::Array(mut arr)) = current.clone() else {
-            unreachable!("checked above")
+
+        let mut root_json = match current {
+            Value::Json(j) => j,
+            other => {
+                return Err(format!(
+                    "push: {root_name}…: cannot subscript {} — it is not a collection",
+                    type_name(&other)
+                ))
+            }
+        };
+
+        // Walk every subscript — including the last — with the shared
+        // no-autoviv intermediate walker: the container the values append
+        // into must already exist, matching `walk_write`'s policy.
+        let mut cur = &mut root_json;
+        let mut prefix = root_name.clone();
+        for seg in subscripts {
+            let step = resolve_step(cur, seg, self, &prefix)
+                .map_err(|e| push_path_error_message(e, &root_name))?;
+            cur = descend_mut(cur, step, &prefix)
+                .map_err(|e| push_path_error_message(e, &root_name))?;
+            prefix.push_str(&render_segment(seg));
+        }
+
+        let serde_json::Value::Array(arr) = cur else {
+            return Err(format!(
+                "push: {prefix} is not a list ({})",
+                type_name(&json_to_value_no_envelope(cur.clone()))
+            ));
         };
         arr.extend(values.iter().map(value_to_json));
-        self.set_global(name, Value::Json(serde_json::Value::Array(arr)));
+        self.set_global(root_name, Value::Json(root_json));
         Ok(())
     }
 
@@ -1335,7 +1396,7 @@ mod tests {
         let mut scope = Scope::new();
         scope.set("xs", Value::Json(serde_json::json!(["a", "b"])));
         scope
-            .walk_append("xs", vec![Value::String("c".into())])
+            .walk_append(&VarPath::simple("xs"), vec![Value::String("c".into())])
             .expect("push should succeed");
         assert_eq!(scope.get("xs"), Some(&Value::Json(serde_json::json!(["a", "b", "c"]))));
     }
@@ -1343,7 +1404,7 @@ mod tests {
     #[test]
     fn walk_append_undefined_target_is_a_loud_error() {
         let mut scope = Scope::new();
-        let r = scope.walk_append("nope", vec![Value::Int(1)]);
+        let r = scope.walk_append(&VarPath::simple("nope"), vec![Value::Int(1)]);
         assert!(r.is_err(), "expected a loud error for an undefined target");
     }
 
@@ -1351,7 +1412,63 @@ mod tests {
     fn walk_append_non_list_target_is_a_loud_error() {
         let mut scope = Scope::new();
         scope.set("y", Value::String("hi".into()));
-        let r = scope.walk_append("y", vec![Value::Int(1)]);
+        let r = scope.walk_append(&VarPath::simple("y"), vec![Value::Int(1)]);
         assert!(r.is_err(), "expected a loud error for a non-list target");
+    }
+
+    #[test]
+    fn walk_append_bracket_path_extends_a_nested_list_in_place() {
+        let mut scope = Scope::new();
+        scope.set(
+            "services",
+            Value::Json(serde_json::json!({"web": {"tags": ["a"]}})),
+        );
+        let path = VarPath {
+            segments: vec![
+                VarSegment::Field("services".into()),
+                VarSegment::Key("web".into()),
+                VarSegment::Key("tags".into()),
+            ],
+        };
+        scope
+            .walk_append(&path, vec![Value::String("b".into())])
+            .expect("bracket-path push should succeed");
+        assert_eq!(
+            scope.get("services"),
+            Some(&Value::Json(serde_json::json!({"web": {"tags": ["a", "b"]}})))
+        );
+    }
+
+    #[test]
+    fn walk_append_bracket_path_missing_intermediate_is_a_loud_error() {
+        let mut scope = Scope::new();
+        scope.set("services", Value::Json(serde_json::json!({})));
+        let path = VarPath {
+            segments: vec![
+                VarSegment::Field("services".into()),
+                VarSegment::Key("web".into()),
+                VarSegment::Key("tags".into()),
+            ],
+        };
+        let r = scope.walk_append(&path, vec![Value::String("x".into())]);
+        assert!(r.is_err(), "expected a loud error for a missing intermediate");
+    }
+
+    #[test]
+    fn walk_append_bracket_path_non_list_leaf_is_a_loud_error() {
+        let mut scope = Scope::new();
+        scope.set(
+            "services",
+            Value::Json(serde_json::json!({"web": {"port": 8080}})),
+        );
+        let path = VarPath {
+            segments: vec![
+                VarSegment::Field("services".into()),
+                VarSegment::Key("web".into()),
+                VarSegment::Key("port".into()),
+            ],
+        };
+        let r = scope.walk_append(&path, vec![Value::Int(1)]);
+        assert!(r.is_err(), "expected a loud error for a non-list leaf");
     }
 }

--- a/crates/kaish-kernel/src/kernel.rs
+++ b/crates/kaish-kernel/src/kernel.rs
@@ -4453,11 +4453,15 @@ impl Kernel {
                 Ok(scope.arg_count().to_string())
             }
             StringPart::Arithmetic(expr) => {
+                // Loud on purpose (GH #183): this used to be `Err(_) =>
+                // Ok(String::new())`, silently splicing in "" for e.g.
+                // `"$((1/0))"` — `echo "value: $((1/0))"` printed "value: "
+                // at exit 0 instead of failing. Matches the bare (non-string)
+                // `Expr::Arithmetic` arm above, which already propagates.
                 let scope = self.scope.read().await;
-                match crate::arithmetic::eval_arithmetic(expr, &scope) {
-                    Ok(value) => Ok(value.to_string()),
-                    Err(_) => Ok(String::new()),
-                }
+                crate::arithmetic::eval_arithmetic(expr, &scope)
+                    .map(|value| value.to_string())
+                    .map_err(|e| anyhow::anyhow!("arithmetic error: {e}"))
             }
             StringPart::CommandSubst(stmts) => {
                 // Snapshot scope, cwd, and session config — command

--- a/crates/kaish-kernel/src/lexer.rs
+++ b/crates/kaish-kernel/src/lexer.rs
@@ -2123,6 +2123,36 @@ struct ValueContext {
     /// suppresses colon-merge fusion. Narrower than `in_literal` on
     /// purpose: a plain scalar assignment `x=foo:bar` must keep fusing.
     in_brace: bool,
+    /// This token is (part of) `push`'s bracket-path TARGET — see
+    /// [`PushTarget`]. Lets `flush_glob_run` fuse `services[web][tags]`
+    /// verbatim into a single `Ident` (a path to walk) instead of a
+    /// `GlobWord` (glob-expanded against the filesystem, GH #183).
+    push_target: bool,
+}
+
+/// Independent tiny tracker (parallel to, but NOT integrated into,
+/// `StmtHead` below) for the one thing `push`'s bracket-path target needs:
+/// recognizing `push`'s own target run so `flush_glob_run` can fuse it
+/// verbatim, the same way an assignment's `=`-followed lvalue is
+/// recognized. Kept separate from `StmtHead` on purpose — folding this into
+/// the Lvalue-root slot would steal it from `push`'s actual target
+/// identifier (see the GH #183 investigation) and threading a text match on
+/// `StmtHead::Start` risks regressing a variable literally named `push`
+/// (`push=5`, `push[0]=x`, both still routed entirely through the
+/// untouched `StmtHead` machinery).
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum PushTarget {
+    /// Not tracking a `push` target right now.
+    None,
+    /// Just saw a bareword `push` at statement-head; the very next token is
+    /// the bracket-path root, if it's an `Ident`.
+    AwaitingRoot,
+    /// Consumed the root identifier (and any glued `[...]` groups so far);
+    /// `usize` is the byte offset just past the last consumed token — used
+    /// to require the next `[` be glued (no whitespace) to extend the path.
+    Root(usize),
+    /// Inside a glued `[...]` group on the target; depth tracks nesting.
+    RootSubscript(usize),
 }
 
 /// Structural frames tracked by the context walker. The stack replaces the
@@ -2226,6 +2256,13 @@ fn compute_value_context(tokens: &[Spanned<Token>]) -> Vec<ValueContext> {
     // to enclosing scopes, frozen while this scope is active).
     let mut scope_floors: Vec<usize> = vec![0];
 
+    // Independent `push`-target tracker — see `PushTarget`. Flat (not
+    // scope-stacked like `scopes`/`frames`): a `push` inside `$( )` still
+    // gets detected via the `StmtHead::Start` check below (scoped
+    // correctly), and the tracker naturally resets once the target's
+    // glued run ends, so it never leaks past one `push` invocation.
+    let mut push_target = PushTarget::None;
+
     for i in 0..tokens.len() {
         let tok = &tokens[i].token;
         let span = &tokens[i].span;
@@ -2238,6 +2275,7 @@ fn compute_value_context(tokens: &[Spanned<Token>]) -> Vec<ValueContext> {
         ctx[i] = ValueContext {
             in_literal: expect_value || in_open_literal,
             in_brace: matches!(top, Some(Frame::Record)),
+            push_target: false, // set below once this token's transition is known
         };
 
         // `in` membership: value position only inside a `[[ ]]` test in
@@ -2252,6 +2290,44 @@ fn compute_value_context(tokens: &[Spanned<Token>]) -> Vec<ValueContext> {
             skip_paired_bracket = false;
             continue;
         }
+
+        // Independent `push`-target tracker (see `PushTarget`) — entirely
+        // separate from the `StmtHead` DFA below so a variable literally
+        // named `push` (`push=5`, `push[0]=x`) keeps going through the
+        // ordinary assignment path untouched. Computed from POST-transition
+        // state: `ctx[i].push_target` should be true only for tokens
+        // actually CONSUMED into the target path, not the token that ends
+        // it (`push xs c` — "c" must not inherit the target's context).
+        let stmt_head_is_start = matches!(scopes.last(), Some(StmtHead::Start));
+        push_target = if is_statement_boundary(tok) {
+            PushTarget::None
+        } else {
+            match (push_target, tok) {
+                (PushTarget::None, Token::Ident(s)) if stmt_head_is_start && s == "push" => {
+                    PushTarget::AwaitingRoot
+                }
+                (PushTarget::AwaitingRoot, Token::Ident(_)) => PushTarget::Root(span.end),
+                (PushTarget::Root(end), Token::LBracket) if span.start == end => {
+                    PushTarget::RootSubscript(1)
+                }
+                (PushTarget::RootSubscript(d), Token::LBracket) => {
+                    PushTarget::RootSubscript(d + 1)
+                }
+                (PushTarget::RootSubscript(d), Token::RBracket) => {
+                    if d == 1 {
+                        PushTarget::Root(span.end)
+                    } else {
+                        PushTarget::RootSubscript(d - 1)
+                    }
+                }
+                // Subscript interior (`Ident`/`Int`/`String`/`SimpleVarRef` —
+                // whatever `lvalue_subscript_parser` accepts): hold depth.
+                (PushTarget::RootSubscript(d), _) => PushTarget::RootSubscript(d),
+                _ => PushTarget::None,
+            }
+        };
+        ctx[i].push_target =
+            matches!(push_target, PushTarget::Root(_) | PushTarget::RootSubscript(_));
 
         match tok {
             Token::LBracket => {
@@ -2708,6 +2784,7 @@ fn merge_glob_adjacent(tokens: Vec<Spanned<Token>>, source: &str) -> Vec<Spanned
                 &mut result,
                 value_ctx[run_start].in_literal,
                 followed_by_eq,
+                value_ctx[run_start].push_target,
                 source,
             );
             if is_glob_mergeable(&token.token) {
@@ -2720,12 +2797,14 @@ fn merge_glob_adjacent(tokens: Vec<Spanned<Token>>, source: &str) -> Vec<Spanned
     }
 
     // End of input: no token follows the final run, so it can't be an
-    // lvalue (an assignment always has a value after `=`).
+    // lvalue (an assignment always has a value after `=`) — but it CAN
+    // still be a `push` target (`push xs[0]` with nothing after it).
     flush_glob_run(
         &mut run,
         &mut result,
         value_ctx[run_start].in_literal,
         false,
+        value_ctx[run_start].push_target,
         source,
     );
 
@@ -2745,11 +2824,18 @@ fn merge_glob_adjacent(tokens: Vec<Spanned<Token>>, source: &str) -> Vec<Spanned
 /// `followed_by_eq` is the SEPARATE lvalue trigger: an `Ident`-led
 /// bracket-pair run with no `*`/`?` immediately before `=` is a
 /// subscripted assignment target (`fruits[0]=kiwi`), not a glob.
+///
+/// `push_target` is a THIRD, independent trigger (see `PushTarget`):
+/// `push`'s own bracket-path target (`push services[web][tags] item`) has
+/// no trailing `=` to key off, so it's recognized separately and fused
+/// verbatim into a single `Ident` (GH #183) — a path for `push` to walk,
+/// never a glob to expand against the filesystem.
 fn flush_glob_run(
     run: &mut Vec<&Spanned<Token>>,
     result: &mut Vec<Spanned<Token>>,
     value_position_suppress: bool,
     followed_by_eq: bool,
+    push_target: bool,
     source: &str,
 ) {
     if run.is_empty() {
@@ -2771,9 +2857,18 @@ fn flush_glob_run(
     let run_starts_with_ident = matches!(run.first().map(|t| &t.token), Some(Token::Ident(_)));
     let lvalue_suppress =
         followed_by_eq && has_bracket_pair && !has_star_or_question && run_starts_with_ident;
+    let push_target_suppress =
+        push_target && has_bracket_pair && !has_star_or_question && run_starts_with_ident;
     let suppress = (value_position_suppress && has_bracket_pair) || lvalue_suppress;
 
-    if !suppress && run.len() >= 2 && has_glob {
+    if push_target_suppress && run.len() >= 2 {
+        // `push`'s target: fuse verbatim to a single `Ident` (never a
+        // `GlobWord` — nothing here is meant to glob-expand).
+        let start = run.first().map(|t| t.span.start).unwrap_or(0);
+        let end = run.last().map(|t| t.span.end).unwrap_or(0);
+        let text = source.get(start..end).unwrap_or_default().to_string();
+        result.push(Spanned::new(Token::Ident(text), start..end));
+    } else if !suppress && run.len() >= 2 && has_glob {
         let start = run.first().map(|t| t.span.start).unwrap_or(0);
         let end = run.last().map(|t| t.span.end).unwrap_or(0);
         let text = source.get(start..end).unwrap_or_default().to_string();
@@ -2926,6 +3021,14 @@ pub fn parse_string_literal(source: &str) -> Result<String, LexerError> {
 
 /// Parse a variable reference, extracting the path segments.
 /// Input: "${VAR.field[0].nested}" → ["VAR", "field", "[0]", "nested"]
+///
+/// The `[...]` collector is quote-aware (GH #183): a subscript opening with
+/// `"` or `'` consumes verbatim up to its OWN matching closing quote before
+/// resuming the search for the subscript's terminating `]` — so an embedded
+/// `]` inside a quoted key (`${r["weird]key"]}`) is just data, not the
+/// bracket's end. Un-quoted subscripts (`[0]`, `[$k]`, `[web]`) are
+/// unaffected — the quote check only fires when the subscript's first
+/// character is actually a quote.
 pub fn parse_var_ref(source: &str) -> Result<Vec<String>, LexerError> {
     // Remove ${ and }
     if source.len() < 4 || !source.starts_with("${") || !source.ends_with('}') {
@@ -2956,8 +3059,24 @@ pub fn parse_var_ref(source: &str) -> Result<Vec<String>, LexerError> {
                     segments.push(current.clone());
                     current.clear();
                 }
-                // Collect the index
+                // Collect the index. Quote-aware: a quoted key's own
+                // matching closer is consumed FIRST, verbatim, so an
+                // embedded `]` inside it (`["weird]key"]`) can't be
+                // mistaken for the subscript's terminator (GH #183).
                 let mut index = String::from("[");
+                if let Some(&quote) = chars.peek() {
+                    if quote == '"' || quote == '\'' {
+                        if let Some(q) = chars.next() {
+                            index.push(q);
+                        }
+                        for c in chars.by_ref() {
+                            index.push(c);
+                            if c == quote {
+                                break;
+                            }
+                        }
+                    }
+                }
                 while let Some(&c) = chars.peek() {
                     if let Some(c) = chars.next() {
                         index.push(c);
@@ -3403,6 +3522,41 @@ mod tests {
         assert_eq!(
             parse_var_ref("${?}").expect("ok"),
             vec!["?"]
+        );
+    }
+
+    /// GH #183: a `]` inside a QUOTED subscript key must not be mistaken for
+    /// the subscript's own terminator. Double- and single-quoted keys alike.
+    #[test]
+    fn parse_var_quoted_subscript_with_embedded_bracket() {
+        assert_eq!(
+            parse_var_ref(r#"${r["weird]key"]}"#).expect("ok"),
+            vec!["r", r#"["weird]key"]"#]
+        );
+        assert_eq!(
+            parse_var_ref("${r['weird]key']}").expect("ok"),
+            vec!["r", "['weird]key']"]
+        );
+    }
+
+    /// A quoted key with NO embedded bracket is unaffected by the
+    /// quote-awareness — same segment shape as before.
+    #[test]
+    fn parse_var_quoted_subscript_without_embedded_bracket() {
+        assert_eq!(
+            parse_var_ref(r#"${r["normal"]}"#).expect("ok"),
+            vec!["r", r#"["normal"]"#]
+        );
+    }
+
+    /// Trailing content after a quoted subscript closes (a further chained
+    /// hop) still parses — the quote-awareness only governs the ONE
+    /// subscript it opens inside.
+    #[test]
+    fn parse_var_quoted_subscript_with_embedded_bracket_then_more_path() {
+        assert_eq!(
+            parse_var_ref(r#"${r["weird]key"][0]}"#).expect("ok"),
+            vec!["r", r#"["weird]key"]"#, "[0]"]
         );
     }
 

--- a/crates/kaish-kernel/src/parser.rs
+++ b/crates/kaish-kernel/src/parser.rs
@@ -2416,9 +2416,36 @@ where
     let single_key = select! { Token::SingleString(s) => RecordKey::Quoted(s) };
     let key = choice((double_key, single_key, bare_key)).labelled("record key");
 
+    // Guard against the classic unquoted multi-word value mistake
+    // (`{msg: hello world}`): without this, "world" is consumed by the
+    // NEXT `entry` attempt as a candidate key (kaish allows a bare
+    // space — no comma — between entries, so `{a: 1 b: 2}` is legal), which
+    // then fails at `}` expecting `:` — chumsky's generic message ("found
+    // '}' expected ':'") without ever naming the actual mistake. Peeked via
+    // `.rewind()` (consumes nothing — a legitimate following entry, comma
+    // or not, is still parsed normally by the outer `repeated()`): an
+    // `Ident` right after this value that ISN'T itself followed by `:` can
+    // only be a stray unquoted word, since a real next entry always looks
+    // like `Ident :` (or a quoted key) at this position.
+    let stray_bareword_after_value = select! { Token::Ident(s) => s }
+        .then(just(Token::Colon).or_not())
+        .rewind()
+        .or_not()
+        .try_map(|maybe, span| match maybe {
+            Some((word, None)) => Err(Rich::custom(
+                span,
+                format!(
+                    "record value: unexpected word \"{word}\" after the value — a multi-word \
+                     value must be quoted, e.g. {{key: \"hello world\"}}"
+                ),
+            )),
+            _ => Ok(()),
+        });
+
     let entry = key
         .then_ignore(just(Token::Colon))
         .then(value)
+        .then_ignore(stray_bareword_after_value)
         .map(|(key, value)| RecordEntry { key, value });
 
     let sep = choice((just(Token::Comma).to(()), just(Token::Newline).to(()))).repeated();

--- a/crates/kaish-kernel/src/scheduler/pipeline.rs
+++ b/crates/kaish-kernel/src/scheduler/pipeline.rs
@@ -1040,16 +1040,19 @@ pub fn build_tool_args(
 
 /// Simple expression evaluation for args (without full scope access).
 ///
-/// `Ok(None)` means "not representable in this reduced sync context" (binary
-/// ops, command substitution — these need the async kernel path; callers
-/// treat that the same as before, e.g. falling back to a bare flag). `Err`
-/// means a genuine [`PathError`] — undefined-subscripted-root, a missing key,
-/// or a shape mismatch — and MUST propagate loud, the same as the async
-/// `build_args_async`/`eval_expr_async` (`kernel.rs`) and the sync
-/// interpreter (`eval.rs`) treat it. Before this, every arm here discarded
-/// the error via `.ok()`/`if let Ok(..)`, so a bad subscript in a scatter/gather
-/// flag value silently dropped the argument instead of failing (docs/issues.md,
-/// now closed).
+/// `Ok(None)` means "not representable in this reduced sync context" (only
+/// binary ops fall here now — everything else this reduced binder can't
+/// evaluate, like command substitution, has its own explicit `Err` arm
+/// below; callers treat `None` the same as before, e.g. falling back to a
+/// bare flag). `Err` means a genuine failure — a [`PathError`]
+/// (undefined-subscripted-root, a missing key, a shape mismatch), a bad
+/// `$((...))` arithmetic expansion, or an unsupported `$(...)`/`$(cmd)` — and
+/// MUST propagate loud, the same as the async `build_args_async`/
+/// `eval_expr_async` (`kernel.rs`) and the sync interpreter (`eval.rs`) treat
+/// it. Before this, every arm here discarded the error via
+/// `.ok()`/`if let Ok(..)`, so a bad subscript OR a bad arithmetic expansion
+/// in a scatter/gather flag value silently dropped the argument instead of
+/// failing (docs/issues.md, now closed; the arithmetic swallow was GH #183).
 pub(crate) fn eval_simple_expr(expr: &Expr, ctx: &ExecContext) -> Result<Option<Value>, String> {
     match expr {
         Expr::Literal(value) => Ok(Some(eval_literal(value, ctx))),
@@ -1085,6 +1088,16 @@ pub(crate) fn eval_simple_expr(expr: &Expr, ctx: &ExecContext) -> Result<Option<
             }
         }
         Expr::GlobPattern(s) => Ok(Some(Value::String(s.clone()))),
+        // Bare arithmetic expansion (`scatter --limit $((1+1))`) — mirrors
+        // the async `eval_expr_async`'s `Expr::Arithmetic` arm (kernel.rs),
+        // which already propagates loud. This used to fall into the
+        // catch-all `_ => Ok(None)` below (silently "not representable
+        // here"), so a bare `$((...))` flag value never bound at all — a
+        // valid `--limit $((1+1))` silently ran unlimited, and a bad
+        // `--limit $((1/0))` silently did too, instead of failing (GH #183).
+        Expr::Arithmetic(expr_str) => arithmetic::eval_arithmetic(expr_str, &ctx.scope)
+            .map(|n| Some(Value::Int(n)))
+            .map_err(|e| format!("arithmetic error: {e}")),
         Expr::HereDocBody { parts, strip_tabs } => {
             // Heredoc body materialization for redirect targets. `<<-` tab
             // stripping applies to the literal source, not to tabs from a
@@ -1178,12 +1191,16 @@ fn eval_string_parts_sync(parts: &[crate::ast::StringPart], ctx: &ExecContext) -
                 result.push_str(&ctx.scope.arg_count().to_string());
             }
             crate::ast::StringPart::Arithmetic(expr) => {
-                // Arithmetic errors in this reduced sync context are a
-                // separate, pre-existing swallow (not a collection PathError)
-                // — out of scope here; tracked in docs/issues.md.
-                if let Ok(value) = arithmetic::eval_arithmetic(expr, &ctx.scope) {
-                    result.push_str(&value.to_string());
-                }
+                // Loud on purpose (GH #183): this used to be `if let Ok(..)`,
+                // silently omitting the digits on error — a quoted
+                // `--limit "$((1/0))"` used to surface only as scatter's own
+                // generic int-parse complaint on the resulting "", masking
+                // the real arithmetic error. Matches the bare
+                // `Expr::Arithmetic` arm above and the async
+                // `eval_string_part_async` (kernel.rs).
+                let value = arithmetic::eval_arithmetic(expr, &ctx.scope)
+                    .map_err(|e| format!("arithmetic error: {e}"))?;
+                result.push_str(&value.to_string());
             }
             crate::ast::StringPart::CommandSubst(_) => {
                 // Command substitution can't run in this reduced sync

--- a/crates/kaish-kernel/src/tools/builtin/push.rs
+++ b/crates/kaish-kernel/src/tools/builtin/push.rs
@@ -14,19 +14,23 @@
 //! `push` to an undefined target, or a target that isn't a list, is a loud
 //! runtime error — never a silent create (see `Scope::walk_append`).
 //!
-//! **Scope note — bareword target only.** `push services[web][tags] item`
-//! (a bracket-path target) is deferred: the target isn't followed by `=`, so
-//! the lvalue lexer suppression never fires and `services[web][tags]` fuses
-//! into a `GlobWord` that glob-expands (and fails as "no matches") before
-//! `push` ever runs. Solving that needs its own lexer/parser design pass —
-//! see `docs/issues.md`.
+//! **Bracket-path targets.** `push services[web][tags] item` walks the
+//! nested path the same way an assignment lvalue does — a missing
+//! intermediate key or a non-list leaf is a loud error, never autoviv (see
+//! `Scope::walk_append`). The lexer recognizes `push`'s target with its own
+//! trigger (independent of the `=`-followed lvalue trigger an assignment
+//! uses — the target has no trailing `=` to key off) so
+//! `services[web][tags]` fuses verbatim into a path to walk instead of
+//! glob-expanding against the filesystem (GH #183); see
+//! `lexer::PushTarget`.
 //!
 //! # Examples
 //!
 //! ```kaish
 //! xs=[a b]
-//! push xs c              # xs is now [a b c]
-//! push xs $rec           # values are read as typed Values, not stringified
+//! push xs c                        # xs is now [a b c]
+//! push xs $rec                     # values are read as typed Values, not stringified
+//! push services[web][tags] canary  # bracket-path target
 //! ```
 
 use async_trait::async_trait;
@@ -106,12 +110,19 @@ impl Tool for Push {
             }
         };
 
+        // The lexer hands a bareword (`xs`) and a bracket path
+        // (`services[web][tags]`) through identically — a fused `Ident`
+        // token, verbatim — so both are parsed the same way here via the
+        // shared `${...}` path grammar (`services[web][tags]` round-trips
+        // through it exactly like `${services[web][tags]}`'s interior).
+        let path = crate::parser::parse_varpath(&format!("${{{name}}}"));
+
         let values: Vec<Value> = args.positional[1..].to_vec();
         if values.is_empty() {
             return ExecResult::failure(2, "push: usage: push NAME VALUE...");
         }
 
-        match ctx.scope.walk_append(&name, values) {
+        match ctx.scope.walk_append(&path, values) {
             Ok(()) => ExecResult::success(""),
             Err(msg) => ExecResult::failure(1, msg),
         }
@@ -193,5 +204,28 @@ mod tests {
         let result = Push.execute(args, &mut ctx).await;
         assert!(!result.ok());
         assert!(result.err.contains("not a list"), "got: {}", result.err);
+    }
+
+    /// Bracket-path target (GH #183): the target string arrives already
+    /// fused verbatim by the lexer (`lexer::PushTarget`) — this pins the
+    /// Tool→`Scope::walk_append` wiring directly, independent of lexing.
+    #[tokio::test]
+    async fn push_bracket_path_target_extends_the_nested_list() {
+        let mut ctx = make_ctx();
+        ctx.scope.set(
+            "services",
+            Value::Json(serde_json::json!({"web": {"tags": ["a"]}})),
+        );
+
+        let mut args = ToolArgs::new();
+        args.positional.push(Value::String("services[web][tags]".into()));
+        args.positional.push(Value::String("b".into()));
+
+        let result = Push.execute(args, &mut ctx).await;
+        assert!(result.ok(), "push failed: {}", result.err);
+        assert_eq!(
+            ctx.scope.get("services"),
+            Some(&Value::Json(serde_json::json!({"web": {"tags": ["a", "b"]}})))
+        );
     }
 }

--- a/crates/kaish-kernel/src/tools/builtin/push.rs
+++ b/crates/kaish-kernel/src/tools/builtin/push.rs
@@ -71,6 +71,7 @@ impl Tool for Push {
             [
                 ("Append one element", "push xs date"),
                 ("Append a record value", "push xs $rec"),
+                ("Append to a nested list", "push services[web][tags] canary"),
             ],
         )
     }

--- a/crates/kaish-kernel/tests/collection_access_tests.rs
+++ b/crates/kaish-kernel/tests/collection_access_tests.rs
@@ -90,6 +90,34 @@ async fn record_quoted_key() {
     assert_eq!(out, "text/plain");
 }
 
+/// GH #183: a `]` inside a QUOTED key must not be mistaken for the
+/// subscript's own terminator (`parse_var_ref`'s bracket collector is
+/// quote-aware — see `lexer::parse_var_ref`).
+#[tokio::test]
+async fn record_quoted_key_with_embedded_bracket() {
+    let k = setup().await;
+    let (out, code, err) = run(
+        &k,
+        r#"r=$(fromjson '{"weird]key":"v"}'); echo ${r["weird]key"]}"#,
+    )
+    .await;
+    assert_eq!(code, 0, "err: {err}");
+    assert_eq!(out, "v");
+}
+
+/// Same, single-quoted.
+#[tokio::test]
+async fn record_quoted_key_with_embedded_bracket_single_quotes() {
+    let k = setup().await;
+    let (out, code, err) = run(
+        &k,
+        r#"r=$(fromjson '{"weird]key":"v"}'); echo ${r['weird]key']}"#,
+    )
+    .await;
+    assert_eq!(code, 0, "err: {err}");
+    assert_eq!(out, "v");
+}
+
 // ── Nested / chained subscripts ────────────────────────────────────────────
 
 #[tokio::test]

--- a/crates/kaish-kernel/tests/collection_literals_tests.rs
+++ b/crates/kaish-kernel/tests/collection_literals_tests.rs
@@ -316,7 +316,25 @@ async fn bracket_leading_glob_at_value_position_is_a_loud_error() {
 async fn multiword_bareword_record_value_is_a_loud_error() {
     let k = setup().await;
     let result = k.execute("x={msg: hello world}").await;
-    assert!(result.is_err(), "unquoted multi-word record value must be a loud parse error");
+    let err = result.expect_err("unquoted multi-word record value must be a loud parse error");
+    // GH #183: this used to be chumsky's generic "found '}' expected ':'"
+    // (from the failed second-entry attempt: `world` gets tried as the next
+    // bareword KEY and then fails at `}`) — a `record_literal_parser`
+    // try_map guard now names the actual mistake and hints the fix.
+    let msg = err.to_string();
+    assert!(msg.contains("unexpected word \"world\""), "got: {msg}");
+    assert!(msg.contains("quoted"), "got: {msg}");
+}
+
+/// A comma-optional record entry immediately followed by another bareword
+/// KEY (not a stray word) is unaffected by the new guard — `{a: 1 b: 2}` is
+/// legal kaish (see `list_literal_commas_optional`'s record counterpart).
+#[tokio::test]
+async fn record_literal_comma_optional_entries_unaffected_by_stray_word_guard() {
+    let k = setup().await;
+    let (out, code, err) = run(&k, "u={a: 1 b: 2}; echo ${u[a]} ${u[b]}").await;
+    assert_eq!(code, 0, "err: {err}");
+    assert_eq!(out, "1 2");
 }
 
 #[tokio::test]

--- a/crates/kaish-kernel/tests/collections_lvalue_tests.rs
+++ b/crates/kaish-kernel/tests/collections_lvalue_tests.rs
@@ -1,6 +1,8 @@
 //! Collection lvalue WRITES: `xs[0]=9`, `user[email]=x`,
-//! `services[web][port]=9000`, and the bareword `push` builtin. See
-//! `docs/arrays-and-hashes.md`, "Assignment lvalues" and "Append — push".
+//! `services[web][port]=9000`, and the `push` builtin — bareword
+//! (`push xs val`) and bracket-path (`push services[web][tags] val`)
+//! targets alike. See `docs/arrays-and-hashes.md`, "Assignment lvalues" and
+//! "Append — push".
 //!
 //! Kernel-routed via `KernelConfig::isolated()` WITH validation ON (unlike
 //! the sibling `collection_literals_tests.rs`/`collection_access_tests.rs`,
@@ -243,20 +245,87 @@ async fn bare_char_class_comparison_operand_before_eq_is_not_an_lvalue() {
     assert_eq!(r2.code, 0, "‘[a]’ == ‘[a]’ should be true: {r2:?}");
 }
 
-// ── Deferred: bracket-path push (documented, not silent) ──────────────────
+// ── Bracket-path push target (GH #183) ──────────────────────────────────
+//
+// `push services[web][tags] item` walks a nested bracket path the same way
+// an assignment lvalue does. The lexer recognizes `push`'s target with its
+// own independent trigger (`lexer::PushTarget`) — the target has no
+// trailing `=` to key off the way an assignment lvalue does — so
+// `services[web][tags]` fuses verbatim into a path instead of glob-expanding
+// against the filesystem. See `docs/arrays-and-hashes.md`, "Append — push".
 
 #[tokio::test]
-async fn bracket_path_push_target_is_deferred_but_loud_not_a_crash() {
-    // `push services[web][tags] item` is out of scope for this PR (see
-    // docs/issues.md): the target isn't followed by `=`, so the lvalue
-    // lexer suppression never fires and `services[web][tags]` fuses into a
-    // GlobWord that glob-expands before `push` runs. Pin that it's a loud
-    // error, not silent corruption or a panic, until that's designed.
+async fn bracket_path_push_target_extends_the_nested_list() {
+    let k = setup().await;
+    let out = ok(
+        &k,
+        "services={web: {tags: []}}; push services[web][tags] canary; \
+         echo ${#services[web][tags]} ${services[web][tags][-1]}",
+    )
+    .await;
+    assert_eq!(out, "1 canary");
+}
+
+#[tokio::test]
+async fn bracket_path_push_target_does_not_disturb_sibling_keys() {
+    let k = setup().await;
+    let out = ok(
+        &k,
+        "services={web: {tags: [a], port: 8080}}; push services[web][tags] b; \
+         echo ${services[web][port]}",
+    )
+    .await;
+    assert_eq!(out, "8080", "sibling key must survive a nested push");
+}
+
+#[tokio::test]
+async fn bracket_path_push_target_single_index_works() {
+    // A single `[sub]` hop (not just chained `[a][b]`) exercises the same
+    // lexer trigger with the simplest possible bracket run.
+    let k = setup().await;
+    let out = ok(
+        &k,
+        "lists={xs: [1, 2]}; push lists[xs] 3; echo ${lists[xs]}",
+    )
+    .await;
+    assert_eq!(out, "[1,2,3]");
+}
+
+#[tokio::test]
+async fn bracket_path_push_target_missing_intermediate_is_loud_no_autoviv() {
     let k = setup().await;
     let err = loud_err(
         &k,
-        "services={web: {tags: []}}; push services[web][tags] item",
+        "services={}; push services[web][tags] item",
     )
     .await;
     assert!(!err.is_empty(), "expected a non-empty loud error");
+}
+
+#[tokio::test]
+async fn bracket_path_push_target_non_list_leaf_is_loud() {
+    let k = setup().await;
+    let err = loud_err(
+        &k,
+        "services={web: {port: 8080}}; push services[web][port] item",
+    )
+    .await;
+    assert!(err.contains("not a list"), "got: {err}");
+}
+
+#[tokio::test]
+async fn bracket_path_push_target_undefined_root_is_loud() {
+    let k = setup().await;
+    let err = loud_err(&k, "push nope[web][tags] item").await;
+    assert!(err.contains("not defined"), "got: {err}");
+}
+
+#[tokio::test]
+async fn push_as_variable_name_is_unaffected_by_the_target_tracker() {
+    // The lexer's `push`-target tracker (`PushTarget`) is independent of
+    // the assignment DFA — a variable literally named `push` must keep
+    // working as an ordinary scalar assignment.
+    let k = setup().await;
+    let out = ok(&k, "push=5; echo $push").await;
+    assert_eq!(out, "5");
 }

--- a/crates/kaish-kernel/tests/correctness_oneoffs_tests.rs
+++ b/crates/kaish-kernel/tests/correctness_oneoffs_tests.rs
@@ -102,3 +102,42 @@ async fn jq_finite_division_still_works() {
     assert_eq!(code, 0, "got: {out}");
     assert_eq!(out, "3");
 }
+
+// ──────────── interpolated arithmetic error swallow (GH #183) ────────────
+
+#[tokio::test]
+async fn interpolated_arithmetic_division_by_zero_is_loud() {
+    // `"$((1/0))"` inside a double-quoted string used to silently splice in
+    // an EMPTY string — the async string-interpolation evaluator's
+    // `StringPart::Arithmetic` arm discarded the error entirely
+    // (`Err(_) => Ok(String::new())`) — so `echo "value: $((1/0))"` printed
+    // "value: " at exit 0 instead of failing. The bare (non-string) form
+    // `echo $((1/0))` already failed loud; this brought the interpolated
+    // form in line with it.
+    let tmp = tempfile::tempdir().unwrap();
+    let kernel = kernel_at(tmp.path());
+    let result = kernel
+        .execute(r#"echo "value: $((1/0))""#)
+        .await
+        .expect("kernel execute");
+    assert_ne!(
+        result.code, 0,
+        "division by zero inside a string must fail loudly, not silently splice in \"\""
+    );
+    assert!(
+        result.err.contains("division by zero"),
+        "got: {}",
+        result.err
+    );
+}
+
+#[tokio::test]
+async fn interpolated_arithmetic_still_works_for_valid_expressions() {
+    // Regression guard: the loud-error fix must not disturb the ordinary
+    // (non-erroring) interpolated-arithmetic path.
+    let tmp = tempfile::tempdir().unwrap();
+    let kernel = kernel_at(tmp.path());
+    let (out, code) = run(&kernel, r#"echo "value: $((2 + 2))""#).await;
+    assert_eq!(code, 0, "got: {out}");
+    assert_eq!(out, "value: 4");
+}

--- a/crates/kaish-kernel/tests/lexer_tests.rs
+++ b/crates/kaish-kernel/tests/lexer_tests.rs
@@ -842,3 +842,48 @@ fn lexer_bare_char_class_operand_before_eq_still_fuses() {
         "LBRACK", "LBRACK", "GLOB([a])", "EQ", "IDENT(b)", "RBRACK", "RBRACK",
     ]);
 }
+
+// =============================================================================
+// `push`'s bracket-path TARGET (`push services[web][tags] item`): fused
+// verbatim into a single `Ident` — never a `GlobWord` to glob-expand — by a
+// THIRD, independent trigger (`PushTarget`, `flush_glob_run`'s `push_target`
+// parameter). The target has no trailing `=` to key off the way an
+// assignment lvalue does, so it needs its own recognition. See GH #183,
+// docs/arrays-and-hashes.md ("Append — push").
+// =============================================================================
+
+#[rstest]
+#[case::nested_keys(
+    "push services[web][tags] item",
+    &["IDENT(push)", "IDENT(services[web][tags])", "IDENT(item)"]
+)]
+#[case::single_index("push xs[0]", &["IDENT(push)", "IDENT(xs[0])"])]
+#[case::bareword_target_unaffected("push xs c", &["IDENT(push)", "IDENT(xs)", "IDENT(c)"])]
+fn lexer_push_bracket_target_fused_verbatim(#[case] input: &str, #[case] expected: &[&str]) {
+    run_lexer_test(input, expected);
+}
+
+/// `push` used as a plain variable name (`push=5`) is unaffected — the
+/// tracker is independent of the assignment DFA and never steals its
+/// lvalue-root slot.
+#[test]
+fn lexer_push_as_variable_name_unaffected() {
+    run_lexer_test("push=5", &["IDENT(push)", "EQ", "INT(5)"]);
+}
+
+/// `push` as a plain bareword ARGUMENT to another command (not the command
+/// word itself, so not at statement head) must not trigger the tracker.
+#[test]
+fn lexer_push_as_bareword_argument_unaffected() {
+    run_lexer_test("echo push xs", &["IDENT(echo)", "IDENT(push)", "IDENT(xs)"]);
+}
+
+/// A pushed VALUE that itself looks like a bracket path keeps globbing as
+/// before — only the first word right after `push` is the target.
+#[test]
+fn lexer_push_value_after_target_still_globs() {
+    run_lexer_test(
+        "push xs values[0]",
+        &["IDENT(push)", "IDENT(xs)", "GLOB(values[0])"],
+    );
+}

--- a/crates/kaish-kernel/tests/lexer_tests.rs
+++ b/crates/kaish-kernel/tests/lexer_tests.rs
@@ -887,3 +887,61 @@ fn lexer_push_value_after_target_still_globs() {
         &["IDENT(push)", "IDENT(xs)", "GLOB(values[0])"],
     );
 }
+
+/// A variable literally named `push`, GLUED to a bracket subscript and
+/// assigned (`push[0]=x`), is unaffected by the target tracker: seeing
+/// `push` at statement-head sets `PushTarget::AwaitingRoot`, but the very
+/// next token here is `LBracket`, not `Ident` — `AwaitingRoot`'s only
+/// transition arm requires an `Ident` — so the tracker falls through to its
+/// catch-all reset (`PushTarget::None`) and never suppresses this run.
+/// The ordinary `=`-followed lvalue trigger (`followed_by_eq`, entirely
+/// independent of `PushTarget`) still recognizes `push[0]` as an assignment
+/// lvalue on its own, exactly like any other identifier.
+#[test]
+fn lexer_push_named_variable_bracket_assignment_unaffected() {
+    run_lexer_test(
+        "push[0]=x",
+        &["IDENT(push)", "LBRACK", "INT(0)", "RBRACK", "EQ", "IDENT(x)"],
+    );
+}
+
+/// `push` immediately after a pipe is still the command word — a pipe is a
+/// statement boundary, so both `StmtHead` and the independent `PushTarget`
+/// tracker reset to `Start`/`None` there, and `push`'s target-fusion trigger
+/// re-arms cleanly on the far side.
+#[test]
+fn lexer_push_bracket_target_after_pipe() {
+    run_lexer_test(
+        "echo x | push xs[0] item",
+        &[
+            "IDENT(echo)", "IDENT(x)", "PIPE",
+            "IDENT(push)", "IDENT(xs[0])", "IDENT(item)",
+        ],
+    );
+}
+
+/// Same reset, via `;` instead of a pipe.
+#[test]
+fn lexer_push_bracket_target_after_semicolon() {
+    run_lexer_test(
+        "echo x; push xs[0] item",
+        &[
+            "IDENT(echo)", "IDENT(x)", "SEMI",
+            "IDENT(push)", "IDENT(xs[0])", "IDENT(item)",
+        ],
+    );
+}
+
+/// Same reset, via `&&` — a bareword `push` right after a chain operator is
+/// still recognized as the command word, not swallowed by whatever DFA state
+/// the left-hand command left behind.
+#[test]
+fn lexer_push_bracket_target_after_and_chain() {
+    run_lexer_test(
+        "true && push xs[0] item",
+        &[
+            "BOOL(true)", "AMPAMP",
+            "IDENT(push)", "IDENT(xs[0])", "IDENT(item)",
+        ],
+    );
+}

--- a/crates/kaish-kernel/tests/scatter_gather_jsonl_tests.rs
+++ b/crates/kaish-kernel/tests/scatter_gather_jsonl_tests.rs
@@ -522,3 +522,63 @@ async fn scatter_flag_value_command_substitution_is_loud_not_silently_dropped() 
         "a $(...) scatter flag value must fail loud, not silently coalesce to the default limit: {r:?}"
     );
 }
+
+// ═══════════════════════════════════════════════════════════════════════
+// A bad `$((...))` arithmetic expansion in a scatter/gather flag value
+// (`eval_simple_expr`'s bare `Expr::Arithmetic`, `eval_string_parts_sync`'s
+// `StringPart::Arithmetic` inside a quoted value) used to be silently
+// swallowed instead of propagated — `scatter --limit $((1/0))` ran at the
+// UNLIMITED default instead of failing (GH #183).
+// ═══════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn scatter_bare_arithmetic_flag_value_division_by_zero_is_loud() {
+    let k = kernel_at(tempdir().unwrap().path());
+    let r = run_full(&k, "seq 1 3 | scatter --limit $((1/0)) | echo $ITEM | gather").await;
+    assert_ne!(
+        r.code, 0,
+        "a bad arithmetic scatter flag value must fail loud, not silently run unlimited: {r:?}"
+    );
+    assert!(
+        r.err.contains("arithmetic") || r.err.contains("division by zero"),
+        "got: {}",
+        r.err
+    );
+}
+
+#[tokio::test]
+async fn scatter_quoted_arithmetic_flag_value_division_by_zero_is_loud() {
+    let k = kernel_at(tempdir().unwrap().path());
+    let r = run_full(&k, r#"seq 1 3 | scatter --limit "$((1/0))" | echo $ITEM | gather"#).await;
+    assert_ne!(
+        r.code, 0,
+        "a bad arithmetic scatter flag value must fail loud: {r:?}"
+    );
+    // Before the fix this surfaced as scatter's OWN generic int-parse
+    // complaint ("expected a positive integer, got \"\"") — technically
+    // non-zero, but masking the real cause. The fix must name the actual
+    // arithmetic error instead.
+    assert!(
+        r.err.contains("arithmetic") || r.err.contains("division by zero"),
+        "got: {}",
+        r.err
+    );
+}
+
+#[tokio::test]
+async fn scatter_bare_arithmetic_flag_value_binds_successfully() {
+    // Regression guard, pairing with the loud-error test above: a VALID bare
+    // `$((...))` flag value must actually BIND (not just fail loud on
+    // error) — before the fix, `eval_simple_expr` had no `Expr::Arithmetic`
+    // arm at all, so it fell into the catch-all "not representable here"
+    // `Ok(None)` and the flag silently became a bare boolean with no value.
+    // `--limit` caps CONCURRENT workers, not the item count (see
+    // `bare_length_in_scatter_flag_value_succeeds`'s same convention just
+    // above), so all 5 items still complete — the observable proof the arm
+    // is wired is that a bad `$((1/0))` fails loud (previous test) while
+    // this valid `$((2+2))` succeeds cleanly.
+    let k = kernel_at(tempdir().unwrap().path());
+    let r = run_full(&k, "seq 1 5 | scatter --limit $((2+2)) | echo $ITEM | gather").await;
+    assert_eq!(r.code, 0, "{:?}", r.err);
+    assert_eq!(rows(&r.text_out()).len(), 5);
+}

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -278,20 +278,25 @@ A dotted assignment target is also rejected — kaish is brackets-only, and the
 user.email=x     # error — use `user[email]=x`
 ```
 
-`push` appends to a top-level **list** variable in place. Like `read`/`unset`,
-it takes the variable **name** (bareword), not `$name` — this is what lets it
-write back to the caller:
+`push` appends to a **list** variable in place — a top-level name or a
+bracket path. Like `read`/`unset`, it takes the variable **name** (bareword),
+not `$name` — this is what lets it write back to the caller:
 
 ```sh
 xs=[a b]
-push xs c                 # xs is now [a b c] — mutated in place
-push xs $rec              # values push as typed Values, not stringified text
-echo ${#xs} ${xs[-1]}     # 3 c
+push xs c                          # xs is now [a b c] — mutated in place
+push xs $rec                       # values push as typed Values, not stringified text
+echo ${#xs} ${xs[-1]}              # 3 c
+
+services={web: {tags: []}}
+push services[web][tags] canary    # bracket-path target — same lvalue rules as an assignment
+echo ${services[web][tags]}        # ["canary"]
 ```
 
 `push` to an undefined or non-list target is a loud error, never a silent
-create. Bracket-path `push` (`push services[web][tags] item` — a subscripted
-target) isn't supported yet; only a top-level bareword target.
+create. A bracket-path target follows the same lvalue rules as an
+assignment — no autovivification: every intermediate segment must already
+exist, and the resolved leaf must be a list.
 
 ### Crossing the boundary
 

--- a/docs/arrays-and-hashes.md
+++ b/docs/arrays-and-hashes.md
@@ -4,8 +4,11 @@ Status: read access, `keys`/`values`, membership, shape guards, the shared
 per-hop path resolver, **list/record literals + spread**, and **bracket-path
 assignment + `push`** are SHIPPED (see `docs/LANGUAGE.md` Collections
 section). Bracket-path `push` (a subscripted target, e.g. `push
-services[web][tags] item`) remains deferred — only a top-level bareword
-target ships (see `docs/issues.md`). **The Teaching note #8 pre-sign-off panel
+services[web][tags] item`) **shipped 2026-07-17 (GH #183)** — the lexer
+recognizes `push`'s target with its own independent trigger (the target has
+no trailing `=` to key off the way an assignment lvalue does; see
+`lexer::PushTarget`), and `Scope::walk_append` walks the path the same way
+`walk_write` does (no autoviv, same bounds/shape rules). **The Teaching note #8 pre-sign-off panel
 re-test against the FINAL surface is DONE (2026-07-03)** — 18/18 clean across
 DeepSeek, Gemini, and Claude Haiku, including immediate, unprompted
 convergence on `$(keys $servers)`/`$(values ...)` in the for-head (the
@@ -182,20 +185,15 @@ docs/issues.md entries were simply never updated:
   pre-existing, general arithmetic gap unrelated to path-nesting — see `docs/issues.md`
   P4). `$(( xs[i] ))` variable-subscript reads work fine; only the `${#…}` spelling is
   unsupported there.
-- **Bracket-path `push` target** (`push services[web][tags] item`) — **confirmed, still
-  open.** `push` only accepts a top-level bareword target; a bracket path fuses into a
-  glob word and fails loudly (`no matches: services[web][tags]`) before `push` runs.
-  Workaround — read the nested list out, push, assign it back:
-  ```sh
-  tmp=${services[web][tags]}
-  push tmp item
-  services[web][tags]=$tmp
-  ```
-  Tracked as a real gap in `docs/issues.md` (P3, "Bracket-path `push` target"); needs its
-  own lexer/parser pass (a `push`-aware trigger, or routing `push`'s target through the
-  argv-position bracket-path grammar) before it can close.
-
-See also `help collections` for the same limitation in cheat-sheet form.
+- **Bracket-path `push` target** (`push services[web][tags] item`) — **FIXED (GH #183,
+  2026-07-17).** The lexer recognizes `push`'s target with its own independent trigger
+  (`lexer::PushTarget`) — parallel to, but never integrated into, the assignment DFA, so a
+  variable literally named `push` (`push=5`) still works unchanged — and fuses
+  `services[web][tags]` verbatim into a path instead of a glob word.
+  `Scope::walk_append` now accepts a full `VarPath`: a bareword target still appends to a
+  top-level list; a bracket-path target walks to the nested container the same way
+  `walk_write` does (no autoviv on intermediates) and appends at the resolved leaf. The
+  old read/push/assign-back workaround is no longer necessary but still works.
 
 ## Decisions, and the evidence behind them
 

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -15,6 +15,77 @@ before it ships.
 
 ---
 
+## Collections residuals — bracket-path `push`, quoted `]`, record-value hint, loud arithmetic (landed 2026-07-17, GH #183)
+
+Four independent items off the collections punch list, verified fresh against
+current `main` before touching anything (the issue was written against an
+earlier commit; all four were still live, and the arithmetic item turned out
+worse than described).
+
+- **Bracket-path `push` target ships** (`push services[web][tags] item`).
+  The blocker was the lexer: `push`'s target has no trailing `=` to key off
+  the way an assignment lvalue does, so `services[web][tags]` fused into a
+  `GlobWord` and glob-expanded (loud "no matches") before `push` ever ran.
+  Fix is a THIRD, fully independent tracker (`PushTarget`) alongside the
+  existing assignment DFA in `compute_value_context` — deliberately not
+  folded into it, so a variable literally named `push` (`push=5`,
+  `push[0]=x`) keeps working untouched. It recognizes a bareword `push` at
+  statement-head, then treats the immediately-following glued `[...]` run as
+  a path to fuse verbatim into a single `Ident` (never a `GlobWord`).
+  `Scope::walk_append` now takes a full `VarPath`: a bareword target still
+  appends top-level; a bracket path walks intermediates with the same
+  no-autoviv `resolve_step`/`descend_mut` `walk_write` uses, appending at the
+  resolved leaf instead of replacing it. The old read/push/assign-back
+  workaround in the docs is gone.
+- **Quoted subscript keys can contain `]`** (`${r["weird]key"]}`).
+  `parse_var_ref`'s bracket collector scanned to the *first* `]`, quote-blind,
+  so an embedded `]` inside a quoted key ended the subscript early and
+  produced a mangled, cryptic error. Now: if a subscript opens with a quote,
+  consume verbatim to its OWN matching closer first, then resume the search
+  for the real terminating `]`. Unquoted subscripts are untouched.
+- **Unquoted multi-word record values get an actionable error.**
+  `{msg: hello world}` was already a parse error (kaish's grammar makes a
+  bare space-separated `key: value` pair without a comma legal —
+  `{a: 1 b: 2}` — so "world" gets tried as a NEW key and fails at `}`
+  expecting `:`), but the message was chumsky's generic "found '}' expected
+  ':'". A `try_map` guard in `record_literal_parser`, run right after each
+  entry's value, peeks (via `.rewind()`, consuming nothing) for exactly this
+  shape — an `Ident` not itself followed by `:` — and raises a message that
+  names the mistake and shows the quoted fix. `docs/LANGUAGE.md` already
+  described this as "a parse error with the quoted fix in the message" before
+  today; the code just didn't match the doc yet.
+- **Sync arithmetic errors stopped being silently swallowed — and it was
+  worse than the issue said.** The issue named `scheduler/pipeline.rs`'s
+  reduced sync arg binder (`eval_simple_expr`'s bare `Expr::Arithmetic` fell
+  into the generic "not representable here" `Ok(None)`, silently dropping
+  the flag entirely — even a *valid* `scatter --limit $((1+1))` never
+  bound; `eval_string_parts_sync`'s `StringPart::Arithmetic` used
+  `if let Ok(..)`, silently splicing in nothing on error). Both fixed with
+  `?`-propagation, matching the message convention (`"arithmetic error: {e}"`)
+  the two already-loud sites use. But testing turned up a THIRD, more severe
+  instance in the exact same shape sitting in the PRIMARY async
+  string-interpolation path (`kernel.rs`'s `eval_string_part_async`) —
+  `echo "value: $((1/0))"` printed `value: ` at exit 0, no error at all, in
+  completely ordinary command execution, not just the scatter/gather corner
+  the issue scoped. Left un-fixed that would have been an inconsistent,
+  worse-in-practice sibling of the very bug this item exists to kill, so it
+  got the same treatment. All three now match the sync interpreter's
+  (`eval.rs`) arm, which already propagated correctly and was never part of
+  the swallow.
+
+Kernel-routed tests throughout: `collections_lvalue_tests.rs` (bracket-path
+push, including a `push=5` regression guard that the new lexer tracker
+doesn't touch plain variable assignment), `lexer_tests.rs` (token-level
+fusion pins for the `push` target and the quote-aware bracket collector),
+`collection_access_tests.rs` (quoted-key-with-embedded-bracket reads),
+`collection_literals_tests.rs` (strengthened the existing loud-error test to
+check the actual message, added a comma-optional-entries regression guard),
+`correctness_oneoffs_tests.rs` (interpolated arithmetic), and
+`scatter_gather_jsonl_tests.rs` (the scatter-flag-value arithmetic cases,
+paired loud/happy-path per the file's existing convention).
+
+---
+
 ## The lexer becomes one machine (2026-07-16)
 
 GH #95 sat locked since 2026-07-04: two cross-model batch reviews (gemini-pro,


### PR DESCRIPTION
## Summary

Closes #183 — a punch list of four collections/lexer residuals. Verified fresh against current `main` before touching anything (the issue was written against an earlier commit); all four were still live, and one turned out worse than described.

## Per-item outcome

| # | Item | Outcome |
|---|------|---------|
| 1 | Bracket-path `push` target (`push services[web][tags] item`) | **Fixed.** Was a genuine gap — the target isn't followed by `=`, so the lvalue lexer suppression never fired and the bracket run fused into a `GlobWord` before `push` ran. |
| 2 | `]` inside a quoted subscript key (`${r["weird]key"]}`) | **Fixed.** `parse_var_ref`'s bracket collector scanned to the first `]`, quote-blind. |
| 3 | Unquoted multi-word record value error text (`{msg: hello world}`) | **Fixed.** Was already a parse error, but with chumsky's generic "found '}' expected ':'" instead of naming the mistake. |
| 4 | Sync arithmetic-error swallow (`scatter --limit $((1/0))`) | **Fixed — and worse than described.** Both `scheduler/pipeline.rs` sites the issue named, **plus** a third instance in the primary async string-interpolation path (`kernel.rs`) that the issue didn't scope: `echo "value: $((1/0))"` printed `value: ` at exit 0 with no error at all. All three now propagate loud. |

## Details

**Item 1 — bracket-path `push` target.** The lexer gets a third, fully independent tracker (`lexer::PushTarget`) alongside the existing assignment DFA in `compute_value_context` — deliberately *not* folded into it, so a variable literally named `push` (`push=5`, `push[0]=x`) keeps working untouched (pinned by a regression test). It recognizes a bareword `push` at statement-head and fuses the immediately-following glued `[...]` run verbatim into a single `Ident` (never a `GlobWord`). `Scope::walk_append` now takes a full `VarPath`: a bareword target still appends top-level; a bracket-path target walks intermediates with the same no-autoviv `resolve_step`/`descend_mut` machinery `walk_write` uses, appending at the resolved leaf instead of replacing it. The old read/push/assign-back workaround in the docs is gone.

**Item 2 — quoted subscript `]`.** `parse_var_ref`'s `[`-collector now consumes a quoted subscript verbatim to its own matching closer before resuming the search for the real terminating `]`. Unquoted subscripts are untouched. This also makes item 1's string round-trip (lexer hands `push` a verbatim bracket-path string, `push.rs` re-parses it via the same `${...}` grammar) robust for quoted keys.

**Item 3 — record-value error text.** A `try_map` guard in `record_literal_parser`, run right after each entry's value via `.rewind()` (consumes nothing), peeks for exactly the mistake shape — an `Ident` not itself followed by `:` — and raises an actionable message. Kaish's grammar legally allows a bare (comma-less) space between entries (`{a: 1 b: 2}`), so the guard has to distinguish "a real next key" from "a stray extra word," not just flag any following bareword. `docs/LANGUAGE.md` already described this as "a parse error with the quoted fix in the message" — the code just didn't match the doc yet.

**Item 4 — arithmetic-error swallow.** Fixed all three sites with `?`-propagation / explicit `Err` arms, matching the message convention (`"arithmetic error: {e}"`) the already-correct bare `Expr::Arithmetic` arms use:
- `scheduler/pipeline.rs::eval_simple_expr`'s bare `Expr::Arithmetic` — previously fell into the "not representable here" catch-all, so a bare `$((...))` scatter/gather flag value never bound at all (even a *valid* `--limit $((1+1))` silently no-opped).
- `scheduler/pipeline.rs::eval_string_parts_sync`'s `StringPart::Arithmetic` — previously `if let Ok(..)`, silently splicing in nothing on error (`--limit "$((1/0))"` surfaced only as scatter's own generic int-parse complaint on the resulting `""`, masking the real cause).
- `kernel.rs::eval_string_part_async`'s `StringPart::Arithmetic` — the primary async string-interpolation path, **not named in the issue**. `echo "value: $((1/0))"` silently printed `value: ` at exit 0. Left unfixed this would have been a worse, inconsistent sibling of the exact bug class this item exists to kill, so it got the same treatment.

## Test plan

- [x] `cargo test --all --locked` — clean
- [x] `cargo clippy --all --all-targets` — zero warnings
- [x] `cargo check -p kaish-kernel --no-default-features` — clean
- [x] `cargo insta test --check` — no pending snapshots
- [x] `cargo build -p kaish-wasi --target wasm32-wasip1` — clean
- [x] New kernel-routed tests per item: `collections_lvalue_tests.rs` (bracket-path push + `push=5` regression guard), `lexer_tests.rs` (token-level fusion pins), `collection_access_tests.rs` (quoted-key-with-embedded-bracket reads), `collection_literals_tests.rs` (strengthened the existing loud-error test + comma-optional-entries regression guard), `correctness_oneoffs_tests.rs` (interpolated arithmetic), `scatter_gather_jsonl_tests.rs` (scatter-flag arithmetic, paired loud/happy-path per the file's existing convention)
- [x] `help push` / `help collections` verified manually — reflect the shipped behavior
- [x] `docs/arrays-and-hashes.md`, `docs/LANGUAGE.md`, `crates/kaish-help/src/fragments.rs` (+ regenerated `syntax.md`) updated; `docs/devlog.md` entry added; `CHANGELOG.md` bullets under `Fixed`

Do not merge — leaving for review per project convention.