### PR TITLE
fix(kernel): arg-binding polish — post-`--` WordAssign, --flag=true, short-flag guard (#189)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,34 @@ breaking entries are marked **BREAKING**.
 
 ## [Unreleased]
 
+### Fixed
+- **Arg-binding polish** (GH #189): four small gaps in the shared arg binder
+  (`kernel::bind_tool_args`), verified against current code post-#188/#231:
+  - `export -- A=1`/`alias -- ll=val` no longer bind `A=1`/`ll=val` as a named
+    shell assignment past `--` — every word-assign-accepting builtin now
+    treats a `key=value` after `--` as literal data, like every other tool
+    already did. `unalias -- foo=bar` no longer crashes with a clap
+    "unexpected argument" error (the lingering named entry used to render as
+    a `--foo=bar` flag token `UnaliasArgs` never declares).
+  - `--flag=true`/`--flag=false` now flagifies at bind time instead of
+    landing in `named` as a literal `Value::Bool` — a clap `bool` field's
+    `SetTrue` action rejected it (`seq --json=true` used to exit 2). This
+    fixes every schema-aware builtin uniformly, including `--json` itself
+    (deliberately excluded from every builtin's own schema, so no
+    per-builtin `ToolArgs::flagify_bool_named` call ever covered it).
+  - An undeclared SHORT flag (`-t explorer`) immediately before an unconsumed
+    positional under a `map_positionals` (backend/MCP) schema is now the same
+    loud "ambiguous, would silently drop the value" error the long-flag form
+    (`--type explorer`) already gave since GH #188 — previously it silently
+    defaulted to a bare bool flag and misrouted the value.
+  - A glued redirect target (`> /tmp/$(echo x).txt`, unquoted) now gets a
+    "quote the redirect target" parse-error hint instead of a generic
+    chumsky "expected ..." message, and the no-token-pasting guard now also
+    covers args after `--` and a flag glued straight to a following fragment
+    (`--flag$(echo x)`) — previously both silently split into multiple
+    positionals instead of erroring. The short-flag glued-value idiom
+    (`cut -d,`, `grep -A1`) is unaffected.
+
 ### Added
 - **`ExecuteOptions::interrupt`** — a polled interrupt check for embedders
   whose thread cannot fire `cancel_token` while execution runs (the browser:

--- a/crates/kaish-kernel/src/kernel.rs
+++ b/crates/kaish-kernel/src/kernel.rs
@@ -5836,8 +5836,34 @@ pub(crate) async fn bind_tool_args(
                     // would silently keep only B, and mixing with the `-e` space
                     // form would clobber the array. Route it through the same
                     // accumulator the space form uses.
+                    let is_declared_value_flag = param_lookup
+                        .get(key.as_str())
+                        .is_some_and(|(_, typ, ..)| !is_bool_type(typ));
                     if let Some(&(canonical, _, _, true)) = param_lookup.get(key.as_str()) {
                         push_repeatable_value(&mut tool_args, key, canonical, val)?;
+                    } else if matches!(val, Value::Bool(_)) && !is_declared_value_flag {
+                        // Flagify at bind time (GH #189): `--flag=true`/
+                        // `--flag=false` binds the same way the bare
+                        // `--flag`/its absence already do (true → flag
+                        // presence, false → dropped) instead of landing in
+                        // `named` as a literal `Value::Bool` that a clap
+                        // `bool` field's `SetTrue` action rejects
+                        // (`seq --json=true` used to exit 2 with a clap
+                        // parse error). Covers both a schema-declared bool
+                        // param AND an undeclared flag — `--json` itself is
+                        // deliberately excluded from every builtin's schema
+                        // (`clap_schema::is_skipped`), so this is what makes
+                        // `--json=true` work universally instead of only for
+                        // the builtins that happen to call
+                        // `ToolArgs::flagify_bool_named` themselves. A
+                        // declared VALUE-taking flag's own `=true` literal
+                        // (`spawn --command=true`) is excluded by
+                        // `is_declared_value_flag` and still falls to
+                        // `named` below.
+                        if let Value::Bool(true) = val {
+                            tool_args.flags.insert(key.clone());
+                        }
+                        // Value::Bool(false): absent == false, nothing to insert.
                     } else {
                         tool_args.named.insert(key.clone(), val);
                     }
@@ -5852,7 +5878,13 @@ pub(crate) async fn bind_tool_args(
                 }
                 if let Some(val) = source.eval(value).await? {
                     let val = apply_tilde_expansion(val, home.as_deref());
-                    if accepts_word_assign {
+                    // Past `--`, EVERY token is raw data — including for
+                    // export/alias, whose `key=value` is normally a shell
+                    // assignment (GH #189). `export -- A=1` must bind `A=1`
+                    // as a literal positional, not silently re-enter the
+                    // named-assignment path `past_double_dash` exists to
+                    // suppress for flags right above this arm.
+                    if accepts_word_assign && !past_double_dash {
                         tool_args.named.insert(key.clone(), val);
                     } else {
                         // Stringify "key=value" and pass as a positional.
@@ -5875,6 +5907,40 @@ pub(crate) async fn bind_tool_args(
                 } else if name.len() == 1 {
                     let flag_name = name.as_str();
                     let lookup = param_lookup.get(flag_name);
+
+                    // Same ambiguity guard as the `LongFlag` arm below (GH
+                    // #189 item 4): an undeclared short flag immediately
+                    // followed by an unconsumed positional under a
+                    // map_positionals (backend/MCP) schema is exactly as
+                    // ambiguous as the long-flag case — kaish can't tell a
+                    // space-form value (`-t explorer`) from a bool flag
+                    // sitting before a real positional (`-f file.txt`).
+                    // Unlike `--flag`, there is no `-f=value` escape hatch to
+                    // suggest: a glued `-f=val` is two tokens with a dangling
+                    // `=` that the parser's no-token-pasting guard already
+                    // rejects — the only fix is declaring the flag.
+                    let ambiguous_value = (lookup.is_none()
+                        && leaf.is_some_and(|s| s.map_positionals)
+                        && !consumed.contains(&(i + 1)))
+                        .then(|| match args.get(i + 1) {
+                            Some(Arg::Positional(Expr::Literal(Value::String(s)))) => {
+                                Some(s.clone())
+                            }
+                            Some(Arg::Positional(_)) => Some("VALUE".to_string()),
+                            _ => None,
+                        })
+                        .flatten();
+                    if let Some(val) = ambiguous_value {
+                        let tool = leaf.map(|s| s.name.as_str()).unwrap_or("command");
+                        anyhow::bail!(
+                            "{tool}: -{name} is not a declared flag, so the \
+                             space-separated value ({val:?}) would be silently \
+                             dropped. Have {tool} declare -{name} in its schema \
+                             (short flags have no -{name}=value form to fall \
+                             back on)."
+                        );
+                    }
+
                     let is_bool = lookup.map(|(_, typ, ..)| is_bool_type(typ)).unwrap_or(true);
 
                     if is_bool {
@@ -9046,6 +9112,40 @@ AFTER="yes"'"#)
         let args = vec![Arg::LongFlag("frob".into()), pos("value")];
         let built = kernel.build_args_async(&args, Some(&schema)).await.unwrap();
         assert!(built.flags.contains("frob"));
+    }
+
+    // ── GH #189 item 4: the short-flag half of the same ambiguity guard ──
+    //
+    // The long-flag guard above was closed by GH #188; an undeclared SHORT
+    // flag under a map_positionals schema was still silently defaulting to
+    // bare bool, divorcing a space-form value (`kj -t explorer`) exactly the
+    // same way the long-flag case used to.
+
+    #[tokio::test]
+    async fn build_args_undeclared_short_space_flag_errors_under_map_positionals() {
+        let kernel = Kernel::transient().expect("kernel");
+        let schema = kj_like_schema();
+        // kj exp -t explorer
+        let args = vec![pos("exp"), Arg::ShortFlag("t".into()), pos("explorer")];
+        let err = kernel
+            .build_args_async(&args, Some(&schema))
+            .await
+            .expect_err("undeclared -t with a space value must fail loud");
+        let msg = err.to_string();
+        assert!(msg.contains("-t"), "message should name the flag: {msg}");
+        assert!(msg.contains("kj"), "message should name the tool: {msg}");
+    }
+
+    #[tokio::test]
+    async fn build_args_undeclared_short_space_flag_ok_for_builtin_schema() {
+        let kernel = Kernel::transient().expect("kernel");
+        // Builtins set map_positionals=false; the ambiguity guard must not
+        // fire there.
+        let schema = ToolSchema::new("frobnicate", "builtin-style")
+            .param(ParamSchema::optional("name", "string", Value::Null, "name"));
+        let args = vec![Arg::ShortFlag("t".into()), pos("value")];
+        let built = kernel.build_args_async(&args, Some(&schema)).await.unwrap();
+        assert!(built.flags.contains("t"));
     }
 
     // ── subcommand-aware binding (select_leaf wired into build_args_async) ──

--- a/crates/kaish-kernel/src/parser.rs
+++ b/crates/kaish-kernel/src/parser.rs
@@ -1733,6 +1733,65 @@ fn is_comma_literal_arg(arg: &Arg) -> bool {
     matches!(arg, Arg::Positional(Expr::Literal(Value::String(s))) if s == ",")
 }
 
+/// True for the argv-fragment `Arg` shapes eligible for the no-token-pasting
+/// glue check below: bareword/expr positionals AND long flags.
+///
+/// `ShortFlag` is deliberately EXCLUDED: a single-char short flag glued
+/// straight to its value with no space (`cut -d,`, `grep -A$n`) is the
+/// getopt-style glued-value idiom the kernel binder (`consume_flag_positionals`
+/// / `bind_glued_short_value`) already supports and tests rely on — the flag
+/// char class covers alnum/dash so a purely-textual glued value (`-f1`,
+/// `-C3`) is already ONE lexer token, but a punctuation/subst value (`-d,`,
+/// `-d$(cmd)`) genuinely arrives as two adjacent `Arg`s and must NOT be
+/// rejected here. `--flag` has no such glued-value idiom (only the explicit
+/// `--flag=value` form, which fuses into `Named` before reaching this list),
+/// so a `LongFlag` glued to a following fragment is always a pasting
+/// accident, not a feature.
+///
+/// `Named`/`WordAssign` are excluded too — those already fuse a span-adjacent
+/// `--key=value`/`key=value` pair into ONE `Arg` before reaching this list
+/// (see `long_flag_with_value`/`word_assign_arg_parser`'s own adjacency
+/// checks), so back-to-back adjacency there is by design, not a pasting
+/// accident.
+fn is_glue_candidate(arg: &Arg) -> bool {
+    matches!(arg, Arg::Positional(_) | Arg::LongFlag(_))
+}
+
+/// Reject a run of argv fragments produced by glued (zero source-gap)
+/// tokens — kaish does no token pasting, so an unquoted `/tmp/$(echo
+/// x).txt` lexes into three fragments (`/tmp/`, the substitution, `.txt`)
+/// that would otherwise silently bind as THREE separate args, and
+/// `--flag$(echo x)` glues a flag straight to the next fragment with no
+/// error at all. Shared by the pre-`--` and post-`--` argument grammars
+/// (GH #189: the post-`--` half of this used to be unchecked entirely — a
+/// script relying on `--` to end flag parsing got a silent argv-splat
+/// instead of this same helpful error).
+fn reject_glued_args<'src>(
+    args: Vec<(Arg, Span)>,
+) -> Result<Vec<Arg>, Rich<'src, Token, Span>> {
+    for pair in args.windows(2) {
+        let (prev, prev_span) = &pair[0];
+        let (next, next_span) = &pair[1];
+        if is_glue_candidate(prev) && is_glue_candidate(next) && prev_span.end == next_span.start {
+            // A bare `,` lexes as its own token, so a comma-bearing word
+            // (`cut -f1,3`, `sort -k2,2n`, `echo a,b`) trips this guard.
+            // It isn't token pasting — `,` is reserved (brace expansion,
+            // lists) — so give a comma-specific hint that teaches quoting.
+            let msg = if is_comma_literal_arg(prev) || is_comma_literal_arg(next) {
+                "an unquoted comma splits this into separate words — kaish reserves \
+                 `,` (brace expansion, lists); quote a comma-bearing argument to keep \
+                 it one word, e.g. cut -f \"1,3\", sort -k \"2,2n\", or echo \"a,b\""
+            } else {
+                "adjacent words with no space between them are not joined into one \
+                 argument (kaish does no token pasting); quote the whole word, e.g. \
+                 \"/tmp/$(echo x).txt\" or \"$dir/out.txt\""
+            };
+            return Err(Rich::custom(*next_span, msg));
+        }
+    }
+    Ok(args.into_iter().map(|(arg, _)| arg).collect())
+}
+
 /// Arguments list parser that handles `--` flag terminator.
 ///
 /// After `--`, all subsequent flags are converted to positional string arguments.
@@ -1742,41 +1801,18 @@ where
     I: ValueInput<'tokens, Token = Token, Span = Span>,
 {
     // Arguments before `--` (normal parsing). Each arg is captured with its
-    // source span so we can reject the silent argv-splat: two positional words
-    // with no whitespace between them (`/tmp/$(echo x).txt` → 3 args). kaish does
-    // no token pasting, so an unquoted interpolated word fragments into separate
-    // args; the fix is to quote the whole word. Single-token words (`file.txt`,
-    // `v1.2.3`) are one arg and never trigger this. See docs/issues.md #2.
+    // source span so we can reject the silent argv-splat: two argv fragments
+    // with no whitespace between them (`/tmp/$(echo x).txt` → 3 args,
+    // `--flag$(echo x)` → a flag glued to one). kaish does no token pasting,
+    // so an unquoted interpolated word fragments into separate args; the fix
+    // is to quote the whole word. Single-token words (`file.txt`, `v1.2.3`)
+    // are one arg and never trigger this. See `reject_glued_args` and
+    // docs/issues.md #2.
     let pre_dash = arg_before_double_dash_parser()
         .map_with(|arg, e| -> (Arg, Span) { (arg, e.span()) })
         .repeated()
         .collect::<Vec<(Arg, Span)>>()
-        .try_map(|args, _span| {
-            for pair in args.windows(2) {
-                let (prev, prev_span) = &pair[0];
-                let (next, next_span) = &pair[1];
-                if matches!(prev, Arg::Positional(_))
-                    && matches!(next, Arg::Positional(_))
-                    && prev_span.end == next_span.start
-                {
-                    // A bare `,` lexes as its own token, so a comma-bearing word
-                    // (`cut -f1,3`, `sort -k2,2n`, `echo a,b`) trips this guard.
-                    // It isn't token pasting — `,` is reserved (brace expansion,
-                    // lists) — so give a comma-specific hint that teaches quoting.
-                    let msg = if is_comma_literal_arg(prev) || is_comma_literal_arg(next) {
-                        "an unquoted comma splits this into separate words — kaish reserves \
-                         `,` (brace expansion, lists); quote a comma-bearing argument to keep \
-                         it one word, e.g. cut -f \"1,3\", sort -k \"2,2n\", or echo \"a,b\""
-                    } else {
-                        "adjacent words with no space between them are not joined into one \
-                         argument (kaish does no token pasting); quote the whole word, e.g. \
-                         \"/tmp/$(echo x).txt\" or \"$dir/out.txt\""
-                    };
-                    return Err(Rich::custom(*next_span, msg));
-                }
-            }
-            Ok(args.into_iter().map(|(arg, _)| arg).collect::<Vec<Arg>>())
-        });
+        .try_map(|args, _span| reject_glued_args(args));
 
     // The `--` marker itself
     let double_dash = select! {
@@ -1803,7 +1839,14 @@ where
         primary_expr_parser().map(Arg::Positional),
     ));
 
-    let post_dash = post_dash_arg.repeated().collect::<Vec<_>>();
+    // Same glue guard as `pre_dash` (GH #189): before this, a post-`--`
+    // glued word silently split into separate positionals instead of
+    // erroring — the pre-`--` guard never ran over these tokens at all.
+    let post_dash = post_dash_arg
+        .map_with(|arg, e| -> (Arg, Span) { (arg, e.span()) })
+        .repeated()
+        .collect::<Vec<(Arg, Span)>>()
+        .try_map(|args, _span| reject_glued_args(args));
 
     // Combine: args_before ++ [--] ++ args_after
     pre_dash
@@ -1982,6 +2025,33 @@ where
     I: ValueInput<'tokens, Token = Token, Span = Span>,
     T: Parser<'tokens, I, Expr, extra::Err<Rich<'tokens, Token, Span>>> + Clone + 'tokens,
 {
+    // `target` only ever parses ONE expression. An unquoted target that
+    // spans multiple lexical fragments with no gap between them
+    // (`/tmp/$(echo x).txt` lexes as three tokens: "/tmp/", the command
+    // substitution, ".txt") only binds its first fragment as the target —
+    // the rest dangle, and the surrounding statement grammar rejects them
+    // with a generic chumsky "expected ..." message that never mentions
+    // quoting (GH #189). Peek (`rewind`, consumes nothing) for an
+    // immediately-adjacent further expr fragment and turn that into the same
+    // "quote it" hint `reject_glued_args` gives positional args, worded for a
+    // redirect target. The peek reuses the caller's own `target` clone
+    // (never a fresh `primary_expr_parser()` built here) — see the
+    // construction-cycle note in this function's doc comment above.
+    let target = target
+        .clone()
+        .map_with(|expr, e| -> (Expr, Span) { (expr, e.span()) })
+        .then(target.clone().map_with(|_, e| e.span()).rewind().or_not())
+        .try_map(|((expr, span), glued), _| match glued {
+            Some(next_span) if next_span.start == span.end => Err(Rich::custom(
+                next_span,
+                "adjacent words with no space between them are not joined into the redirect \
+                 target (kaish does no token pasting); quote the whole target, e.g. \
+                 \"/tmp/$(echo x).txt\"",
+            )),
+            _ => Ok(expr),
+        })
+        .boxed();
+
     // Regular redirects: >, >>, <, 2>, &>
     let regular_redirect = select! {
         Token::GtGt => RedirectKind::StdoutAppend,

--- a/crates/kaish-kernel/src/scheduler/pipeline.rs
+++ b/crates/kaish-kernel/src/scheduler/pipeline.rs
@@ -1851,6 +1851,143 @@ mod tests {
         );
     }
 
+    /// GH #189 item 1: pin the CURRENT (pre-`--`) behavior first — a
+    /// word-assign-accepting tool (`export`, keyed off the root schema name)
+    /// binds a bare `key=value` as a named assignment. This is unchanged by
+    /// the fix below; only the post-`--` case changes.
+    #[tokio::test]
+    async fn word_assign_before_double_dash_binds_named_for_export() {
+        let args = vec![Arg::WordAssign {
+            key: "A".to_string(),
+            value: Expr::Literal(Value::String("1".to_string())),
+        }];
+        let schema = ToolSchema::new("export", "export");
+        let ctx = make_minimal_ctx();
+
+        let tool_args = build_tool_args(&args, &ctx, Some(&schema)).await.expect("build_tool_args");
+        assert_eq!(tool_args.named.get("A"), Some(&Value::String("1".to_string())));
+        assert!(tool_args.positional.is_empty());
+    }
+
+    /// GH #189 item 1: `export -- A=1` must NOT bind `A=1` as a named
+    /// assignment — `--` marks everything after it as literal data, and the
+    /// WordAssign arm used to ignore `past_double_dash` entirely (only the
+    /// flag arms checked it). Before the fix, this test's ONLY visible
+    /// difference from the one above was replacing `WordAssign` with
+    /// `[DoubleDash, WordAssign]` — the fix degrades the value to a
+    /// stringified `"A=1"` positional instead, matching how every other
+    /// tool treats a `key=value` after `--`.
+    #[tokio::test]
+    async fn word_assign_after_double_dash_is_positional_even_for_export() {
+        let args = vec![
+            Arg::DoubleDash,
+            Arg::WordAssign {
+                key: "A".to_string(),
+                value: Expr::Literal(Value::String("1".to_string())),
+            },
+        ];
+        let schema = ToolSchema::new("export", "export");
+        let ctx = make_minimal_ctx();
+
+        let tool_args = build_tool_args(&args, &ctx, Some(&schema)).await.expect("build_tool_args");
+        assert!(
+            tool_args.named.is_empty(),
+            "past `--`, A=1 must not become a named assignment: {:?}",
+            tool_args.named
+        );
+        assert_eq!(tool_args.positional, vec![Value::String("A=1".to_string())]);
+    }
+
+    /// GH #189 item 3: `--flag=true` on an UNDECLARED flag (this is exactly
+    /// `--json`'s situation — `clap_schema::is_skipped` deliberately excludes
+    /// it from every builtin's reflected schema) must flagify at bind time:
+    /// land in `flags`, not `named` as a literal `Value::Bool` a clap `bool`
+    /// field's `SetTrue` action rejects (`seq --json=true` used to exit 2).
+    /// Before this fix, only the ~20 builtins that called
+    /// `ToolArgs::flagify_bool_named` themselves got this normalization.
+    #[tokio::test]
+    async fn named_true_on_undeclared_flag_flagifies() {
+        let args = vec![Arg::Named {
+            key: "json".to_string(),
+            value: Expr::Literal(Value::Bool(true)),
+        }];
+        let schema = make_test_schema(); // declares query/limit/verbose/output, not "json"
+        let ctx = make_minimal_ctx();
+
+        let tool_args = build_tool_args(&args, &ctx, Some(&schema)).await.expect("build_tool_args");
+        assert!(tool_args.flags.contains("json"), "flags: {:?}", tool_args.flags);
+        assert!(!tool_args.named.contains_key("json"), "named: {:?}", tool_args.named);
+    }
+
+    /// `--flag=false` on an undeclared flag drops entirely — absence and
+    /// explicit false are the same thing, matching `ToolArgs::flagify_bool_named`.
+    #[tokio::test]
+    async fn named_false_on_undeclared_flag_drops() {
+        let args = vec![Arg::Named {
+            key: "json".to_string(),
+            value: Expr::Literal(Value::Bool(false)),
+        }];
+        let schema = make_test_schema();
+        let ctx = make_minimal_ctx();
+
+        let tool_args = build_tool_args(&args, &ctx, Some(&schema)).await.expect("build_tool_args");
+        assert!(!tool_args.flags.contains("json"));
+        assert!(!tool_args.named.contains_key("json"));
+    }
+
+    /// A schema-DECLARED bool param (`verbose`) behaves the same as an
+    /// undeclared one: `--verbose=true` flagifies instead of landing in
+    /// `named`.
+    #[tokio::test]
+    async fn named_true_on_declared_bool_param_flagifies() {
+        let args = vec![Arg::Named {
+            key: "verbose".to_string(),
+            value: Expr::Literal(Value::Bool(true)),
+        }];
+        let schema = make_test_schema();
+        let ctx = make_minimal_ctx();
+
+        let tool_args = build_tool_args(&args, &ctx, Some(&schema)).await.expect("build_tool_args");
+        assert!(tool_args.flags.contains("verbose"));
+        assert!(!tool_args.named.contains_key("verbose"));
+    }
+
+    /// A schema-declared VALUE-taking flag's own `=true` literal
+    /// (`spawn --command=true`, `output` here — both string-typed in
+    /// `make_test_schema`) must NOT flagify — `true` is the flag's actual
+    /// value, not a bool-flag presence marker, and clap's `Option<String>`
+    /// field for it accepts `--output=true` fine.
+    #[tokio::test]
+    async fn named_true_on_declared_value_flag_keeps_value() {
+        let args = vec![Arg::Named {
+            key: "output".to_string(),
+            value: Expr::Literal(Value::Bool(true)),
+        }];
+        let schema = make_test_schema();
+        let ctx = make_minimal_ctx();
+
+        let tool_args = build_tool_args(&args, &ctx, Some(&schema)).await.expect("build_tool_args");
+        assert_eq!(tool_args.named.get("output"), Some(&Value::Bool(true)));
+        assert!(!tool_args.flags.contains("output"));
+    }
+
+    /// The fix must not depend on a schema being present at all — a
+    /// completely schemaless invocation (`schema=None`, e.g. a shell
+    /// function call) sees an empty `param_lookup`, so `--flag=true` still
+    /// flagifies rather than landing in `named`.
+    #[tokio::test]
+    async fn named_true_with_no_schema_flagifies() {
+        let args = vec![Arg::Named {
+            key: "verbose".to_string(),
+            value: Expr::Literal(Value::Bool(true)),
+        }];
+        let ctx = make_minimal_ctx();
+
+        let tool_args = build_tool_args(&args, &ctx, None).await.expect("build_tool_args");
+        assert!(tool_args.flags.contains("verbose"));
+        assert!(!tool_args.named.contains_key("verbose"));
+    }
+
     #[tokio::test]
     async fn test_no_schema_fallback() {
         // Without schema, all --flags are treated as bool flags
@@ -1918,6 +2055,77 @@ mod tests {
             tool_args.named.get("query"),
             Some(&Value::String("value".to_string()))
         );
+    }
+
+    /// GH #189 item 4: the SAME ambiguity guard as
+    /// `test_unknown_flag_ambiguous_space_value_now_errors_loud` above, but
+    /// for an undeclared SHORT flag. Before the fix, an undeclared short
+    /// flag under a `map_positionals` schema always defaulted to a bare bool
+    /// (`is_bool = lookup.map(...).unwrap_or(true)`), silently divorcing the
+    /// following positional's value (`-t explorer` → flag "t" set, "explorer"
+    /// mapped onto the first unfilled param instead of "t"'s value) — the
+    /// long-flag half of this was closed by GH #188; this closes the
+    /// short-flag half.
+    #[tokio::test]
+    async fn test_unknown_short_flag_ambiguous_space_value_now_errors_loud() {
+        let args = vec![
+            Arg::ShortFlag("t".to_string()),
+            Arg::Positional(Expr::Literal(Value::String("value".to_string()))),
+        ];
+        let schema = make_test_schema();
+        let ctx = make_minimal_ctx();
+
+        let err = build_tool_args(&args, &ctx, Some(&schema))
+            .await
+            .expect_err("an undeclared short flag immediately before a positional must be ambiguous, not silently bool");
+        assert!(
+            err.contains("-t is not a declared flag"),
+            "got: {err}"
+        );
+    }
+
+    /// The unambiguous half: an undeclared short flag with nothing after it
+    /// can't be silently swallowing a positional, so it still defaults to a
+    /// bare bool flag.
+    #[tokio::test]
+    async fn test_unknown_short_bool_flag_with_no_following_positional_is_fine() {
+        let args = vec![
+            Arg::Positional(Expr::Literal(Value::String("value".to_string()))),
+            Arg::ShortFlag("t".to_string()),
+        ];
+        let schema = make_test_schema();
+        let ctx = make_minimal_ctx();
+
+        let tool_args = build_tool_args(&args, &ctx, Some(&schema)).await.expect("build_tool_args");
+
+        assert!(tool_args.flags.contains("t"));
+        assert!(tool_args.positional.is_empty(), "value consumed as query param");
+        assert_eq!(
+            tool_args.named.get("query"),
+            Some(&Value::String("value".to_string()))
+        );
+    }
+
+    /// The guard is specific to `map_positionals` (backend/MCP) schemas — a
+    /// builtin (no `map_positionals`) keeps the pre-existing behavior of
+    /// treating an undeclared short flag as bare bool, since a builtin
+    /// handles its own positionals rather than relying on this ambiguity
+    /// class at all.
+    #[tokio::test]
+    async fn test_unknown_short_flag_not_ambiguous_without_map_positionals() {
+        let args = vec![
+            Arg::ShortFlag("t".to_string()),
+            Arg::Positional(Expr::Literal(Value::String("value".to_string()))),
+        ];
+        // A builtin-shaped schema: same params as make_test_schema but no
+        // positional mapping.
+        let schema = ToolSchema::new("test-tool", "A test tool")
+            .param(ParamSchema::required("query", "string", "Search query"));
+        let ctx = make_minimal_ctx();
+
+        let tool_args = build_tool_args(&args, &ctx, Some(&schema)).await.expect("build_tool_args");
+        assert!(tool_args.flags.contains("t"));
+        assert_eq!(tool_args.positional, vec![Value::String("value".to_string())]);
     }
 
     #[tokio::test]

--- a/crates/kaish-kernel/tests/flag_true_literal_tests.rs
+++ b/crates/kaish-kernel/tests/flag_true_literal_tests.rs
@@ -1,0 +1,62 @@
+//! GH #189 item 3: `--flag=true` on a bool flag must bind like the bare
+//! `--flag` (a flag presence), not as a literal `Value::Bool` that a clap
+//! `bool` field's `SetTrue` action rejects.
+//!
+//! Before the fix this only worked for the ~20 builtins that happened to
+//! call `ToolArgs::flagify_bool_named` themselves in `execute()` — anything
+//! else, including the kernel-owned `--json` (deliberately excluded from
+//! every builtin's *own* schema — see `clap_schema::is_skipped` — so no
+//! builtin's own `flagify_bool_named` call ever normalized it either), hit a
+//! clap parse error. The fix moved the normalization into the shared kernel
+//! binder (`kernel::bind_tool_args`'s `Arg::Named` arm) so it applies once,
+//! for every schema-aware tool, regardless of whether the tool also calls
+//! `flagify_bool_named` itself.
+
+// Test-fixture code: unwrap/expect on known-good setup is the idiom here.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use kaish_kernel::{Kernel, KernelConfig};
+
+fn kernel() -> Kernel {
+    Kernel::new(KernelConfig::isolated()).expect("kernel")
+}
+
+/// `--json` is excluded from every builtin's OWN schema (it's the kernel-
+/// owned global flag), so no per-builtin `flagify_bool_named` call ever
+/// covered it — this is the case that could only be fixed in the kernel.
+#[tokio::test]
+async fn seq_json_equals_true_renders_json() {
+    let k = kernel();
+    let r = k.execute("seq --json=true 1 3").await.expect("kernel execute");
+    assert_eq!(r.code, 0, "seq --json=true must not be a clap parse error: {r:?}");
+    assert_eq!(r.text_out().trim(), r#"["1","2","3"]"#, "got: {}", r.text_out());
+}
+
+/// `seq` never calls `flagify_bool_named` on its OWN bool flags either
+/// (`--width`/`-w`) — `--width=true` used to hand clap's `bool` field a
+/// value it rejects.
+#[tokio::test]
+async fn seq_width_equals_true_does_not_crash() {
+    let k = kernel();
+    let r = k.execute("seq --width=true 1 3").await.expect("kernel execute");
+    assert_eq!(r.code, 0, "seq --width=true must not be a clap parse error: {r:?}");
+}
+
+/// `--json=false` behaves like omitting the flag: plain text output.
+#[tokio::test]
+async fn seq_json_equals_false_renders_plain_text() {
+    let k = kernel();
+    let r = k.execute("seq --json=false 1 3").await.expect("kernel execute");
+    assert_eq!(r.code, 0, "got: {r:?}");
+    assert_eq!(r.text_out().trim(), "1\n2\n3");
+}
+
+/// The bare `--json` flag (no `=true`) is unaffected — pinning the
+/// unglued-value control case alongside the glued one above.
+#[tokio::test]
+async fn seq_bare_json_flag_still_works() {
+    let k = kernel();
+    let r = k.execute("seq --json 1 3").await.expect("kernel execute");
+    assert_eq!(r.code, 0, "got: {r:?}");
+    assert_eq!(r.text_out().trim(), r#"["1","2","3"]"#);
+}

--- a/crates/kaish-kernel/tests/parser_tests.rs
+++ b/crates/kaish-kernel/tests/parser_tests.rs
@@ -1165,3 +1165,88 @@ fn angle_brackets_stay_redirection() {
         "`>` must remain a redirect, not become a positional: {sexpr}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// GH #189 (arg-binding polish): the no-token-pasting guard used to cover
+// pre-`--` positional args only. A glued redirect target fell through to a
+// generic chumsky "expected ..." error with no quoting hint, and args glued
+// together AFTER `--` (or a flag glued straight to a following fragment)
+// silently split into separate args instead of erroring at all.
+// ---------------------------------------------------------------------------
+
+fn parse_err_message(input: &str) -> String {
+    match parse(input) {
+        Ok(program) => panic!(
+            "expected a parse error for {input:?}, got: {}",
+            format_program(&program)
+        ),
+        Err(errors) => errors.iter().map(|e| e.to_string()).collect::<Vec<_>>().join("; "),
+    }
+}
+
+/// A redirect target that fragments into multiple glued lexical pieces
+/// (`/tmp/$(echo x).txt`) used to fail with a generic, unhelpful chumsky
+/// error. It now gets the same "quote it" hint the plain-positional glue
+/// guard gives, worded for a redirect target.
+#[test]
+fn glued_redirect_target_hints_to_quote() {
+    let msg = parse_err_message("echo > /tmp/$(echo x).txt");
+    assert!(msg.contains("redirect target"), "should name the redirect target: {msg}");
+    assert!(msg.to_lowercase().contains("quote"), "should hint to quote: {msg}");
+}
+
+/// The same guard applies to `<` (stdin) redirect targets, not just `>`.
+#[test]
+fn glued_stdin_redirect_target_hints_to_quote() {
+    let msg = parse_err_message("cat < /tmp/$(echo x).txt");
+    assert!(msg.contains("redirect target"), "got: {msg}");
+}
+
+/// A single-fragment redirect target (no glue) is unaffected.
+#[test]
+fn unglued_redirect_target_still_parses() {
+    one_stmt_sexpr(r#"echo > "/tmp/$(echo x).txt""#);
+    one_stmt_sexpr("echo > /tmp/out.txt");
+}
+
+/// The pre-`--` guard already rejected glued positionals; the post-`--` half
+/// used to be unchecked entirely, silently splitting `/tmp/$(echo x).txt`
+/// into three positionals instead of erroring.
+#[test]
+fn glued_positional_after_double_dash_is_rejected() {
+    let msg = parse_err_message("echo hi -- /tmp/$(echo x).txt");
+    assert!(msg.to_lowercase().contains("quote"), "should hint to quote: {msg}");
+}
+
+/// A spaced (non-glued) positional after `--` is unaffected.
+#[test]
+fn spaced_positional_after_double_dash_still_parses() {
+    let sexpr = one_stmt_sexpr("echo hi -- --this-is-data");
+    assert!(sexpr.contains("(doubledash)"), "got: {sexpr}");
+    assert!(
+        sexpr.contains(r#"(pos (string "--this-is-data"))"#),
+        "got: {sexpr}"
+    );
+}
+
+/// `--flag` has no glued-value idiom (only the explicit `--flag=value` form
+/// does) — a long flag glued straight to a following expression fragment
+/// with no `=` (`--flag$(echo x)`) is always a pasting accident, not a
+/// feature, and must be rejected rather than silently splitting into a bare
+/// `--flag` bool plus a stray positional.
+#[test]
+fn glued_long_flag_then_fragment_is_rejected() {
+    let msg = parse_err_message("echo --flag$(echo x)");
+    assert!(msg.to_lowercase().contains("quote"), "should hint to quote: {msg}");
+}
+
+/// The short-flag glued-value idiom (`cut -d,`, `grep -A1`, `head -c5`) must
+/// keep working: a `ShortFlag` glued to exactly one following fragment is a
+/// deliberate feature (`consume_flag_positionals`/`bind_glued_short_value`
+/// in the kernel binder), not a pasting accident, so it must NOT trip the
+/// guard above.
+#[test]
+fn glued_short_flag_then_single_fragment_still_parses() {
+    one_stmt_sexpr("echo -f$(echo x)");
+    one_stmt_sexpr("cut -d, -f2");
+}

--- a/crates/kaish-kernel/tests/redirect_target_pasting_tests.rs
+++ b/crates/kaish-kernel/tests/redirect_target_pasting_tests.rs
@@ -1,0 +1,51 @@
+//! Kernel-routed (GH #189): a glued redirect target now fails with a
+//! "quote the redirect target" hint instead of a generic parse error, and
+//! the no-token-pasting guard now also covers post-`--` positionals.
+//!
+//! `parser_tests.rs` pins the exact parser-level message/AST shape for these
+//! and the companion "flag glued to a fragment" / "short-flag glued value
+//! still works" cases; this file only checks the behavior is reachable
+//! through the real `kernel.execute()` path. `KernelConfig::isolated()`
+//! (memory-only VFS) is used throughout so the executing test never touches
+//! a real host path (per CLAUDE.md's no-hardcoded-`/tmp` rule) — the parse-
+//! error tests never reach execution at all, so the FS backing is moot for
+//! them, but using the same isolated kernel everywhere keeps the file simple.
+
+// Test-fixture code: unwrap/expect on known-good setup is the idiom here.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use kaish_kernel::{Kernel, KernelConfig};
+
+fn kernel() -> Kernel {
+    Kernel::new(KernelConfig::isolated()).expect("kernel")
+}
+
+#[tokio::test]
+async fn glued_redirect_target_errors_with_quote_hint() {
+    let kernel = kernel();
+    let result = kernel.execute("echo hi > /tmp/$(echo x).txt").await;
+    assert!(result.is_err(), "glued redirect target must be a loud error");
+    let msg = format!("{:#}", result.unwrap_err());
+    assert!(msg.contains("redirect target"), "should name the redirect target: {msg}");
+    assert!(msg.to_lowercase().contains("quote"), "should hint to quote: {msg}");
+}
+
+#[tokio::test]
+async fn quoted_redirect_target_still_works() {
+    let kernel = kernel();
+    let result = kernel
+        .execute(r#"echo hi > "/out-$(echo x).txt"; cat "/out-$(echo x).txt""#)
+        .await
+        .expect("kernel execute");
+    assert_eq!(result.code, 0, "got: {result:?}");
+    assert_eq!(result.text_out().trim(), "hi");
+}
+
+#[tokio::test]
+async fn glued_positional_after_double_dash_errors_loud() {
+    let kernel = kernel();
+    let result = kernel.execute("echo hi -- /tmp/$(echo x).txt").await;
+    assert!(result.is_err(), "glued post-`--` positional must be a loud error");
+    let msg = format!("{:#}", result.unwrap_err());
+    assert!(msg.to_lowercase().contains("quote"), "should hint to quote: {msg}");
+}

--- a/crates/kaish-kernel/tests/word_assign_double_dash_tests.rs
+++ b/crates/kaish-kernel/tests/word_assign_double_dash_tests.rs
@@ -1,0 +1,72 @@
+//! GH #189 item 1: a `key=value` WordAssign token after `--` must bind as a
+//! literal positional, not a named shell assignment, even for the
+//! word-assign-accepting builtins (`export`, `alias`, `unalias`).
+//!
+//! `--` is supposed to mark everything after it as literal data (matching
+//! how the flag arms of the shared binder already treat `past_double_dash`).
+//! The `Arg::WordAssign` arm used to ignore `past_double_dash` entirely, so
+//! `export -- A=1` still bound `A=1` as a named assignment instead of a
+//! stringified `"A=1"` positional. `unalias` is the sharpest demonstration:
+//! its `execute()` reconstructs argv via `ToolArgs::to_argv()` and re-parses
+//! with clap, which renders a lingering named entry as `--A=1` — a flag
+//! `UnaliasArgs` never declares — so before the fix `unalias -- foo=bar`
+//! crashed with a clap "unexpected argument" error (exit 2) instead of
+//! treating `foo=bar` as a literal (if odd) alias name to remove.
+
+// Test-fixture code: unwrap/expect on known-good setup is the idiom here.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use kaish_kernel::{Kernel, KernelConfig};
+
+fn kernel() -> Kernel {
+    Kernel::new(KernelConfig::isolated()).expect("kernel")
+}
+
+#[tokio::test]
+async fn export_after_double_dash_still_sets_the_variable() {
+    let k = kernel();
+    let r = k
+        .execute("export -- A=1; export -p")
+        .await
+        .expect("kernel execute");
+    assert_eq!(r.code, 0, "got: {r:?}");
+    assert!(
+        r.text_out().contains("declare -x A=\"1\""),
+        "export -- A=1 should still export A=1, got: {}",
+        r.text_out()
+    );
+}
+
+#[tokio::test]
+async fn alias_after_double_dash_still_defines_the_alias() {
+    let k = kernel();
+    let r = k
+        .execute("alias -- ll=foo; alias ll")
+        .await
+        .expect("kernel execute");
+    assert_eq!(r.code, 0, "got: {r:?}");
+    assert!(
+        r.text_out().contains("alias ll='foo'"),
+        "alias -- ll=foo should still define the alias, got: {}",
+        r.text_out()
+    );
+}
+
+/// The sharpest regression: before the fix, `unalias -- foo=bar` crashed
+/// with clap's "unexpected argument '--foo' found" (exit 2) because the
+/// lingering named entry rendered as a flag token `to_argv()` had no
+/// business emitting past `--`. It must now succeed (as a no-op removal of
+/// a nonexistent alias literally named "foo=bar" — `unalias` on a
+/// nonexistent name is not an error, matching its pre-existing behavior).
+#[tokio::test]
+async fn unalias_after_double_dash_does_not_crash_on_clap_reparse() {
+    let k = kernel();
+    let r = k
+        .execute("unalias -- foo=bar")
+        .await
+        .expect("kernel execute");
+    assert_eq!(
+        r.code, 0,
+        "unalias -- foo=bar must not hit the clap unexpected-argument crash: {r:?}"
+    );
+}

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -15,6 +15,76 @@ before it ships.
 
 ---
 
+## Arg-binding polish: four small gaps, one shared core (2026-07-17, GH #189)
+
+Sequenced right after #188/#231 merged the sync/async arg binders into one
+`bind_tool_args` core specifically so this punch list would land once instead
+of twice. Each of the four items was re-verified against the merged code
+before touching anything, since the issue predated #215/#221/#224 too — two
+of the four turned out to need a different fix than the issue's own text
+suggested, and one uncovered a sharper bug than expected.
+
+**Post-`--` `WordAssign`.** The `Arg::WordAssign` arm checked `accepts_word_assign`
+(the export/alias/unalias allowlist) but never `past_double_dash` — only the
+flag arms checked that. `export -- A=1` still bound `A=1` as a named
+assignment. Chasing down whether this was actually *observable* (export and
+alias both defensively read `args.named` **and** `args.positional`, so the
+export/alias examples in the issue text turn out functionally harmless either
+way) led to `unalias`, which is on the same allowlist for symmetry but never
+reads `args.named` at all — it reconstructs argv via `to_argv()` and re-parses
+with clap. A lingering named entry renders as a flag token (`--foo=bar`)
+`UnaliasArgs` never declares, so `unalias -- foo=bar` crashed with clap's
+"unexpected argument" error instead of treating `foo=bar` as a literal (if
+odd) alias name to remove. Fix: `accepts_word_assign && !past_double_dash`.
+
+**`--flag=true` flagify.** Confirmed live: `seq --json=true 1 3` exits 2
+today. The issue's own suggested fix ("flagify once in the kernel before
+dispatch") pointed at a post-hoc pass over the built `ToolArgs`, but that
+would also catch `export A=true` (a `WordAssign`, not a `--flag=` token) and
+silently turn a real assignment into a bare flag — a regression the pipeline
+tests would never have caught since none exercise that shape. Scoping the
+fix to the `Arg::Named` arm specifically (the only place `--flag=value`
+syntax actually binds) avoids that: a `Value::Bool` lands in `flags`/gets
+dropped only when the key isn't a declared *value-taking* param, mirroring
+`ToolArgs::flagify_bool_named`'s logic without needing a schema object
+(`param_lookup`, already assembled for the rest of the binder, has enough).
+This also fixes `--json` itself — deliberately excluded from every builtin's
+reflected schema (`clap_schema::is_skipped`), so no per-builtin
+`flagify_bool_named` call ever normalized it; only the shared binder can.
+
+**Short space-flag guard.** The long-flag ambiguity guard (`--type explorer`
+under a `map_positionals` schema) was a straight port to the single-char
+`ShortFlag` arm — same "fail loud, don't guess" logic, minus the `--flag=value`
+escape-hatch suggestion in the error message, since kaish has no `-f=value`
+form for short flags (confirmed: it's a parse error today, the no-pasting
+guard's own turf).
+
+**Pasting hints.** This one had a real landmine. Extending the no-pasting
+guard from "adjacent `Positional`s" to "adjacent `Positional`s or `LongFlag`s"
+(so `--flag$(echo x)` errors instead of silently splitting into a bare flag
+plus a stray positional) seemed safe — until `cargo test --all` turned up
+`cut_bare_comma_delimiter_glued` failing. `cut -d,` is `-d` (a `ShortFlag`)
+glued to a bare `,` (a `Positional`, zero source-gap) — exactly the
+getopt-style glued-short-value idiom (`cut -d,`, `head -c5`) the binder
+already supports, and a comma isn't in the flag char class so it can't fuse
+into one lexer token the way `-f1` does. `ShortFlag` stayed out of the glue
+check entirely; `LongFlag` went in (there's no long-flag glued-value idiom to
+protect). The redirect-target half (`> /tmp/$(echo x).txt`, previously a
+generic chumsky "expected ..." error with zero quoting hint) needed its own
+peek-and-reject wrapper around `redirect_parser`'s `target` parser — first
+draft called a fresh `primary_expr_parser()` for the peek and blew the stack
+immediately, because the module's own doc comment already warns why: `target`
+is threaded in specifically so `$(cmd > file)` doesn't reconstruct
+`redirect → primary_expr → cmd_subst → redirect` forever. Reusing the
+caller's own `target.clone()` for the peek (chumsky's `rewind()`, no
+consumption) fixed it — the grammar was already built once by the caller, so
+cloning the *value* is cheap and doesn't re-enter construction.
+
+Full `cargo test --all --locked` / `cargo clippy --all --all-targets` /
+`cargo check -p kaish-kernel --no-default-features` clean throughout. GH #189.
+
+---
+
 ## Eliminating the sync `build_tool_args` twin (2026-07-17, GH #188)
 
 The scheduler had a second, hand-rolled arg binder living next to the real


### PR DESCRIPTION
## Summary

Four small gaps in the shared arg binder (`kernel::bind_tool_args`, unified by #188/#231), each **re-verified against current code first** — the issue predated #231 (the sync/async binder merge) and #215/#221/#224 too, so some items needed a different fix than the original text suggested.

## Per-item outcomes

| # | Item | Verify result | Fix |
|---|------|---------------|-----|
| 1 | Post-`--` WordAssign | **Confirmed live.** `Arg::WordAssign` checked `accepts_word_assign` (export/alias/unalias) but never `past_double_dash`. `export -- A=1` still bound as a named assignment. | Added `&& !past_double_dash` to the WordAssign arm's condition. |
| 2 | Pasting hints | **Confirmed live**, two distinct gaps. `> /tmp/$(echo x).txt` was a hard, generic chumsky parse error; the no-pasting guard ran on pre-`--` positionals only (post-`--` and flag-glued-to-fragment cases weren't flagged at all). | Added a "quote the redirect target" peek-and-reject wrapper around `redirect_parser`'s target parser; extended the glue guard to run over post-`--` args too, and to also catch a `LongFlag` glued to a following fragment (`--flag$(echo x)`). |
| 3 | `--flag=true` flagify | **Confirmed live.** `seq --json=true 1 3` exits 2 (clap rejects a value on a `bool`/`SetTrue` field). | Flagify at bind time in the `Arg::Named` arm (not a post-hoc `ToolArgs` pass, which would also wrongly catch `export A=true` — see below). Fixes every schema-aware builtin uniformly, including `--json` itself (excluded from every builtin's own schema, so no per-builtin `flagify_bool_named()` call ever covered it). |
| 4 | Short space-flag guard | **Confirmed live.** The long-flag ambiguity guard (closed by #231) had no short-flag counterpart — an undeclared `-t` under a `map_positionals` schema silently defaulted to bare bool, divorcing `-t explorer`'s value. | Ported the same guard to the single-char `ShortFlag` arm, with wording that doesn't suggest a `-t=value` escape hatch (kaish has none — that's a parse error today, the pasting guard's own turf). |

## Notable decisions / landmines hit during verification

- **Item 1's real bite is `unalias`, not export/alias.** `export`/`alias` both defensively read `args.named` *and* `args.positional`, so the issue's own `export -- A=1` example is functionally harmless either way. `unalias` is on the same word-assign allowlist (for family symmetry) but never reads `args.named` — it reconstructs argv via `to_argv()` and re-parses with clap. A lingering named entry rendered as a flag token (`--foo=bar`) `UnaliasArgs` never declares, so **`unalias -- foo=bar` crashed with a clap "unexpected argument" error** before this fix.
- **Item 3 needed a narrower fix than the issue suggested.** "Flagify once in the kernel before dispatch" (a post-hoc pass over the built `ToolArgs`) would also flagify `export A=true` — a `WordAssign`, not a `--flag=` token — silently turning a real assignment into a bare flag. Scoped the fix to the `Arg::Named` arm specifically, where `--flag=value` syntax actually binds.
- **Item 2/4 both needed care not to break an existing feature.** Expanding the pasting guard to flag-glued-to-fragment broke `cut -d,` (`cut_bare_comma_delimiter_glued`) until `ShortFlag` was excluded from the expanded check — a short flag glued to its value with no space is the getopt idiom the binder already supports (`cut -d,`, `head -c5`), not a pasting accident. `LongFlag` has no such idiom, so it's the only flag type added to the glue check. Similarly, item 4's error message deliberately omits a `-t=value` suggestion since that's not valid kaish syntax for short flags.
- **The redirect-target peek almost caused a stack overflow.** First draft called a fresh `primary_expr_parser()` for the "is something glued after this?" peek — `redirect_parser`'s own doc comment already warns why not to: `target` is threaded in by the caller specifically to avoid an unbounded `redirect → primary_expr → cmd_subst → redirect` construction cycle. Fixed by reusing the caller's own `target.clone()` for the peek via chumsky's `rewind()` (no consumption, no re-entering grammar construction).

## Tests

Per-item: unit tests on the shared core (`pipeline.rs`'s `build_tool_args` for items 1/3/4, `parser.rs`'s grammar for item 2) plus at least one `kernel.execute()`-routed test:
- `crates/kaish-kernel/tests/word_assign_double_dash_tests.rs` (item 1: export/alias/unalias, all through `kernel.execute()`)
- `crates/kaish-kernel/tests/flag_true_literal_tests.rs` (item 3: `seq --json=true`/`--width=true` through `kernel.execute()`)
- `crates/kaish-kernel/tests/parser_tests.rs` additions + `crates/kaish-kernel/tests/redirect_target_pasting_tests.rs` (item 2)
- Item 4's kernel-routed-equivalent tests live in `kernel.rs`'s own test module (`build_args_undeclared_short_space_flag_*`), matching the existing precedent for the long-flag guard (`build_args_undeclared_space_flag_*`, from #231) — this ambiguity class only exists for `map_positionals` (backend/MCP) schemas, which no built-in reaches via `kernel.execute()` script text, so testing through `kernel.build_args_async` on a real `Kernel::transient()` (as #231 already did for the long-flag half) is the closest equivalent without adding a new mock-backend fixture.

Regression coverage: existing `cut -d,`/`grep -A1`/`head -c5` glued-short-flag-value tests, and existing redirect/heredoc parser snapshot tests, all still pass unchanged.

## Gates

- `cargo test --all --locked` — clean
- `cargo clippy --all --all-targets` — zero warnings
- `cargo check -p kaish-kernel --no-default-features` — clean
- `cargo build -p kaish-wasi --target wasm32-wasip1` — clean (spot-checked, not in the required gate list)
- `cargo insta test --check` — no pending snapshots

Closes #189.

🤖 Generated with [Claude Code](https://claude.com/claude-code)