### PR TITLE
chore: bump to v0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,18 @@ breaking entries are marked **BREAKING**.
 
 ## [0.13.0] - 2026-07-18
 
+### Added
+- **`OutputData.rich_json` now persists through serde** (self-describing
+  formats: JSON, CBOR). The `--json` render override — set by `grep --json`,
+  available to any builtin — was `#[serde(skip)]` as a transient render hint.
+  It now serializes when `Some` (omitted when `None` via
+  `skip_serializing_if`), so an embedder can carry a builtin's rich structured
+  output onto a stored record and read it back — e.g. kaijutsu persisting a
+  `kj` command's structured output onto a CRDT block for its MCP surface. The
+  `None` (common) case is unchanged on the wire. Caveat: a `Some` value can't
+  round-trip through non-self-describing formats (postcard/bincode lack
+  `deserialize_any`) — kaish uses neither, and kaijutsu is CBOR.
+
 ### Fixed
 - **Arg-binding polish** (GH #189): four small gaps in the shared arg binder
   (`kernel::bind_tool_args`), verified against current code post-#188/#231:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ breaking entries are marked **BREAKING**.
 
 ## [Unreleased]
 
+## [0.13.0] - 2026-07-18
+
 ### Fixed
 - **Arg-binding polish** (GH #189): four small gaps in the shared arg binder
   (`kernel::bind_tool_args`), verified against current code post-#188/#231:
@@ -1629,7 +1631,8 @@ Initial public release of **kaish** (会sh) — a predictable Bourne-like shell 
 - **REPL** (`kaish-repl`) with multi-line input, completion, and history; **MCP server** (`kaish-mcp`) exposing `kaish_execute` with help resources and structured + plain-text content blocks.
 - **`KernelClient` trait** + `EmbeddedClient` for in-process embedding; topic-based help system; `kaish-wasi` `wasm32-wasip1` target.
 
-[Unreleased]: https://github.com/tobert/kaish/compare/v0.12.0...HEAD
+[Unreleased]: https://github.com/tobert/kaish/compare/v0.13.0...HEAD
+[0.13.0]: https://github.com/tobert/kaish/compare/v0.12.0...v0.13.0
 [0.12.0]: https://github.com/tobert/kaish/compare/v0.11.0...v0.12.0
 [0.11.0]: https://github.com/tobert/kaish/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/tobert/kaish/compare/v0.9.1...v0.10.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,11 @@ breaking entries are marked **BREAKING**.
   `skip_serializing_if`), so an embedder can carry a builtin's rich structured
   output onto a stored record and read it back — e.g. kaijutsu persisting a
   `kj` command's structured output onto a CRDT block for its MCP surface. The
-  `None` (common) case is unchanged on the wire. Caveat: a `Some` value can't
-  round-trip through non-self-describing formats (postcard/bincode lack
-  `deserialize_any`) — kaish uses neither, and kaijutsu is CBOR.
+  `None` (common) case is unchanged on the wire. Caveat: **decoding** a `Some`
+  value from a non-self-describing format fails — `serde_json::Value` needs
+  `deserialize_any`, which postcard/bincode lack. kaish and its embedders use
+  only self-describing formats (JSON/CBOR), so this is a documented boundary,
+  not a live path.
 
 ### Fixed
 - **Arg-binding polish** (GH #189): four small gaps in the shared arg binder

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -965,7 +965,7 @@ dependencies = [
 
 [[package]]
 name = "kaish-client"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -980,7 +980,7 @@ dependencies = [
 
 [[package]]
 name = "kaish-glob"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "async-trait",
  "ignore",
@@ -992,14 +992,14 @@ dependencies = [
 
 [[package]]
 name = "kaish-help"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "kaish-types",
 ]
 
 [[package]]
 name = "kaish-kernel"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "ariadne",
@@ -1056,7 +1056,7 @@ dependencies = [
 
 [[package]]
 name = "kaish-repl"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1077,7 +1077,7 @@ dependencies = [
 
 [[package]]
 name = "kaish-tool-api"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "async-trait",
  "clap",
@@ -1087,7 +1087,7 @@ dependencies = [
 
 [[package]]
 name = "kaish-tools-host"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "async-trait",
  "clap",
@@ -1098,7 +1098,7 @@ dependencies = [
 
 [[package]]
 name = "kaish-types"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "base64",
  "schemars",
@@ -1111,7 +1111,7 @@ dependencies = [
 
 [[package]]
 name = "kaish-vfs"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "async-trait",
  "getrandom 0.3.4",
@@ -1122,7 +1122,7 @@ dependencies = [
 
 [[package]]
 name = "kaish-wasi"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "kaish-kernel",
  "kaish-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.12.0"
+version = "0.13.0"
 edition = "2024"
 rust-version = "1.85"
 authors = ["Amy Tobey <tobert@gmail.com>"]

--- a/crates/kaish-client/Cargo.toml
+++ b/crates/kaish-client/Cargo.toml
@@ -16,8 +16,8 @@ readme = "../../README.md"
 # Feature-neutral on purpose: the embedder decides the kernel's feature set
 # (kaish-web builds no-default for wasm; native hosts add localfs etc.).
 # Unification means enabling defaults here would trample that choice.
-kaish-kernel = { path = "../kaish-kernel", version = "0.12.0", default-features = false }
-kaish-types = { path = "../kaish-types", version = "0.12.0" }
+kaish-kernel = { path = "../kaish-kernel", version = "0.13.0", default-features = false }
+kaish-types = { path = "../kaish-types", version = "0.13.0" }
 
 # Async traits only — no runtime: the library spawns nothing itself, and a
 # tokio dep here would drag net/mio into wasm builds (kaish-extras).
@@ -39,7 +39,7 @@ tracing = { workspace = true }
 # this, `cargo test -p kaish-client` alone sees a no-localfs kernel while a
 # whole-workspace run gets localfs unified in by the REPL, and outcomes
 # depend on which crates happened to build.
-kaish-kernel = { path = "../kaish-kernel", version = "0.12.0", features = ["localfs"] }
+kaish-kernel = { path = "../kaish-kernel", version = "0.13.0", features = ["localfs"] }
 proptest = { workspace = true }
 # Tests drive the async client API; the library itself needs no runtime —
 # and must not pull one in: wasm builds (kaish-extras) break on tokio/net.

--- a/crates/kaish-help/Cargo.toml
+++ b/crates/kaish-help/Cargo.toml
@@ -13,7 +13,7 @@ categories.workspace = true
 readme = "../../README.md"
 
 [dependencies]
-kaish-types = { path = "../kaish-types", version = "0.12.0" }
+kaish-types = { path = "../kaish-types", version = "0.13.0" }
 
 [lints]
 workspace = true

--- a/crates/kaish-kernel/Cargo.toml
+++ b/crates/kaish-kernel/Cargo.toml
@@ -14,11 +14,11 @@ readme = "../../README.md"
 exclude = ["tests/snapshots/"]
 
 [dependencies]
-kaish-glob = { path = "../kaish-glob", version = "0.12.0" }
-kaish-types = { path = "../kaish-types", version = "0.12.0", features = [] }
-kaish-help = { path = "../kaish-help", version = "0.12.0" }
-kaish-tool-api = { path = "../kaish-tool-api", version = "0.12.0" }
-kaish-vfs = { path = "../kaish-vfs", version = "0.12.0", features = ["memory", "overlay"] }
+kaish-glob = { path = "../kaish-glob", version = "0.13.0" }
+kaish-types = { path = "../kaish-types", version = "0.13.0", features = [] }
+kaish-help = { path = "../kaish-help", version = "0.13.0" }
+kaish-tool-api = { path = "../kaish-tool-api", version = "0.13.0" }
+kaish-vfs = { path = "../kaish-vfs", version = "0.13.0", features = ["memory", "overlay"] }
 
 # Async runtime — minimal base; `localfs` adds tokio/fs, `subprocess` adds
 # tokio/process + tokio/rt-multi-thread (see [features]).
@@ -87,7 +87,7 @@ jaq-json = { workspace = true }
 # Optional deps, each pulled in by its capability feature:
 #   kaish-tools-host → host, trash/directories → os-integration,
 #   tiktoken-rs → tokens.
-kaish-tools-host = { path = "../kaish-tools-host", version = "0.12.0", optional = true }
+kaish-tools-host = { path = "../kaish-tools-host", version = "0.13.0", optional = true }
 trash = { workspace = true, optional = true }
 directories = { workspace = true, optional = true }
 tiktoken-rs = { workspace = true, optional = true }

--- a/crates/kaish-repl/Cargo.toml
+++ b/crates/kaish-repl/Cargo.toml
@@ -19,8 +19,8 @@ path = "src/main.rs"
 [dependencies]
 # The REPL is the full interactive human shell: it needs every capability
 # (external commands + job control, git, host introspection, tokens, trash).
-kaish-kernel = { path = "../kaish-kernel", version = "0.12.0", features = ["full"] }
-kaish-client = { path = "../kaish-client", version = "0.12.0" }
+kaish-kernel = { path = "../kaish-kernel", version = "0.13.0", features = ["full"] }
+kaish-client = { path = "../kaish-client", version = "0.13.0" }
 
 # Line editing
 rustyline = { workspace = true }

--- a/crates/kaish-tool-api/Cargo.toml
+++ b/crates/kaish-tool-api/Cargo.toml
@@ -12,7 +12,7 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-kaish-types = { path = "../kaish-types", version = "0.12.0", features = [] }
+kaish-types = { path = "../kaish-types", version = "0.13.0", features = [] }
 
 async-trait = { workspace = true }
 clap = { workspace = true }

--- a/crates/kaish-tools-host/Cargo.toml
+++ b/crates/kaish-tools-host/Cargo.toml
@@ -12,8 +12,8 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-kaish-types = { path = "../kaish-types", version = "0.12.0", features = [] }
-kaish-tool-api = { path = "../kaish-tool-api", version = "0.12.0" }
+kaish-types = { path = "../kaish-types", version = "0.13.0", features = [] }
+kaish-tool-api = { path = "../kaish-tool-api", version = "0.13.0" }
 
 async-trait = { workspace = true }
 clap = { workspace = true }

--- a/crates/kaish-types/src/output.rs
+++ b/crates/kaish-types/src/output.rs
@@ -210,11 +210,14 @@ pub struct OutputData {
     /// through self-describing formats (JSON, CBOR): an embedder can carry a
     /// builtin's rich `--json` payload onto a stored record and read it back.
     /// Kept off the wire when `None` (the common case), which also keeps that
-    /// case safe for non-self-describing formats. Caveat: a `Some(Value)` can't
-    /// round-trip through postcard/bincode (they have no `deserialize_any`), so
-    /// don't add such a serializer for `OutputData` while `rich_json` may be set.
+    /// case safe for non-self-describing formats. Caveat: the risk is on
+    /// **deserialization** — `serde_json::Value`'s `Deserialize` calls
+    /// `deserialize_any`, which non-self-describing formats (postcard/bincode)
+    /// don't support, so decoding an `OutputData` whose `rich_json` is `Some`
+    /// from one of those fails. kaish and its embedders use only self-describing
+    /// formats (JSON/CBOR); don't decode `OutputData` from postcard/bincode
+    /// while `rich_json` may be set.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[cfg_attr(feature = "schema", schemars(skip))]
     pub rich_json: Option<serde_json::Value>,
 }
 

--- a/crates/kaish-types/src/output.rs
+++ b/crates/kaish-types/src/output.rs
@@ -201,15 +201,19 @@ pub struct OutputData {
     pub headers: Option<Vec<String>>,
     /// Top-level nodes.
     pub root: Vec<OutputNode>,
-    /// Render-only override for `--json` consumers. When `Some`,
-    /// `to_json()` returns this verbatim instead of inferring from
-    /// `headers` / `root` / `cells`. Use it when a builtin wants its
-    /// `--json` shape to be richer than the table form (e.g. grep
-    /// emitting per-match objects with submatches and byte offsets).
+    /// Override for `--json` consumers. When `Some`, `to_json()` returns this
+    /// verbatim instead of inferring from `headers` / `root` / `cells`. Use it
+    /// when a builtin wants its `--json` shape to be richer than the table form
+    /// (e.g. grep emitting per-match objects with submatches and byte offsets).
     ///
-    /// Skipped by serde (and thus by postcard / bincode) — this is a
-    /// transient render hint, not part of the persisted shape.
-    #[serde(skip)]
+    /// Serialized only when `Some` (`skip_serializing_if`), so it **persists**
+    /// through self-describing formats (JSON, CBOR): an embedder can carry a
+    /// builtin's rich `--json` payload onto a stored record and read it back.
+    /// Kept off the wire when `None` (the common case), which also keeps that
+    /// case safe for non-self-describing formats. Caveat: a `Some(Value)` can't
+    /// round-trip through postcard/bincode (they have no `deserialize_any`), so
+    /// don't add such a serializer for `OutputData` while `rich_json` may be set.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     #[cfg_attr(feature = "schema", schemars(skip))]
     pub rich_json: Option<serde_json::Value>,
 }
@@ -774,6 +778,39 @@ mod tests {
     fn to_json_empty() {
         let output = OutputData::new();
         assert_eq!(output.to_json(), serde_json::json!([]));
+    }
+
+    #[test]
+    fn rich_json_round_trips_through_serde() {
+        // rich_json is now a persisted field on self-describing formats: a
+        // builtin's `--json` override survives serialize -> deserialize, so an
+        // embedder can store it on a record and read it back. (It was
+        // `#[serde(skip)]` before, which silently dropped it.)
+        let rich = serde_json::json!({"matches": [{"line": 1, "text": "hi"}]});
+        let output = OutputData::new().with_rich_json(rich.clone());
+
+        let encoded = serde_json::to_string(&output).unwrap();
+        let decoded: OutputData = serde_json::from_str(&encoded).unwrap();
+        assert_eq!(
+            decoded.rich_json,
+            Some(rich),
+            "rich_json must survive a serde round trip"
+        );
+    }
+
+    #[test]
+    fn rich_json_none_stays_off_the_wire() {
+        // The common case (no override) keeps the serialized shape minimal via
+        // `skip_serializing_if`, leaving nothing that could trip a
+        // non-self-describing decoder.
+        let output = OutputData::nodes(vec![OutputNode::new("f")]);
+        let encoded = serde_json::to_string(&output).unwrap();
+        assert!(
+            !encoded.contains("rich_json"),
+            "a None rich_json must not serialize: {encoded}"
+        );
+        let decoded: OutputData = serde_json::from_str(&encoded).unwrap();
+        assert_eq!(decoded.rich_json, None);
     }
 
     #[test]

--- a/crates/kaish-vfs/Cargo.toml
+++ b/crates/kaish-vfs/Cargo.toml
@@ -12,7 +12,7 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-kaish-types = { path = "../kaish-types", version = "0.12.0", features = [] }
+kaish-types = { path = "../kaish-types", version = "0.13.0", features = [] }
 async-trait = { workspace = true }
 # DevFs's /dev/urandom pulls from the OS CSPRNG. Pure (no tokio); works on
 # Unix/macOS/WASI.

--- a/docs/EMBEDDING.md
+++ b/docs/EMBEDDING.md
@@ -6,7 +6,7 @@ and output capture.
 
 ## Stability
 
-kaish is pre-1.0 (currently 0.11.x, MSRV 1.85). The language has settled;
+kaish is pre-1.0 (currently 0.13.x, MSRV 1.85). The language has settled;
 the embedding API may still change between minor versions where it improves
 both kaish and its embedders — [kaijutsu](https://github.com/tobert/kaijutsu)
 is the reference embedder. Pin a minor version and read release notes when

--- a/docs/EMBEDDING.md
+++ b/docs/EMBEDDING.md
@@ -377,6 +377,15 @@ let config = KernelConfig::agent()
 There's no equivalent flag to force `Disk` on a `NoLocal`/`with_backend`
 kernel — by design, since neither owns a host mount to spill to.
 
+> **v0.13.0:** the public `output_limit::spill_aware_collect` function (and its
+> private helpers) is removed — it was dead since external-process capture
+> moved onto `BoundedStream`/`drain_to_stream`, with spill applied post-hoc at
+> the pipeline level (`Kernel::execute_pipeline` → `spill_if_needed`, both
+> internal) instead of inline during capture. `OutputLimitConfig` and the
+> disk/memory spill behavior documented above are unaffected; there was no
+> embedder-facing replacement to migrate to because the function was never a
+> supported extension point, just a capture helper that happened to be `pub`.
+
 ## Initial Variables and Hermetic Subprocess Env
 
 The kernel is **hermetic by default** — it never reads `std::env::vars()`,
@@ -455,6 +464,16 @@ Fields:
   internal token for the duration of the call (not stored). Cancellation
   cascades to forks and external children (SIGTERM → grace → SIGKILL on
   the process group).
+- **`interrupt`** — `with_interrupt(Arc<dyn Fn() -> bool + Send + Sync>)`, a
+  polled interrupt check for embedders whose thread can't fire `cancel_token`
+  while execution runs — the motivating case is `wasm32-unknown-unknown`:
+  single-threaded, so the page's main thread can only flip a
+  `SharedArrayBuffer` flag for a Web Worker to poll, never cancel a token from
+  outside. The kernel checks the closure at its existing cancellation
+  checkpoints; a firing check takes the same exit-130 path as
+  `Kernel::cancel()`/`cancel_token`, and session state survives. Scoped to the
+  one call and cleared on every exit path — prefer `cancel_token` when your
+  embedder's threading model allows it.
 - **`cwd`** — per-call working directory override.
 - **`stdin`** — standard input for this call as a ready, bytes-typed buffer
   (`impl Into<Vec<u8>>` — a `&str`/`String` or a raw `Vec<u8>` both work),
@@ -468,7 +487,10 @@ Fields:
   so an open process stdin that never sends EOF doesn't block a command that
   never reads it — use `Kernel::execute_with_pipe_stdin(_streaming)` with a
   `PipeReader` instead (this is how the non-interactive `kaish` CLI forwards its
-  own process stdin, e.g. `sleep 10 | kaish -c 'echo hi'`).
+  own process stdin, e.g. `sleep 10 | kaish -c 'echo hi'`). See
+  [docs/binary-data.md](binary-data.md) for the full text-vs-bytes design
+  behind this (`Value::Bytes`, `read_stdin_to_text` vs `_bytes`, which
+  builtins are binary-aware).
 - **`traceparent` / `tracestate` / `baggage`** — W3C trace context;
   kaish's execution span parents onto your trace, and baggage merges back
   out through `ExecResult.baggage`.
@@ -478,9 +500,21 @@ Fields:
 `Kernel::execute(&str)` is string-native — it lexes and parses its input. If your
 embedder already holds **tokenized** arguments (a structured tool call, a
 multicall-style frontend), re-quoting them into a string just to have the lexer
-split them apart again is wasteful and **lossy**: `to_argv()` stringifies typed
-values, so a `Value::Bytes` blob or a `Value::Json` record can't survive the
-round-trip. `execute_argv` is the peer door that skips it:
+split them apart again is wasteful and **lossy**: `ToolArgs::to_argv()` — the
+argv-reconstruction step builtins use internally to feed their clap parsers —
+stringifies typed values, so a `Value::Json` record loses its structure in the
+round-trip. A `Value::Bytes` blob is worse than lossy: in a **named/flag**
+argument it's a loud error (`to_argv()` returns
+`Result<Vec<String>, ToolArgvError>`, not a bare `Vec<String>`) rather than
+silent corruption; in a **positional** argument it renders as an opaque
+`[binary: N bytes]` placeholder without erroring, since a clap-reflected
+positional field is a validation-only sink no builtin reads for its value.
+`ToolArgs::to_argv_excluding(keys)` is the same reconstruction with given
+named keys skipped entirely — for a tool that deliberately reads one of its
+own params raw off `args.named` (to preserve a `Value::Bytes` payload past the
+argv/text boundary) instead of through the round-trip (`write`'s `content`
+param does this). `execute_argv` is the peer door that skips the round-trip
+entirely:
 
 ```rust
 use kaish_kernel::ast::Value;
@@ -522,7 +556,9 @@ Semantics:
 - **Typed-passthrough caveat.** Because builtins re-parse their own `to_argv()`
   internally (the two-layer clap model), the un-stringified-value win fully lands
   only for tools that read `args.positional` directly (the documented pattern),
-  not those that trust their clap struct after a `to_argv()` round-trip.
+  not those that trust their clap struct after a `to_argv()` round-trip. A
+  `Value::Bytes` passed as a **named** argument to such a tool surfaces as the
+  tool's own `to_argv()` failure (`ExecResult::failure`), not a silent stringify.
 
 Concurrent callers serialize on the same execute lock as `execute`, and the
 kernel's configured `request_timeout` applies (a hung builtin or external is
@@ -786,6 +822,45 @@ same API as a foreground gate.
 
 The status strings are exactly `running`, `done:0`, and `failed:{code}` —
 match on those, not on `completed`.
+
+## Frontend Completion Helpers (`kaish_client::completion`)
+
+Answering Tab in a frontend (a REPL, a browser playground, any custom UI
+around the kernel) needs two things: figuring out *what* the cursor is
+completing, and turning a live kernel's schemas/vars into candidate
+spellings. Both are extracted into `kaish_client::completion` so every
+frontend shares one implementation instead of re-deriving it — the bundled
+`kaish-repl` and the kaish-extras browser playground both consume this crate
+rather than duplicating the logic.
+
+```rust
+use kaish_client::completion::{
+    detect_completion_context, word_start, current_command, flag_candidates,
+    CompletionContext,
+};
+
+// What kind of thing is being completed at `pos` in `line`?
+match detect_completion_context(line, pos) {
+    CompletionContext::Command => { /* complete a tool/alias name */ }
+    CompletionContext::Variable => { /* complete a $VAR / ${VAR */ }
+    CompletionContext::Path => { /* complete a filesystem path, or a
+                                     flag if the word starts with `-` */ }
+}
+
+let start = word_start(line, pos); // byte offset the word under the cursor begins at
+
+// Given the governing command and its ToolSchema, offer canonical flag spellings
+if let Some((cs, ce)) = current_command(line, pos) {
+    let candidates = flag_candidates(&schema.params, &line[cs..ce]);
+    // -> canonical "--long" and "-x" spellings; snake_case field-id aliases
+    //    stay reachable as input but aren't offered as candidates
+}
+```
+
+Context detection is pure (no kernel access needed); turning a
+`CompletionContext` into actual candidates is the frontend's job — walk
+`kernel.tool_schemas()` for commands/flags, `kernel.list_vars()` for
+variables, `kernel.vfs()` for paths, as `kaish-repl` and kaish-extras both do.
 
 ## Exported Types
 

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -1152,6 +1152,8 @@ Git is an ordinary external command (`git status`, `git log`) that runs via the
 kaish carries binary as a first-class typed value (`Value::Bytes`) that flows
 through pipes intact. A bytes value **coerces to text only if it is valid UTF-8**;
 otherwise an operation that requires text fails loudly rather than corrupting data.
+[docs/binary-data.md](binary-data.md) is the full design writeup — this section
+is the language-level summary.
 
 ```sh
 # Produce bytes and copy them with explicit block sizing


### PR DESCRIPTION
## Summary
Version bump + changelog stamp for the v0.13.0 release. 85 commits since v0.12.0 (2026-07-12), three BREAKING changes:

- **`ExecContext::stdin`/`ExecuteOptions::stdin`: `String` → `Vec<u8>`** (GH #176) — binary-safe stdin; `read_stdin_to_string` removed.
- **`ToolArgs::to_argv()`: `Vec<String>` → `Result<Vec<String>, ToolArgvError>`** (GH #164) — loud on a `Value::Bytes` named/flag argument instead of silent corruption.
- **`output_limit::spill_aware_collect` and its private helpers removed** (GH #133) — dead since capture moved to `BoundedStream`/pipeline-level `spill_if_needed`.

Also: the full lexer pipeline rewrite (GH #95, one composed scanner), the kernel running in the browser (`wasm32-unknown-unknown`, `kaish_types::clock`), arg-binding polish (GH #189), and a long tail of loud-not-silent fixes across binary handling, collections, case patterns, and printf. Full detail in `CHANGELOG.md`'s new `## [0.13.0]` section.

## Review
Pre-release review via kaibo (cast `deepseek`) against the actual code (not a diff) — verified all three BREAKING changes are correctly implemented with proper error propagation and test coverage, and cross-checked every CHANGELOG claim against source. Found 6 embedder-facing docs gaps in `docs/EMBEDDING.md`/`docs/LANGUAGE.md` (most notably: the doc still described `to_argv()` as silently lossy rather than returning `Result`), fixed in this branch before the bump commit. Full review posted as a PR comment.

## What's in this PR
1. `docs(embedding)`: closes the 6 docs gaps kaibo's review found
2. `chore`: workspace version 0.12.0 → 0.13.0 (root + all 16 inter-crate `path + version` pins), `CHANGELOG.md` stamped

## Test plan
- [x] `cargo test --all` — clean (2000+ tests)
- [x] `cargo clippy --all --all-targets` — 0 warnings
- [x] `cargo insta test --check` — no pending snapshots
- [x] `cargo check --all` — all crates resolve at 0.13.0
- [ ] CI green