### PR TITLE
feat(types): persist OutputData.rich_json through serde

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,18 @@ breaking entries are marked **BREAKING**.
 
 ## [0.13.0] - 2026-07-18
 
+### Added
+- **`OutputData.rich_json` now persists through serde** (self-describing
+  formats: JSON, CBOR). The `--json` render override — set by `grep --json`,
+  available to any builtin — was `#[serde(skip)]` as a transient render hint.
+  It now serializes when `Some` (omitted when `None` via
+  `skip_serializing_if`), so an embedder can carry a builtin's rich structured
+  output onto a stored record and read it back — e.g. kaijutsu persisting a
+  `kj` command's structured output onto a CRDT block for its MCP surface. The
+  `None` (common) case is unchanged on the wire. Caveat: a `Some` value can't
+  round-trip through non-self-describing formats (postcard/bincode lack
+  `deserialize_any`) — kaish uses neither, and kaijutsu is CBOR.
+
 ### Fixed
 - **Arg-binding polish** (GH #189): four small gaps in the shared arg binder
   (`kernel::bind_tool_args`), verified against current code post-#188/#231:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,11 @@ breaking entries are marked **BREAKING**.
   `skip_serializing_if`), so an embedder can carry a builtin's rich structured
   output onto a stored record and read it back — e.g. kaijutsu persisting a
   `kj` command's structured output onto a CRDT block for its MCP surface. The
-  `None` (common) case is unchanged on the wire. Caveat: a `Some` value can't
-  round-trip through non-self-describing formats (postcard/bincode lack
-  `deserialize_any`) — kaish uses neither, and kaijutsu is CBOR.
+  `None` (common) case is unchanged on the wire. Caveat: **decoding** a `Some`
+  value from a non-self-describing format fails — `serde_json::Value` needs
+  `deserialize_any`, which postcard/bincode lack. kaish and its embedders use
+  only self-describing formats (JSON/CBOR), so this is a documented boundary,
+  not a live path.
 
 ### Fixed
 - **Arg-binding polish** (GH #189): four small gaps in the shared arg binder

--- a/crates/kaish-types/src/output.rs
+++ b/crates/kaish-types/src/output.rs
@@ -210,11 +210,14 @@ pub struct OutputData {
     /// through self-describing formats (JSON, CBOR): an embedder can carry a
     /// builtin's rich `--json` payload onto a stored record and read it back.
     /// Kept off the wire when `None` (the common case), which also keeps that
-    /// case safe for non-self-describing formats. Caveat: a `Some(Value)` can't
-    /// round-trip through postcard/bincode (they have no `deserialize_any`), so
-    /// don't add such a serializer for `OutputData` while `rich_json` may be set.
+    /// case safe for non-self-describing formats. Caveat: the risk is on
+    /// **deserialization** — `serde_json::Value`'s `Deserialize` calls
+    /// `deserialize_any`, which non-self-describing formats (postcard/bincode)
+    /// don't support, so decoding an `OutputData` whose `rich_json` is `Some`
+    /// from one of those fails. kaish and its embedders use only self-describing
+    /// formats (JSON/CBOR); don't decode `OutputData` from postcard/bincode
+    /// while `rich_json` may be set.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[cfg_attr(feature = "schema", schemars(skip))]
     pub rich_json: Option<serde_json::Value>,
 }
 

--- a/crates/kaish-types/src/output.rs
+++ b/crates/kaish-types/src/output.rs
@@ -201,15 +201,19 @@ pub struct OutputData {
     pub headers: Option<Vec<String>>,
     /// Top-level nodes.
     pub root: Vec<OutputNode>,
-    /// Render-only override for `--json` consumers. When `Some`,
-    /// `to_json()` returns this verbatim instead of inferring from
-    /// `headers` / `root` / `cells`. Use it when a builtin wants its
-    /// `--json` shape to be richer than the table form (e.g. grep
-    /// emitting per-match objects with submatches and byte offsets).
+    /// Override for `--json` consumers. When `Some`, `to_json()` returns this
+    /// verbatim instead of inferring from `headers` / `root` / `cells`. Use it
+    /// when a builtin wants its `--json` shape to be richer than the table form
+    /// (e.g. grep emitting per-match objects with submatches and byte offsets).
     ///
-    /// Skipped by serde (and thus by postcard / bincode) — this is a
-    /// transient render hint, not part of the persisted shape.
-    #[serde(skip)]
+    /// Serialized only when `Some` (`skip_serializing_if`), so it **persists**
+    /// through self-describing formats (JSON, CBOR): an embedder can carry a
+    /// builtin's rich `--json` payload onto a stored record and read it back.
+    /// Kept off the wire when `None` (the common case), which also keeps that
+    /// case safe for non-self-describing formats. Caveat: a `Some(Value)` can't
+    /// round-trip through postcard/bincode (they have no `deserialize_any`), so
+    /// don't add such a serializer for `OutputData` while `rich_json` may be set.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     #[cfg_attr(feature = "schema", schemars(skip))]
     pub rich_json: Option<serde_json::Value>,
 }
@@ -774,6 +778,39 @@ mod tests {
     fn to_json_empty() {
         let output = OutputData::new();
         assert_eq!(output.to_json(), serde_json::json!([]));
+    }
+
+    #[test]
+    fn rich_json_round_trips_through_serde() {
+        // rich_json is now a persisted field on self-describing formats: a
+        // builtin's `--json` override survives serialize -> deserialize, so an
+        // embedder can store it on a record and read it back. (It was
+        // `#[serde(skip)]` before, which silently dropped it.)
+        let rich = serde_json::json!({"matches": [{"line": 1, "text": "hi"}]});
+        let output = OutputData::new().with_rich_json(rich.clone());
+
+        let encoded = serde_json::to_string(&output).unwrap();
+        let decoded: OutputData = serde_json::from_str(&encoded).unwrap();
+        assert_eq!(
+            decoded.rich_json,
+            Some(rich),
+            "rich_json must survive a serde round trip"
+        );
+    }
+
+    #[test]
+    fn rich_json_none_stays_off_the_wire() {
+        // The common case (no override) keeps the serialized shape minimal via
+        // `skip_serializing_if`, leaving nothing that could trip a
+        // non-self-describing decoder.
+        let output = OutputData::nodes(vec![OutputNode::new("f")]);
+        let encoded = serde_json::to_string(&output).unwrap();
+        assert!(
+            !encoded.contains("rich_json"),
+            "a None rich_json must not serialize: {encoded}"
+        );
+        let decoded: OutputData = serde_json::from_str(&encoded).unwrap();
+        assert_eq!(decoded.rich_json, None);
     }
 
     #[test]


### PR DESCRIPTION
## What

Flip `OutputData.rich_json` from `#[serde(skip)]` to
`#[serde(default, skip_serializing_if = "Option::is_none")]` so it persists
through self-describing serde formats (JSON, CBOR).

## Why

`rich_json` is the `--json` render override (set by `grep --json`, available to
any builtin). It was skipped as a "transient render hint." The parenthetical
reason was postcard/bincode safety — `serde_json::Value` can't deserialize from
non-self-describing formats (no `deserialize_any`), so skipping kept
`OutputData` safe for them.

**But there's no such path.** No `postcard::`/`bincode::` call touches
`OutputData` or `ExecResult` anywhere in kaish, and the embedder that persists
them (kaijutsu) is CBOR — self-describing, where `serde_json::Value` round-trips
fine. The skip cost embedders the ability to persist a builtin's rich `--json`
output. Concretely: kaijutsu wires a `kj` command's structured payload onto
`rich_json` to reach its MCP surface, and serde silently dropped it before the
block was stored — so MCP agents saw `null`/empty where the structured data
should be. Discovered while wiring that surface.

## The change

- serializes when `Some` -> persists through JSON/CBOR
- omitted when `None` (the common case) via `skip_serializing_if` -> wire shape
  unchanged, and a `None` stays safe even for non-self-describing formats
- `default` handles absence on decode

**Caveat** (documented on the field + CHANGELOG): don't add a postcard/bincode
serializer for `OutputData` while `rich_json` may be `Some`.

## Tests

- `rich_json_round_trips_through_serde` — serialize -> deserialize keeps it
- `rich_json_none_stays_off_the_wire` — `skip_serializing_if` omits `None`

`cargo test --all --locked` green, `cargo clippy --all-targets -D warnings` clean.

A kaibo review will follow as a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)